### PR TITLE
feat: add request body size limit of 10KB (#9)

### DIFF
--- a/apps/api/src/index.ts
+++ b/apps/api/src/index.ts
@@ -5,7 +5,8 @@ import usersRouter from "./routes/users";
 const app = express();
 const port = process.env.PORT || 4000;
 
-app.use(express.json());
+// Conservative JSON body size limit (10KB) for security
+app.use(express.json({ limit: "10kb" }));
 
 app.get("/health", (_req, res) => {
   res.json({ status: "ok", service: "taskflow-api" });


### PR DESCRIPTION
在 Express 应用的 JSON 解析中间件中添加 10KB 的 body 大小限制，并添加注释说明，以增强安全性。