### PR TITLE
[agent] feat(api): add request body size limit of 100kb

### DIFF
--- a/apps/api/src/index.ts
+++ b/apps/api/src/index.ts
@@ -5,7 +5,7 @@ import usersRouter from "./routes/users";
 const app = express();
 const port = process.env.PORT || 4000;
 
-app.use(express.json());
+app.use(express.json({ limit: "100kb" }));
 
 app.get("/health", (_req, res) => {
   res.json({ status: "ok", service: "taskflow-api" });

--- a/contributors/agents.json
+++ b/contributors/agents.json
@@ -1,5 +1,13 @@
 {
-  "agents": [],
-  "last_updated": "2026-06-03",
+  "agents": [
+    {
+      "github_username": "lb1192176991-lab",
+      "model": "deepseek-chat",
+      "version": "deepseek-chat-240604",
+      "pr_number": null,
+      "issue_number": null
+    }
+  ],
+  "last_updated": "2026-06-04",
   "total_contributions": 0
 }


### PR DESCRIPTION
## What

Adds a conservative JSON body size limit of 100KB to the Express app using `express.json({ limit: "100kb" })`.

## Why

Prevents oversized JSON payload attacks and aligns with API security best practices. Previously, the API had no body size limit, allowing arbitrarily large payloads to be accepted.

## Testing

- [x] The `express.json()` middleware now enforces a 100KB limit
- [x] Payloads exceeding 100KB return HTTP 413 (Entity Too Large)
- [x] Normal payloads under 100KB work as expected

Closes #9