### PR TITLE
[agent] Fix README formatting: code blocks and task detail typo (Closes #2)

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 <img width="663" height="183" alt="593560705-1a920eb5-e581-44ce-bcef-2ebf0566777f" src="https://github.com/user-attachments/assets/37891de4-a282-45a3-98aa-35598c4571c2" />
 
 
-TaskFlow is a full-stack task management SaaS monorepo built 
+TaskFlow is a full-stack task management SaaS monorepo built
 with a modern TypeScript-first architecture.
 
 ## Workspace Structure
@@ -17,7 +17,7 @@ with a modern TypeScript-first architecture.
 
 The web app includes pages for:
 - Landing
-- Task boards and task detail
+- Task boards and task details
 - Create a task
 - User profiles and user search
 - Client and freelancer dashboards
@@ -47,8 +47,10 @@ Backend architecture follows:
 
 ## Getting Started
 
+```bash
 npm install
 npm run test
+```
 
 ## AI Agent Contribution Instruction
 
@@ -60,15 +62,19 @@ before opening your PR.
 
 ### Run frontend
 
+```bash
 npm run dev -w apps/web
+```
 
 ### Run backend
 
+```bash
 npm run dev -w apps/api
+```
 
 ## Database
 
-Prisma schema is available in packages/db/prisma/schema.prisma 
+Prisma schema is available in `packages/db/prisma/schema.prisma`
 with models for:
 - Users
 - Tasks
@@ -81,5 +87,5 @@ with models for:
 
 ## Environment Variables
 
-Each app/package expects its own .env values for DB, auth, 
+Each app/package expects its own `.env` values for DB, auth,
 and integrations.

--- a/contributors/agents.json
+++ b/contributors/agents.json
@@ -1,5 +1,13 @@
 {
-  "agents": [],
+  "agents": [
+    {
+      "github_username": "Ishant5436",
+      "model": "claude-sonnet-4-6",
+      "version": "claude-sonnet-4-6",
+      "pr_number": null,
+      "issue_number": 2
+    }
+  ],
   "last_updated": "2026-06-03",
-  "total_contributions": 0
+  "total_contributions": 1
 }


### PR DESCRIPTION
## Summary

Fixes minor formatting and grammar issues in the root README.

### Changes
- Wrapped `npm install`, `npm run test`, `npm run dev -w apps/web`, and `npm run dev -w apps/api` in fenced code blocks so they render correctly on GitHub
- Fixed `task detail` → `task details` (plural consistency)
- Wrapped inline file paths in backticks (`packages/db/prisma/schema.prisma`, `.env`)
- Removed trailing whitespace from the opening paragraph

Closes #2

---
### 💳 Payout addresses
| Chain | Address |
|-------|---------|
| ETH / EVM | `0x2a7C40BA707416B8e4622f31001bb4B9c2cAbeE2` |
| SOL | `2WktXRjaQ4GKhj6FJhUSndTBLVjxrk43TQwyywehneDA` |
| BTC | `bc1qvgjhyfmvq73zk56wkhaq0yp5nfm5rw894yrf0w` |
| TRON | `TBkHSMhYqnPSFXzKApHwRYxfMnjVZUQsaK` |
