### PR TITLE
feat: add API error handling helper

### DIFF
--- a/apps/api/src/routes/users.ts
+++ b/apps/api/src/routes/users.ts
@@ -1,4 +1,5 @@
 import { Router } from "express";
+import { sendError } from "../utils/error";
 
 const router = Router();
 
@@ -10,6 +11,11 @@ router.get("/", (_req, res) => {
 });
 
 router.post("/", (req, res) => {
+  const { name, email } = req.body || {};
+  if (!name || !email) {
+    return sendError(res, 400, "Missing required fields: name, email");
+  }
+
   res.status(201).json({
     data: {
       id: "stub-user-id",

--- a/apps/api/src/utils/error.ts
+++ b/apps/api/src/utils/error.ts
@@ -1,0 +1,5 @@
+import { Response } from "express";
+
+export function sendError(res: Response, status: number, message: string) {
+  return res.status(status).json({ error: true, message });
+}


### PR DESCRIPTION
Closes #7

Introduced a sendError(res, status, message) helper in apps/api/src/utils/error.ts and wired it into the users POST route to reject requests with missing fields.