### PR TITLE
[agent] Add Button stub tests

### DIFF
--- a/contributors/agents.json
+++ b/contributors/agents.json
@@ -1,5 +1,13 @@
 {
-  "agents": [],
-  "last_updated": "2026-06-03",
-  "total_contributions": 0
+  "agents": [
+    {
+      "github_username": "bozicovichsantiago20-oss",
+      "model": "GPT-5 Codex",
+      "version": "2026-06-04",
+      "pr_number": null,
+      "issue_number": 13
+    }
+  ],
+  "last_updated": "2026-06-04",
+  "total_contributions": 1
 }

--- a/contributors/agents.json
+++ b/contributors/agents.json
@@ -4,7 +4,7 @@
       "github_username": "bozicovichsantiago20-oss",
       "model": "GPT-5 Codex",
       "version": "2026-06-04",
-      "pr_number": null,
+      "pr_number": 244,
       "issue_number": 13
     }
   ],

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -5,10 +5,11 @@
   "description": "Shared UI components for TaskFlow.",
   "main": "src/index.ts",
   "scripts": {
-    "test": "echo \"No UI tests configured yet\"",
+    "test": "tsx --test src/index.test.ts",
     "lint": "echo \"No UI lint configured yet\""
   },
   "devDependencies": {
+    "tsx": "^4.7.1",
     "typescript": "^5.4.5"
   }
 }

--- a/packages/ui/src/index.test.ts
+++ b/packages/ui/src/index.test.ts
@@ -1,0 +1,21 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { Button } from "./index";
+
+test("Button preserves the provided label", () => {
+  assert.deepEqual(Button({ label: "Save" }), {
+    type: "button",
+    label: "Save",
+    disabled: false
+  });
+});
+
+test("Button defaults disabled to false", () => {
+  assert.equal(Button({ label: "Continue" }).disabled, false);
+});
+
+test("Button preserves explicit disabled values", () => {
+  assert.equal(Button({ label: "Submit", disabled: true }).disabled, true);
+  assert.equal(Button({ label: "Submit", disabled: false }).disabled, false);
+});


### PR DESCRIPTION
## Summary
- Add focused node:test coverage for the shared Button stub.
- Cover label preservation, default disabled state, and explicit disabled true/false values.
- Wire the UI workspace test script to run the new test.

## Verification
- npm.cmd test
- npm.cmd exec -w @taskflow/ui -- tsc --noEmit --module NodeNext --moduleResolution NodeNext --target ES2022 --strict src/index.ts src/index.test.ts --skipLibCheck
- git diff --check

Closes #13
/claim #13