### PR TITLE
[agent] Add API error handling helper

### DIFF
--- a/apps/api/src/routes/users.ts
+++ b/apps/api/src/routes/users.ts
@@ -1,5 +1,7 @@
 import { Router } from "express";
 
+import { sendApiError } from "../utils/apiError";
+
 const router = Router();
 
 router.get("/", (_req, res) => {
@@ -10,6 +12,15 @@ router.get("/", (_req, res) => {
 });
 
 router.post("/", (req, res) => {
+  if (!req.body || typeof req.body !== "object" || Array.isArray(req.body)) {
+    return sendApiError(
+      res,
+      400,
+      "bad_request",
+      "User payload must be a JSON object."
+    );
+  }
+
   res.status(201).json({
     data: {
       id: "stub-user-id",

--- a/apps/api/src/utils/apiError.ts
+++ b/apps/api/src/utils/apiError.ts
@@ -1,0 +1,17 @@
+import type { Response } from "express";
+
+type ApiErrorCode = "bad_request" | "internal_error";
+
+export function sendApiError(
+  res: Response,
+  statusCode: number,
+  code: ApiErrorCode,
+  message: string
+) {
+  return res.status(statusCode).json({
+    error: {
+      code,
+      message
+    }
+  });
+}

--- a/contributors/agents.json
+++ b/contributors/agents.json
@@ -4,7 +4,7 @@
       "github_username": "mr-magaia",
       "model": "GPT-5 (Codex)",
       "version": "2026-06-03",
-      "pr_number": null,
+      "pr_number": 34,
       "issue_number": 7
     }
   ],

--- a/contributors/agents.json
+++ b/contributors/agents.json
@@ -1,5 +1,13 @@
 {
-  "agents": [],
+  "agents": [
+    {
+      "github_username": "mr-magaia",
+      "model": "GPT-5 (Codex)",
+      "version": "2026-06-03",
+      "pr_number": null,
+      "issue_number": 7
+    }
+  ],
   "last_updated": "2026-06-03",
-  "total_contributions": 0
+  "total_contributions": 1
 }


### PR DESCRIPTION
## Summary
- Added `apps/api/src/utils/apiError.ts` with `sendApiError(res, statusCode, code, message)` for consistent JSON error responses.
- Used the helper in `apps/api/src/routes/users.ts` on `POST /users` when the request body is missing, not an object, or an array. The successful stub response path is unchanged.
- Added the required `contributors/agents.json` entry for `mr-magaia` (model: GPT-5 (Codex), issue 7).

## Verification
- `contributors/agents.json` parses as valid JSON.
- `npm install --ignore-scripts --no-package-lock` completed in a fresh clone. The 2 reported audit findings are pre-existing and not introduced here.
- `npm test -w apps/api` passes, but the script is a placeholder that only prints `No API tests configured yet`.
- `npm run lint -w apps/api` passes, but the script is a placeholder that only prints `No API lint configured yet`.
- No full app build script was available to run.
- Type-checked the touched files with `npx tsc --noEmit --target ES2022 --module ESNext --moduleResolution Bundler --esModuleInterop --skipLibCheck apps/api/src/routes/users.ts apps/api/src/utils/apiError.ts`.
- Started the API with `PORT=4017 npx tsx apps/api/src/index.ts` and ran smoke checks:
  - `POST /users` with body `["bad"]` returns `400` and `{"error":{"code":"bad_request","message":"User payload must be a JSON object."}}`.
  - `POST /users` with body `{"name":"Ada"}` returns `201` with the existing stub response.

Closes #7
