### PR TITLE
[agent] fix: type Button return shape

### DIFF
--- a/contributors/agents.json
+++ b/contributors/agents.json
@@ -1,5 +1,13 @@
 {
-  "agents": [],
-  "last_updated": "2026-06-03",
-  "total_contributions": 0
+  "agents": [
+    {
+      "github_username": "exal-gh-33",
+      "model": "Codex",
+      "version": "GPT-5",
+      "pr_number": null,
+      "issue_number": 3
+    }
+  ],
+  "last_updated": "2026-06-04",
+  "total_contributions": 1
 }

--- a/contributors/agents.json
+++ b/contributors/agents.json
@@ -4,7 +4,7 @@
       "github_username": "exal-gh-33",
       "model": "Codex",
       "version": "GPT-5",
-      "pr_number": null,
+      "pr_number": 353,
       "issue_number": 3
     }
   ],

--- a/packages/ui/src/index.ts
+++ b/packages/ui/src/index.ts
@@ -3,10 +3,16 @@ export type ButtonProps = {
   disabled?: boolean;
 };
 
-export function Button({ label, disabled = false }: ButtonProps) {
+export type ButtonResult = {
+  type: "button";
+  label: string;
+  disabled: boolean;
+};
+
+export function Button({ label, disabled = false }: ButtonProps): ButtonResult {
   return {
     type: "button",
     label,
-    disabled
+    disabled,
   };
 }


### PR DESCRIPTION
## Summary
- Adds an explicit `ButtonResult` type for the shared Button stub.
- Annotates the Button return type without changing the public props shape.
- Adds the required agent registry entry for this issue.

## Validation
- Parsed `contributors/agents.json` successfully with PowerShell `ConvertFrom-Json`
- `git diff --check`
- `node --check packages/ui/src/index.ts` using the bundled Codex Node runtime

Closes #3.