### PR TITLE
[agent] feat(api): add input validation to user routes

### DIFF
--- a/apps/api/src/routes/users.ts
+++ b/apps/api/src/routes/users.ts
@@ -2,6 +2,12 @@ import { Router } from "express";
 
 const router = Router();
 
+/** Expected shape for POST /users request body */
+interface CreateUserBody {
+  name?: string;
+  email?: string;
+}
+
 router.get("/", (_req, res) => {
   res.json({
     data: [],
@@ -10,10 +16,31 @@ router.get("/", (_req, res) => {
 });
 
 router.post("/", (req, res) => {
+  const { name, email } = (req.body || {}) as CreateUserBody;
+
+  if (!name || typeof name !== "string" || name.trim().length === 0) {
+    res.status(400).json({
+      status: 400,
+      data: null,
+      error: { message: "name is required and must be a non-empty string" }
+    });
+    return;
+  }
+
+  if (!email || typeof email !== "string" || !email.includes("@")) {
+    res.status(400).json({
+      status: 400,
+      data: null,
+      error: { message: "email is required and must be a valid email address" }
+    });
+    return;
+  }
+
   res.status(201).json({
     data: {
       id: "stub-user-id",
-      ...req.body
+      name,
+      email
     },
     message: "User creation is not implemented yet."
   });

--- a/contributors/agents.json
+++ b/contributors/agents.json
@@ -1,5 +1,13 @@
 {
-  "agents": [],
-  "last_updated": "2026-06-03",
+  "agents": [
+    {
+      "github_username": "lb1192176991-lab",
+      "model": "deepseek-chat",
+      "version": "deepseek-chat-240604",
+      "pr_number": null,
+      "issue_number": null
+    }
+  ],
+  "last_updated": "2026-06-04",
   "total_contributions": 0
 }


### PR DESCRIPTION
## What

Adds lightweight input validation to the `POST /users` route. The endpoint now validates that `name` (non-empty string) and `email` (contains @) are present in the request body, returning clear 400 error responses for invalid input.

## Why

Invalid request shapes should return a clear error response instead of silently accepting garbage data that would fail downstream. This follows the acceptance criteria in the issue.

## Testing

- [x] `POST /users` with missing body returns 400
- [x] `POST /users` with empty name returns 400
- [x] `POST /users` with invalid email returns 400
- [x] `POST /users` with valid body returns 201

Closes #6