### PR TITLE
[agent] fix: add API JSON body size limit

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,3 +83,10 @@ with models for:
 
 Each app/package expects its own .env values for DB, auth, 
 and integrations.
+
+### API
+
+| Variable | Default | Description |
+|---|---|---|
+| `PORT` | `4000` | Port used by the Express API server |
+| `API_JSON_BODY_LIMIT` | `100kb` | Maximum JSON request body size accepted by the API |

--- a/apps/api/src/index.ts
+++ b/apps/api/src/index.ts
@@ -4,8 +4,9 @@ import usersRouter from "./routes/users";
 
 const app = express();
 const port = process.env.PORT || 4000;
+const jsonBodyLimit = process.env.API_JSON_BODY_LIMIT || "100kb";
 
-app.use(express.json());
+app.use(express.json({ limit: jsonBodyLimit }));
 
 app.get("/health", (_req, res) => {
   res.json({ status: "ok", service: "taskflow-api" });

--- a/contributors/agents.json
+++ b/contributors/agents.json
@@ -1,5 +1,13 @@
 {
-  "agents": [],
-  "last_updated": "2026-06-03",
-  "total_contributions": 0
+  "agents": [
+    {
+      "github_username": "exal-gh-33",
+      "model": "Codex",
+      "version": "GPT-5",
+      "pr_number": null,
+      "issue_number": 9
+    }
+  ],
+  "last_updated": "2026-06-04",
+  "total_contributions": 1
 }

--- a/contributors/agents.json
+++ b/contributors/agents.json
@@ -4,7 +4,7 @@
       "github_username": "exal-gh-33",
       "model": "Codex",
       "version": "GPT-5",
-      "pr_number": null,
+      "pr_number": 339,
       "issue_number": 9
     }
   ],


### PR DESCRIPTION
## Summary
- Adds a conservative `100kb` default JSON body limit to the Express API.
- Allows overriding the limit with `API_JSON_BODY_LIMIT`.
- Documents the API environment variables and adds the required agent registry entry.

## Validation
- Parsed `contributors/agents.json` successfully with PowerShell `ConvertFrom-Json`
- `git diff --check`
- `node --check apps/api/src/index.ts` using the bundled Codex Node runtime

Closes #9.