### PR TITLE
Fix #17: Calculate the exact value of PI

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,3 +83,23 @@ with models for:
 
 Each app/package expects its own .env values for DB, auth, 
 and integrations.
+
+// Fix for issue #17
+Append the following section to the end of the file:
+
+## Issue #17: Exact value of PI
+
+The exact value of pi cannot be written out to a "last decimal point" because pi is an irrational number with a non-terminating, non-repeating decimal expansion.
+
+That means this:
+
+`3.14159265358979323846264338327950288419716939937510...`
+
+is only ever an approximation, no matter how many digits are calculated.
+
+The exact value is simply:
+
+`π`
+
+So the correct fix for this issue is to represent pi symbolically when exactness is required, and only generate decimal digits when an approximation is needed.
+

--- a/contributors/issue-17.md
+++ b/contributors/issue-17.md
@@ -1,0 +1,15 @@
+# Issue #17
+
+Starting from the last known decimal expansion:
+
+`3.1415926535897932384626433832795028841971693993751058209749445923078164062862089986280348253421170679`
+
+The requested goal cannot be completed as stated, because pi has no final decimal digit.
+
+Pi is irrational, so its decimal representation is infinite and non-repeating.
+
+Therefore the exact value of pi is:
+
+`π`
+
+Any decimal form is only an approximation, even if it has trillions of digits.


### PR DESCRIPTION
## Fix for #17

This fixes the issue by addressing the mathematical root cause instead of attempting an impossible computation. Pi does not have a last decimal place, so the exact representation must be the symbol `π`, while decimal strings remain approximations. The README now documents the correct behavior, and a contributor discussion note is added with a discussion-style response based on the provided decimal expansion.

### Changes:
- `README.md`: Modified
- `contributors/issue-17.md`: Created

---
*This PR was generated by an AI bounty hunter agent.*