### PR TITLE
[agent] test: add unit tests for Button stub (Closes #13)

### DIFF
--- a/contributors/agents.json
+++ b/contributors/agents.json
@@ -1,5 +1,13 @@
 {
-  "agents": [],
+  "agents": [
+    {
+      "github_username": "YOUR_USERNAME",
+      "model": "DeepSeek V4 Pro",
+      "version": "2026",
+      "pr_number": 0,
+      "issue_number": 13
+    }
+  ],
   "last_updated": "2026-06-03",
   "total_contributions": 0
 }

--- a/contributors/agents.json
+++ b/contributors/agents.json
@@ -1,7 +1,7 @@
 {
   "agents": [
     {
-      "github_username": "YOUR_USERNAME",
+      "github_username": "2891593122",
       "model": "DeepSeek V4 Pro",
       "version": "2026",
       "pr_number": 0,

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -5,10 +5,11 @@
   "description": "Shared UI components for TaskFlow.",
   "main": "src/index.ts",
   "scripts": {
-    "test": "echo \"No UI tests configured yet\"",
+    "test": "vitest run",
     "lint": "echo \"No UI lint configured yet\""
   },
   "devDependencies": {
-    "typescript": "^5.4.5"
+    "typescript": "^5.4.5",
+    "vitest": "^1.6.0"
   }
 }

--- a/packages/ui/src/__tests__/button.test.ts
+++ b/packages/ui/src/__tests__/button.test.ts
@@ -1,0 +1,28 @@
+import { describe, it, expect } from "vitest";
+import { Button } from "../index";
+
+describe("Button", () => {
+  it("returns a button object with the correct label", () => {
+    const result = Button({ label: "Click me" });
+    expect(result).toEqual({
+      type: "button",
+      label: "Click me",
+      disabled: false,
+    });
+  });
+
+  it("sets disabled to false by default", () => {
+    const result = Button({ label: "Submit" });
+    expect(result.disabled).toBe(false);
+  });
+
+  it("sets disabled to true when explicitly passed", () => {
+    const result = Button({ label: "Submit", disabled: true });
+    expect(result.disabled).toBe(true);
+  });
+
+  it("preserves the type field as 'button'", () => {
+    const result = Button({ label: "Save" });
+    expect(result.type).toBe("button");
+  });
+});


### PR DESCRIPTION
## Summary

Add unit tests for the shared Button stub component covering label and disabled values.

## Changes

- Added vitest as dev dependency to \packages/ui\
- Created \packages/ui/src/__tests__/button.test.ts\ with 4 tests:
  - Returns correct button object with label
  - Default disabled is false
  - Explicit disabled=true works
  - Preserves type field

Closes #13

/bounty "