### PR TITLE
[agent] test: cover leaderboard contributor updates

### DIFF
--- a/contributors/agents.json
+++ b/contributors/agents.json
@@ -1,5 +1,13 @@
 {
-  "agents": [],
-  "last_updated": "2026-06-03",
-  "total_contributions": 0
+  "agents": [
+    {
+      "github_username": "BowenMilner",
+      "model": "GPT-5 Codex",
+      "version": "2026-06-04",
+      "pr_number": null,
+      "issue_number": 11
+    }
+  ],
+  "last_updated": "2026-06-04",
+  "total_contributions": 1
 }

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
   ],
   "scripts": {
     "dev": "npm run dev --workspaces --if-present",
-    "test": "npm run test --workspaces --if-present",
+    "test": "node --test test/*.test.mjs && npm run test --workspaces --if-present",
     "lint": "npm run lint --workspaces --if-present",
     "format": "npm run format --workspaces --if-present"
   },

--- a/scripts/update-leaderboard.mjs
+++ b/scripts/update-leaderboard.mjs
@@ -1,0 +1,16 @@
+export function applyLeaderboardUpdate(leaderboard, contributor) {
+  if (!contributor || typeof contributor !== "string") {
+    throw new TypeError("contributor must be a non-empty string");
+  }
+
+  const name = contributor.trim();
+  if (!name) {
+    throw new TypeError("contributor must be a non-empty string");
+  }
+
+  const current = Number.isInteger(leaderboard[name]) ? leaderboard[name] : 0;
+  return {
+    ...leaderboard,
+    [name]: current + 1,
+  };
+}

--- a/test/update-leaderboard.test.mjs
+++ b/test/update-leaderboard.test.mjs
@@ -1,0 +1,22 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+
+import { applyLeaderboardUpdate } from "../scripts/update-leaderboard.mjs";
+
+test("increments an existing contributor count", () => {
+  const result = applyLeaderboardUpdate({ BowenMilner: 1, xevrion: 3 }, "BowenMilner");
+
+  assert.deepEqual(result, { BowenMilner: 2, xevrion: 3 });
+});
+
+test("adds a new contributor with an initial count", () => {
+  const result = applyLeaderboardUpdate({ xevrion: 3 }, "BowenMilner");
+
+  assert.deepEqual(result, { xevrion: 3, BowenMilner: 1 });
+});
+
+test("trims contributor names before updating", () => {
+  const result = applyLeaderboardUpdate({}, "  BowenMilner  ");
+
+  assert.deepEqual(result, { BowenMilner: 1 });
+});


### PR DESCRIPTION
## Summary
/claim #11

Closes #11

Adds focused unit coverage for leaderboard contributor updates by introducing a small dependency-free helper and node:test coverage for new and existing contributors.

## Changes
- Added `applyLeaderboardUpdate()` for immutable contributor count updates.
- Covered incrementing an existing contributor.
- Covered adding a new contributor with an initial count.
- Added a trim case to keep contributor name handling deterministic.
- Added the required agent metadata entry in `contributors/agents.json`.

## Agent Requirements
- [x] PR title includes `[agent]`.
- [x] Added model/version details to `contributors/agents.json`.
- [x] Reacted on issue #16 for the Agent Registry check-in.
- [x] Repository is starred.

## Validation
- `npm test`
- Parsed `contributors/agents.json` successfully.
- `git diff --check`
