### PR TITLE
Add unit tests for leaderboard updates

### DIFF
--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -7,7 +7,7 @@
   "main": "src/index.ts",
   "scripts": {
     "dev": "tsx src/index.ts",
-    "test": "echo \"No API tests configured yet\"",
+    "test": "vitest run",
     "lint": "echo \"No API lint configured yet\""
   },
   "dependencies": {
@@ -16,6 +16,7 @@
   "devDependencies": {
     "@types/express": "^4.17.21",
     "tsx": "^4.7.1",
-    "typescript": "^5.4.5"
+    "typescript": "^5.4.5",
+    "vitest": "^1.6.0"
   }
 }

--- a/apps/api/src/leaderboard.test.ts
+++ b/apps/api/src/leaderboard.test.ts
@@ -1,0 +1,172 @@
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { writeFileSync, unlinkSync, existsSync } from "fs";
+import { resolve } from "path";
+import {
+  loadLeaderboard,
+  saveLeaderboard,
+  addContribution,
+  removeContributor,
+  getSortedLeaderboard,
+  type Leaderboard,
+} from "./leaderboard.js";
+
+const TEST_FILE = resolve(__dirname, "../test-leaderboard.json");
+
+afterEach(() => {
+  if (existsSync(TEST_FILE)) unlinkSync(TEST_FILE);
+});
+
+// ── loadLeaderboard ──────────────────────────────────────────────────────────
+
+describe("loadLeaderboard", () => {
+  it("returns an empty object when the file does not exist", () => {
+    expect(loadLeaderboard("/tmp/nonexistent-board.json")).toEqual({});
+  });
+
+  it("returns the parsed contents of an existing file", () => {
+    writeFileSync(TEST_FILE, JSON.stringify({ alice: 5, bob: 3 }));
+    expect(loadLeaderboard(TEST_FILE)).toEqual({ alice: 5, bob: 3 });
+  });
+
+  it("returns an empty object when the file contains invalid JSON", () => {
+    writeFileSync(TEST_FILE, "not-json");
+    expect(loadLeaderboard(TEST_FILE)).toEqual({});
+  });
+});
+
+// ── saveLeaderboard ──────────────────────────────────────────────────────────
+
+describe("saveLeaderboard", () => {
+  it("writes the board to disk and round-trips through loadLeaderboard", () => {
+    const board: Leaderboard = { carol: 10, dave: 7 };
+    saveLeaderboard(TEST_FILE, board);
+    expect(loadLeaderboard(TEST_FILE)).toEqual(board);
+  });
+
+  it("overwrites an existing file", () => {
+    saveLeaderboard(TEST_FILE, { old: 1 });
+    saveLeaderboard(TEST_FILE, { fresh: 42 });
+    expect(loadLeaderboard(TEST_FILE)).toEqual({ fresh: 42 });
+  });
+});
+
+// ── addContribution ──────────────────────────────────────────────────────────
+
+describe("addContribution", () => {
+  it("adds a new contributor with the given points", () => {
+    const result = addContribution({}, "alice", 5);
+    expect(result).toEqual({ alice: 5 });
+  });
+
+  it("increments an existing contributor's score", () => {
+    const result = addContribution({ alice: 3 }, "alice", 2);
+    expect(result).toEqual({ alice: 5 });
+  });
+
+  it("defaults to 1 point when points is omitted", () => {
+    const result = addContribution({}, "bob");
+    expect(result).toEqual({ bob: 1 });
+  });
+
+  it("does not mutate the input board", () => {
+    const original: Leaderboard = { alice: 3 };
+    addContribution(original, "alice", 2);
+    expect(original).toEqual({ alice: 3 });
+  });
+
+  it("keeps other contributors unchanged", () => {
+    const result = addContribution({ alice: 5, bob: 2 }, "carol", 4);
+    expect(result).toEqual({ alice: 5, bob: 2, carol: 4 });
+  });
+
+  it("throws when contributor name is empty", () => {
+    expect(() => addContribution({}, "", 1)).toThrow(
+      "Contributor name must be a non-empty string"
+    );
+  });
+
+  it("throws when points is negative", () => {
+    expect(() => addContribution({}, "alice", -1)).toThrow(
+      "Points must be a non-negative number"
+    );
+  });
+});
+
+// ── removeContributor ────────────────────────────────────────────────────────
+
+describe("removeContributor", () => {
+  it("removes an existing contributor", () => {
+    const result = removeContributor({ alice: 5, bob: 3 }, "alice");
+    expect(result).toEqual({ bob: 3 });
+  });
+
+  it("returns the same shape when contributor does not exist", () => {
+    const result = removeContributor({ alice: 5 }, "unknown");
+    expect(result).toEqual({ alice: 5 });
+  });
+
+  it("does not mutate the input board", () => {
+    const original: Leaderboard = { alice: 5 };
+    removeContributor(original, "alice");
+    expect(original).toEqual({ alice: 5 });
+  });
+});
+
+// ── getSortedLeaderboard ─────────────────────────────────────────────────────
+
+describe("getSortedLeaderboard", () => {
+  it("returns entries sorted by score descending", () => {
+    const board: Leaderboard = { alice: 3, bob: 10, carol: 7 };
+    const sorted = getSortedLeaderboard(board);
+    expect(sorted).toEqual([
+      { contributor: "bob", score: 10 },
+      { contributor: "carol", score: 7 },
+      { contributor: "alice", score: 3 },
+    ]);
+  });
+
+  it("returns an empty array for an empty board", () => {
+    expect(getSortedLeaderboard([] as unknown as Leaderboard)).toEqual([]);
+  });
+
+  it("handles a single contributor", () => {
+    expect(getSortedLeaderboard({ alice: 1 })).toEqual([
+      { contributor: "alice", score: 1 },
+    ]);
+  });
+});
+
+// ── integration: full update flow ────────────────────────────────────────────
+
+describe("full leaderboard update flow", () => {
+  it("loads, updates, saves, and re-loads correctly", () => {
+    // Start empty
+    saveLeaderboard(TEST_FILE, {});
+    let board = loadLeaderboard(TEST_FILE);
+
+    // Add contributions
+    board = addContribution(board, "alice", 5);
+    board = addContribution(board, "bob", 3);
+    board = addContribution(board, "alice", 2);
+    saveLeaderboard(TEST_FILE, board);
+
+    // Reload and verify
+    board = loadLeaderboard(TEST_FILE);
+    expect(board).toEqual({ alice: 7, bob: 3 });
+
+    // Remove and re-add
+    board = removeContributor(board, "bob");
+    board = addContribution(board, "carol", 10);
+    saveLeaderboard(TEST_FILE, board);
+
+    // Final state
+    const final = loadLeaderboard(TEST_FILE);
+    expect(final).toEqual({ alice: 7, carol: 10 });
+
+    // Sorted order
+    expect(getSortedLeaderboard(final)).toEqual([
+      { contributor: "carol", score: 10 },
+      { contributor: "alice", score: 7 },
+    ]);
+  });
+});

--- a/apps/api/src/leaderboard.ts
+++ b/apps/api/src/leaderboard.ts
@@ -1,0 +1,68 @@
+import { readFileSync, writeFileSync } from "fs";
+import { resolve } from "path";
+
+export type Leaderboard = Record<string, number>;
+
+/**
+ * Load the leaderboard from a JSON file on disk.
+ * Returns an empty object when the file does not exist or is empty.
+ */
+export function loadLeaderboard(filePath: string): Leaderboard {
+  try {
+    const raw = readFileSync(filePath, "utf-8");
+    return JSON.parse(raw) as Leaderboard;
+  } catch {
+    return {};
+  }
+}
+
+/**
+ * Persist the leaderboard object to a JSON file.
+ */
+export function saveLeaderboard(filePath: string, board: Leaderboard): void {
+  writeFileSync(filePath, JSON.stringify(board, null, 2) + "\n", "utf-8");
+}
+
+/**
+ * Add (or increment) a contributor's score on the leaderboard.
+ * Returns the updated leaderboard without mutating the input.
+ */
+export function addContribution(
+  board: Leaderboard,
+  contributor: string,
+  points: number = 1
+): Leaderboard {
+  if (!contributor || typeof contributor !== "string") {
+    throw new Error("Contributor name must be a non-empty string");
+  }
+  if (typeof points !== "number" || points < 0) {
+    throw new Error("Points must be a non-negative number");
+  }
+  return {
+    ...board,
+    [contributor]: (board[contributor] ?? 0) + points,
+  };
+}
+
+/**
+ * Remove a contributor from the leaderboard.
+ * Returns the updated leaderboard without mutating the input.
+ */
+export function removeContributor(
+  board: Leaderboard,
+  contributor: string
+): Leaderboard {
+  const { [contributor]: _, ...rest } = board;
+  return rest;
+}
+
+/**
+ * Return the leaderboard sorted by score descending.
+ */
+export function getSortedLeaderboard(
+  board: Leaderboard
+): Array<{ contributor: string; score: number }> {
+  return Object.entries(board)
+    .map(([contributor, score]) => ({ contributor, score }))
+    .sort((a, b) => b.score - a.score);
+}


### PR DESCRIPTION
## Summary

Adds a leaderboard utility module and a comprehensive vitest test suite that covers all leaderboard update operations for new and existing contributors.

### Files added

- `apps/api/src/leaderboard.ts` — Utility functions: loadLeaderboard, saveLeaderboard, addContribution, removeContributor, getSortedLeaderboard
- `apps/api/src/leaderboard.test.ts` — 16 test cases across 6 describe blocks
- `apps/api/package.json` — Added vitest dependency and updated test script

### Test coverage

- **loadLeaderboard** — Missing file, valid file, corrupt JSON
- **saveLeaderboard** — Write and round-trip, overwrite
- **addContribution** — New contributor, existing contributor, default points, immutability, preserves others, empty name error, negative points error
- **removeContributor** — Existing, nonexistent, immutability
- **getSortedLeaderboard** — Descending sort, empty, single entry
- **Full flow** — End-to-end load, update, save, reload cycle

Closes #11