### PR TITLE
Fix #33: Bug Bounty Program — How to Participate

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -57,3 +57,28 @@ for bounty review.
 ## Code of Conduct
 
 Collaborate respectfully in all issue and PR discussions.
+
+// Fix for issue #33
+Add a dedicated `## Bug Bounty Workflow` section describing the expected contributor flow for bounty-backed fixes, including issue creation, `/bounty` syntax, reference to `#33`, and PR submission requirements:
+
+```md
+## Bug Bounty Workflow
+
+If you are contributing a fix as part of the bug bounty program:
+
+1. Open an issue with a clear description of the bug, security issue, or improvement opportunity.
+2. Add `/bounty $[amount]` to the issue body.
+3. Reference issue `#33` in the same issue.
+4. Submit a pull request that fixes the reported problem.
+
+Suggested bounty ranges:
+
+- Low: `$50-$200`
+- Medium: `$200-$500`
+- High: `$500-$1200`
+
+Please keep reports specific and include reproduction steps, affected areas, and any relevant screenshots or logs when possible.
+
+If the issue may expose a security risk, follow the process in `SECURITY.md` instead of posting sensitive details publicly.
+```
+

--- a/README.md
+++ b/README.md
@@ -83,3 +83,29 @@ with models for:
 
 Each app/package expects its own .env values for DB, auth, 
 and integrations.
+
+// Fix for issue #33
+Add a new `## Bug Bounty Program` section near the contribution/security guidance that explains how to participate, links to `CONTRIBUTING.md` and `SECURITY.md`, and includes the required reporting steps from issue #33:
+
+```md
+## Bug Bounty Program
+
+This repository runs an open bug bounty program for valid bugs, security issues, and meaningful improvement opportunities.
+
+If you find an issue, please:
+
+1. Open a new issue describing the problem clearly
+2. Include `/bounty $[amount]` in the issue body
+3. Reference issue `#33` in the issue body
+4. Submit a PR with the fix
+
+Suggested bounty ranges:
+
+- Low: `$50-$200`
+- Medium: `$200-$500`
+- High: `$500-$1200`
+
+For security-sensitive reports, please review `SECURITY.md` before opening a public issue.
+For contribution expectations and PR workflow, see `CONTRIBUTING.md`.
+```
+

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -48,3 +48,22 @@ Include:
 ## AI Agent Reports
 
 AI agents should include `[agent]` in the issue or pull request title, list the model used, and keep the report concise enough for maintainers to validate quickly.
+
+// Fix for issue #33
+Add a short `## Bug Bounty Reports` section clarifying how bug bounty submissions should handle security-sensitive findings and when to avoid public disclosure:
+
+```md
+## Bug Bounty Reports
+
+This repository accepts bug bounty submissions for security issues as part of the workflow described in issue `#33`.
+
+If your report contains sensitive exploit details, do not disclose those details publicly at first. Share the minimum information needed to triage safely, then coordinate the fix through the maintainers' preferred security process.
+
+For non-sensitive issues or improvements, you may:
+
+1. Open a new issue
+2. Include `/bounty $[amount]` in the issue body
+3. Reference issue `#33`
+4. Submit a PR with the fix
+```
+


### PR DESCRIPTION
## Fix for #33

The repository issue describes an open bug bounty program, but the core contributor-facing documentation should explicitly explain how to participate. This fix adds clear bug bounty instructions to `README.md`, formalizes the contributor workflow in `CONTRIBUTING.md`, and clarifies how security-sensitive bounty reports should be handled in `SECURITY.md`. These changes make the process discoverable, consistent, and safer for both general bugs and security disclosures.

### Changes:
- `README.md`: Modified
- `CONTRIBUTING.md`: Modified
- `SECURITY.md`: Modified


---
*This PR was generated by an AI bounty hunter agent.*