### PR TITLE
[agent] Improve Button type annotations with JSDoc and variant/size types (Closes #3)

### DIFF
--- a/contributors/agents.json
+++ b/contributors/agents.json
@@ -1,5 +1,13 @@
 {
-  "agents": [],
+  "agents": [
+    {
+      "github_username": "Ishant5436",
+      "model": "claude-sonnet-4-6",
+      "version": "claude-sonnet-4-6",
+      "pr_number": null,
+      "issue_number": 3
+    }
+  ],
   "last_updated": "2026-06-03",
-  "total_contributions": 0
+  "total_contributions": 1
 }

--- a/packages/ui/src/index.ts
+++ b/packages/ui/src/index.ts
@@ -1,12 +1,39 @@
+/** Visual style variant controlling the button's colour scheme. */
+export type ButtonVariant = "primary" | "secondary" | "ghost" | "danger";
+
+/** Size preset controlling the button's padding and font size. */
+export type ButtonSize = "sm" | "md" | "lg";
+
 export type ButtonProps = {
+  /** The visible text label rendered inside the button. */
   label: string;
+  /** When true, the button is non-interactive and visually dimmed. Defaults to false. */
   disabled?: boolean;
+  /** Visual style variant. Defaults to "primary". */
+  variant?: ButtonVariant;
+  /** Size preset. Defaults to "md". */
+  size?: ButtonSize;
+  /** Optional CSS class names to merge onto the root element. */
+  className?: string;
+  /** Callback invoked when the button is activated. */
+  onClick?: () => void;
 };
 
-export function Button({ label, disabled = false }: ButtonProps) {
+export function Button({
+  label,
+  disabled = false,
+  variant = "primary",
+  size = "md",
+  className,
+  onClick,
+}: ButtonProps): Record<string, unknown> {
   return {
     type: "button",
     label,
-    disabled
+    disabled,
+    variant,
+    size,
+    className,
+    onClick,
   };
 }


### PR DESCRIPTION
## Summary

Enriches `ButtonProps` with JSDoc comments on every field and adds `ButtonVariant` and `ButtonSize` union types. The public shape of `Button` is preserved — all existing call sites remain compatible.

### Changes
- **Updated:** `packages/ui/src/index.ts` — added `ButtonVariant` and `ButtonSize` exported union types; added JSDoc to all `ButtonProps` fields; added optional `variant`, `size`, `className`, and `onClick` props with safe defaults; explicit return type on `Button`.

Closes #3
