### PR TITLE
test: add unit tests for user routes (Closes #12)

### DIFF
--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -7,7 +7,7 @@
   "main": "src/index.ts",
   "scripts": {
     "dev": "tsx src/index.ts",
-    "test": "echo \"No API tests configured yet\"",
+    "test": "vitest run",
     "lint": "echo \"No API lint configured yet\""
   },
   "dependencies": {
@@ -15,7 +15,10 @@
   },
   "devDependencies": {
     "@types/express": "^4.17.21",
+    "@types/supertest": "^6.0.2",
+    "supertest": "^7.0.0",
     "tsx": "^4.7.1",
-    "typescript": "^5.4.5"
+    "typescript": "^5.4.5",
+    "vitest": "^3.1.1"
   }
 }

--- a/apps/api/src/__tests__/users.test.ts
+++ b/apps/api/src/__tests__/users.test.ts
@@ -1,0 +1,56 @@
+import { describe, it, expect } from "vitest";
+import request from "supertest";
+import express from "express";
+import usersRouter from "../routes/users";
+
+function createApp() {
+  const app = express();
+  app.use(express.json());
+  app.use("/users", usersRouter);
+  return app;
+}
+
+describe("GET /users", () => {
+  it("should return 200 with an empty data array and a not-implemented message", async () => {
+    const app = createApp();
+    const res = await request(app).get("/users");
+
+    expect(res.status).toBe(200);
+    expect(res.body).toHaveProperty("data");
+    expect(Array.isArray(res.body.data)).toBe(true);
+    expect(res.body.data).toEqual([]);
+    expect(res.body).toHaveProperty("message");
+    expect(res.body.message).toContain("not implemented");
+  });
+
+  it("should return JSON content type", async () => {
+    const app = createApp();
+    const res = await request(app).get("/users");
+
+    expect(res.headers["content-type"]).toMatch(/json/);
+  });
+});
+
+describe("POST /users", () => {
+  it("should return 201 with stub user data including the request body fields", async () => {
+    const app = createApp();
+    const payload = { name: "Alice", email: "alice@example.com" };
+    const res = await request(app).post("/users").send(payload);
+
+    expect(res.status).toBe(201);
+    expect(res.body).toHaveProperty("data");
+    expect(res.body.data).toHaveProperty("id", "stub-user-id");
+    expect(res.body.data).toHaveProperty("name", payload.name);
+    expect(res.body.data).toHaveProperty("email", payload.email);
+    expect(res.body).toHaveProperty("message");
+    expect(res.body.message).toContain("not implemented");
+  });
+
+  it("should return 201 even with an empty body", async () => {
+    const app = createApp();
+    const res = await request(app).post("/users").send({});
+
+    expect(res.status).toBe(201);
+    expect(res.body.data).toHaveProperty("id", "stub-user-id");
+  });
+});

--- a/apps/api/vitest.config.ts
+++ b/apps/api/vitest.config.ts
@@ -1,0 +1,7 @@
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+  test: {
+    globals: true,
+  },
+});


### PR DESCRIPTION
## Summary

Adds unit tests for the Express user route stubs covering list (GET) and create (POST) behavior.

## Changes

- **apps/api/src/__tests__/users.test.ts** — New test file with 4 test cases:
  - GET /users returns 200 with empty data array and not-implemented message
  - GET /users returns JSON content type
  - POST /users returns 201 with stub data including request body fields
  - POST /users handles empty body correctly
- **apps/api/package.json** — Added `vitest`, `supertest`, `@types/supertest` as devDependencies; updated `test` script to `vitest run`
- **apps/api/vitest.config.ts** — Minimal vitest configuration

## Testing

```bash
cd apps/api && npm test
```

Closes #12