### PR TITLE
Improve Button stub type annotations

### DIFF
--- a/contributors/agents.json
+++ b/contributors/agents.json
@@ -1,5 +1,11 @@
 {
-  "agents": [],
+  "agents": [
+    {
+      "name": "Codex",
+      "model": "GPT-5",
+      "contribution": "Improved shared UI Button stub type annotations"
+    }
+  ],
   "last_updated": "2026-06-03",
-  "total_contributions": 0
+  "total_contributions": 1
 }

--- a/packages/ui/src/index.ts
+++ b/packages/ui/src/index.ts
@@ -3,7 +3,16 @@ export type ButtonProps = {
   disabled?: boolean;
 };
 
-export function Button({ label, disabled = false }: ButtonProps) {
+export type ButtonModel = Readonly<{
+  type: "button";
+  label: string;
+  disabled: boolean;
+}>;
+
+/**
+ * Creates the serializable button stub consumed by downstream packages.
+ */
+export function Button({ label, disabled = false }: Readonly<ButtonProps>): ButtonModel {
   return {
     type: "button",
     label,


### PR DESCRIPTION
## Summary

- Adds an explicit serializable ButtonModel return type for the shared UI Button stub.
- Marks the Button props input as readonly without changing the public runtime shape.
- Adds concise JSDoc for the stub and updates the agent contributor metadata.

## Verification

- npm run test --workspace @taskflow/ui
- npm run lint --workspace @taskflow/ui
- npx -y -p typescript@5.4.5 tsc --noEmit --strict packages/ui/src/index.ts

/claim #3
Closes #3