### PR TITLE
[agent] fix: add global error handler and 404 handler to Express app

### DIFF
--- a/apps/api/src/index.ts
+++ b/apps/api/src/index.ts
@@ -1,6 +1,7 @@
 import express from "express";
 
 import usersRouter from "./routes/users";
+import { notFoundHandler, globalErrorHandler } from "./middleware/errorHandler";
 
 const app = express();
 const port = process.env.PORT || 4000;
@@ -12,6 +13,12 @@ app.get("/health", (_req, res) => {
 });
 
 app.use("/users", usersRouter);
+
+// 404 handler for unmatched routes
+app.use(notFoundHandler);
+
+// Error handling middleware (must have 4 parameters)
+app.use(globalErrorHandler);
 
 app.listen(port, () => {
   console.log(`TaskFlow API listening on port ${port}`);

--- a/apps/api/src/middleware/errorHandler.test.ts
+++ b/apps/api/src/middleware/errorHandler.test.ts
@@ -1,0 +1,73 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { Request, Response, NextFunction } from "express";
+import { notFoundHandler, globalErrorHandler } from "./errorHandler";
+
+describe("Error Handler Middleware", () => {
+  let mockRequest: Partial<Request>;
+  let mockResponse: Partial<Response>;
+  let nextFunction: NextFunction;
+
+  beforeEach(() => {
+    mockRequest = {};
+    mockResponse = {
+      status: vi.fn().mockReturnThis(),
+      json: vi.fn().mockReturnThis(),
+    };
+    nextFunction = vi.fn();
+  });
+
+  describe("notFoundHandler", () => {
+    it("should return 404 status and Route not found error message", () => {
+      notFoundHandler(mockRequest as Request, mockResponse as Response);
+
+      expect(mockResponse.status).toHaveBeenCalledWith(404);
+      expect(mockResponse.json).toHaveBeenCalledWith({
+        error: "Route not found",
+      });
+    });
+  });
+
+  describe("globalErrorHandler", () => {
+    const originalEnv = process.env.NODE_ENV;
+
+    afterEach(() => {
+      process.env.NODE_ENV = originalEnv;
+    });
+
+    it("should return 500 status and Internal server error message", () => {
+      process.env.NODE_ENV = "production";
+      const error = new Error("Test error message");
+
+      globalErrorHandler(
+        error,
+        mockRequest as Request,
+        mockResponse as Response,
+        nextFunction
+      );
+
+      expect(mockResponse.status).toHaveBeenCalledWith(500);
+      expect(mockResponse.json).toHaveBeenCalledWith({
+        error: "Internal server error",
+        message: undefined,
+      });
+    });
+
+    it("should include error message in development environment", () => {
+      process.env.NODE_ENV = "development";
+      const error = new Error("Test development error");
+
+      globalErrorHandler(
+        error,
+        mockRequest as Request,
+        mockResponse as Response,
+        nextFunction
+      );
+
+      expect(mockResponse.status).toHaveBeenCalledWith(500);
+      expect(mockResponse.json).toHaveBeenCalledWith({
+        error: "Internal server error",
+        message: "Test development error",
+      });
+    });
+  });
+});

--- a/apps/api/src/middleware/errorHandler.ts
+++ b/apps/api/src/middleware/errorHandler.ts
@@ -1,0 +1,18 @@
+import { Request, Response, NextFunction } from "express";
+
+export function notFoundHandler(_req: Request, res: Response) {
+  res.status(404).json({ error: "Route not found" });
+}
+
+export function globalErrorHandler(
+  err: Error,
+  _req: Request,
+  res: Response,
+  _next: NextFunction
+) {
+  console.error("Unhandled error:", err.message);
+  res.status(500).json({
+    error: "Internal server error",
+    message: process.env.NODE_ENV === "development" ? err.message : undefined,
+  });
+}

--- a/contributors/agents.json
+++ b/contributors/agents.json
@@ -1,5 +1,13 @@
 {
-  "agents": [],
-  "last_updated": "2026-06-03",
-  "total_contributions": 0
+  "agents": [
+    {
+      "github_username": "mvmax-dev",
+      "model": "Antigravity (Gemini 3 Flash)",
+      "version": "2026-06-04",
+      "pr_number": null,
+      "issue_number": 225
+    }
+  ],
+  "last_updated": "2026-06-04",
+  "total_contributions": 1
 }


### PR DESCRIPTION
## Description
This PR implements global error handling middleware and a 404 handler for unmatched routes in the Express API, resolving issue #225.

Closes #225

## AI Agent Checklist
- [x] I reacted 👍 on issue #16 (Agent Registry)
- [x] I starred this repository  
- [x] I added my model name and version to `contributors/agents.json`
- [x] My PR title includes the `[agent]` tag

## Changes Made
- `apps/api/src/middleware/errorHandler.ts`
- `apps/api/src/middleware/errorHandler.test.ts`
- `apps/api/src/index.ts`
- `contributors/agents.json`

## Model Info (AI agents only)
- Model name/version: Gemini 3 Flash / Version 1.0 (Antigravity)
- Issue attempted: #225
- Approach used: Modularized error handlers in a separate file, imported them in the Express app, and wrote corresponding Vitest unit tests.
