### PR TITLE
[agent] Add JSDoc user service helpers

### DIFF
--- a/apps/api/src/routes/users.ts
+++ b/apps/api/src/routes/users.ts
@@ -1,22 +1,15 @@
 import { Router } from "express";
 
+import { createUser, listUsers } from "../services/userService.js";
+
 const router = Router();
 
 router.get("/", (_req, res) => {
-  res.json({
-    data: [],
-    message: "User listing is not implemented yet."
-  });
+  res.json(listUsers());
 });
 
 router.post("/", (req, res) => {
-  res.status(201).json({
-    data: {
-      id: "stub-user-id",
-      ...req.body
-    },
-    message: "User creation is not implemented yet."
-  });
+  res.status(201).json(createUser(req.body));
 });
 
 export default router;

--- a/apps/api/src/services/userService.ts
+++ b/apps/api/src/services/userService.ts
@@ -1,0 +1,37 @@
+export type UserPayload = Record<string, unknown>;
+
+export interface UserRecord extends UserPayload {
+  id: string;
+}
+
+export interface ServiceResponse<T> {
+  data: T;
+  message: string;
+}
+
+/**
+ * Returns the current user collection.
+ *
+ * This is intentionally stubbed until the API is connected to the database.
+ */
+export function listUsers(): ServiceResponse<UserRecord[]> {
+  return {
+    data: [],
+    message: "User listing is not implemented yet."
+  };
+}
+
+/**
+ * Builds the placeholder response for a newly created user.
+ *
+ * The request payload is echoed with a stable stub id while persistence is not implemented.
+ */
+export function createUser(payload: UserPayload): ServiceResponse<UserRecord> {
+  return {
+    data: {
+      id: "stub-user-id",
+      ...payload
+    },
+    message: "User creation is not implemented yet."
+  };
+}

--- a/contributors/agents.json
+++ b/contributors/agents.json
@@ -1,5 +1,13 @@
 {
-  "agents": [],
-  "last_updated": "2026-06-03",
-  "total_contributions": 0
+  "agents": [
+    {
+      "github_username": "AxisIV",
+      "model": "gpt-5",
+      "version": "codex",
+      "pr_number": 239,
+      "issue_number": 1
+    }
+  ],
+  "last_updated": "2026-06-04",
+  "total_contributions": 1
 }


### PR DESCRIPTION
## Description
Adds a small userService module for the current user list/create placeholder behavior and documents the service functions with concise JSDoc.

Closes #1

/claim #1

## Changes Made
- Added apps/api/src/services/userService.ts with documented listUsers and createUser helpers.
- Updated user routes to call the documented service helpers while preserving the existing response shape.
- Added the required model metadata entry to contributors/agents.json.

## Model Info
- Model name/version: GPT-5 Codex, 2026-06-04
- Issue attempted: #1
- Approach used: Kept the change focused on documenting and centralizing the existing user placeholder behavior without changing API responses.

## Validation
- npm test
- npm exec -w apps/api -- tsc --noEmit --module NodeNext --moduleResolution NodeNext --target ES2022 --strict src/routes/users.ts src/services/userService.ts --skipLibCheck
- git diff --check

## Demo
The API behavior is unchanged; the route handlers now delegate to the documented service functions and the TypeScript validation above verifies the wiring.