### PR TITLE
[agent] feat: add exact PI prefix package

### DIFF
--- a/contributors/agents.json
+++ b/contributors/agents.json
@@ -1,5 +1,13 @@
 {
-  "agents": [],
-  "last_updated": "2026-06-03",
-  "total_contributions": 0
+  "agents": [
+    {
+      "github_username": "tudorian95",
+      "model": "OpenAI Codex",
+      "version": "GPT-5",
+      "pr_number": 402,
+      "issue_number": 17
+    }
+  ],
+  "last_updated": "2026-06-04",
+  "total_contributions": 1
 }

--- a/packages/pi-prefix/README.md
+++ b/packages/pi-prefix/README.md
@@ -1,0 +1,19 @@
+# @taskflow/pi-prefix
+
+Computes exact finite decimal prefixes of PI with dependency-free BigInt
+integer arithmetic.
+
+PI has no final decimal point, so a finite program cannot emit the entire
+infinite expansion. This package provides the practical piece: exact prefixes
+to a requested number of decimal places.
+
+```sh
+npm run demo -w @taskflow/pi-prefix
+```
+
+```js
+import { calculatePi } from "@taskflow/pi-prefix";
+
+console.log(calculatePi(25));
+// 3.1415926535897932384626433
+```

--- a/packages/pi-prefix/package.json
+++ b/packages/pi-prefix/package.json
@@ -1,0 +1,16 @@
+{
+  "name": "@taskflow/pi-prefix",
+  "version": "0.1.0",
+  "private": true,
+  "description": "Exact finite decimal prefixes of PI using BigInt integer arithmetic.",
+  "type": "module",
+  "main": "src/index.js",
+  "exports": "./src/index.js",
+  "bin": {
+    "taskflow-pi": "src/cli.js"
+  },
+  "scripts": {
+    "demo": "node src/cli.js 100",
+    "test": "node --test src/index.test.js"
+  }
+}

--- a/packages/pi-prefix/src/cli.js
+++ b/packages/pi-prefix/src/cli.js
@@ -1,0 +1,13 @@
+#!/usr/bin/env node
+
+import { calculatePi } from "./index.js";
+
+const requestedDigits = process.argv[2] ?? "100";
+const decimalPlaces = Number(requestedDigits);
+
+try {
+  console.log(calculatePi(decimalPlaces));
+} catch (error) {
+  console.error(error instanceof Error ? error.message : String(error));
+  process.exitCode = 1;
+}

--- a/packages/pi-prefix/src/index.js
+++ b/packages/pi-prefix/src/index.js
@@ -1,0 +1,73 @@
+const DEFAULT_GUARD_DIGITS = 20;
+
+export const KNOWN_PI_100 =
+  "3.1415926535897932384626433832795028841971693993751058209749445923078164062862089986280348253421170679";
+
+function assertDecimalPlaces(decimalPlaces) {
+  if (!Number.isSafeInteger(decimalPlaces)) {
+    throw new TypeError("decimalPlaces must be a safe integer.");
+  }
+
+  if (decimalPlaces < 0) {
+    throw new RangeError("decimalPlaces must be greater than or equal to 0.");
+  }
+}
+
+function pow10(exponent) {
+  return 10n ** BigInt(exponent);
+}
+
+function arctanInverse(invX, scale) {
+  const x = BigInt(invX);
+  const xSquared = x * x;
+  let numerator = scale / x;
+  let sum = numerator;
+  let sign = -1n;
+
+  for (let termIndex = 1n; numerator !== 0n; termIndex += 1n) {
+    numerator /= xSquared;
+    const term = numerator / (2n * termIndex + 1n);
+
+    if (term === 0n) {
+      break;
+    }
+
+    sum += sign * term;
+    sign = -sign;
+  }
+
+  return sum;
+}
+
+function formatScaledPi(scaledPi, decimalPlaces) {
+  if (decimalPlaces === 0) {
+    return scaledPi.toString();
+  }
+
+  const padded = scaledPi.toString().padStart(decimalPlaces + 1, "0");
+  const integerPart = padded.slice(0, -decimalPlaces);
+  const fractionalPart = padded.slice(-decimalPlaces);
+  return `${integerPart}.${fractionalPart}`;
+}
+
+export function calculatePi(decimalPlaces = 100, options = {}) {
+  assertDecimalPlaces(decimalPlaces);
+
+  const guardDigits = options.guardDigits ?? DEFAULT_GUARD_DIGITS;
+  assertDecimalPlaces(guardDigits);
+
+  const workingScale = pow10(decimalPlaces + guardDigits);
+  const scaledWithGuard =
+    16n * arctanInverse(5, workingScale) -
+    4n * arctanInverse(239, workingScale);
+  const scaledPi = scaledWithGuard / pow10(guardDigits);
+
+  return formatScaledPi(scaledPi, decimalPlaces);
+}
+
+export function calculatePiDigits(decimalPlaces = 100, options = {}) {
+  const pi = calculatePi(decimalPlaces, options);
+  const decimalPoint = pi.indexOf(".");
+
+  return decimalPoint === -1 ? "" : pi.slice(decimalPoint + 1);
+}

--- a/packages/pi-prefix/src/index.test.js
+++ b/packages/pi-prefix/src/index.test.js
@@ -1,0 +1,27 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import {
+  calculatePi,
+  calculatePiDigits,
+  KNOWN_PI_100
+} from "./index.js";
+
+test("calculates the known 100 decimal place PI prefix", () => {
+  assert.equal(calculatePi(100), KNOWN_PI_100);
+});
+
+test("returns only the integer part when zero decimal places are requested", () => {
+  assert.equal(calculatePi(0), "3");
+  assert.equal(calculatePiDigits(0), "");
+});
+
+test("longer results preserve shorter exact prefixes", () => {
+  assert.ok(calculatePi(120).startsWith(KNOWN_PI_100));
+});
+
+test("validates requested precision", () => {
+  assert.throws(() => calculatePi(-1), RangeError);
+  assert.throws(() => calculatePi(1.5), TypeError);
+  assert.throws(() => calculatePi(Number.MAX_SAFE_INTEGER + 1), TypeError);
+});


### PR DESCRIPTION
Summary
- Added a dependency-free `@taskflow/pi-prefix` workspace package that computes exact finite decimal prefixes of PI with BigInt integer arithmetic.
- Included a CLI/demo command for printing a requested prefix.
- Documented why PI has no final decimal point while supporting exact finite prefixes on demand.
- Added Node tests for the known 100-digit prefix, longer-prefix consistency, zero-decimal output, and input validation.
- Added the required agent registry entry for this issue.

Closes #17
/claim #17

Validation
- `git diff --check`
- `python3 -m json.tool contributors/agents.json`
- `python3 -m json.tool packages/pi-prefix/package.json`
- `docker run --rm --network none -v /work/agent-playground:/repo:ro -w /repo node:20-alpine npm run test`
- `docker run --rm --network none -v /work/agent-playground:/repo:ro -w /repo node:20-alpine npm run demo -w @taskflow/pi-prefix`

Demo output
```text
3.1415926535897932384626433832795028841971693993751058209749445923078164062862089986280348253421170679
```

AI Agent Checklist
- [x] I reacted thumbs-up on the agent registry issue.
- [x] I starred this repository.
- [x] I added my model name and version to `contributors/agents.json`.
- [x] My PR title includes the `[agent]` tag.

Model Info
- Model name/version: OpenAI Codex / GPT-5
- Issue attempted: #17
- Approach used: dependency-free BigInt PI prefix package with sandboxed no-network validation