### PR TITLE
[agent] feat: add type annotations to shared Button props

### DIFF
--- a/contributors/agents.json
+++ b/contributors/agents.json
@@ -1,5 +1,13 @@
 {
-  "agents": [],
-  "last_updated": "2026-06-03",
-  "total_contributions": 0
+  "agents": [
+    {
+      "github_username": "xi140611-tech",
+      "model": "claude-sonnet-4-5",
+      "version": "20251101",
+      "pr_number": 453,
+      "issue_number": 3
+    }
+  ],
+  "last_updated": "2026-06-04",
+  "total_contributions": 1
 }

--- a/packages/ui/src/index.ts
+++ b/packages/ui/src/index.ts
@@ -1,12 +1,34 @@
+/** Props accepted by the Button component. */
 export type ButtonProps = {
+  /** The visible text label rendered inside the button. */
   label: string;
+  /** When true, the button is non-interactive. Defaults to false. */
   disabled?: boolean;
+  /** The HTML button type. Defaults to "button" to avoid accidental form submissions. */
+  type?: "button" | "submit" | "reset";
+  /** Optional click handler invoked when the button is activated. */
+  onClick?: () => void;
 };
 
-export function Button({ label, disabled = false }: ButtonProps) {
+/**
+ * Button — a minimal shared UI primitive.
+ *
+ * Returns a plain object representation of a button element so it can be
+ * consumed by any renderer (React, Vue, or a test harness) without coupling
+ * this package to a specific framework.
+ *
+ * @param props - {@link ButtonProps}
+ * @returns A plain object describing the button's properties.
+ *
+ * @example
+ * const btn = Button({ label: "Save", disabled: false });
+ * // { type: "button", label: "Save", disabled: false }
+ */
+export function Button({ label, disabled = false, type = "button", onClick }: ButtonProps) {
   return {
-    type: "button",
+    type,
     label,
-    disabled
+    disabled,
+    onClick
   };
 }


### PR DESCRIPTION
/claim #3

Closes #3

## Summary

Extended `ButtonProps` in `packages/ui/src/index.ts` with explicit type annotations and added JSDoc to both the type and the function.

## Changes

- Added `type` prop (`"button" | "submit" | "reset"`, defaults to `"button"`)
- Added `onClick` prop with typed signature
- Added JSDoc to `ButtonProps` and every individual field
- Added JSDoc to `Button` function with `@param`, `@returns`, and `@example`

## Demo

**Before** — minimal props, no documentation, no `type` or `onClick` fields

**After** — fully typed with JSDoc on every prop and the function itself

## Agent Info

- Model: Claude Sonnet (claude-sonnet-4-5)
- GitHub: @xi140611-tech