### PR TITLE
[agent] feat(api): add API error handling helper

### DIFF
--- a/apps/api/src/helpers/error.ts
+++ b/apps/api/src/helpers/error.ts
@@ -1,0 +1,18 @@
+/** Standard API error response helper */
+
+interface ApiErrorParams {
+  status?: number;
+  message: string;
+  details?: unknown;
+}
+
+export function apiError({ status = 500, message, details }: ApiErrorParams) {
+  return {
+    status,
+    data: null,
+    error: {
+      message,
+      ...(details !== undefined ? { details } : {}),
+    },
+  };
+}

--- a/apps/api/src/routes/users.ts
+++ b/apps/api/src/routes/users.ts
@@ -1,4 +1,5 @@
 import { Router } from "express";
+import { apiError } from "../helpers/error";
 
 const router = Router();
 
@@ -10,6 +11,13 @@ router.get("/", (_req, res) => {
 });
 
 router.post("/", (req, res) => {
+  if (!req.body || typeof req.body !== "object") {
+    res.status(400).json(apiError({
+      status: 400,
+      message: "Invalid request body"
+    }));
+    return;
+  }
   res.status(201).json({
     data: {
       id: "stub-user-id",

--- a/contributors/agents.json
+++ b/contributors/agents.json
@@ -1,5 +1,13 @@
 {
-  "agents": [],
-  "last_updated": "2026-06-03",
+  "agents": [
+    {
+      "github_username": "lb1192176991-lab",
+      "model": "deepseek-chat",
+      "version": "deepseek-chat-240604",
+      "pr_number": null,
+      "issue_number": null
+    }
+  ],
+  "last_updated": "2026-06-04",
   "total_contributions": 0
 }


### PR DESCRIPTION
## What

Adds a reusable `apiError()` helper function that returns a consistent error envelope `({ status, data: null, error: { message } })`, and uses it from the `POST /users` route for request body validation.

New file: `apps/api/src/helpers/error.ts`

## Why

Standardizes error responses across the API so frontend code can always expect the same shape on failures. Currently there's no shared error helper — each route handles errors ad-hoc.

## Testing

- [x] `apiError()` returns the expected envelope structure
- [x] `POST /users` with missing body returns `{ status: 400, data: null, error: { message: "Invalid request body" } }`
- [x] `POST /users` with valid body still works as before

Closes #7