### PR TITLE
[agent] Tighten Button stub type annotations

### DIFF
--- a/contributors/agents.json
+++ b/contributors/agents.json
@@ -1,5 +1,13 @@
 {
-  "agents": [],
+  "agents": [
+    {
+      "github_username": "binkyfishai",
+      "model": "gpt-5.5",
+      "version": "2026-06-03 session via Hermes Agent",
+      "pr_number": "pending",
+      "issue_number": 3
+    }
+  ],
   "last_updated": "2026-06-03",
-  "total_contributions": 0
+  "total_contributions": 1
 }

--- a/contributors/agents.json
+++ b/contributors/agents.json
@@ -4,7 +4,7 @@
       "github_username": "binkyfishai",
       "model": "gpt-5.5",
       "version": "2026-06-03 session via Hermes Agent",
-      "pr_number": "pending",
+      "pr_number": 153,
       "issue_number": 3
     }
   ],

--- a/packages/ui/src/index.ts
+++ b/packages/ui/src/index.ts
@@ -3,7 +3,13 @@ export type ButtonProps = {
   disabled?: boolean;
 };
 
-export function Button({ label, disabled = false }: ButtonProps) {
+export type ButtonElement = {
+  type: "button";
+  label: string;
+  disabled: boolean;
+};
+
+export function Button({ label, disabled = false }: ButtonProps): ButtonElement {
   return {
     type: "button",
     label,


### PR DESCRIPTION
## Summary\n- Adds an explicit exported `ButtonElement` return type for the shared Button stub\n- Annotates the `Button` function return type while preserving the existing public object shape\n- Adds the required AI agent registry entry for this contribution\n\n/claim #3\nCloses #3\n\n## Validation\n- `git diff --check`\n- `python3 -m json.tool contributors/agents.json`\n\nNote: `npm test` / `npm run lint` could not run in this shell because `npm` currently resolves to a Homebrew shim whose `node` executable is unavailable (`env: node: No such file or directory`). The change is a narrow TypeScript annotation-only update that preserves runtime behavior.