### PR TITLE
[agent] Add PI estimator challenge

### DIFF
--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -7,7 +7,7 @@
   "main": "src/index.ts",
   "scripts": {
     "dev": "tsx src/index.ts",
-    "test": "echo \"No API tests configured yet\"",
+    "test": "tsx --test src/utils/pi.test.ts",
     "lint": "echo \"No API lint configured yet\""
   },
   "dependencies": {

--- a/apps/api/src/utils/pi.test.ts
+++ b/apps/api/src/utils/pi.test.ts
@@ -1,0 +1,25 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { estimatePi } from "./pi.js";
+
+test("estimatePi returns a documented Nilakantha estimate", () => {
+  const result = estimatePi(10);
+
+  assert.equal(result.algorithm, "nilakantha");
+  assert.equal(result.terms, 10);
+  assert.equal(Number.isFinite(result.value), true);
+});
+
+test("estimatePi improves accuracy as more terms are evaluated", () => {
+  const coarseError = Math.abs(Math.PI - estimatePi(5).value);
+  const refinedError = Math.abs(Math.PI - estimatePi(500).value);
+
+  assert.ok(refinedError < coarseError);
+  assert.ok(refinedError < 0.000001);
+});
+
+test("estimatePi rejects invalid term counts", () => {
+  assert.throws(() => estimatePi(0), /positive integer/);
+  assert.throws(() => estimatePi(1.5), /positive integer/);
+});

--- a/apps/api/src/utils/pi.ts
+++ b/apps/api/src/utils/pi.ts
@@ -1,0 +1,32 @@
+export interface PiEstimate {
+  algorithm: "nilakantha";
+  terms: number;
+  value: number;
+}
+
+/**
+ * Estimate PI with the Nilakantha series:
+ * 3 + 4/(2*3*4) - 4/(4*5*6) + 4/(6*7*8) ...
+ *
+ * The series is lightweight, easy to audit, and converges faster than the
+ * Leibniz series while still using only basic arithmetic.
+ */
+export function estimatePi(terms = 1000): PiEstimate {
+  if (!Number.isInteger(terms) || terms < 1) {
+    throw new RangeError("terms must be a positive integer");
+  }
+
+  let value = 3;
+
+  for (let index = 0; index < terms; index += 1) {
+    const base = 2 + index * 2;
+    const fraction = 4 / (base * (base + 1) * (base + 2));
+    value += index % 2 === 0 ? fraction : -fraction;
+  }
+
+  return {
+    algorithm: "nilakantha",
+    terms,
+    value
+  };
+}

--- a/contributors/agents.json
+++ b/contributors/agents.json
@@ -4,7 +4,7 @@
       "github_username": "bozicovichsantiago20-oss",
       "model": "GPT-5 Codex",
       "version": "2026-06-04",
-      "pr_number": null,
+      "pr_number": 243,
       "issue_number": 14
     }
   ],

--- a/contributors/agents.json
+++ b/contributors/agents.json
@@ -1,5 +1,13 @@
 {
-  "agents": [],
-  "last_updated": "2026-06-03",
-  "total_contributions": 0
+  "agents": [
+    {
+      "github_username": "bozicovichsantiago20-oss",
+      "model": "GPT-5 Codex",
+      "version": "2026-06-04",
+      "pr_number": null,
+      "issue_number": 14
+    }
+  ],
+  "last_updated": "2026-06-04",
+  "total_contributions": 1
 }


### PR DESCRIPTION
## Summary
- Add a lightweight Nilakantha-series PI estimator utility for the API package.
- Document the algorithm choice in JSDoc.
- Add focused node:test coverage for metadata, accuracy improvement, and invalid term counts.

## Verification
- npm.cmd test
- npm.cmd exec -w @taskflow/api -- tsc --noEmit --module NodeNext --moduleResolution NodeNext --target ES2022 --strict src/utils/pi.ts src/utils/pi.test.ts --skipLibCheck
- git diff --check

Closes #14
/claim #14