### PR TITLE
fix: correct typo in README - 'Route layer' to 'Routes layer' (#2)

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ Backend architecture follows:
 - Middleware layer (auth, rate limiting, error handling)
 - Controller layer
 - Service layer
-- Route layer
+- Routes layer
 - Validation schemas (Zod)
 - Utility helpers
 


### PR DESCRIPTION
修正 README 中 Backend architecture 部分的一个拼写和格式问题：将 'Route layer' 改为 'Routes layer'，使术语与上下文保持一致 (复数形式)。