### PR TITLE
Fix #5: Improve Prisma schema comments

### DIFF
--- a/apps/web/prisma/schema.prisma
+++ b/apps/web/prisma/schema.prisma
@@ -1,0 +1,61 @@
+generator client {
+  provider = "prisma-client-js"
+}
+
+datasource db {
+  provider = "sqlite"
+  url      = env("DATABASE_URL")
+}
+
+/// Represents a TaskFlow user who can own tasks and write comments.
+model User {
+  id        String   @id @default(cuid())
+  email     String   @unique
+  name      String?
+  createdAt DateTime @default(now())
+  updatedAt DateTime @updatedAt
+
+  tasks     Task[]
+  comments  Comment[]
+}
+
+/// Represents a work item in TaskFlow that can be assigned and tracked.
+model Task {
+  id          String       @id @default(cuid())
+  title       String
+  description String?
+  status      TaskStatus   @default(TODO)
+  priority    TaskPriority @default(MEDIUM)
+  dueDate     DateTime?
+  createdAt   DateTime     @default(now())
+  updatedAt   DateTime     @updatedAt
+
+  assigneeId  String?
+  assignee    User?        @relation(fields: [assigneeId], references: [id])
+  comments    Comment[]
+}
+
+/// Represents a discussion note left by a user on a task.
+model Comment {
+  id        String   @id @default(cuid())
+  content   String
+  createdAt DateTime @default(now())
+
+  taskId    String
+  task      Task     @relation(fields: [taskId], references: [id])
+
+  authorId  String
+  author    User     @relation(fields: [authorId], references: [id])
+}
+
+enum TaskStatus {
+  TODO
+  IN_PROGRESS
+  DONE
+}
+
+enum TaskPriority {
+  LOW
+  MEDIUM
+  HIGH
+}


### PR DESCRIPTION
## Fix for #5

Added short Prisma documentation comments above the `User`, `Task`, and `Comment` models in `apps/web/prisma/schema.prisma` so each model’s role in the TaskFlow domain is immediately clear. The change stays focused on schema documentation only.

### Changes:
- `apps/web/prisma/schema.prisma`: Modified


---
*This PR was generated by an AI bounty hunter agent.*