### PR TITLE
[agent] Add JSDoc-covered user service helpers

### DIFF
--- a/apps/api/src/routes/users.ts
+++ b/apps/api/src/routes/users.ts
@@ -1,20 +1,18 @@
 import { Router } from "express";
+import { createUser, listUsers } from "../services/userService.js";
 
 const router = Router();
 
 router.get("/", (_req, res) => {
   res.json({
-    data: [],
+    data: listUsers(),
     message: "User listing is not implemented yet."
   });
 });
 
 router.post("/", (req, res) => {
   res.status(201).json({
-    data: {
-      id: "stub-user-id",
-      ...req.body
-    },
+    data: createUser(req.body),
     message: "User creation is not implemented yet."
   });
 });

--- a/apps/api/src/services/userService.ts
+++ b/apps/api/src/services/userService.ts
@@ -1,0 +1,27 @@
+export type UserRecord = {
+  id: string;
+  [key: string]: unknown;
+};
+
+/**
+ * Returns the current user collection placeholder.
+ *
+ * This service keeps the route handler free of data-access details while the
+ * real persistence layer is still being implemented.
+ */
+export function listUsers(): UserRecord[] {
+  return [];
+}
+
+/**
+ * Builds a placeholder user record from the incoming request payload.
+ *
+ * The generated id mirrors the current stub API behavior; callers are expected
+ * to add validation before this is backed by persistent storage.
+ */
+export function createUser(payload: Record<string, unknown>): UserRecord {
+  return {
+    id: "stub-user-id",
+    ...payload
+  };
+}

--- a/contributors/agents.json
+++ b/contributors/agents.json
@@ -4,7 +4,7 @@
       "github_username": "DENGXUELIN",
       "model": "GPT-5 Codex",
       "version": "2026-06-03",
-      "pr_number": null,
+      "pr_number": 66,
       "issue_number": 1
     }
   ],

--- a/contributors/agents.json
+++ b/contributors/agents.json
@@ -1,5 +1,13 @@
 {
-  "agents": [],
+  "agents": [
+    {
+      "github_username": "DENGXUELIN",
+      "model": "GPT-5 Codex",
+      "version": "2026-06-03",
+      "pr_number": null,
+      "issue_number": 1
+    }
+  ],
   "last_updated": "2026-06-03",
-  "total_contributions": 0
+  "total_contributions": 1
 }


### PR DESCRIPTION
## Summary

- Adds a small `userService` module for the current user list/create placeholder behavior.
- Documents the service functions with concise JSDoc.
- Wires the existing user routes through the documented service without changing API responses.
- Registers this AI-assisted contribution in `contributors/agents.json`.

Closes #1
/claim #1

## Verification

- `npm test`
- `npx tsc --noEmit --module NodeNext --moduleResolution NodeNext --target ES2022 --esModuleInterop --skipLibCheck apps/api/src/routes/users.ts apps/api/src/services/userService.ts`

Note: `npm run lint` currently fails in `apps/web` because `next lint` cannot find the `next` binary in this checkout; the API lint script is a placeholder.