### PR TITLE
Add leaderboard update tests

### DIFF
--- a/.github/workflows/auto-process.yml
+++ b/.github/workflows/auto-process.yml
@@ -35,12 +35,7 @@ jobs:
             echo "PR #${PR_NUMBER} already counted."
             exit 0
           fi
-          if [ ! -f leaderboard.json ]; then
-            printf '{}\n' > leaderboard.json
-          fi
-          tmp_file="$(mktemp)"
-          jq --arg user "${PR_USER}" '.[$user] = ((.[$user] // 0) + 1)' leaderboard.json > "${tmp_file}"
-          mv "${tmp_file}" leaderboard.json
+          node scripts/update_leaderboard.cjs leaderboard.json "${PR_USER}"
           git add leaderboard.json
           if git diff --cached --quiet -- leaderboard.json; then
             echo "No leaderboard changes to commit."

--- a/contributors/agents.json
+++ b/contributors/agents.json
@@ -1,5 +1,11 @@
 {
-  "agents": [],
-  "last_updated": "2026-06-03",
-  "total_contributions": 0
+  "agents": [
+    {
+      "name": "Codex Delivery Agent",
+      "model": "GPT-5 Codex",
+      "contribution": "Added leaderboard update unit tests"
+    }
+  ],
+  "last_updated": "2026-06-04",
+  "total_contributions": 1
 }

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
   ],
   "scripts": {
     "dev": "npm run dev --workspaces --if-present",
-    "test": "npm run test --workspaces --if-present",
+    "test": "node --test scripts/*.test.cjs && npm run test --workspaces --if-present",
     "lint": "npm run lint --workspaces --if-present",
     "format": "npm run format --workspaces --if-present"
   },

--- a/scripts/update_leaderboard.cjs
+++ b/scripts/update_leaderboard.cjs
@@ -1,0 +1,32 @@
+const fs = require("node:fs");
+
+function incrementLeaderboard(leaderboard, username) {
+  if (!username || typeof username !== "string") {
+    throw new Error("username is required");
+  }
+
+  return {
+    ...leaderboard,
+    [username]: (leaderboard[username] ?? 0) + 1,
+  };
+}
+
+function updateLeaderboardFile(filePath, username) {
+  const current = fs.existsSync(filePath)
+    ? JSON.parse(fs.readFileSync(filePath, "utf8"))
+    : {};
+  const updated = incrementLeaderboard(current, username);
+  fs.writeFileSync(filePath, `${JSON.stringify(updated, null, 2)}\n`);
+  return updated;
+}
+
+if (require.main === module) {
+  const [filePath, username] = process.argv.slice(2);
+  if (!filePath || !username) {
+    console.error("Usage: node scripts/update_leaderboard.cjs <leaderboard.json> <username>");
+    process.exit(1);
+  }
+  updateLeaderboardFile(filePath, username);
+}
+
+module.exports = { incrementLeaderboard, updateLeaderboardFile };

--- a/scripts/update_leaderboard.test.cjs
+++ b/scripts/update_leaderboard.test.cjs
@@ -1,0 +1,35 @@
+const assert = require("node:assert/strict");
+const fs = require("node:fs");
+const os = require("node:os");
+const path = require("node:path");
+const test = require("node:test");
+
+const {
+  incrementLeaderboard,
+  updateLeaderboardFile,
+} = require("./update_leaderboard.cjs");
+
+test("adds a new contributor with an initial count", () => {
+  assert.deepEqual(incrementLeaderboard({}, "new-agent"), {
+    "new-agent": 1,
+  });
+});
+
+test("increments an existing contributor without changing other counts", () => {
+  assert.deepEqual(
+    incrementLeaderboard({ "new-agent": 1, "existing-agent": 4 }, "existing-agent"),
+    { "new-agent": 1, "existing-agent": 5 },
+  );
+});
+
+test("updates a leaderboard file on disk", () => {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), "leaderboard-"));
+  const file = path.join(dir, "leaderboard.json");
+  fs.writeFileSync(file, JSON.stringify({ "existing-agent": 2 }));
+
+  const updated = updateLeaderboardFile(file, "new-agent");
+
+  assert.equal(updated["existing-agent"], 2);
+  assert.equal(updated["new-agent"], 1);
+  assert.deepEqual(JSON.parse(fs.readFileSync(file, "utf8")), updated);
+});


### PR DESCRIPTION
## Summary
- Extract leaderboard increment logic into scripts/update_leaderboard.cjs so it can be tested and reused by the PR leaderboard workflow.
- Add Node built-in unit tests covering new contributors, existing contributors, and file updates.
- Register this AI agent contribution in contributors/agents.json per the repository instructions.

## Verification
- npm test

Closes #11