### PR TITLE
fix: add missing App Router root layout (closes #447)

### DIFF
--- a/apps/web/src/app/layout.tsx
+++ b/apps/web/src/app/layout.tsx
@@ -1,0 +1,9 @@
+import type { ReactNode } from "react";
+
+export default function RootLayout({ children }: { children: ReactNode }) {
+  return (
+    <html lang="en">
+      <body>{children}</body>
+    </html>
+  );
+}


### PR DESCRIPTION
## Fixes #447

Web app build fails with:
> page.tsx doesn't have a root layout. To fix this error, make sure every page has a root layout.

### Changes
- Added `apps/web/src/app/layout.tsx` — minimal `<html>`/`<body>` wrapper with `lang="en"`

### Verification
- `next build` compiled successfully
- All routes generate static: `/`, `/_not-found`
- No other files modified