### PR TITLE
[agent] test(ui): add unit tests for UI Button stub component

### DIFF
--- a/contributors/agents.json
+++ b/contributors/agents.json
@@ -1,5 +1,13 @@
 {
-  "agents": [],
-  "last_updated": "2026-06-03",
-  "total_contributions": 0
+  "agents": [
+    {
+      "github_username": "codeboost-tr",
+      "model": "Gemini 3.5 Flash",
+      "version": "Medium",
+      "pr_number": null,
+      "issue_number": 13
+    }
+  ],
+  "last_updated": "2026-06-04",
+  "total_contributions": 1
 }

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -5,10 +5,11 @@
   "description": "Shared UI components for TaskFlow.",
   "main": "src/index.ts",
   "scripts": {
-    "test": "echo \"No UI tests configured yet\"",
+    "test": "tsx --test src/index.test.ts",
     "lint": "echo \"No UI lint configured yet\""
   },
   "devDependencies": {
-    "typescript": "^5.4.5"
+    "tsx": "^4.22.4",
+    "typescript": "^5.9.3"
   }
 }

--- a/packages/ui/src/index.test.ts
+++ b/packages/ui/src/index.test.ts
@@ -1,0 +1,24 @@
+import { test } from "node:test";
+import assert from "node:assert";
+import { Button } from "./index.js";
+
+test("Button component returns correct representation with label", () => {
+  const result = Button({ label: "Submit" });
+  assert.strictEqual(result.type, "button");
+  assert.strictEqual(result.label, "Submit");
+  assert.strictEqual(result.disabled, false);
+});
+
+test("Button component respects disabled prop when true", () => {
+  const result = Button({ label: "Submit", disabled: true });
+  assert.strictEqual(result.type, "button");
+  assert.strictEqual(result.label, "Submit");
+  assert.strictEqual(result.disabled, true);
+});
+
+test("Button component respects disabled prop when false", () => {
+  const result = Button({ label: "Submit", disabled: false });
+  assert.strictEqual(result.type, "button");
+  assert.strictEqual(result.label, "Submit");
+  assert.strictEqual(result.disabled, false);
+});


### PR DESCRIPTION
Closes #13. Adds a unit test suite covering the shared Button stub component label and disabled values.