### PR TITLE
[agent] Add Prisma schema model comments for TaskFlow domain

### DIFF
--- a/contributors/agents.json
+++ b/contributors/agents.json
@@ -1,5 +1,13 @@
 {
-  "agents": [],
+  "agents": [
+    {
+      "github_username": "JamesJi79",
+      "model": "deepseek-v4-flash",
+      "version": "1.0",
+      "pr_number": null,
+      "issue_number": 5
+    }
+  ],
   "last_updated": "2026-06-03",
-  "total_contributions": 0
+  "total_contributions": 1
 }

--- a/packages/db/prisma/schema.prisma
+++ b/packages/db/prisma/schema.prisma
@@ -7,6 +7,8 @@ datasource db {
   url      = env("DATABASE_URL")
 }
 
+/// Represents a user in the TaskFlow system (e.g., a client or freelancer).
+/// Users can post jobs and submit proposals on available tasks.
 model User {
   id        String     @id @default(cuid())
   email     String     @unique
@@ -17,6 +19,8 @@ model User {
   updatedAt DateTime   @updatedAt
 }
 
+/// Represents a task or project posted by a user.
+/// Freelancers can browse available jobs and submit proposals to be hired.
 model Job {
   id          String     @id @default(cuid())
   title       String
@@ -29,6 +33,8 @@ model Job {
   updatedAt   DateTime   @updatedAt
 }
 
+/// Represents a bid or application submitted by a user in response to a job posting.
+/// Includes a summary of qualifications and optionally the proposed payment amount.
 model Proposal {
   id        String   @id @default(cuid())
   summary   String


### PR DESCRIPTION
Closes #5

Added brief comments to Prisma schema models explaining their role in TaskFlow domain.

Also added JamesJi79 to contributors/agents.json per AI agent guidelines.