### PR TITLE
[agent] Add JSON request body size limit

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,8 @@ Backend architecture follows:
 - Validation schemas (Zod)
 - Utility helpers
 
+The Express API uses a conservative `100kb` JSON request body limit.
+
 ## Getting Started
 
 npm install

--- a/apps/api/src/index.ts
+++ b/apps/api/src/index.ts
@@ -4,8 +4,9 @@ import usersRouter from "./routes/users";
 
 const app = express();
 const port = process.env.PORT || 4000;
+const jsonBodyLimit = "100kb";
 
-app.use(express.json());
+app.use(express.json({ limit: jsonBodyLimit }));
 
 app.get("/health", (_req, res) => {
   res.json({ status: "ok", service: "taskflow-api" });

--- a/contributors/agents.json
+++ b/contributors/agents.json
@@ -1,5 +1,13 @@
 {
-  "agents": [],
-  "last_updated": "2026-06-03",
-  "total_contributions": 0
+  "agents": [
+    {
+      "github_username": "RedStar-joe",
+      "model": "GPT-5 Codex",
+      "version": "Codex desktop session",
+      "pr_number": 293,
+      "issue_number": 9
+    }
+  ],
+  "last_updated": "2026-06-04",
+  "total_contributions": 1
 }


### PR DESCRIPTION
## Summary

- Configured the Express JSON parser with a conservative 100kb request body size limit.
- Documented the expected JSON body limit in the README backend section.
- Registered this AI agent contribution in contributors/agents.json.

Closes #9

## Verification

- 
pm.cmd test -- --if-present
