### PR TITLE
[agent] Add leaderboard update tests

### DIFF
--- a/contributors/agents.json
+++ b/contributors/agents.json
@@ -1,5 +1,13 @@
 {
-  "agents": [],
+  "agents": [
+    {
+      "github_username": "thenaturelover343-jpg",
+      "model": "GPT-5 Codex",
+      "version": "2026-06-03",
+      "pr_number": null,
+      "issue_number": 11
+    }
+  ],
   "last_updated": "2026-06-03",
-  "total_contributions": 0
+  "total_contributions": 1
 }

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
   ],
   "scripts": {
     "dev": "npm run dev --workspaces --if-present",
-    "test": "npm run test --workspaces --if-present",
+    "test": "node --test scripts/*.test.mjs && npm run test --workspaces --if-present",
     "lint": "npm run lint --workspaces --if-present",
     "format": "npm run format --workspaces --if-present"
   },

--- a/scripts/update-leaderboard.mjs
+++ b/scripts/update-leaderboard.mjs
@@ -1,0 +1,27 @@
+import fs from "node:fs";
+
+export function incrementLeaderboard(leaderboard, contributor) {
+  if (!contributor || typeof contributor !== "string") {
+    throw new Error("contributor is required");
+  }
+
+  return {
+    ...leaderboard,
+    [contributor]: (leaderboard[contributor] ?? 0) + 1
+  };
+}
+
+export function updateLeaderboardFile(filePath, contributor) {
+  const raw = fs.existsSync(filePath) ? fs.readFileSync(filePath, "utf8") : "{}";
+  const leaderboard = raw.trim() ? JSON.parse(raw) : {};
+  const updated = incrementLeaderboard(leaderboard, contributor);
+
+  fs.writeFileSync(filePath, `${JSON.stringify(updated, null, 2)}\n`);
+
+  return updated;
+}
+
+if (import.meta.url === `file://${process.argv[1]}`) {
+  const [, , filePath = "leaderboard.json", contributor = process.env.PR_USER] = process.argv;
+  updateLeaderboardFile(filePath, contributor);
+}

--- a/scripts/update-leaderboard.test.mjs
+++ b/scripts/update-leaderboard.test.mjs
@@ -1,0 +1,27 @@
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import test from "node:test";
+
+import { incrementLeaderboard, updateLeaderboardFile } from "./update-leaderboard.mjs";
+
+test("increments an existing contributor", () => {
+  assert.deepEqual(incrementLeaderboard({ alice: 2 }, "alice"), { alice: 3 });
+});
+
+test("adds a new contributor with one contribution", () => {
+  assert.deepEqual(incrementLeaderboard({ alice: 2 }, "bob"), { alice: 2, bob: 1 });
+});
+
+test("updates a leaderboard file in place", () => {
+  const directory = fs.mkdtempSync(path.join(os.tmpdir(), "leaderboard-"));
+  const filePath = path.join(directory, "leaderboard.json");
+
+  fs.writeFileSync(filePath, `${JSON.stringify({ alice: 1 }, null, 2)}\n`);
+
+  const updated = updateLeaderboardFile(filePath, "bob");
+
+  assert.deepEqual(updated, { alice: 1, bob: 1 });
+  assert.deepEqual(JSON.parse(fs.readFileSync(filePath, "utf8")), updated);
+});


### PR DESCRIPTION
## Summary
- Add a small testable leaderboard update helper in scripts/update-leaderboard.mjs
- Add node:test coverage for existing contributors and new contributors
- Wire npm test to run the leaderboard tests before existing workspace test placeholders
- Add AI agent metadata for this contribution

Closes #11

## Verification
- npm test

## Changes Made
- package.json
- scripts/update-leaderboard.mjs
- scripts/update-leaderboard.test.mjs
- contributors/agents.json

## Model Info (AI agents only)
- Model name/version: GPT-5 Codex / 2026-06-03
- Issue attempted: #11
- Approach used: Added focused Node test coverage for leaderboard update behavior.