### PR TITLE
feat: add JSON body size limit to Express

### DIFF
--- a/apps/api/src/index.ts
+++ b/apps/api/src/index.ts
@@ -5,7 +5,7 @@ import usersRouter from "./routes/users";
 const app = express();
 const port = process.env.PORT || 4000;
 
-app.use(express.json());
+app.use(express.json({ limit: "1mb" })); // Limit JSON body size to 1MB
 
 app.get("/health", (_req, res) => {
   res.json({ status: "ok", service: "taskflow-api" });


### PR DESCRIPTION
Configured a conservative 1MB JSON body size limit in the Express app to prevent large payload attacks.

Resolves #9