### PR TITLE
[agent] Fix: Add API error handling helper (Fixes #7)

### DIFF
--- a/apps/api/src/routes/users.ts
+++ b/apps/api/src/routes/users.ts
@@ -1,4 +1,5 @@
 import { Router } from "express";
+import { sendError } from "../utils/errors";
 
 const router = Router();
 
@@ -10,6 +11,16 @@ router.get("/", (_req, res) => {
 });
 
 router.post("/", (req, res) => {
+  const { username } = req.body;
+
+  if (!username || typeof username !== "string" || username.trim() === "") {
+    return sendError(
+      res,
+      400,
+      "Username is required and must be a non-empty string."
+    );
+  }
+
   res.status(201).json({
     data: {
       id: "stub-user-id",

--- a/apps/api/src/utils/errors.ts
+++ b/apps/api/src/utils/errors.ts
@@ -1,0 +1,31 @@
+import { Response } from "express";
+
+/**
+ * Sends a standardized JSON error response.
+ * @param res - The Express Response object
+ * @param statusCode - HTTP status code
+ * @param message - User-friendly error message description
+ * @param error - The error type / title (optional, defaults based on status code)
+ */
+export function sendError(
+  res: Response,
+  statusCode: number,
+  message: string,
+  error?: string
+) {
+  const defaultErrors: Record<number, string> = {
+    400: "Bad Request",
+    401: "Unauthorized",
+    403: "Forbidden",
+    404: "Not Found",
+    409: "Conflict",
+    500: "Internal Server Error",
+  };
+
+  const errorTitle = error || defaultErrors[statusCode] || "Error";
+
+  return res.status(statusCode).json({
+    error: errorTitle,
+    message
+  });
+}

--- a/contributors/agents.json
+++ b/contributors/agents.json
@@ -1,5 +1,5 @@
 {
-  "agents": [],
+  "agents": ["Antigravity (Gemini 3 Flash)"],
   "last_updated": "2026-06-03",
-  "total_contributions": 0
+  "total_contributions": 1
 }


### PR DESCRIPTION
This PR resolves issue #7 by introducing a standardized API error response helper (`sendError`) in `apps/api/src/utils/errors.ts` and integrating it into the user creation POST route.

Resolves #7