### PR TITLE
chore: document environment variables — issue #4

### DIFF
--- a/apps/api/.env.example
+++ b/apps/api/.env.example
@@ -1,0 +1,13 @@
+# TaskFlow API — Environment Variables
+# Copy this file to .env and fill in the values for local development.
+
+# Port the Express server listens on (default: 3001)
+PORT=3001
+
+# Database connection string (Prisma-compatible format)
+# Example: postgresql://user:password@localhost:5432/taskflow?schema=public
+DATABASE_URL="postgresql://postgres:postgres@localhost:5432/taskflow?schema=public"
+
+# CORS — comma-separated list of allowed origins
+# Only requests from these origins will be accepted
+ALLOWED_ORIGINS=http://localhost:5173,http://localhost:3000


### PR DESCRIPTION
## Summary

Adds a `.env.example` file for the API app documenting all expected local environment variables.

## Variables Documented

| Variable | Description | Default |
|----------|-------------|---------|
| `PORT` | Express server listen port | `3001` |
| `DATABASE_URL` | Prisma-compatible PostgreSQL connection string | local dev |
| `ALLOWED_ORIGINS` | CORS allowed origins (comma-separated) | `http://localhost:5173,http://localhost:3000` |

## Acceptance Criteria

- [x] Keep the pull request focused
- [x] Include a short summary of the change
- [x] Link this issue in the pull request description

Closes #4