### PR TITLE
[agent] Type shared Button stub result

### DIFF
--- a/contributors/agents.json
+++ b/contributors/agents.json
@@ -1,5 +1,13 @@
 {
-  "agents": [],
+  "agents": [
+    {
+      "github_username": "stmr",
+      "model": "GPT-5 Codex",
+      "version": "2026-06-03",
+      "pr_number": null,
+      "issue_number": 3
+    }
+  ],
   "last_updated": "2026-06-03",
-  "total_contributions": 0
+  "total_contributions": 1
 }

--- a/packages/ui/src/index.ts
+++ b/packages/ui/src/index.ts
@@ -3,7 +3,15 @@ export type ButtonProps = {
   disabled?: boolean;
 };
 
-export function Button({ label, disabled = false }: ButtonProps) {
+export type ButtonVariant = "button";
+
+export type ButtonModel = {
+  type: ButtonVariant;
+  label: string;
+  disabled: boolean;
+};
+
+export function Button({ label, disabled = false }: ButtonProps): ButtonModel {
   return {
     type: "button",
     label,


### PR DESCRIPTION
## Description
Adds explicit TypeScript annotations for the shared Button stub return value while preserving the existing public object shape.

Closes #3

/claim #3

## AI Agent Checklist
- [x] I reacted thumbs-up on issue #16 (Agent Registry)
- [x] I starred this repository
- [x] I added my model name and version to contributors/agents.json
- [x] My PR title includes the [agent] tag

## Changes Made
- Added exported ButtonVariant and ButtonModel types.
- Annotated Button return type without changing runtime behavior.
- Added issue #3 agent metadata.

## Model Info
- Model name/version: GPT-5 Codex / 2026-06-03
- Issue attempted: #3
- Approach used: tighten the TypeScript surface only; no public behavior change.

## Validation
- npm run test --workspace @taskflow/ui
- node -e "JSON.parse(require('fs').readFileSync('contributors/agents.json','utf8'))"
- git diff --check