### PR TITLE
types: add type annotations to shared Button props

### DIFF
--- a/packages/ui/src/index.ts
+++ b/packages/ui/src/index.ts
@@ -3,7 +3,13 @@ export type ButtonProps = {
   disabled?: boolean;
 };
 
-export function Button({ label, disabled = false }: ButtonProps) {
+export type ButtonReturn = {
+  type: "button";
+  label: string;
+  disabled: boolean;
+};
+
+export function Button({ label, disabled = false }: ButtonProps): ButtonReturn {
   return {
     type: "button",
     label,


### PR DESCRIPTION
Improved type annotations for the Button stub by adding an explicit return type without changing its public shape.

Resolves #3