### PR TITLE
[agent] Add deterministic PI prefix utility

### DIFF
--- a/contributors/agents.json
+++ b/contributors/agents.json
@@ -1,5 +1,13 @@
 {
-  "agents": [],
-  "last_updated": "2026-06-03",
-  "total_contributions": 0
+  "agents": [
+    {
+      "github_username": "bozicovichsantiago20-oss",
+      "model": "GPT-5 Codex",
+      "version": "2026-06-04",
+      "pr_number": 444,
+      "issue_number": 17
+    }
+  ],
+  "last_updated": "2026-06-04",
+  "total_contributions": 1
 }

--- a/packages/pi/README.md
+++ b/packages/pi/README.md
@@ -1,0 +1,22 @@
+# TaskFlow PI Utility
+
+This package provides a deterministic PI prefix calculator for the internal
+engineering playground challenge.
+
+PI has no final decimal point, so a finite program cannot print the complete
+decimal expansion. The useful engineering target is an exact finite prefix:
+given `n`, calculate the first `n` digits after the decimal point with integer
+arithmetic and reproducible validation.
+
+## Usage
+
+```sh
+npm run demo -w @taskflow/pi -- 100
+```
+
+## Validation
+
+```sh
+npm test -w @taskflow/pi
+```
+

--- a/packages/pi/package.json
+++ b/packages/pi/package.json
@@ -1,0 +1,20 @@
+{
+  "name": "@taskflow/pi",
+  "version": "0.1.0",
+  "private": true,
+  "description": "Deterministic PI prefix utility for TaskFlow engineering challenges.",
+  "type": "module",
+  "main": "src/index.ts",
+  "exports": {
+    ".": "./src/index.ts"
+  },
+  "scripts": {
+    "demo": "tsx src/cli.ts 120",
+    "test": "tsx --test src/index.test.ts",
+    "lint": "echo \"No PI lint configured yet\""
+  },
+  "devDependencies": {
+    "tsx": "^4.22.4",
+    "typescript": "^5.4.5"
+  }
+}

--- a/packages/pi/src/cli.ts
+++ b/packages/pi/src/cli.ts
@@ -1,0 +1,6 @@
+import { calculatePiPrefix, explainPiLimit } from "./index.js";
+
+const requestedDigits = Number.parseInt(process.argv[2] ?? "100", 10);
+
+console.log(explainPiLimit());
+console.log(calculatePiPrefix(requestedDigits));

--- a/packages/pi/src/index.test.ts
+++ b/packages/pi/src/index.test.ts
@@ -1,0 +1,41 @@
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+import { calculatePiPrefix, explainPiLimit, integerSqrt } from "./index.js";
+
+const PI_100 =
+  "3.1415926535897932384626433832795028841971693993751058209749445923078164062862089986280348253421170679";
+
+describe("calculatePiPrefix", () => {
+  it("returns only the integer part when no decimal places are requested", () => {
+    assert.equal(calculatePiPrefix(0), "3");
+  });
+
+  it("calculates known finite decimal prefixes", () => {
+    assert.equal(calculatePiPrefix(10), "3.1415926535");
+    assert.equal(calculatePiPrefix(50), PI_100.slice(0, 52));
+    assert.equal(calculatePiPrefix(100), PI_100);
+  });
+
+  it("rejects unsupported precision inputs", () => {
+    assert.throws(() => calculatePiPrefix(-1), RangeError);
+    assert.throws(() => calculatePiPrefix(1.5), RangeError);
+    assert.throws(() => calculatePiPrefix(10001), RangeError);
+  });
+});
+
+describe("integerSqrt", () => {
+  it("returns the floored square root for bigint values", () => {
+    assert.equal(integerSqrt(0n), 0n);
+    assert.equal(integerSqrt(1n), 1n);
+    assert.equal(integerSqrt(2n), 1n);
+    assert.equal(integerSqrt(10_000n), 100n);
+    assert.equal(integerSqrt(10_001n), 100n);
+  });
+});
+
+describe("explainPiLimit", () => {
+  it("documents why a finite implementation returns prefixes", () => {
+    assert.match(explainPiLimit(), /no final decimal point/i);
+    assert.match(explainPiLimit(), /finite decimal prefixes/i);
+  });
+});

--- a/packages/pi/src/index.ts
+++ b/packages/pi/src/index.ts
@@ -1,0 +1,113 @@
+const CHUDNOVSKY_C = 640320n;
+const CHUDNOVSKY_C3_OVER_24 = (CHUDNOVSKY_C ** 3n) / 24n;
+const DIGITS_PER_TERM = 14;
+const DEFAULT_GUARD_DIGITS = 10;
+const DEFAULT_MAX_DECIMAL_PLACES = 10000;
+
+export interface PiPrefixOptions {
+  guardDigits?: number;
+  maxDecimalPlaces?: number;
+}
+
+interface SplitResult {
+  p: bigint;
+  q: bigint;
+  t: bigint;
+}
+
+export function calculatePiPrefix(decimalPlaces = 100, options: PiPrefixOptions = {}): string {
+  const guardDigits = options.guardDigits ?? DEFAULT_GUARD_DIGITS;
+  const maxDecimalPlaces = options.maxDecimalPlaces ?? DEFAULT_MAX_DECIMAL_PLACES;
+
+  assertSafeNonNegativeInteger(decimalPlaces, "decimalPlaces");
+  assertSafeNonNegativeInteger(guardDigits, "guardDigits");
+
+  if (decimalPlaces > maxDecimalPlaces) {
+    throw new RangeError(`decimalPlaces must be <= ${maxDecimalPlaces}`);
+  }
+
+  const workingDigits = decimalPlaces + guardDigits;
+  const termCount = Math.ceil(workingDigits / DIGITS_PER_TERM) + 2;
+  const scale = pow10(workingDigits);
+  const { q, t } = binarySplit(0, termCount);
+  const sqrt = integerSqrt(10005n * scale * scale);
+  let scaledPi = (426880n * sqrt * q) / t;
+
+  if (guardDigits > 0) {
+    scaledPi /= pow10(guardDigits);
+  }
+
+  return formatScaledDecimal(scaledPi, decimalPlaces);
+}
+
+export function explainPiLimit(): string {
+  return "PI is irrational, so it has no final decimal point. This utility computes exact finite decimal prefixes with BigInt integer arithmetic.";
+}
+
+export function integerSqrt(value: bigint): bigint {
+  if (value < 0n) {
+    throw new RangeError("integerSqrt requires a non-negative bigint");
+  }
+
+  if (value < 2n) {
+    return value;
+  }
+
+  let x0 = value;
+  let x1 = (x0 + value / x0) >> 1n;
+
+  while (x1 < x0) {
+    x0 = x1;
+    x1 = (x1 + value / x1) >> 1n;
+  }
+
+  return x0;
+}
+
+function binarySplit(a: number, b: number): SplitResult {
+  if (b - a === 1) {
+    if (a === 0) {
+      return { p: 1n, q: 1n, t: 13591409n };
+    }
+
+    const k = BigInt(a);
+    const p = (6n * k - 5n) * (2n * k - 1n) * (6n * k - 1n);
+    const q = k ** 3n * CHUDNOVSKY_C3_OVER_24;
+    let t = p * (13591409n + 545140134n * k);
+
+    if (a % 2 === 1) {
+      t = -t;
+    }
+
+    return { p, q, t };
+  }
+
+  const mid = Math.floor((a + b) / 2);
+  const left = binarySplit(a, mid);
+  const right = binarySplit(mid, b);
+
+  return {
+    p: left.p * right.p,
+    q: left.q * right.q,
+    t: left.t * right.q + left.p * right.t
+  };
+}
+
+function formatScaledDecimal(value: bigint, decimalPlaces: number): string {
+  if (decimalPlaces === 0) {
+    return value.toString();
+  }
+
+  const raw = value.toString().padStart(decimalPlaces + 1, "0");
+  return `${raw.slice(0, -decimalPlaces)}.${raw.slice(-decimalPlaces)}`;
+}
+
+function pow10(exponent: number): bigint {
+  return 10n ** BigInt(exponent);
+}
+
+function assertSafeNonNegativeInteger(value: number, name: string): void {
+  if (!Number.isSafeInteger(value) || value < 0) {
+    throw new RangeError(`${name} must be a non-negative safe integer`);
+  }
+}


### PR DESCRIPTION
## Summary

Adds a focused PI utility package that calculates exact finite decimal prefixes with BigInt integer arithmetic.

Closes #17

/claim #17

## Why this shape

PI has no final decimal point, so a finite program cannot emit the complete decimal expansion. This implementation makes the useful engineering target explicit: deterministic finite prefixes for any requested precision within the configured limit.

## Changes Made

- Added `@taskflow/pi` under `packages/pi`.
- Implemented a Chudnovsky binary-splitting calculator using BigInt only.
- Added a CLI/demo command for printing requested decimal places.
- Added Node tests for known prefixes, invalid input handling, integer square root behavior, and the finite-prefix explanation.
- Added the required AI agent metadata entry.

## AI Agent Checklist

- [x] I reacted thumbs-up on issue #16 (Agent Registry)
- [x] I starred this repository
- [x] I added my model name and version to `contributors/agents.json`
- [x] My PR title includes the `[agent]` tag

## Model Info (AI agents only)

- Model name/version: GPT-5 Codex, 2026-06-04
- Issue attempted: #17
- Approach used: Implemented exact finite PI prefixes with Chudnovsky binary splitting and BigInt validation.

## Validation

- `node node_modules/tsx/dist/cli.mjs --test packages/pi/src/index.test.ts` -> 5 passed
- `node node_modules/tsx/dist/cli.mjs packages/pi/src/cli.ts 120` -> printed a 120-decimal-place prefix
- `node node_modules/typescript/bin/tsc --noEmit --module NodeNext --moduleResolution NodeNext --target ES2022 --strict packages/pi/src/index.ts packages/pi/src/cli.ts packages/pi/src/index.test.ts --skipLibCheck`
- `git diff --check`

## Demo

```text
PI is irrational, so it has no final decimal point. This utility computes exact finite decimal prefixes with BigInt integer arithmetic.
3.141592653589793238462643383279502884197169399375105820974944592307816406286208998628034825342117067982148086513282306647
```