### PR TITLE
test: add unit tests for users routes

### DIFF
--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -7,7 +7,7 @@
   "main": "src/index.ts",
   "scripts": {
     "dev": "tsx src/index.ts",
-    "test": "echo \"No API tests configured yet\"",
+    "test": "vitest run",
     "lint": "echo \"No API lint configured yet\""
   },
   "dependencies": {
@@ -15,7 +15,10 @@
   },
   "devDependencies": {
     "@types/express": "^4.17.21",
+    "@types/supertest": "^6.0.2",
+    "supertest": "^7.0.0",
     "tsx": "^4.7.1",
-    "typescript": "^5.4.5"
+    "typescript": "^5.4.5",
+    "vitest": "^2.1.0"
   }
 }

--- a/apps/api/src/routes/users.test.ts
+++ b/apps/api/src/routes/users.test.ts
@@ -1,0 +1,54 @@
+import { describe, it, expect } from "vitest";
+import express from "express";
+import request from "supertest";
+import usersRouter from "./users";
+
+function createApp() {
+  const app = express();
+  app.use(express.json());
+  app.use("/users", usersRouter);
+  return app;
+}
+
+describe("Users routes", () => {
+  describe("GET /users", () => {
+    it("should return a 200 status with an empty data array", async () => {
+      const app = createApp();
+      const res = await request(app).get("/users");
+
+      expect(res.status).toBe(200);
+      expect(res.body).toHaveProperty("data");
+      expect(res.body.data).toEqual([]);
+      expect(res.body).toHaveProperty("message");
+    });
+
+    it("should include a message about not being implemented", async () => {
+      const app = createApp();
+      const res = await request(app).get("/users");
+
+      expect(res.body.message).toContain("not implemented");
+    });
+  });
+
+  describe("POST /users", () => {
+    it("should create a stub user and return 201", async () => {
+      const app = createApp();
+      const payload = { name: "Alice", email: "alice@example.com" };
+      const res = await request(app).post("/users").send(payload);
+
+      expect(res.status).toBe(201);
+      expect(res.body.data).toMatchObject(payload);
+      expect(res.body.data).toHaveProperty("id");
+    });
+
+    it("should assign a stub id when creating a user", async () => {
+      const app = createApp();
+      const res = await request(app)
+        .post("/users")
+        .send({ name: "Bob" });
+
+      expect(res.status).toBe(201);
+      expect(res.body.data.id).toBeDefined();
+    });
+  });
+});

--- a/apps/api/vitest.config.ts
+++ b/apps/api/vitest.config.ts
@@ -1,0 +1,7 @@
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+  test: {
+    globals: true,
+  },
+});


### PR DESCRIPTION
Closes #12

Add vitest + supertest and basic unit tests for Express user route stubs covering GET list and POST create behaviors.