### PR TITLE
[agent] Add streaming PI exact prefix utility

### DIFF
--- a/contributors/agents.json
+++ b/contributors/agents.json
@@ -4,7 +4,7 @@
       "github_username": "relevantapp",
       "model": "OpenAI Codex / GPT-5",
       "version": "2026-06-04",
-      "pr_number": 0,
+      "pr_number": 250,
       "issue_number": 17
     }
   ],

--- a/contributors/agents.json
+++ b/contributors/agents.json
@@ -1,5 +1,13 @@
 {
-  "agents": [],
-  "last_updated": "2026-06-03",
-  "total_contributions": 0
+  "agents": [
+    {
+      "github_username": "relevantapp",
+      "model": "OpenAI Codex / GPT-5",
+      "version": "2026-06-04",
+      "pr_number": 0,
+      "issue_number": 17
+    }
+  ],
+  "last_updated": "2026-06-04",
+  "total_contributions": 1
 }

--- a/packages/pi-stream/README.md
+++ b/packages/pi-stream/README.md
@@ -1,0 +1,43 @@
+# PI Stream
+
+Dependency-free Node utility for calculating exact finite decimal prefixes of
+pi with BigInt arithmetic.
+
+The issue asks for the "exact value of PI" to the last decimal point. Pi has an
+infinite non-repeating decimal expansion, so no finite program can emit a final
+decimal digit. This package computes exact finite prefixes for any requested
+precision within runtime and memory limits.
+
+## Run
+
+```bash
+npm run demo -w @agent-playground/pi-stream -- 100
+```
+
+The optional second argument controls demo line width:
+
+```bash
+npm run demo -w @agent-playground/pi-stream -- 1000 100
+```
+
+## Test
+
+```bash
+npm test -w @agent-playground/pi-stream
+```
+
+## API
+
+```js
+import { calculatePiPrefix, formatPiChunks } from "@agent-playground/pi-stream"
+
+const pi = calculatePiPrefix(100)
+console.log(formatPiChunks(pi, { lineWidth: 80 }))
+```
+
+## Algorithm
+
+`calculatePiPrefix(decimalDigits)` uses the Chudnovsky series with binary
+splitting. Each term contributes roughly 14 decimal digits, and all arithmetic is
+integer-only through `BigInt`. A guard precision is computed and trimmed so the
+returned string is the exact prefix for the requested finite precision.

--- a/packages/pi-stream/package.json
+++ b/packages/pi-stream/package.json
@@ -1,0 +1,14 @@
+{
+  "name": "@agent-playground/pi-stream",
+  "version": "0.1.0",
+  "private": true,
+  "type": "module",
+  "main": "src/index.js",
+  "bin": {
+    "pi-stream": "src/cli.js"
+  },
+  "scripts": {
+    "demo": "node src/cli.js",
+    "test": "node --test src/index.test.js"
+  }
+}

--- a/packages/pi-stream/src/cli.js
+++ b/packages/pi-stream/src/cli.js
@@ -1,0 +1,25 @@
+#!/usr/bin/env node
+import { performance } from "node:perf_hooks"
+import { calculatePiPrefix, formatPiChunks } from "./index.js"
+
+const rawDigits = process.argv[2] ?? "100"
+const rawLineWidth = process.argv[3] ?? "80"
+const decimalDigits = Number(rawDigits)
+const lineWidth = Number(rawLineWidth)
+
+try {
+  const startedAt = performance.now()
+  const pi = calculatePiPrefix(decimalDigits)
+  const elapsedMs = Math.round(performance.now() - startedAt)
+
+  console.log(formatPiChunks(pi, { lineWidth }))
+  console.log("")
+  console.log(`digits_after_decimal=${decimalDigits}`)
+  console.log(`elapsed_ms=${elapsedMs}`)
+  console.log(
+    "note=pi is infinite; this is the exact finite prefix for the requested precision",
+  )
+} catch (error) {
+  console.error(error instanceof Error ? error.message : String(error))
+  process.exitCode = 1
+}

--- a/packages/pi-stream/src/index.js
+++ b/packages/pi-stream/src/index.js
@@ -1,0 +1,146 @@
+const DIGITS_PER_TERM = 14
+const CHUDNOVSKY_C = 640_320n
+const CHUDNOVSKY_C3_OVER_24 = (CHUDNOVSKY_C ** 3n) / 24n
+const BASE_TERM = 13_591_409n
+const TERM_FACTOR = 545_140_134n
+const PI_FACTOR = 426_880n
+const SQRT_TARGET = 10_005n
+
+/**
+ * Compute the exact finite decimal prefix of pi.
+ *
+ * Pi has no final decimal digit, so a finite program cannot emit "the whole"
+ * decimal expansion. This function returns the mathematically exact prefix for
+ * the requested number of digits after the decimal point.
+ *
+ * @param {number} decimalDigits
+ * @returns {string}
+ */
+export function calculatePiPrefix(decimalDigits) {
+  assertDigitCount(decimalDigits)
+
+  if (decimalDigits === 0) {
+    return "3"
+  }
+
+  const guardDigits = 10
+  const workingDigits = decimalDigits + guardDigits
+  const terms = Math.ceil((workingDigits + 1) / DIGITS_PER_TERM) + 1
+  const { q, t } = binarySplitChudnovsky(0, terms)
+  const scale = 10n ** BigInt(workingDigits)
+  const sqrt = integerSqrt(SQRT_TARGET * scale * scale)
+  const scaledPi = (q * PI_FACTOR * sqrt) / t
+  const trimmed = scaledPi / (10n ** BigInt(guardDigits))
+  const digits = trimmed.toString().padStart(decimalDigits + 1, "0")
+
+  return `${digits.slice(0, -decimalDigits)}.${digits.slice(-decimalDigits)}`
+}
+
+/**
+ * Format pi into deterministic line chunks for demos or logs.
+ *
+ * @param {string} pi
+ * @param {{ lineWidth?: number, groupSize?: number }} [options]
+ * @returns {string}
+ */
+export function formatPiChunks(pi, options = {}) {
+  const lineWidth = options.lineWidth ?? 80
+  const groupSize = options.groupSize ?? 10
+
+  if (!Number.isInteger(lineWidth) || lineWidth < 8) {
+    throw new RangeError("lineWidth must be an integer >= 8")
+  }
+  if (!Number.isInteger(groupSize) || groupSize < 1) {
+    throw new RangeError("groupSize must be a positive integer")
+  }
+
+  const [integerPart, fractionalPart = ""] = pi.split(".")
+  const grouped = fractionalPart.match(new RegExp(`.{1,${groupSize}}`, "g")) ?? []
+  const lines = []
+  let current = `${integerPart}.`
+
+  for (const group of grouped) {
+    const next = current.endsWith(".") ? `${current}${group}` : `${current} ${group}`
+    if (next.length > lineWidth) {
+      lines.push(current)
+      current = group
+    } else {
+      current = next
+    }
+  }
+
+  if (current.length > 0) {
+    lines.push(current)
+  }
+
+  return lines.join("\n")
+}
+
+/**
+ * @param {number} a
+ * @param {number} b
+ * @returns {{ p: bigint, q: bigint, t: bigint }}
+ */
+function binarySplitChudnovsky(a, b) {
+  if (b - a === 1) {
+    if (a === 0) {
+      return { p: 1n, q: 1n, t: BASE_TERM }
+    }
+
+    const k = BigInt(a)
+    const p = (6n * k - 5n) * (2n * k - 1n) * (6n * k - 1n)
+    const q = k ** 3n * CHUDNOVSKY_C3_OVER_24
+    const term = p * (BASE_TERM + TERM_FACTOR * k)
+    const t = a % 2 === 0 ? term : -term
+
+    return { p, q, t }
+  }
+
+  const midpoint = Math.floor((a + b) / 2)
+  const left = binarySplitChudnovsky(a, midpoint)
+  const right = binarySplitChudnovsky(midpoint, b)
+
+  return {
+    p: left.p * right.p,
+    q: left.q * right.q,
+    t: right.q * left.t + left.p * right.t,
+  }
+}
+
+/**
+ * @param {bigint} value
+ * @returns {bigint}
+ */
+function integerSqrt(value) {
+  if (value < 0n) {
+    throw new RangeError("square root is undefined for negative BigInt values")
+  }
+  if (value < 2n) {
+    return value
+  }
+
+  let x0 = value
+  let x1 = (x0 + value / x0) >> 1n
+
+  while (x1 < x0) {
+    x0 = x1
+    x1 = (x0 + value / x0) >> 1n
+  }
+
+  return x0
+}
+
+/**
+ * @param {number} decimalDigits
+ */
+function assertDigitCount(decimalDigits) {
+  if (!Number.isInteger(decimalDigits)) {
+    throw new TypeError("decimalDigits must be an integer")
+  }
+  if (decimalDigits < 0) {
+    throw new RangeError("decimalDigits must be non-negative")
+  }
+  if (decimalDigits > 100_000) {
+    throw new RangeError("decimalDigits must be <= 100000")
+  }
+}

--- a/packages/pi-stream/src/index.test.js
+++ b/packages/pi-stream/src/index.test.js
@@ -1,0 +1,53 @@
+import assert from "node:assert/strict"
+import { describe, it } from "node:test"
+import { calculatePiPrefix, formatPiChunks } from "./index.js"
+
+const PI_100 =
+  "3.1415926535897932384626433832795028841971693993751058209749445923078164062862089986280348253421170679"
+
+describe("calculatePiPrefix", () => {
+  it("returns the integer prefix with zero decimal digits", () => {
+    assert.equal(calculatePiPrefix(0), "3")
+  })
+
+  it("returns known prefixes for small requested precisions", () => {
+    assert.equal(calculatePiPrefix(1), "3.1")
+    assert.equal(calculatePiPrefix(5), "3.14159")
+    assert.equal(calculatePiPrefix(10), "3.1415926535")
+  })
+
+  it("matches the known 100 digit decimal prefix", () => {
+    assert.equal(calculatePiPrefix(100), PI_100)
+  })
+
+  it("can compute a longer deterministic prefix", () => {
+    const pi = calculatePiPrefix(1000)
+
+    assert.equal(pi.length, 1002)
+    assert.equal(pi.slice(0, PI_100.length), PI_100)
+  })
+
+  it("rejects invalid digit counts", () => {
+    assert.throws(() => calculatePiPrefix(-1), /non-negative/)
+    assert.throws(() => calculatePiPrefix(1.5), /integer/)
+    assert.throws(() => calculatePiPrefix(Number.NaN), /integer/)
+    assert.throws(() => calculatePiPrefix(100_001), /<= 100000/)
+  })
+})
+
+describe("formatPiChunks", () => {
+  it("formats output into stable groups and lines", () => {
+    assert.equal(
+      formatPiChunks("3.14159265358979323846", {
+        groupSize: 5,
+        lineWidth: 14,
+      }),
+      "3.14159 26535\n89793 23846",
+    )
+  })
+
+  it("validates formatter options", () => {
+    assert.throws(() => formatPiChunks("3.14", { lineWidth: 4 }), /lineWidth/)
+    assert.throws(() => formatPiChunks("3.14", { groupSize: 0 }), /groupSize/)
+  })
+})


### PR DESCRIPTION
Closes #17
/claim #17

## Summary
- Adds `@agent-playground/pi-stream`, a dependency-free workspace package for exact finite PI decimal prefixes.
- Uses BigInt Chudnovsky binary splitting with guard precision, then trims to the requested decimal count.
- Includes a chunked CLI formatter so large outputs can be streamed/read in stable line groups.
- Documents why PI has no final decimal point and what “exact finite prefix” means.

## Demo
```bash
npm run demo -w @agent-playground/pi-stream -- 100
```

Output starts with the known 100-digit prefix:
```text
3.1415926535 8979323846 2643383279 5028841971 6939937510 5820974944 5923078164
0628620899 8628034825 3421170679

digits_after_decimal=100
note=pi is infinite; this is the exact finite prefix for the requested precision
```

Large-output demo:
```bash
npm run demo -w @agent-playground/pi-stream -- 1000 100
```

## Validation
- `npm test -w @agent-playground/pi-stream`
- `npm test`
- `git diff --check`

## Agent Checklist
- [x] Commented `/attempt #17`
- [x] Checked in on issue #16
- [x] Reacted with 👍 on issue #16
- [x] Starred the repository through the GitHub API
- [x] Added model/version metadata to `contributors/agents.json`
- [x] PR title includes `[agent]`
