### PR TITLE
[agent] docs: improve Prisma schema comments

### DIFF
--- a/contributors/agents.json
+++ b/contributors/agents.json
@@ -1,5 +1,13 @@
 {
-  "agents": [],
-  "last_updated": "2026-06-03",
-  "total_contributions": 0
+  "agents": [
+    {
+      "github_username": "xi140611-tech",
+      "model": "claude-sonnet-4-5",
+      "version": "20251101",
+      "pr_number": 452,
+      "issue_number": 5
+    }
+  ],
+  "last_updated": "2026-06-04",
+  "total_contributions": 1
 }

--- a/packages/db/prisma/schema.prisma
+++ b/packages/db/prisma/schema.prisma
@@ -1,43 +1,76 @@
+/// Prisma client generator — produces the TypeScript client used throughout the API.
 generator client {
   provider = "prisma-client-js"
 }
 
+/// Primary database connection. Reads the connection string from the DATABASE_URL environment variable.
 datasource db {
   provider = "postgresql"
   url      = env("DATABASE_URL")
 }
 
+/// Represents a registered user on the platform.
+/// A user can own multiple jobs and submit proposals on other jobs.
 model User {
+  /// Unique identifier (cuid).
   id        String     @id @default(cuid())
+  /// User's email address — must be unique across the platform.
   email     String     @unique
+  /// Optional display name.
   name      String?
+  /// Jobs posted by this user.
   jobs      Job[]
+  /// Proposals submitted by this user.
   proposals Proposal[]
+  /// Timestamp when the record was created.
   createdAt DateTime   @default(now())
+  /// Timestamp when the record was last updated.
   updatedAt DateTime   @updatedAt
 }
 
+/// Represents a job posting created by a user.
+/// Jobs can receive multiple proposals from other users.
 model Job {
+  /// Unique identifier (cuid).
   id          String     @id @default(cuid())
+  /// Short title describing the job.
   title       String
+  /// Optional detailed description of the job requirements.
   description String?
+  /// Current status of the job. Defaults to "draft". Common values: "draft", "open", "closed".
   status      String     @default("draft")
+  /// Foreign key referencing the user who owns this job.
   ownerId     String
+  /// The user who posted this job.
   owner       User       @relation(fields: [ownerId], references: [id])
+  /// Proposals submitted for this job.
   proposals   Proposal[]
+  /// Timestamp when the record was created.
   createdAt   DateTime   @default(now())
+  /// Timestamp when the record was last updated.
   updatedAt   DateTime   @updatedAt
 }
 
+/// Represents a proposal submitted by a user in response to a job posting.
 model Proposal {
+  /// Unique identifier (cuid).
   id        String   @id @default(cuid())
+  /// Short summary of the proposal.
   summary   String
+  /// Optional proposed amount for the job.
   amount    Decimal?
+  /// Current status of the proposal. Defaults to "pending". Common values: "pending", "accepted", "rejected".
   status    String   @default("pending")
+  /// Foreign key referencing the user who submitted this proposal.
   userId    String
+  /// The user who submitted this proposal.
   user      User     @relation(fields: [userId], references: [id])
+  /// Foreign key referencing the job this proposal is for.
   jobId     String
+  /// The job this proposal is associated with.
   job       Job      @relation(fields: [jobId], references: [id])
+  /// Timestamp when the record was created.
   createdAt DateTime @default(now())
+  /// Timestamp when the record was last updated.
   updatedAt DateTime @updatedAt
 }


### PR DESCRIPTION
/claim #5

Closes #5

## Summary

Added comprehensive inline comments to all models and fields in `packages/db/prisma/schema.prisma` to help contributors understand the data model at a glance.

## Changes

- Added `///` doc comments to `generator`, `datasource`, and all three models (`User`, `Job`, `Proposal`)
- Documented every field with its purpose, default value semantics, and common enum values where applicable

## Demo

**Before** — schema with no comments, field purposes unclear

**After** — every model and field documented inline, e.g. status fields now show common values like "draft", "open", "closed"

## Agent Info

- Model: Claude Sonnet (claude-sonnet-4-5)
- GitHub: @xi140611-tech