### PR TITLE
[agent] docs: add JSDoc user service

### DIFF
--- a/apps/api/src/routes/users.ts
+++ b/apps/api/src/routes/users.ts
@@ -1,22 +1,15 @@
 import { Router } from "express";
 
+import { createUser, listUsers } from "../services/userService";
+
 const router = Router();
 
 router.get("/", (_req, res) => {
-  res.json({
-    data: [],
-    message: "User listing is not implemented yet."
-  });
+  res.json(listUsers());
 });
 
 router.post("/", (req, res) => {
-  res.status(201).json({
-    data: {
-      id: "stub-user-id",
-      ...req.body
-    },
-    message: "User creation is not implemented yet."
-  });
+  res.status(201).json(createUser(req.body));
 });
 
 export default router;

--- a/apps/api/src/services/userService.ts
+++ b/apps/api/src/services/userService.ts
@@ -1,0 +1,43 @@
+export interface CreatedUser {
+  id: string;
+  [key: string]: unknown;
+}
+
+export interface UserListResponse {
+  data: unknown[];
+  message: string;
+}
+
+export interface UserCreateResponse {
+  data: CreatedUser;
+  message: string;
+}
+
+/**
+ * Returns the current placeholder user list response.
+ *
+ * This keeps the not-yet-implemented list behavior in one service layer so the
+ * route can stay thin while the real data source is added later.
+ */
+export function listUsers(): UserListResponse {
+  return {
+    data: [],
+    message: "User listing is not implemented yet."
+  };
+}
+
+/**
+ * Builds the current placeholder user creation response.
+ *
+ * @param input - Request body fields to echo in the stubbed user payload.
+ * @returns The existing creation response shape with the fixed stub user id.
+ */
+export function createUser(input: Record<string, unknown>): UserCreateResponse {
+  return {
+    data: {
+      id: "stub-user-id",
+      ...input
+    },
+    message: "User creation is not implemented yet."
+  };
+}

--- a/contributors/agents.json
+++ b/contributors/agents.json
@@ -1,5 +1,13 @@
 {
-  "agents": [],
-  "last_updated": "2026-06-03",
-  "total_contributions": 0
+  "agents": [
+    {
+      "github_username": "tudorian95",
+      "model": "OpenAI Codex",
+      "version": "GPT-5",
+      "pr_number": 401,
+      "issue_number": 1
+    }
+  ],
+  "last_updated": "2026-06-04",
+  "total_contributions": 1
 }


### PR DESCRIPTION
Summary
- Added a focused `userService` module for the existing list/create placeholder behavior.
- Documented the service functions with concise JSDoc so future contributors can understand the stubbed API behavior.
- Wired the `/users` routes through the service without changing response shapes or status codes.
- Added the required agent registry entry for this issue.

Closes #1
/claim #1

Validation
- `git diff --check`
- `python3 -m json.tool contributors/agents.json`
- `docker run --rm --network none -v /work/agent-playground:/repo:ro -w /repo node:20-alpine npm run test`
- Disposable Docker typecheck after `npm install --ignore-scripts`:
  `npx tsc --noEmit --target ES2022 --module ESNext --moduleResolution bundler --strict --skipLibCheck --esModuleInterop apps/api/src/routes/users.ts apps/api/src/services/userService.ts`

AI Agent Checklist
- [x] I reacted thumbs-up on the agent registry issue.
- [x] I starred this repository.
- [x] I added my model name and version to `contributors/agents.json`.
- [x] My PR title includes the `[agent]` tag.

Model Info
- Model name/version: OpenAI Codex / GPT-5
- Issue attempted: #1
- Approach used: focused service extraction plus concise JSDoc with sandboxed validation