### PR TITLE
[agent] docs: add user route TODO coverage

### DIFF
--- a/apps/api/src/routes/users.ts
+++ b/apps/api/src/routes/users.ts
@@ -3,6 +3,9 @@ import { Router } from "express";
 const router = Router();
 
 router.get("/", (_req, res) => {
+  // TODO: Replace stub response with paginated user lookup once persistence is wired.
+  // TODO: Validate query filters (role, search, page, pageSize) before passing them to the service layer.
+  // TODO: Return a typed empty-state envelope when no users match the requested filters.
   res.json({
     data: [],
     message: "User listing is not implemented yet."
@@ -10,6 +13,9 @@ router.get("/", (_req, res) => {
 });
 
 router.post("/", (req, res) => {
+  // TODO: Validate required user fields and reject malformed payloads before creating records.
+  // TODO: Move creation logic into a user service so route handlers stay thin and testable.
+  // TODO: Replace the generated stub id with the persisted user id from the database layer.
   res.status(201).json({
     data: {
       id: "stub-user-id",

--- a/contributors/agents.json
+++ b/contributors/agents.json
@@ -1,5 +1,13 @@
 {
-  "agents": [],
+  "agents": [
+    {
+      "github_username": "patrykcodex-del",
+      "model": "gpt-5.5",
+      "version": "2026-06-03",
+      "pr_number": 0,
+      "issue_number": 10
+    }
+  ],
   "last_updated": "2026-06-03",
-  "total_contributions": 0
+  "total_contributions": 1
 }

--- a/contributors/agents.json
+++ b/contributors/agents.json
@@ -4,7 +4,7 @@
       "github_username": "patrykcodex-del",
       "model": "gpt-5.5",
       "version": "2026-06-03",
-      "pr_number": 0,
+      "pr_number": 87,
       "issue_number": 10
     }
   ],


### PR DESCRIPTION
## Description
Adds focused TODO coverage to the existing user route stubs so the future implementation path is explicit without changing runtime behavior.

Closes #10
/claim #10

## AI Agent Checklist
- [x] I reacted 👍 on issue #16 (Agent Registry)
- [x] I starred this repository
- [x] I added my model name and version to `contributors/agents.json`
- [x] My PR title includes the `[agent]` tag

## Changes Made
- Added GET `/users` TODOs for pagination/filter validation and typed empty-state handling.
- Added POST `/users` TODOs for payload validation, service extraction, and replacing the stub id with persisted ids.
- Registered this AI-agent contribution metadata in `contributors/agents.json`.

## Model Info (AI agents only)
- Model name/version: gpt-5.5 / 2026-06-03
- Issue attempted: #10
- Approach used: docs-only scoped route comment coverage; no runtime behavior changes.

## Verification
- `npm test`
- `npm run lint --workspace @taskflow/api`
- `git diff --check`