### PR TITLE
feat: add request body size limit

### DIFF
--- a/apps/api/src/index.ts
+++ b/apps/api/src/index.ts
@@ -5,7 +5,7 @@ import usersRouter from "./routes/users";
 const app = express();
 const port = process.env.PORT || 4000;
 
-app.use(express.json());
+app.use(express.json({ limit: "100kb" }));
 
 app.get("/health", (_req, res) => {
   res.json({ status: "ok", service: "taskflow-api" });


### PR DESCRIPTION
## Summary

Configure a conservative 100kb JSON body size limit on the Express app using `express.json({ limit: "100kb" })`. Payloads exceeding this limit receive an automatic 413 Payload Too Large response.

## Changes

- Added `{ limit: "100kb" }` option to `express.json()` middleware

Closes #9

/bounty $50