### PR TITLE
[agent] feat: add lightweight pi estimator

### DIFF
--- a/contributors/agents.json
+++ b/contributors/agents.json
@@ -1,5 +1,13 @@
 {
-  "agents": [],
-  "last_updated": "2026-06-03",
-  "total_contributions": 0
+  "agents": [
+    {
+      "github_username": "BowenMilner",
+      "model": "GPT-5 Codex",
+      "version": "2026-06-05",
+      "pr_number": null,
+      "issue_number": 14
+    }
+  ],
+  "last_updated": "2026-06-05",
+  "total_contributions": 1
 }

--- a/packages/math/README.md
+++ b/packages/math/README.md
@@ -1,0 +1,19 @@
+# TaskFlow Math Utilities
+
+This package contains small dependency-free algorithm examples.
+
+## PI Estimation
+
+`estimatePi()` uses the Nilakantha series:
+
+```text
+3 + 4/(2*3*4) - 4/(4*5*6) + 4/(6*7*8) ...
+```
+
+The approach is intentionally lightweight and readable. It is not the fastest way to compute PI, but it demonstrates a converging algorithm and includes tests that show accuracy improves as more terms are used.
+
+```js
+import { formatPiEstimate } from "@taskflow/math";
+
+console.log(formatPiEstimate(1000, 5)); // 3.14159
+```

--- a/packages/math/package.json
+++ b/packages/math/package.json
@@ -1,0 +1,11 @@
+{
+  "name": "@taskflow/math",
+  "version": "0.1.0",
+  "private": true,
+  "description": "Lightweight math and algorithm utilities for TaskFlow examples.",
+  "type": "module",
+  "main": "src/pi.js",
+  "scripts": {
+    "test": "node --test test/*.test.js"
+  }
+}

--- a/packages/math/src/pi.js
+++ b/packages/math/src/pi.js
@@ -1,0 +1,43 @@
+/**
+ * Estimate PI with the Nilakantha series.
+ *
+ * The series starts at 3 and alternates fractions:
+ *   3 + 4/(2*3*4) - 4/(4*5*6) + 4/(6*7*8) ...
+ *
+ * It is slower than production-grade algorithms such as Chudnovsky, but it is
+ * compact, dependency-free, and useful as a readable algorithm challenge.
+ *
+ * @param {number} terms number of Nilakantha correction terms to apply
+ * @returns {number} PI estimate
+ */
+export function estimatePi(terms = 1000) {
+  if (!Number.isInteger(terms) || terms < 0) {
+    throw new RangeError("terms must be a non-negative integer");
+  }
+
+  let estimate = 3;
+  let sign = 1;
+
+  for (let index = 0; index < terms; index += 1) {
+    const first = 2 + index * 2;
+    estimate += sign * (4 / (first * (first + 1) * (first + 2)));
+    sign *= -1;
+  }
+
+  return estimate;
+}
+
+/**
+ * Return a fixed-width decimal string for an estimated PI value.
+ *
+ * @param {number} terms number of Nilakantha correction terms to apply
+ * @param {number} digits digits after the decimal point
+ * @returns {string} formatted PI estimate
+ */
+export function formatPiEstimate(terms = 1000, digits = 10) {
+  if (!Number.isInteger(digits) || digits < 0 || digits > 100) {
+    throw new RangeError("digits must be an integer between 0 and 100");
+  }
+
+  return estimatePi(terms).toFixed(digits);
+}

--- a/packages/math/test/pi.test.js
+++ b/packages/math/test/pi.test.js
@@ -1,0 +1,25 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+
+import { estimatePi, formatPiEstimate } from "../src/pi.js";
+
+test("returns the initial Nilakantha value with zero correction terms", () => {
+  assert.equal(estimatePi(0), 3);
+});
+
+test("improves PI accuracy as more terms are used", () => {
+  const coarseError = Math.abs(Math.PI - estimatePi(1));
+  const refinedError = Math.abs(Math.PI - estimatePi(1000));
+
+  assert.ok(refinedError < coarseError);
+  assert.ok(refinedError < 0.000001);
+});
+
+test("formats the estimated PI value with a fixed decimal width", () => {
+  assert.equal(formatPiEstimate(1000, 5), "3.14159");
+});
+
+test("rejects invalid term counts", () => {
+  assert.throws(() => estimatePi(-1), /terms must be a non-negative integer/);
+  assert.throws(() => estimatePi(1.5), /terms must be a non-negative integer/);
+});


### PR DESCRIPTION
## Summary
/claim #14

Closes #14

Adds a lightweight dependency-free PI estimation challenge using the Nilakantha series, with documentation and focused tests.

## Changes
- Added a new `@taskflow/math` workspace package.
- Added `estimatePi()` using the Nilakantha series.
- Added `formatPiEstimate()` for fixed-width decimal output.
- Documented the chosen approach in `packages/math/README.md`.
- Added tests for the initial value, improving accuracy, formatting, and invalid input.
- Added the required agent metadata entry in `contributors/agents.json`.

## Agent Requirements
- [x] PR title includes `[agent]`.
- [x] Added model/version details to `contributors/agents.json`.
- [x] Reacted on issue #16 for the Agent Registry check-in.
- [x] Repository is starred.

## Validation
- `npm test --workspace @taskflow/math`
- `npm test`
- Parsed `contributors/agents.json` successfully.
- `git diff --check`
