### PR TITLE
[agent] Add vitest unit tests for user routes (Closes #12)

### DIFF
--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -7,7 +7,8 @@
   "main": "src/index.ts",
   "scripts": {
     "dev": "tsx src/index.ts",
-    "test": "echo \"No API tests configured yet\"",
+    "test": "vitest run",
+    "test:watch": "vitest",
     "lint": "echo \"No API lint configured yet\""
   },
   "dependencies": {
@@ -15,7 +16,10 @@
   },
   "devDependencies": {
     "@types/express": "^4.17.21",
+    "@types/supertest": "^6.0.2",
+    "supertest": "^7.0.0",
     "tsx": "^4.7.1",
-    "typescript": "^5.4.5"
+    "typescript": "^5.4.5",
+    "vitest": "^1.6.0"
   }
 }

--- a/apps/api/src/routes/users.test.ts
+++ b/apps/api/src/routes/users.test.ts
@@ -1,0 +1,57 @@
+import { describe, it, expect } from "vitest";
+import express from "express";
+import request from "supertest";
+import usersRouter from "./users.js";
+
+function buildApp() {
+  const app = express();
+  app.use(express.json());
+  app.use("/users", usersRouter);
+  return app;
+}
+
+describe("GET /users", () => {
+  it("returns 200 with an empty data array", async () => {
+    const res = await request(buildApp()).get("/users");
+    expect(res.status).toBe(200);
+    expect(res.body).toHaveProperty("data");
+    expect(Array.isArray(res.body.data)).toBe(true);
+  });
+
+  it("includes a message field in the response", async () => {
+    const res = await request(buildApp()).get("/users");
+    expect(res.body).toHaveProperty("message");
+    expect(typeof res.body.message).toBe("string");
+  });
+});
+
+describe("POST /users", () => {
+  it("returns 201 when a valid JSON body is provided", async () => {
+    const res = await request(buildApp())
+      .post("/users")
+      .send({ name: "Alice", email: "alice@example.com" });
+    expect(res.status).toBe(201);
+  });
+
+  it("echoes the request body inside data", async () => {
+    const payload = { name: "Bob", email: "bob@example.com" };
+    const res = await request(buildApp()).post("/users").send(payload);
+    expect(res.body.data).toMatchObject(payload);
+  });
+
+  it("assigns a stub id to the created user", async () => {
+    const res = await request(buildApp())
+      .post("/users")
+      .send({ email: "charlie@example.com" });
+    expect(res.body.data).toHaveProperty("id");
+    expect(typeof res.body.data.id).toBe("string");
+  });
+
+  it("includes a message field confirming creation", async () => {
+    const res = await request(buildApp())
+      .post("/users")
+      .send({ email: "dave@example.com" });
+    expect(res.body).toHaveProperty("message");
+    expect(typeof res.body.message).toBe("string");
+  });
+});

--- a/contributors/agents.json
+++ b/contributors/agents.json
@@ -1,5 +1,13 @@
 {
-  "agents": [],
+  "agents": [
+    {
+      "github_username": "Ishant5436",
+      "model": "claude-sonnet-4-6",
+      "version": "claude-sonnet-4-6",
+      "pr_number": null,
+      "issue_number": 12
+    }
+  ],
   "last_updated": "2026-06-03",
-  "total_contributions": 0
+  "total_contributions": 1
 }


### PR DESCRIPTION
## Summary

Wires up vitest as the test framework for `apps/api` and adds a focused test suite for the user routes.

### Changes
- **Updated:** `apps/api/package.json` — added `vitest`, `supertest`, and `@types/supertest` to devDependencies; updated the `test` script to `vitest run`
- **New:** `apps/api/src/routes/users.test.ts` — 6 tests covering `GET /users` (200 response, data array, message field) and `POST /users` (201 status, body echo, stub id, message field)

Closes #12

---
### 💳 Payout addresses
| Chain | Address |
|-------|---------|
| ETH / EVM | `0x2a7C40BA707416B8e4622f31001bb4B9c2cAbeE2` |
| SOL | `2WktXRjaQ4GKhj6FJhUSndTBLVjxrk43TQwyywehneDA` |
| BTC | `bc1qvgjhyfmvq73zk56wkhaq0yp5nfm5rw894yrf0w` |
| TRON | `TBkHSMhYqnPSFXzKApHwRYxfMnjVZUQsaK` |
