### PR TITLE
feat(api): add request body size limit

### DIFF
--- a/apps/api/src/index.ts
+++ b/apps/api/src/index.ts
@@ -8,7 +8,14 @@ const port = process.env.PORT || 4000;
 app.use(express.json());
 
 app.get("/health", (_req, res) => {
-  res.json({ status: "ok", service: "taskflow-api" });
+  res.json({
+    status: "ok",
+    data: {
+      service: "taskflow-api",
+      uptime: process.uptime(),
+      timestamp: new Date().toISOString(),
+    },
+  });
 });
 
 app.use("/users", usersRouter);

--- a/apps/api/src/index.ts
+++ b/apps/api/src/index.ts
@@ -5,17 +5,22 @@ import usersRouter from "./routes/users";
 const app = express();
 const port = process.env.PORT || 4000;
 
-app.use(express.json());
+app.use(express.json({ limit: "1mb" }));
+
+// Handle payload too large errors
+app.use((err: any, _req: express.Request, res: express.Response, next: express.NextFunction) => {
+  if (err.type === "entity.too.large") {
+    res.status(413).json({
+      error: "Payload too large",
+      message: "Request body must not exceed 1mb",
+    });
+    return;
+  }
+  next(err);
+});
 
 app.get("/health", (_req, res) => {
-  res.json({
-    status: "ok",
-    data: {
-      service: "taskflow-api",
-      uptime: process.uptime(),
-      timestamp: new Date().toISOString(),
-    },
-  });
+  res.json({ status: "ok", service: "taskflow-api" });
 });
 
 app.use("/users", usersRouter);


### PR DESCRIPTION
Configure a conservative JSON body size limit in the Express app.

## Changes
- Set `express.json({ limit: "1mb" })` as a conservative default for JSON request bodies
- Added error handler middleware that returns HTTP 413 with a descriptive error message when the limit is exceeded
- The 1mb limit prevents oversized payloads from consuming excessive server memory

## Behavior
- Requests with body ≤ 1mb: processed normally
- Requests with body > 1mb: `413 Payload too large` with JSON error response

## Example Error Response
```json
{
  "error": "Payload too large",
  "message": "Request body must not exceed 1mb"
}
```

Closes #9