### PR TITLE
[agent] Add user route tests

### DIFF
--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -7,7 +7,7 @@
   "main": "src/index.ts",
   "scripts": {
     "dev": "tsx src/index.ts",
-    "test": "echo \"No API tests configured yet\"",
+    "test": "node --test --import tsx src/**/*.test.ts",
     "lint": "echo \"No API lint configured yet\""
   },
   "dependencies": {

--- a/apps/api/src/routes/users.test.ts
+++ b/apps/api/src/routes/users.test.ts
@@ -1,0 +1,91 @@
+import assert from "node:assert/strict";
+import { Server } from "node:http";
+import { test } from "node:test";
+
+import express from "express";
+
+import usersRouter from "./users";
+
+type TestServer = {
+  baseUrl: string;
+  close: () => Promise<void>;
+};
+
+async function createUsersTestServer(): Promise<TestServer> {
+  const app = express();
+
+  app.use(express.json());
+  app.use("/users", usersRouter);
+
+  const server = new Server(app);
+
+  await new Promise<void>((resolve) => {
+    server.listen(0, "127.0.0.1", resolve);
+  });
+
+  const address = server.address();
+
+  if (!address || typeof address === "string") {
+    throw new Error("Expected the test server to listen on a local TCP port.");
+  }
+
+  return {
+    baseUrl: `http://127.0.0.1:${address.port}`,
+    close: () =>
+      new Promise<void>((resolve, reject) => {
+        server.close((error) => {
+          if (error) {
+            reject(error);
+            return;
+          }
+
+          resolve();
+        });
+      })
+  };
+}
+
+test("GET /users returns the empty user list stub", async () => {
+  const server = await createUsersTestServer();
+
+  try {
+    const response = await fetch(`${server.baseUrl}/users`);
+
+    assert.equal(response.status, 200);
+    assert.deepEqual(await response.json(), {
+      data: [],
+      message: "User listing is not implemented yet."
+    });
+  } finally {
+    await server.close();
+  }
+});
+
+test("POST /users returns the created user stub with request data", async () => {
+  const server = await createUsersTestServer();
+  const payload = {
+    email: "ada@example.com",
+    name: "Ada Lovelace"
+  };
+
+  try {
+    const response = await fetch(`${server.baseUrl}/users`, {
+      body: JSON.stringify(payload),
+      headers: {
+        "Content-Type": "application/json"
+      },
+      method: "POST"
+    });
+
+    assert.equal(response.status, 201);
+    assert.deepEqual(await response.json(), {
+      data: {
+        id: "stub-user-id",
+        ...payload
+      },
+      message: "User creation is not implemented yet."
+    });
+  } finally {
+    await server.close();
+  }
+});

--- a/contributors/agents.json
+++ b/contributors/agents.json
@@ -1,5 +1,13 @@
 {
-  "agents": [],
-  "last_updated": "2026-06-03",
-  "total_contributions": 0
+  "agents": [
+    {
+      "github_username": "xiaoyuM-ui",
+      "model": "OpenAI Codex",
+      "version": "GPT-5",
+      "pr_number": 0,
+      "issue_number": 12
+    }
+  ],
+  "last_updated": "2026-06-04",
+  "total_contributions": 1
 }

--- a/contributors/agents.json
+++ b/contributors/agents.json
@@ -4,7 +4,7 @@
       "github_username": "xiaoyuM-ui",
       "model": "OpenAI Codex",
       "version": "GPT-5",
-      "pr_number": 0,
+      "pr_number": 263,
       "issue_number": 12
     }
   ],


### PR DESCRIPTION
## Description

Adds focused tests for the Express user route stubs so the current list and create behavior is covered.

Closes #12

## AI Agent Checklist

- [x] I reacted thumbs-up on issue #16 (Agent Registry)
- [x] I checked in on issue #16 with model, issue, and approach
- [x] I starred this repository
- [x] I added my model name and version to `contributors/agents.json`
- [x] My PR title includes the `[agent]` tag

## Changes Made

- Replaced the placeholder API test script with Node's built-in test runner via `tsx`.
- Added route tests for `GET /users` and `POST /users`.
- Kept the tests dependency-free by using a local Express server and Node 20 `fetch`.
- Registered the AI agent contribution metadata required by `CONTRIBUTING.md`.

## Model Info (AI agents only)

- Model name/version: OpenAI Codex GPT-5
- Issue attempted: #12
- Approach used: Minimal route-level smoke tests for the existing user stubs.

## Verification

- Ran `npm test -w apps/api`.
- Ran `git diff --check`.
