### PR TITLE
[agent] Add infinite sequence utility

### DIFF
--- a/contributors/agents.json
+++ b/contributors/agents.json
@@ -1,5 +1,13 @@
 {
-  "agents": [],
+  "agents": [
+    {
+      "github_username": "IvanchitorJR",
+      "model": "GPT-5 Codex",
+      "version": "Codex desktop session, 2026-06-03",
+      "pr_number": 266,
+      "issue_number": 15
+    }
+  ],
   "last_updated": "2026-06-03",
-  "total_contributions": 0
+  "total_contributions": 1
 }

--- a/docs/infinite-sequences.md
+++ b/docs/infinite-sequences.md
@@ -1,0 +1,20 @@
+# Infinite Sequence Utility
+
+TaskFlow's engineering playground includes a dependency-free infinite sequence helper in `scripts/infinite-sequence.mjs`.
+
+Use `sequence(seed, next)` to define deterministic unbounded iterators, then consume them with `take(iterable, count)` so examples and tests always stop at a known limit.
+
+```js
+import { naturalNumbers, take } from "../scripts/infinite-sequence.mjs";
+
+const firstFive = take(naturalNumbers(1), 5);
+// [1, 2, 3, 4, 5]
+```
+
+The module also includes `fibonacci()` as a safe example of an infinite recurrence.
+
+Run the coverage with:
+
+```sh
+npm test
+```

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
   ],
   "scripts": {
     "dev": "npm run dev --workspaces --if-present",
-    "test": "npm run test --workspaces --if-present",
+    "test": "node scripts/infinite-sequence.test.mjs && npm run test --workspaces --if-present",
     "lint": "npm run lint --workspaces --if-present",
     "format": "npm run format --workspaces --if-present"
   },

--- a/scripts/infinite-sequence.mjs
+++ b/scripts/infinite-sequence.mjs
@@ -1,0 +1,90 @@
+/**
+ * Builds an infinite sequence from an initial state and a deterministic step.
+ *
+ * The returned iterator is intentionally unbounded. Always consume it through a
+ * bounded helper such as `take()` so callers cannot accidentally loop forever.
+ *
+ * @template T
+ * @param {T} seed
+ * @param {(current: T, index: number) => T} next
+ * @returns {Generator<T, never, unknown>}
+ *
+ * @example
+ * take(sequence(1, (value) => value + 1), 5); // [1, 2, 3, 4, 5]
+ */
+export function sequence(seed, next) {
+  if (typeof next !== "function") {
+    throw new TypeError("sequence next step must be a function");
+  }
+
+  return (function* generate() {
+    let current = seed;
+    let index = 0;
+
+    while (true) {
+      yield current;
+      current = next(current, index);
+      index += 1;
+    }
+  })();
+}
+
+/**
+ * Safely consumes a finite prefix from any iterable.
+ *
+ * @template T
+ * @param {Iterable<T>} iterable
+ * @param {number} count
+ * @returns {T[]}
+ */
+export function take(iterable, count) {
+  if (!Number.isInteger(count) || count < 0) {
+    throw new RangeError("take count must be a non-negative integer");
+  }
+
+  const values = [];
+
+  if (count === 0) {
+    return values;
+  }
+
+  for (const value of iterable) {
+    values.push(value);
+
+    if (values.length === count) {
+      break;
+    }
+  }
+
+  return values;
+}
+
+/**
+ * Infinite arithmetic sequence for simple counters and ranges.
+ *
+ * @param {number} start
+ * @param {number} step
+ * @returns {Generator<number, never, unknown>}
+ */
+export function naturalNumbers(start = 0, step = 1) {
+  if (!Number.isFinite(start) || !Number.isFinite(step) || step === 0) {
+    throw new RangeError("naturalNumbers requires finite start and non-zero step values");
+  }
+
+  return sequence(start, (value) => value + step);
+}
+
+/**
+ * Infinite Fibonacci sequence starting at 0, 1.
+ *
+ * @returns {Generator<number, never, unknown>}
+ */
+export function* fibonacci() {
+  let previous = 0;
+  let current = 1;
+
+  while (true) {
+    yield previous;
+    [previous, current] = [current, previous + current];
+  }
+}

--- a/scripts/infinite-sequence.test.mjs
+++ b/scripts/infinite-sequence.test.mjs
@@ -1,0 +1,33 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { fibonacci, naturalNumbers, sequence, take } from "./infinite-sequence.mjs";
+
+test("take consumes a bounded prefix from an infinite arithmetic sequence", () => {
+  assert.deepEqual(take(naturalNumbers(1), 5), [1, 2, 3, 4, 5]);
+  assert.deepEqual(take(naturalNumbers(10, 2), 4), [10, 12, 14, 16]);
+});
+
+test("fibonacci produces a deterministic infinite sequence", () => {
+  assert.deepEqual(take(fibonacci(), 8), [0, 1, 1, 2, 3, 5, 8, 13]);
+});
+
+test("sequence supports custom recurrence logic", () => {
+  const powersOfTwo = sequence(1, (value) => value * 2);
+
+  assert.deepEqual(take(powersOfTwo, 6), [1, 2, 4, 8, 16, 32]);
+});
+
+test("take handles empty prefixes without advancing the iterator", () => {
+  const iterator = naturalNumbers(5);
+
+  assert.deepEqual(take(iterator, 0), []);
+  assert.deepEqual(take(iterator, 3), [5, 6, 7]);
+});
+
+test("helpers reject unsafe limits and invalid sequence inputs", () => {
+  assert.throws(() => take(naturalNumbers(), -1), /non-negative integer/);
+  assert.throws(() => take(naturalNumbers(), 1.5), /non-negative integer/);
+  assert.throws(() => naturalNumbers(0, 0), /non-zero step/);
+  assert.throws(() => sequence(1, null), /next step/);
+});


### PR DESCRIPTION
Closes #15

## Summary
- Add a dependency-free infinite sequence utility with bounded `take()` consumption.
- Include deterministic examples for arithmetic sequences, Fibonacci, and custom recurrence logic.
- Document safe usage in `docs/infinite-sequences.md` and wire the coverage into root `npm test`.

## Tests
- `node scripts/infinite-sequence.test.mjs`
- `npm test`