### PR TITLE
[agent] Add API error response helper and apply to users route (Closes #7)

### DIFF
--- a/apps/api/src/helpers/apiError.ts
+++ b/apps/api/src/helpers/apiError.ts
@@ -1,0 +1,31 @@
+import { Response } from "express";
+
+export interface ApiErrorBody {
+  success: false;
+  error: {
+    message: string;
+    code: string;
+    statusCode: number;
+  };
+}
+
+/**
+ * Sends a standardised JSON error response.
+ *
+ * @param res     - Express Response object
+ * @param status  - HTTP status code (e.g. 400, 404, 500)
+ * @param message - Human-readable error description
+ * @param code    - Machine-readable error code (e.g. "VALIDATION_ERROR")
+ */
+export function sendApiError(
+  res: Response,
+  status: number,
+  message: string,
+  code = "INTERNAL_ERROR"
+): void {
+  const body: ApiErrorBody = {
+    success: false,
+    error: { message, code, statusCode: status },
+  };
+  res.status(status).json(body);
+}

--- a/apps/api/src/routes/users.ts
+++ b/apps/api/src/routes/users.ts
@@ -1,21 +1,28 @@
-import { Router } from "express";
+import { Router, Request, Response } from "express";
+
+import { sendApiError } from "../helpers/apiError";
 
 const router = Router();
 
-router.get("/", (_req, res) => {
+router.get("/", (_req: Request, res: Response) => {
   res.json({
     data: [],
-    message: "User listing is not implemented yet."
+    message: "User listing is not implemented yet.",
   });
 });
 
-router.post("/", (req, res) => {
+router.post("/", (req: Request, res: Response) => {
+  if (!req.body || typeof req.body !== "object" || Array.isArray(req.body)) {
+    sendApiError(res, 400, "Request body must be a JSON object.", "BAD_REQUEST");
+    return;
+  }
+
   res.status(201).json({
     data: {
       id: "stub-user-id",
-      ...req.body
+      ...req.body,
     },
-    message: "User creation is not implemented yet."
+    message: "User creation is not implemented yet.",
   });
 });
 

--- a/contributors/agents.json
+++ b/contributors/agents.json
@@ -1,5 +1,13 @@
 {
-  "agents": [],
+  "agents": [
+    {
+      "github_username": "Ishant5436",
+      "model": "claude-sonnet-4-6",
+      "version": "claude-sonnet-4-6",
+      "pr_number": null,
+      "issue_number": 7
+    }
+  ],
   "last_updated": "2026-06-03",
-  "total_contributions": 0
+  "total_contributions": 1
 }


### PR DESCRIPTION
## Summary

Introduces `apps/api/src/helpers/apiError.ts` — a typed helper that standardises JSON error responses across the Express API.

### Changes
- **New:** `apps/api/src/helpers/apiError.ts` — exports `sendApiError(res, status, message, code)` and the `ApiErrorBody` interface.
- **Updated:** `apps/api/src/routes/users.ts` — POST route now calls `sendApiError` when the request body is not a valid JSON object.

Closes #7
