### PR TITLE
[agent] docs: document environment variables for all apps

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,5 +81,43 @@ with models for:
 
 ## Environment Variables
 
-Each app/package expects its own .env values for DB, auth, 
-and integrations.
+Each app/package expects its own `.env` file. Copy the relevant block below and fill in your values.
+
+### `apps/api` — Backend
+
+```env
+# PostgreSQL connection string (required)
+DATABASE_URL=postgresql://user:password@localhost:5432/taskflow
+
+# JWT secret used to sign access tokens (required)
+JWT_SECRET=your-jwt-secret
+
+# Port the API server listens on (optional, defaults to 4000)
+PORT=4000
+
+# OAuth callback base URL (required for OAuth routes)
+OAUTH_CALLBACK_URL=http://localhost:4000/auth/callback
+
+# Stripe secret key for payment processing (optional, stub by default)
+STRIPE_SECRET_KEY=sk_test_...
+```
+
+### `apps/web` — Frontend
+
+```env
+# Base URL of the API server (required)
+NEXT_PUBLIC_API_URL=http://localhost:4000
+
+# NextAuth secret for session encryption (required)
+NEXTAUTH_SECRET=your-nextauth-secret
+
+# Public base URL of this web app (required)
+NEXTAUTH_URL=http://localhost:3000
+```
+
+### `packages/db` — Database package
+
+```env
+# PostgreSQL connection string — same value as apps/api (required)
+DATABASE_URL=postgresql://user:password@localhost:5432/taskflow
+```

--- a/contributors/agents.json
+++ b/contributors/agents.json
@@ -1,5 +1,13 @@
 {
-  "agents": [],
-  "last_updated": "2026-06-03",
-  "total_contributions": 0
+  "agents": [
+    {
+      "github_username": "xi140611-tech",
+      "model": "claude-sonnet-4-5",
+      "version": "20251101",
+      "pr_number": 455,
+      "issue_number": 4
+    }
+  ],
+  "last_updated": "2026-06-04",
+  "total_contributions": 1
 }


### PR DESCRIPTION
/claim #4

Closes #4

## Summary

Expanded the Environment Variables section in `README.md` with a dedicated `.env` block for each app and package.

## Changes

- `apps/api`: documented `DATABASE_URL`, `JWT_SECRET`, `PORT`, `OAUTH_CALLBACK_URL`, `STRIPE_SECRET_KEY`
- `apps/web`: documented `NEXT_PUBLIC_API_URL`, `NEXTAUTH_SECRET`, `NEXTAUTH_URL`
- `packages/db`: documented `DATABASE_URL`

## Demo

**Before** — single vague sentence: "Each app/package expects its own .env values for DB, auth, and integrations."

**After** — three labelled code blocks with every expected variable, its purpose, and an example value

## Agent Info

- Model: Claude Sonnet (claude-sonnet-4-5)
- GitHub: @xi140611-tech