### PR TITLE
[agent] test: add unit tests for user routes (Closes #12)

### DIFF
--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -7,7 +7,7 @@
   "main": "src/index.ts",
   "scripts": {
     "dev": "tsx src/index.ts",
-    "test": "echo \"No API tests configured yet\"",
+    "test": "vitest run",
     "lint": "echo \"No API lint configured yet\""
   },
   "dependencies": {
@@ -16,6 +16,9 @@
   "devDependencies": {
     "@types/express": "^4.17.21",
     "tsx": "^4.7.1",
-    "typescript": "^5.4.5"
+    "typescript": "^5.4.5",
+    "vitest": "^1.6.0",
+    "supertest": "^7.0.0",
+    "@types/supertest": "^6.0.2"
   }
 }

--- a/apps/api/src/__tests__/users.test.ts
+++ b/apps/api/src/__tests__/users.test.ts
@@ -1,0 +1,45 @@
+import { describe, it, expect, beforeAll, afterAll } from "vitest";
+import request from "supertest";
+import express from "express";
+import usersRouter from "../routes/users";
+
+const app = express();
+app.use(express.json());
+app.use("/users", usersRouter);
+
+describe("User Routes", () => {
+  describe("GET /users", () => {
+    it("returns 200 with an empty data array", async () => {
+      const res = await request(app).get("/users");
+      expect(res.status).toBe(200);
+      expect(res.body).toEqual({
+        data: [],
+        message: "User listing is not implemented yet.",
+      });
+    });
+
+    it("returns JSON content type", async () => {
+      const res = await request(app).get("/users");
+      expect(res.headers["content-type"]).toMatch(/json/);
+    });
+  });
+
+  describe("POST /users", () => {
+    it("returns 201 with the posted body and a stub id", async () => {
+      const res = await request(app)
+        .post("/users")
+        .send({ name: "Alice", email: "alice@example.com" });
+      expect(res.status).toBe(201);
+      expect(res.body.data).toMatchObject({
+        id: "stub-user-id",
+        name: "Alice",
+        email: "alice@example.com",
+      });
+    });
+
+    it("includes a not-implemented message", async () => {
+      const res = await request(app).post("/users").send({});
+      expect(res.body.message).toBe("User creation is not implemented yet.");
+    });
+  });
+});

--- a/contributors/agents.json
+++ b/contributors/agents.json
@@ -1,5 +1,13 @@
 {
-  "agents": [],
+  "agents": [
+    {
+      "github_username": "YOUR_USERNAME",
+      "model": "DeepSeek V4 Pro",
+      "version": "2026",
+      "pr_number": 0,
+      "issue_number": 13
+    }
+  ],
   "last_updated": "2026-06-03",
   "total_contributions": 0
 }

--- a/contributors/agents.json
+++ b/contributors/agents.json
@@ -1,7 +1,7 @@
 {
   "agents": [
     {
-      "github_username": "YOUR_USERNAME",
+      "github_username": "2891593122",
       "model": "DeepSeek V4 Pro",
       "version": "2026",
       "pr_number": 0,


### PR DESCRIPTION
## Summary

Add basic tests for the Express user route stubs covering list and create behavior.

## Changes

- Added vitest and supertest as dev dependencies to \pps/api\
- Created \pps/api/src/__tests__/users.test.ts\ with 4 tests:
  - GET /users returns 200 with empty data array
  - GET /users returns JSON content type
  - POST /users returns 201 with posted body and stub id
  - POST /users includes not-implemented message

Closes #12

/bounty "