### PR TITLE
Fix #13: Write unit tests for UI Button stub

### DIFF
--- a/packages/ui/src/button.test.tsx
+++ b/packages/ui/src/button.test.tsx
@@ -1,0 +1,18 @@
+import { render, screen } from '@testing-library/react';
+import { describe, expect, it } from 'vitest';
+
+import { Button } from './button';
+
+describe('Button', () => {
+  it('renders the provided label', () => {
+    render(<Button label="Click me" />);
+
+    expect(screen.getByRole('button', { name: 'Click me' })).toBeInTheDocument();
+  });
+
+  it('applies the disabled state', () => {
+    render(<Button label="Disabled" disabled />);
+
+    expect(screen.getByRole('button', { name: 'Disabled' })).toBeDisabled();
+  });
+});


### PR DESCRIPTION
## Fix for #13

Added a focused unit test for the shared Button stub in `packages/ui/src/button.test.tsx`. The test covers the two requested behaviors: rendering the passed `label` value and applying the `disabled` prop to the underlying button element. This keeps the change small and aligned with the issue scope.

### Changes:

- `packages/ui/src/button.test.tsx`: Created

---
*This PR was generated by an AI bounty hunter agent.*