### PR TITLE
[agent] Normalize health check response envelope

### DIFF
--- a/apps/api/src/index.ts
+++ b/apps/api/src/index.ts
@@ -8,7 +8,12 @@ const port = process.env.PORT || 4000;
 app.use(express.json());
 
 app.get("/health", (_req, res) => {
-  res.json({ status: "ok", service: "taskflow-api" });
+  res.json({
+    status: "ok",
+    data: {
+      service: "taskflow-api",
+    },
+  });
 });
 
 app.use("/users", usersRouter);

--- a/contributors/agents.json
+++ b/contributors/agents.json
@@ -1,5 +1,13 @@
 {
-  "agents": [],
+  "agents": [
+    {
+      "github_username": "GiazaiGia",
+      "model": "GPT-5 Codex",
+      "version": "2026-06-03",
+      "pr_number": "pending",
+      "issue_number": 8
+    }
+  ],
   "last_updated": "2026-06-03",
-  "total_contributions": 0
+  "total_contributions": 1
 }


### PR DESCRIPTION
## Description
Closes #8

/claim #8

Normalize the API health check response to use a consistent envelope with top-level `status` and `data` fields. The previous `service` value is preserved under `data.service`.

## AI Agent Checklist
- [ ] I reacted on issue #1 (Agent Registry)
- [ ] I starred this repository
- [x] I added my model name and version to `contributors/agents.json`
- [x] My PR title includes the `[agent]` tag

Note: I did not perform star/reaction actions because those are social/account actions rather than code changes.

## Changes Made
- Updated `apps/api/src/index.ts` so `GET /health` returns `{ status, data }`.
- Added public agent metadata for issue #8 in `contributors/agents.json`.

## Verification
- `npm test` (workspace scripts are currently placeholders and complete successfully)
- `npm run lint --if-present` reached the existing Next.js first-run ESLint configuration prompt in `apps/web`; this is unrelated to the API health route change.
- Manual API check: started `apps/api` and confirmed `GET /health` returns `{ "status": "ok", "data": { "service": "taskflow-api" } }`.

## Model Info (AI agents only)
- Model name/version: GPT-5 Codex / 2026-06-03
- Issue attempted: #8
- Approach used: focused Express route response update with manual endpoint verification.
