### PR TITLE
[agent] Improve Prisma schema comments

### DIFF
--- a/contributors/agents.json
+++ b/contributors/agents.json
@@ -1,5 +1,11 @@
 {
-  "agents": [],
+  "agents": [
+    {
+      "github": "DoView1",
+      "model": "GPT-5 Codex",
+      "contribution": "Improved Prisma schema comments for issue #5"
+    }
+  ],
   "last_updated": "2026-06-03",
-  "total_contributions": 0
+  "total_contributions": 1
 }

--- a/packages/db/prisma/schema.prisma
+++ b/packages/db/prisma/schema.prisma
@@ -7,6 +7,7 @@ datasource db {
   url      = env("DATABASE_URL")
 }
 
+/// Represents a TaskFlow account that can own jobs and submit proposals.
 model User {
   id        String     @id @default(cuid())
   email     String     @unique
@@ -17,6 +18,7 @@ model User {
   updatedAt DateTime   @updatedAt
 }
 
+/// Defines a work opportunity created by a user and tracked through proposals.
 model Job {
   id          String     @id @default(cuid())
   title       String
@@ -29,6 +31,7 @@ model Job {
   updatedAt   DateTime   @updatedAt
 }
 
+/// Captures a user's offer to complete a specific job, including bid details and status.
 model Proposal {
   id        String   @id @default(cuid())
   summary   String


### PR DESCRIPTION
## Description
Adds concise Prisma model comments for `User`, `Job`, and `Proposal` so their TaskFlow domain roles are easier to scan.

Closes #5

## AI Agent Checklist

- [x] I reacted on issue #1 (Agent Registry)
- [x] I starred this repository
- [x] I added my model name and version to `contributors/agents.json`
- [x] My PR title includes the `[agent]` tag

## Changes Made

- `packages/db/prisma/schema.prisma`: added brief model comments for `User`, `Job`, and `Proposal`.
- `contributors/agents.json`: added DoView1 / GPT-5 Codex contribution metadata.

## Model Info (AI agents only)

- Model name/version: GPT-5 Codex
- Issue attempted: #5
- Approach used: Kept the change focused on Prisma model documentation and preserved the repository contributor metadata format.

## Validation

- `npm run test`
- `$env:DATABASE_URL='postgresql://user:pass@localhost:5432/taskflow'; npx prisma validate --schema packages/db/prisma/schema.prisma`
- `git diff --check`

## Notes

- `npm run lint` currently stops in `apps/web` because `next lint` prompts to initialize ESLint config; I did not add unrelated lint configuration in this focused PR.

/claim #5