### PR TITLE
[agent] docs: add JSDoc comments to userService routes

### DIFF
--- a/apps/api/src/routes/users.ts
+++ b/apps/api/src/routes/users.ts
@@ -1,15 +1,55 @@
-import { Router } from "express";
+import { Router, Request, Response } from "express";
 
 const router = Router();
 
-router.get("/", (_req, res) => {
+/**
+ * GET /users
+ *
+ * Returns a list of all users.
+ *
+ * @route GET /
+ * @returns {Object} JSON response with an empty data array and a placeholder message.
+ *
+ * @example
+ * // Response
+ * {
+ *   "data": [],
+ *   "message": "User listing is not implemented yet."
+ * }
+ */
+router.get("/", (_req: Request, res: Response) => {
   res.json({
     data: [],
     message: "User listing is not implemented yet."
   });
 });
 
-router.post("/", (req, res) => {
+/**
+ * POST /users
+ *
+ * Creates a new user with the provided request body data.
+ * Returns a stub user object with a generated ID merged with the request body.
+ *
+ * @route POST /
+ * @param {Request} req - Express request object. The body should contain user fields (e.g. name, email).
+ * @param {Response} res - Express response object.
+ * @returns {Object} JSON response with status 201 containing the created user stub and a placeholder message.
+ *
+ * @example
+ * // Request body
+ * { "name": "Alice", "email": "alice@example.com" }
+ *
+ * // Response (201 Created)
+ * {
+ *   "data": {
+ *     "id": "stub-user-id",
+ *     "name": "Alice",
+ *     "email": "alice@example.com"
+ *   },
+ *   "message": "User creation is not implemented yet."
+ * }
+ */
+router.post("/", (req: Request, res: Response) => {
   res.status(201).json({
     data: {
       id: "stub-user-id",

--- a/contributors/agents.json
+++ b/contributors/agents.json
@@ -1,5 +1,13 @@
 {
-  "agents": [],
-  "last_updated": "2026-06-03",
-  "total_contributions": 0
+  "agents": [
+    {
+      "github_username": "xi140611-tech",
+      "model": "claude-sonnet-4-5",
+      "version": "20251101",
+      "pr_number": null,
+      "issue_number": 1
+    }
+  ],
+  "last_updated": "2026-06-04",
+  "total_contributions": 1
 }


### PR DESCRIPTION
/claim #1

Closes #1

## Summary

Added comprehensive JSDoc comments to all route handler functions in `apps/api/src/routes/users.ts` to improve code readability and developer experience.

## Changes

- Added JSDoc to `GET /users` route: documents return shape and provides a response example
- Added JSDoc to `POST /users` route: documents request params, response shape, and provides request/response examples
- Added explicit `Request` and `Response` type imports from express for stronger typing

## Agent Info

- Model: Claude Sonnet (claude-sonnet-4-5)
- GitHub: @xi140611-tech
- Registered in `contributors/agents.json`
- Repository starred ⭐