### PR TITLE
Add PI calculation with Machin-like formula

### DIFF
--- a/apps/api/src/pi.test.ts
+++ b/apps/api/src/pi.test.ts
@@ -1,0 +1,50 @@
+import { describe, it, expect } from "vitest";
+import { calculatePi, verifyPi } from "./pi.js";
+
+describe("calculatePi", () => {
+  it("produces a string starting with 3.", () => {
+    const result = calculatePi(10);
+    expect(result.startsWith("3.")).toBe(true);
+  });
+
+  it("matches known digits for 10 decimal places", () => {
+    const result = calculatePi(10);
+    expect(result).toBe("3.1415926536");
+  });
+
+  it("matches known digits for 50 decimal places", () => {
+    const result = calculatePi(50);
+    const expected = "3.14159265358979323846264338327950288419716939937510";
+    expect(result).toBe(expected);
+  });
+
+  it("matches known digits for 100 decimal places", () => {
+    const result = calculatePi(100);
+    const known =
+      "3.14159265358979323846264338327950288419716939937510" +
+      "58209749445923078164062862089986280348253421170679";
+    expect(result).toBe(known);
+  });
+
+  it("clamps digits to minimum 1", () => {
+    const result = calculatePi(0);
+    expect(result.startsWith("3.")).toBe(true);
+    expect(result.length).toBeGreaterThanOrEqual(3);
+  });
+
+  it("clamps digits to maximum 1000", () => {
+    const result = calculatePi(2000);
+    // "3." + up to 1000 decimal digits
+    expect(result.length).toBeLessThanOrEqual(1002);
+  });
+});
+
+describe("verifyPi", () => {
+  it("accepts correct digits", () => {
+    expect(verifyPi(calculatePi(50))).toBe(true);
+  });
+
+  it("rejects wrong digits", () => {
+    expect(verifyPi("2.718281828")).toBe(false);
+  });
+});

--- a/apps/api/src/pi.ts
+++ b/apps/api/src/pi.ts
@@ -1,0 +1,59 @@
+/**
+ * PI Calculator using the Machin-like formula.
+ *
+ * Uses:  π/4 = 4·arctan(1/5) − arctan(1/239)
+ *
+ * This is a classic formula that converges quickly and is easy
+ * to implement with BigInt fixed-point arithmetic for arbitrary
+ * precision. Each arctan term is computed via its Taylor series:
+ *
+ *   arctan(1/x) = 1/x − 1/(3x³) + 1/(5x⁵) − 1/(7x⁷) + ...
+ */
+
+const MAX_DIGITS = 1000;
+
+/**
+ * Compute arctan(1/x) in fixed-point arithmetic.
+ * unity is the fixed-point unit (e.g. 10^(digits+10)).
+ */
+function arccot(x: bigint, unity: bigint): bigint {
+  const X = x;
+  let sum = 0n;
+  let power = unity / X;
+  let n = 1n;
+  let sign = true;
+
+  while (power !== 0n) {
+    sum += (sign ? power : -power) / n;
+    power = power / (X * X);
+    n += 2n;
+    sign = !sign;
+  }
+  return sum;
+}
+
+/**
+ * Calculate π to the given number of decimal places.
+ *
+ * @param digits - Desired decimal places (1–1000, default 100)
+ * @returns String representation of π (e.g. "3.14159...")
+ */
+export function calculatePi(digits: number = 100): string {
+  const clamped = Math.min(Math.max(digits, 1), MAX_DIGITS);
+  const guard = 10; // extra digits to avoid rounding artifacts
+  const unity = 10n ** BigInt(clamped + guard);
+
+  // Machin: π/4 = 4·arctan(1/5) − arctan(1/239)
+  const pi = 4n * (4n * arccot(5n, unity) - arccot(239n, unity));
+
+  const raw = pi.toString();
+  const intPart = raw[0]; // "3"
+  const fracPart = raw.slice(1, clamped + 1).padEnd(clamped, "0");
+  return `${intPart}.${fracPart}`;
+}
+
+/** Verify result against the known first 50 digits of π */
+export function verifyPi(value: string): boolean {
+  const known = "3.14159265358979323846264338327950288419716939937510";
+  return value.startsWith(known);
+}


### PR DESCRIPTION
## Summary

Adds a lightweight PI calculation utility that computes π to up to 1000 decimal places using the **Machin-like formula**:

**π/4 = 4·arctan(1/5) − arctan(1/239)**

## Approach

The arctan terms are computed via their Taylor series using **BigInt fixed-point arithmetic**, which avoids floating-point precision limits entirely. A guard-digit buffer of 10 extra places prevents rounding artifacts in the final output.

## What's included

- `apps/api/src/pi.ts` — `calculatePi(digits)` and `verifyPi()` functions
- `apps/api/src/pi.test.ts` — Unit tests verifying output against known π digits at 10, 50, and 100 places, plus clamping behavior

## Testing

```bash
cd apps/api && npm install && npm test
```

Closes #14