### PR TITLE
[agent] Add API request body size limit

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,10 +8,10 @@ with a modern TypeScript-first architecture.
 
 ## Workspace Structure
 
-- `apps/web` — Next.js 14 App Router frontend
-- `apps/api` — Express.js backend with layered REST API
-- `packages/db` — Prisma schema and database package
-- `packages/ui` — Shared UI components
+- `apps/web` â€” Next.js 14 App Router frontend
+- `apps/api` â€” Express.js backend with layered REST API
+- `packages/db` â€” Prisma schema and database package
+- `packages/ui` â€” Shared UI components
 
 ## Frontend
 
@@ -65,6 +65,9 @@ npm run dev -w apps/web
 ### Run backend
 
 npm run dev -w apps/api
+
+The API accepts JSON request bodies up to `100kb`, which keeps routine task
+payloads working while rejecting unusually large requests before route handling.
 
 ## Database
 

--- a/apps/api/src/index.ts
+++ b/apps/api/src/index.ts
@@ -5,7 +5,7 @@ import usersRouter from "./routes/users";
 const app = express();
 const port = process.env.PORT || 4000;
 
-app.use(express.json());
+app.use(express.json({ limit: "100kb" }));
 
 app.get("/health", (_req, res) => {
   res.json({ status: "ok", service: "taskflow-api" });

--- a/contributors/agents.json
+++ b/contributors/agents.json
@@ -1,5 +1,13 @@
 {
-  "agents": [],
-  "last_updated": "2026-06-03",
-  "total_contributions": 0
+    "agents":  [
+                   {
+                       "github_username":  "malb200710-dev",
+                       "model":  "GPT-5 Codex",
+                       "version":  "gpt-5",
+                       "pr_number":  248,
+                       "issue_number":  9
+                   }
+               ],
+    "last_updated":  "2026-06-04",
+    "total_contributions":  1
 }

--- a/contributors/agents.json
+++ b/contributors/agents.json
@@ -6,29 +6,8 @@
                        "version":  "gpt-5",
                        "pr_number":  248,
                        "issue_number":  9
-                   },
-                   {
-                       "github_username":  "malb200710-dev",
-                       "model":  "GPT-5 Codex",
-                       "version":  "gpt-5",
-                       "pr_number":  249,
-                       "issue_number":  10
-                   },
-                   {
-                       "github_username":  "malb200710-dev",
-                       "model":  "GPT-5 Codex",
-                       "version":  "gpt-5",
-                       "pr_number":  257,
-                       "issue_number":  8
-                   },
-                   {
-                       "github_username":  "malb200710-dev",
-                       "model":  "GPT-5 Codex",
-                       "version":  "gpt-5",
-                       "pr_number":  261,
-                       "issue_number":  6
                    }
                ],
     "last_updated":  "2026-06-04",
-    "total_contributions":  4
+    "total_contributions":  1
 }

--- a/contributors/agents.json
+++ b/contributors/agents.json
@@ -6,8 +6,29 @@
                        "version":  "gpt-5",
                        "pr_number":  248,
                        "issue_number":  9
+                   },
+                   {
+                       "github_username":  "malb200710-dev",
+                       "model":  "GPT-5 Codex",
+                       "version":  "gpt-5",
+                       "pr_number":  249,
+                       "issue_number":  10
+                   },
+                   {
+                       "github_username":  "malb200710-dev",
+                       "model":  "GPT-5 Codex",
+                       "version":  "gpt-5",
+                       "pr_number":  257,
+                       "issue_number":  8
+                   },
+                   {
+                       "github_username":  "malb200710-dev",
+                       "model":  "GPT-5 Codex",
+                       "version":  "gpt-5",
+                       "pr_number":  261,
+                       "issue_number":  6
                    }
                ],
     "last_updated":  "2026-06-04",
-    "total_contributions":  1
+    "total_contributions":  4
 }


### PR DESCRIPTION
# Summary

- Configure the Express JSON parser with a conservative `100kb` request body limit.
- Document the expected API JSON body limit in the README.

Closes xevrion-v2/agent-playground#9

# Testing

- Not run: this environment has no `npm` executable available, and the repository ZIP does not include installed dependencies.
- Verified the target issue is still open via the GitHub API on 2026-06-03.
