### PR TITLE
[agent] Split API app construction from server startup

### DIFF
--- a/apps/api/src/app.ts
+++ b/apps/api/src/app.ts
@@ -1,0 +1,15 @@
+import express from "express";
+
+import usersRouter from "./routes/users";
+
+const app = express();
+
+app.use(express.json());
+
+app.get("/health", (_req, res) => {
+  res.json({ status: "ok", service: "taskflow-api" });
+});
+
+app.use("/users", usersRouter);
+
+export default app;

--- a/apps/api/src/index.ts
+++ b/apps/api/src/index.ts
@@ -1,17 +1,6 @@
-import express from "express";
+import app from "./app";
 
-import usersRouter from "./routes/users";
-
-const app = express();
 const port = process.env.PORT || 4000;
-
-app.use(express.json());
-
-app.get("/health", (_req, res) => {
-  res.json({ status: "ok", service: "taskflow-api" });
-});
-
-app.use("/users", usersRouter);
 
 app.listen(port, () => {
   console.log(`TaskFlow API listening on port ${port}`);

--- a/contributors/agents.json
+++ b/contributors/agents.json
@@ -4,7 +4,7 @@
       "github_username": "nieniedeveloper",
       "model": "GPT-5 Codex",
       "version": "2026-06-04",
-      "pr_number": "pending",
+      "pr_number": "227",
       "issue_number": 221
     }
   ],

--- a/contributors/agents.json
+++ b/contributors/agents.json
@@ -1,5 +1,13 @@
 {
-  "agents": [],
-  "last_updated": "2026-06-03",
-  "total_contributions": 0
+  "agents": [
+    {
+      "github_username": "nieniedeveloper",
+      "model": "GPT-5 Codex",
+      "version": "2026-06-04",
+      "pr_number": "pending",
+      "issue_number": 221
+    }
+  ],
+  "last_updated": "2026-06-04",
+  "total_contributions": 1
 }


### PR DESCRIPTION
Closes #221
/claim #221

## Summary
- moved Express app construction into `apps/api/src/app.ts`
- kept the `listen()` side effect isolated in `apps/api/src/index.ts`
- registered this agent contribution in `contributors/agents.json`

## Why
Importing the current API entrypoint also starts the server. That makes route-level tests and future app reuse awkward because imports can bind port 4000 as a side effect. Splitting app creation from startup keeps runtime behavior the same while making the API easier to test.

## Verification
- Reviewed the changed files for import paths and startup behavior.
- Did not run the full workspace tests because the local GitHub clone repeatedly failed from network resets; the change was applied through GitHub's API.