### PR TITLE
feat: add API error handling helper

### DIFF
--- a/apps/api/src/routes/users.ts
+++ b/apps/api/src/routes/users.ts
@@ -1,21 +1,26 @@
 import { Router } from "express";
+import { sendError } from "../utils/errors";
 
 const router = Router();
 
 router.get("/", (_req, res) => {
   res.json({
     data: [],
-    message: "User listing is not implemented yet."
+    message: "User listing is not implemented yet.",
   });
 });
 
 router.post("/", (req, res) => {
+  if (!req.body || Object.keys(req.body).length === 0) {
+    sendError(res, 400, "Request body is required for user creation.");
+    return;
+  }
   res.status(201).json({
     data: {
       id: "stub-user-id",
-      ...req.body
+      ...req.body,
     },
-    message: "User creation is not implemented yet."
+    message: "User creation is not implemented yet.",
   });
 });
 

--- a/apps/api/src/utils/errors.ts
+++ b/apps/api/src/utils/errors.ts
@@ -1,0 +1,20 @@
+import { Response } from "express";
+
+/**
+ * Send a standardized API error response.
+ *
+ * @param res - Express response object
+ * @param statusCode - HTTP status code (default 500)
+ * @param message - Human-readable error description
+ */
+export function sendError(
+  res: Response,
+  statusCode: number = 500,
+  message: string = "Internal Server Error"
+): void {
+  res.status(statusCode).json({
+    error: true,
+    status: statusCode,
+    message,
+  });
+}


### PR DESCRIPTION
## Summary

Introduce a reusable sendError utility that returns standardized API error responses with { error, status, message } envelope. Used from the POST /users route to reject empty request bodies.

## Changes

- New apps/api/src/utils/errors.ts - sendError() helper
- Updated POST /users to validate body and return 400 for empty payloads

Closes #7

/bounty $50