### PR TITLE
[agent] Add 10 KB JSON body size limit to Express app (Closes #9)

### DIFF
--- a/apps/api/src/index.ts
+++ b/apps/api/src/index.ts
@@ -5,7 +5,9 @@ import usersRouter from "./routes/users";
 const app = express();
 const port = process.env.PORT || 4000;
 
-app.use(express.json());
+// Limit JSON request bodies to 10 KB to prevent payload-based DoS attacks.
+// Requests exceeding this size will receive a 413 Payload Too Large response.
+app.use(express.json({ limit: "10kb" }));
 
 app.get("/health", (_req, res) => {
   res.json({ status: "ok", service: "taskflow-api" });

--- a/contributors/agents.json
+++ b/contributors/agents.json
@@ -1,5 +1,13 @@
 {
-  "agents": [],
+  "agents": [
+    {
+      "github_username": "Ishant5436",
+      "model": "claude-sonnet-4-6",
+      "version": "claude-sonnet-4-6",
+      "pr_number": null,
+      "issue_number": 9
+    }
+  ],
   "last_updated": "2026-06-03",
-  "total_contributions": 0
+  "total_contributions": 1
 }


### PR DESCRIPTION
## Summary

Configures a conservative `10kb` limit on JSON request bodies to prevent payload-based DoS attacks. Express will automatically respond with `413 Payload Too Large` for oversized requests.

### Changes
- **Updated:** `apps/api/src/index.ts` — `express.json()` now receives `{ limit: '10kb' }` with an inline comment explaining the chosen value and its security purpose.

Closes #9
