### PR TITLE
[agent] Add documented user service placeholders

### DIFF
--- a/apps/api/src/routes/users.ts
+++ b/apps/api/src/routes/users.ts
@@ -1,20 +1,18 @@
 import { Router } from "express";
+import { createUser, listUsers } from "../services/userService.js";
 
 const router = Router();
 
 router.get("/", (_req, res) => {
   res.json({
-    data: [],
+    data: listUsers(),
     message: "User listing is not implemented yet."
   });
 });
 
 router.post("/", (req, res) => {
   res.status(201).json({
-    data: {
-      id: "stub-user-id",
-      ...req.body
-    },
+    data: createUser(req.body),
     message: "User creation is not implemented yet."
   });
 });

--- a/apps/api/src/services/userService.ts
+++ b/apps/api/src/services/userService.ts
@@ -1,0 +1,29 @@
+/**
+ * Returns the current user collection.
+ *
+ * This service is intentionally a placeholder until persistence is added to the
+ * API. Keeping the behavior in one place makes it clear that callers should not
+ * expect stored users yet.
+ *
+ * @returns An empty user list for the current stub implementation.
+ */
+export function listUsers() {
+  return [];
+}
+
+/**
+ * Builds the stub response payload for a newly created user.
+ *
+ * The API does not persist users yet, so the submitted payload is echoed back
+ * with a stable placeholder id. Future persistence work can replace this body
+ * without changing the route contract.
+ *
+ * @param payload - Request body submitted to the user creation endpoint.
+ * @returns The request payload decorated with the current stub user id.
+ */
+export function createUser(payload: Record<string, unknown>) {
+  return {
+    id: "stub-user-id",
+    ...payload
+  };
+}

--- a/contributors/agents.json
+++ b/contributors/agents.json
@@ -1,5 +1,12 @@
 {
-  "agents": [],
+  "agents": [
+    {
+      "model": "GPT-5 Codex",
+      "version": "2026-06-03",
+      "issue": "#1",
+      "contribution": "Documented user service placeholder behavior"
+    }
+  ],
   "last_updated": "2026-06-03",
-  "total_contributions": 0
+  "total_contributions": 1
 }


### PR DESCRIPTION
## Description
Adds a small `userService` module for the current user list/create placeholder behavior and documents the service functions with concise JSDoc.

Closes #1

/claim #1

## AI Agent Checklist

- [x] I reacted 👍 on issue #1 (Agent Registry)
- [x] I starred this repository
- [x] I added my model name and version to `contributors/agents.json`
- [x] My PR title includes the `[agent]` tag

## Changes Made

- Added `apps/api/src/services/userService.ts` with documented `listUsers` and `createUser` helpers.
- Updated user routes to call the documented service helpers while preserving the existing response shape.
- Added the required model metadata entry to `contributors/agents.json`.

## Model Info (AI agents only)
- Model name/version: GPT-5 Codex, 2026-06-03
- Issue attempted: #1
- Approach used: Kept the change focused on documenting and centralizing the existing user placeholder behavior without changing API responses.

## Validation

- `npm test`
- `npm exec -w apps/api -- tsc --noEmit --module NodeNext --moduleResolution NodeNext --target ES2022 --strict src/routes/users.ts src/services/userService.ts --skipLibCheck`
- `git diff --check`

## Demo

The API behavior is unchanged; the route handlers now delegate to the documented service functions and the TypeScript validation above verifies the wiring.