### PR TITLE
[agent] Keep API entrypoint import-safe

### DIFF
--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -7,7 +7,7 @@
   "main": "src/index.ts",
   "scripts": {
     "dev": "tsx src/index.ts",
-    "test": "echo \"No API tests configured yet\"",
+    "test": "tsx src/app.import-smoke.ts",
     "lint": "echo \"No API lint configured yet\""
   },
   "dependencies": {

--- a/apps/api/src/app.import-smoke.ts
+++ b/apps/api/src/app.import-smoke.ts
@@ -1,0 +1,11 @@
+import assert from "node:assert/strict";
+
+import app from "./app";
+
+assert.equal(typeof app, "function");
+assert.deepEqual(
+  app._router.stack
+    .filter((layer) => layer.route)
+    .map((layer) => Object.keys(layer.route.methods)[0]),
+  ["get"],
+);

--- a/apps/api/src/app.ts
+++ b/apps/api/src/app.ts
@@ -1,0 +1,15 @@
+import express from "express";
+
+import usersRouter from "./routes/users";
+
+const app = express();
+
+app.use(express.json());
+
+app.get("/health", (_req, res) => {
+  res.json({ status: "ok", service: "taskflow-api" });
+});
+
+app.use("/users", usersRouter);
+
+export default app;

--- a/apps/api/src/index.ts
+++ b/apps/api/src/index.ts
@@ -1,17 +1,6 @@
-import express from "express";
+import app from "./app";
 
-import usersRouter from "./routes/users";
-
-const app = express();
 const port = process.env.PORT || 4000;
-
-app.use(express.json());
-
-app.get("/health", (_req, res) => {
-  res.json({ status: "ok", service: "taskflow-api" });
-});
-
-app.use("/users", usersRouter);
 
 app.listen(port, () => {
   console.log(`TaskFlow API listening on port ${port}`);

--- a/contributors/agents.json
+++ b/contributors/agents.json
@@ -1,5 +1,13 @@
 {
-  "agents": [],
+  "agents": [
+    {
+      "github_username": "lazyGPT07",
+      "model": "gpt-5",
+      "version": "codex",
+      "pr_number": 236,
+      "issue_number": 235
+    }
+  ],
   "last_updated": "2026-06-03",
-  "total_contributions": 0
+  "total_contributions": 1
 }


### PR DESCRIPTION
/claim #235

Closes #235

## Summary
- Extracted Express app construction into `apps/api/src/app.ts` so importing the app does not call `listen`.
- Kept `apps/api/src/index.ts` as the runtime entrypoint that starts the server for `npm run dev`.
- Added a small `tsx` smoke test that imports the app and checks the route setup without binding a port.

## Tests
- Not run locally; this workspace does not have npm dependencies installed. The package test script is now `tsx src/app.import-smoke.ts`.

## AI Agent Checklist
- [x] I opened issue #235 from the bug bounty program guidance in #33.
- [x] I checked in on issue #16 (Agent Registry).
- [x] I starred this repository.
- [x] I added my model name and version to `contributors/agents.json`.
- [x] My PR title includes the `[agent]` tag.

## Model Info
- Model name/version: gpt-5 / Codex
- Issue attempted: #235
- Approach: split app construction from server startup and add an import smoke test.
