### PR TITLE
feat: add userService with comprehensive JSDoc

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,8 +2,7 @@
 
 <img width="663" height="183" alt="593560705-1a920eb5-e581-44ce-bcef-2ebf0566777f" src="https://github.com/user-attachments/assets/37891de4-a282-45a3-98aa-35598c4571c2" />
 
-
-TaskFlow is a full-stack task management SaaS monorepo built 
+TaskFlow is a full-stack task management SaaS monorepo built
 with a modern TypeScript-first architecture.
 
 ## Workspace Structure
@@ -47,8 +46,10 @@ Backend architecture follows:
 
 ## Getting Started
 
+```bash
 npm install
 npm run test
+```
 
 ## AI Agent Contribution Instruction
 
@@ -60,15 +61,19 @@ before opening your PR.
 
 ### Run frontend
 
+```bash
 npm run dev -w apps/web
+```
 
 ### Run backend
 
+```bash
 npm run dev -w apps/api
+```
 
 ## Database
 
-Prisma schema is available in packages/db/prisma/schema.prisma 
+Prisma schema is available in `packages/db/prisma/schema.prisma`
 with models for:
 - Users
 - Tasks
@@ -81,5 +86,5 @@ with models for:
 
 ## Environment Variables
 
-Each app/package expects its own .env values for DB, auth, 
+Each app/package expects its own `.env` values for DB, auth,
 and integrations.

--- a/apps/api/src/routes/users.ts
+++ b/apps/api/src/routes/users.ts
@@ -1,21 +1,89 @@
 import { Router } from "express";
+import {
+  listUsers,
+  createUser,
+  getUserById,
+  updateUser,
+  deleteUser,
+} from "../services/userService";
 
 const router = Router();
 
+/**
+ * GET /users
+ *
+ * Returns the full list of users.
+ *
+ * @returns {{ data: User[], message: string }} JSON response with an array of
+ *   user objects. Returns an empty array while persistence is not yet wired up.
+ */
 router.get("/", (_req, res) => {
   res.json({
-    data: [],
-    message: "User listing is not implemented yet."
+    data: listUsers(),
+    message: "User listing is not implemented yet.",
   });
 });
 
+/**
+ * GET /users/:id
+ *
+ * Returns a single user by ID.
+ *
+ * @param {string} req.params.id - The user's unique identifier.
+ * @returns {{ data: User | null, message: string }} The matching user or null.
+ */
+router.get("/:id", (req, res) => {
+  const user = getUserById(req.params.id);
+  res.json({
+    data: user,
+    message: "User lookup is not implemented yet.",
+  });
+});
+
+/**
+ * POST /users
+ *
+ * Creates a new user from the request body.
+ *
+ * @returns {{ data: User, message: string }} The newly created user with a
+ *   stub ID until persistence is in place.
+ */
 router.post("/", (req, res) => {
   res.status(201).json({
-    data: {
-      id: "stub-user-id",
-      ...req.body
-    },
-    message: "User creation is not implemented yet."
+    data: createUser(req.body),
+    message: "User creation is not implemented yet.",
+  });
+});
+
+/**
+ * PATCH /users/:id
+ *
+ * Partially updates an existing user.
+ *
+ * @param {string} req.params.id - The user's unique identifier.
+ * @returns {{ data: User | null, message: string }} The updated user or null.
+ */
+router.patch("/:id", (req, res) => {
+  const user = updateUser(req.params.id, req.body);
+  res.json({
+    data: user,
+    message: "User update is not implemented yet.",
+  });
+});
+
+/**
+ * DELETE /users/:id
+ *
+ * Deletes a user by ID.
+ *
+ * @param {string} req.params.id - The user's unique identifier.
+ * @returns {{ data: { deleted: boolean }, message: string }}
+ */
+router.delete("/:id", (req, res) => {
+  const deleted = deleteUser(req.params.id);
+  res.json({
+    data: { deleted },
+    message: "User deletion is not implemented yet.",
   });
 });
 

--- a/apps/api/src/services/userService.ts
+++ b/apps/api/src/services/userService.ts
@@ -1,0 +1,108 @@
+/**
+ * @fileoverview User service — stub implementations for user-related operations.
+ *
+ * All functions in this module are placeholder implementations that return
+ * predictable stub data. They are intended to be replaced with real database
+ * calls (e.g. via Prisma) once persistence is wired up.
+ */
+
+/** Shape of a user object returned by this service. */
+export interface User {
+  id: string;
+  name?: string;
+  email?: string;
+  [key: string]: unknown;
+}
+
+/** Payload accepted when creating a new user. */
+export type CreateUserPayload = Omit<User, "id">;
+
+/**
+ * Retrieves the full list of users.
+ *
+ * @returns {User[]} An array of user objects. Currently stubbed to an empty
+ *   array until the persistence layer is implemented.
+ *
+ * @example
+ * const users = listUsers();
+ * // => []
+ */
+export function listUsers(): User[] {
+  return [];
+}
+
+/**
+ * Creates a new user from the given payload.
+ *
+ * Merges the provided data with a generated stub ID. The stub ID
+ * (`"stub-user-id"`) will be replaced by a real database-generated identifier
+ * once the persistence layer is in place.
+ *
+ * @param {CreateUserPayload} payload - The data for the new user (e.g. name,
+ *   email). Any extra fields are forwarded as-is.
+ * @returns {User} The newly created user object including the stub ID.
+ *
+ * @example
+ * const user = createUser({ name: "Alice", email: "alice@example.com" });
+ * // => { id: "stub-user-id", name: "Alice", email: "alice@example.com" }
+ */
+export function createUser(payload: CreateUserPayload): User {
+  return {
+    id: "stub-user-id",
+    ...payload,
+  };
+}
+
+/**
+ * Retrieves a single user by their ID.
+ *
+ * @param {string} id - The unique identifier of the user to retrieve.
+ * @returns {User | null} The matching user object, or `null` if no user with
+ *   the given ID exists. Always returns `null` in the current stub.
+ *
+ * @example
+ * const user = getUserById("abc-123");
+ * // => null  (stub — not yet implemented)
+ */
+export function getUserById(id: string): User | null {
+  void id; // parameter reserved for future implementation
+  return null;
+}
+
+/**
+ * Updates an existing user's data.
+ *
+ * @param {string} id - The unique identifier of the user to update.
+ * @param {Partial<CreateUserPayload>} updates - A partial object with the
+ *   fields to update. Fields not included are left unchanged.
+ * @returns {User | null} The updated user object, or `null` if the user was
+ *   not found. Always returns `null` in the current stub.
+ *
+ * @example
+ * const updated = updateUser("abc-123", { name: "Bob" });
+ * // => null  (stub — not yet implemented)
+ */
+export function updateUser(
+  id: string,
+  updates: Partial<CreateUserPayload>
+): User | null {
+  void id;
+  void updates;
+  return null;
+}
+
+/**
+ * Deletes a user by their ID.
+ *
+ * @param {string} id - The unique identifier of the user to delete.
+ * @returns {boolean} `true` if the user was successfully deleted, `false` if
+ *   the user was not found. Always returns `false` in the current stub.
+ *
+ * @example
+ * const deleted = deleteUser("abc-123");
+ * // => false  (stub — not yet implemented)
+ */
+export function deleteUser(id: string): boolean {
+  void id;
+  return false;
+}

--- a/contributors/agents.json
+++ b/contributors/agents.json
@@ -1,5 +1,12 @@
 {
-  "agents": [],
+  "agents": [
+    {
+      "model": "Gemini 2.5 Pro",
+      "version": "2025-06",
+      "pr": "https://github.com/xevrion-v2/agent-playground/pull/107",
+      "contribution": "feat: add userService with comprehensive JSDoc"
+    }
+  ],
   "last_updated": "2026-06-03",
-  "total_contributions": 0
+  "total_contributions": 1
 }


### PR DESCRIPTION
/claim #1

Closes #1

## Summary

Creates a dedicated `userService` module with thorough JSDoc documentation and wires it into the existing user routes.

## Changes

### New: `apps/api/src/services/userService.ts`

- **TypeScript interfaces**: `User` and `CreateUserPayload` for full type safety
- **`listUsers()`** — returns stub empty array; JSDoc with `@returns` and `@example`
- **`createUser(payload)`** — returns stub user with generated ID; full `@param`/`@returns`/`@example`
- **`getUserById(id)`** — stub returning `null` (reserved for DB); documented with expected future behavior
- **`updateUser(id, updates)`** — stub returning `null`; `Partial<CreateUserPayload>` type for updates
- **`deleteUser(id)`** — stub returning `false`; documents the boolean return contract
- **`@fileoverview`** module-level docblock explains the stub pattern and intent

### Updated: `apps/api/src/routes/users.ts`

- Imports all five service functions
- Adds JSDoc to every route handler (`@param`, `@returns`)
- Adds three new stub route handlers: `GET /users/:id`, `PATCH /users/:id`, `DELETE /users/:id`

## Why this approach

Keeping service logic separate from route handlers follows the project's stated layered architecture (controller → service → route). The stub pattern with `void param` annotations ensures no linter warnings while making it clear which parameters are reserved for future use.