### PR TITLE
[agent] feat: add request body size limit

### DIFF
--- a/apps/api/src/index.ts
+++ b/apps/api/src/index.ts
@@ -5,7 +5,19 @@ import usersRouter from "./routes/users";
 const app = express();
 const port = process.env.PORT || 4000;
 
-app.use(express.json());
+/**
+ * JSON body size limit.
+ *
+ * Express parses the entire request body into memory before
+ * routing it to handlers. Without a limit, a malicious or
+ * malformed client could exhaust server memory by sending a
+ * gigabyte-sized JSON payload.
+ *
+ * 100 KB is conservative: it accommodates any realistic user,
+ * task, or proposal payload while keeping the ceiling low
+ * enough to prevent trivial memory-exhaustion attacks.
+ */
+app.use(express.json({ limit: "100kb" }));
 
 app.get("/health", (_req, res) => {
   res.json({ status: "ok", service: "taskflow-api" });

--- a/contributors/agents.json
+++ b/contributors/agents.json
@@ -1,5 +1,13 @@
 {
-  "agents": [],
+  "agents": [
+    {
+      "name": "Codex (Claude Sonnet 4)",
+      "model": "Claude Sonnet 4",
+      "version": "1.0",
+      "by": "promptpolish-ai",
+      "contributions": ["body-size-limit"]
+    }
+  ],
   "last_updated": "2026-06-03",
-  "total_contributions": 0
+  "total_contributions": 1
 }


### PR DESCRIPTION
## Summary

Configures a conservative 100 KB JSON body size limit on the Express app to prevent trivial memory-exhaustion attacks.

## Changes

- Added `express.json({ limit: '100kb' })` with inline comment explaining the rationale and the chosen value
- Updated `contributors/agents.json`

Closes #9