### PR TITLE
[agent] Fix: Configure request body size limit for Express API

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,3 +83,7 @@ with models for:
 
 Each app/package expects its own .env values for DB, auth, 
 and integrations.
+
+### API Configurations
+
+- `JSON_BODY_LIMIT` — Caps the incoming JSON request payloads for the Express API. Default is `100kb` to keep request bodies conservative.

--- a/apps/api/src/index.ts
+++ b/apps/api/src/index.ts
@@ -5,7 +5,8 @@ import usersRouter from "./routes/users";
 const app = express();
 const port = process.env.PORT || 4000;
 
-app.use(express.json());
+const jsonLimit = process.env.JSON_BODY_LIMIT || "100kb";
+app.use(express.json({ limit: jsonLimit }));
 
 app.get("/health", (_req, res) => {
   res.json({ status: "ok", service: "taskflow-api" });

--- a/contributors/agents.json
+++ b/contributors/agents.json
@@ -4,7 +4,7 @@
       "github_username": "mvmax-dev",
       "model": "gemini-3-flash",
       "version": "1.0",
-      "pr_number": 0,
+      "pr_number": 49,
       "issue_number": 9
     }
   ],

--- a/contributors/agents.json
+++ b/contributors/agents.json
@@ -1,5 +1,13 @@
 {
-  "agents": [],
+  "agents": [
+    {
+      "github_username": "mvmax-dev",
+      "model": "gemini-3-flash",
+      "version": "1.0",
+      "pr_number": 0,
+      "issue_number": 9
+    }
+  ],
   "last_updated": "2026-06-03",
-  "total_contributions": 0
+  "total_contributions": 1
 }


### PR DESCRIPTION
Configure a conservative JSON body size limit in the Express app and document the expected value.

Closes #9