### PR TITLE
Add unit tests for user routes

### DIFF
--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -7,7 +7,7 @@
   "main": "src/index.ts",
   "scripts": {
     "dev": "tsx src/index.ts",
-    "test": "echo \"No API tests configured yet\"",
+    "test": "vitest run",
     "lint": "echo \"No API lint configured yet\""
   },
   "dependencies": {
@@ -16,6 +16,9 @@
   "devDependencies": {
     "@types/express": "^4.17.21",
     "tsx": "^4.7.1",
-    "typescript": "^5.4.5"
+    "typescript": "^5.4.5",
+    "vitest": "^1.3.1",
+    "supertest": "^6.3.4",
+    "@types/supertest": "^6.0.2"
   }
 }

--- a/apps/api/src/routes/users.test.ts
+++ b/apps/api/src/routes/users.test.ts
@@ -1,0 +1,59 @@
+import { describe, it, expect } from "vitest";
+import express from "express";
+import request from "supertest";
+import usersRouter from "./users.js";
+
+function createApp() {
+  const app = express();
+  app.use(express.json());
+  app.use("/users", usersRouter);
+  return app;
+}
+
+describe("GET /users", () => {
+  it("returns 200 with a data array and a message", async () => {
+    const app = createApp();
+    const res = await request(app).get("/users");
+
+    expect(res.status).toBe(200);
+    expect(res.body).toHaveProperty("data");
+    expect(Array.isArray(res.body.data)).toBe(true);
+    expect(res.body).toHaveProperty("message");
+  });
+
+  it("returns an empty array from the stub", async () => {
+    const app = createApp();
+    const res = await request(app).get("/users");
+
+    expect(res.body.data).toEqual([]);
+  });
+});
+
+describe("POST /users", () => {
+  it("returns 201 with the posted body echoed back", async () => {
+    const app = createApp();
+    const payload = { email: "test@example.com", name: "Test User" };
+    const res = await request(app).post("/users").send(payload);
+
+    expect(res.status).toBe(201);
+    expect(res.body.data).toMatchObject(payload);
+    expect(res.body.data).toHaveProperty("id");
+  });
+
+  it("echoes back whatever fields are sent", async () => {
+    const app = createApp();
+    const payload = { email: "a@b.com" };
+    const res = await request(app).post("/users").send(payload);
+
+    expect(res.status).toBe(201);
+    expect(res.body.data.email).toBe("a@b.com");
+  });
+
+  it("returns a stub message indicating the route is not implemented", async () => {
+    const app = createApp();
+    const res = await request(app).post("/users").send({ email: "x@y.com" });
+
+    expect(res.body).toHaveProperty("message");
+    expect(typeof res.body.message).toBe("string");
+  });
+});


### PR DESCRIPTION
## Summary

Adds basic tests for the Express user route stubs covering list and create behavior.

## What changed

- Created `apps/api/src/routes/users.test.ts` with tests for both GET and POST /users
- **GET /users** – verifies 200 status, data array shape, and empty stub response
- **POST /users** – verifies 201 status, body echo with id, and message presence
- Updated `apps/api/package.json` test script to use vitest + added dev dependencies

## Testing

Run `npm test` from `apps/api` (requires `npm install` first).

Closes #12