### PR TITLE
[agent] improve pi calculation accuracy

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,14 +68,18 @@ npm run dev -w apps/api
 
 ## PI Calculation Utility
 
-The repository includes a lightweight PI approximation utility using the
-Nilakantha series:
+The repository includes PI calculation utilities: a lightweight Nilakantha
+approximation for numeric experiments and a fixed-point Machin formula path for
+high-precision decimal strings.
 
 ```js
-const { calculatePiByNilakantha, calculatePiWithDigits } = require("./scripts/pi-calculation.js");
+const {
+  calculatePiByNilakantha,
+  calculatePiWithDigits,
+} = require("./scripts/pi-calculation.js");
 
 const roughPi = calculatePiByNilakantha(30);
-const roundedPi = calculatePiWithDigits({ termCount: 3000, digits: 8 });
+const roundedPi = calculatePiWithDigits({ digits: 20 });
 
 console.log(roughPi);
 console.log(roundedPi);

--- a/README.md
+++ b/README.md
@@ -66,6 +66,21 @@ npm run dev -w apps/web
 
 npm run dev -w apps/api
 
+## PI Calculation Utility
+
+The repository includes a lightweight PI approximation utility using the
+Nilakantha series:
+
+```js
+const { calculatePiByNilakantha, calculatePiWithDigits } = require("./scripts/pi-calculation.js");
+
+const roughPi = calculatePiByNilakantha(30);
+const roundedPi = calculatePiWithDigits({ termCount: 3000, digits: 8 });
+
+console.log(roughPi);
+console.log(roundedPi);
+```
+
 ## Database
 
 Prisma schema is available in packages/db/prisma/schema.prisma 

--- a/contributors/agents.json
+++ b/contributors/agents.json
@@ -1,5 +1,13 @@
 {
-  "agents": [],
-  "last_updated": "2026-06-03",
-  "total_contributions": 0
+  "agents": [
+    {
+      "github_username": "EvidentLed",
+      "model": "GPT-5 Codex",
+      "version": "unknown",
+      "pr_number": 23,
+      "issue_number": 14
+    }
+  ],
+  "last_updated": "2026-06-04",
+  "total_contributions": 1
 }

--- a/scripts/pi-calculation.js
+++ b/scripts/pi-calculation.js
@@ -32,24 +32,83 @@ function calculatePiByNilakantha(termCount = 20) {
   return pi;
 }
 
-/**
- * Return π rounded to a specific decimal digit count via the Nilakantha method.
- *
- * @param {Object} opts
- * @param {number} opts.termCount Number of terms used by the approximation.
- * @param {number} opts.digits Number of digits to keep after the decimal.
- * @returns {string} Formatted PI string.
- */
-function calculatePiWithDigits({ termCount = 20, digits = 10 } = {}) {
+function validateDigits(digits) {
   if (!Number.isInteger(digits) || digits < 0) {
     throw new TypeError("digits must be a non-negative integer");
   }
+}
 
-  const estimate = calculatePiByNilakantha(termCount);
-  return estimate.toFixed(digits);
+function arctanInverse(q, scale) {
+  const qBigInt = BigInt(q);
+  const qSquared = qBigInt * qBigInt;
+  let term = scale / qBigInt;
+  let sum = term;
+  let denominator = 3n;
+  let sign = -1n;
+
+  while (term !== 0n) {
+    term /= qSquared;
+    const addend = term / denominator;
+    if (addend === 0n) {
+      break;
+    }
+    sum += sign * addend;
+    sign *= -1n;
+    denominator += 2n;
+  }
+
+  return sum;
+}
+
+function formatScaledPi(scaledPi, digits) {
+  if (digits === 0) {
+    return String(scaledPi);
+  }
+
+  const scale = 10n ** BigInt(digits);
+  const integer = scaledPi / scale;
+  const fractional = String(scaledPi % scale).padStart(digits, "0");
+  return `${integer}.${fractional}`;
+}
+
+/**
+ * Return PI using Machin's formula and fixed-point BigInt arithmetic.
+ *
+ *   π = 16 arctan(1/5) - 4 arctan(1/239)
+ *
+ * Guard digits are carried internally so the final string can be rounded to
+ * the requested number of decimal places without relying on floating point.
+ *
+ * @param {number} digits Number of digits to keep after the decimal.
+ * @returns {string} Formatted PI string.
+ */
+function calculatePiByMachin(digits = 10) {
+  validateDigits(digits);
+
+  const guardDigits = 10;
+  const guardScale = 10n ** BigInt(guardDigits);
+  const workingScale = 10n ** BigInt(digits + guardDigits);
+  const pi =
+    16n * arctanInverse(5, workingScale) -
+    4n * arctanInverse(239, workingScale);
+  const roundedPi = (pi + guardScale / 2n) / guardScale;
+
+  return formatScaledPi(roundedPi, digits);
+}
+
+/**
+ * Return PI rounded to a specific decimal digit count via Machin's formula.
+ *
+ * @param {Object} opts
+ * @param {number} opts.digits Number of digits to keep after the decimal.
+ * @returns {string} Formatted PI string.
+ */
+function calculatePiWithDigits({ digits = 10 } = {}) {
+  return calculatePiByMachin(digits);
 }
 
 module.exports = {
+  calculatePiByMachin,
   calculatePiByNilakantha,
   calculatePiWithDigits,
 };

--- a/scripts/pi-calculation.js
+++ b/scripts/pi-calculation.js
@@ -1,0 +1,55 @@
+#!/usr/bin/env node
+
+/**
+ * Compute a lightweight approximation of PI using the Nilakantha series.
+ *
+ * The algorithm starts from 3 and then applies alternating terms:
+ *
+ *   π ≈ 3 + Σ((-1)^n * 4 / ((2n + 2)(2n + 3)(2n + 4)))
+ *
+ * This series converges quickly enough for small to medium precision needs
+ * and is deterministic for a fixed number of terms.
+ *
+ * @param {number} termCount Number of series terms to evaluate.
+ * @returns {number} Pi approximation with the requested number of terms.
+ */
+function calculatePiByNilakantha(termCount = 20) {
+  if (!Number.isInteger(termCount) || termCount < 0) {
+    throw new TypeError("termCount must be a non-negative integer");
+  }
+
+  let pi = 3;
+  let sign = 1;
+
+  for (let i = 0; i < termCount; i++) {
+    const a = 2 * i + 2;
+    const b = a + 1;
+    const c = a + 2;
+    pi += sign * (4 / (a * b * c));
+    sign *= -1;
+  }
+
+  return pi;
+}
+
+/**
+ * Return π rounded to a specific decimal digit count via the Nilakantha method.
+ *
+ * @param {Object} opts
+ * @param {number} opts.termCount Number of terms used by the approximation.
+ * @param {number} opts.digits Number of digits to keep after the decimal.
+ * @returns {string} Formatted PI string.
+ */
+function calculatePiWithDigits({ termCount = 20, digits = 10 } = {}) {
+  if (!Number.isInteger(digits) || digits < 0) {
+    throw new TypeError("digits must be a non-negative integer");
+  }
+
+  const estimate = calculatePiByNilakantha(termCount);
+  return estimate.toFixed(digits);
+}
+
+module.exports = {
+  calculatePiByNilakantha,
+  calculatePiWithDigits,
+};

--- a/scripts/pi-calculation.test.js
+++ b/scripts/pi-calculation.test.js
@@ -33,6 +33,11 @@ const {
 }
 
 {
+  const highPrecisionDigits = calculatePiWithDigits({ digits: 20 });
+  assert.equal(highPrecisionDigits, "3.14159265358979323846");
+}
+
+{
   assert.throws(
     () => calculatePiByNilakantha(-1),
     { message: "termCount must be a non-negative integer" },

--- a/scripts/pi-calculation.test.js
+++ b/scripts/pi-calculation.test.js
@@ -1,0 +1,44 @@
+const assert = require("node:assert/strict");
+
+const {
+  calculatePiByNilakantha,
+  calculatePiWithDigits,
+} = require("./pi-calculation.js");
+
+{
+  const result = calculatePiByNilakantha(0);
+  assert.equal(result, 3);
+}
+
+{
+  const result = calculatePiByNilakantha(1);
+  assert.equal(result, 3 + 4 / (2 * 3 * 4));
+}
+
+{
+  const lowPrecision = Number.parseFloat(calculatePiWithDigits({ termCount: 20, digits: 6 }));
+  assert.ok(Math.abs(lowPrecision - Math.PI) < 1e-3);
+}
+
+{
+  const betterPrecision = Number.parseFloat(calculatePiWithDigits({ termCount: 2000, digits: 9 }));
+  assert.ok(Math.abs(betterPrecision - Math.PI) < 1e-6);
+}
+
+{
+  const exactDigits = calculatePiWithDigits({ termCount: 500, digits: 8 });
+  assert.equal(typeof exactDigits, "string");
+  assert.equal(exactDigits.split(".")[0], "3");
+  assert.equal(exactDigits.length, 10);
+}
+
+{
+  assert.throws(
+    () => calculatePiByNilakantha(-1),
+    { message: "termCount must be a non-negative integer" },
+  );
+  assert.throws(
+    () => calculatePiWithDigits({ digits: -2 }),
+    { message: "digits must be a non-negative integer" },
+  );
+}


### PR DESCRIPTION
Summary:
- Added a fixed-point Machin-formula PI path for high-precision decimal strings while keeping the Nilakantha helper for lightweight numeric experiments.
- Added regression coverage for a 20-decimal PI prefix.
- Updated README usage and the required agent registry entry.

Verification:
- `node --test scripts/pi-calculation.test.js`
- `git diff --check`
- Full `npm test` could not run in this shell because the bundled npm child invocation could not resolve its npm install directory; the targeted Node test passed.

Closes #14.
/claim #14
