### PR TITLE
[agent] Add domain comments to Prisma schema models (Closes #5)

### DIFF
--- a/contributors/agents.json
+++ b/contributors/agents.json
@@ -1,5 +1,13 @@
 {
-  "agents": [],
+  "agents": [
+    {
+      "github_username": "Ishant5436",
+      "model": "claude-sonnet-4-6",
+      "version": "claude-sonnet-4-6",
+      "pr_number": null,
+      "issue_number": 5
+    }
+  ],
   "last_updated": "2026-06-03",
-  "total_contributions": 0
+  "total_contributions": 1
 }

--- a/packages/db/prisma/schema.prisma
+++ b/packages/db/prisma/schema.prisma
@@ -7,6 +7,8 @@ datasource db {
   url      = env("DATABASE_URL")
 }
 
+/// A platform user who can act as a job poster (client) or proposal submitter (freelancer).
+/// Central identity record; all activity — jobs and proposals — is anchored to a User.
 model User {
   id        String     @id @default(cuid())
   email     String     @unique
@@ -17,10 +19,13 @@ model User {
   updatedAt DateTime   @updatedAt
 }
 
+/// A piece of work advertised by a client. Moves through a draft → open → closed lifecycle.
+/// Each Job can receive multiple Proposals from freelancers.
 model Job {
   id          String     @id @default(cuid())
   title       String
   description String?
+  /// Lifecycle state: "draft" | "open" | "closed"
   status      String     @default("draft")
   ownerId     String
   owner       User       @relation(fields: [ownerId], references: [id])
@@ -29,10 +34,14 @@ model Job {
   updatedAt   DateTime   @updatedAt
 }
 
+/// A freelancer's bid on a Job, including a plain-text summary and an optional monetary amount.
+/// Approval state is tracked via status: "pending" | "accepted" | "rejected"
 model Proposal {
   id        String   @id @default(cuid())
   summary   String
+  /// Proposed payment amount; optional until the freelancer provides a quote.
   amount    Decimal?
+  /// Workflow state: "pending" | "accepted" | "rejected"
   status    String   @default("pending")
   userId    String
   user      User     @relation(fields: [userId], references: [id])


### PR DESCRIPTION
## Summary

Adds `///` Prisma doc-comments to each model explaining its role in the TaskFlow domain — what it represents, its lifecycle states, and how it relates to other models.

### Changes
- **Updated:** `packages/db/prisma/schema.prisma` — `User`, `Job`, and `Proposal` models now have doc-comments above each model and on fields with non-obvious semantics (`status`, `amount`).

Closes #5
