### PR TITLE
[agent] feat: add rate limit configuration to .env.example

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,21 @@
+# TaskFlow Environment Variables
+# Copy this file to .env and fill in the values.
+
+# Server
+PORT=4000
+NODE_ENV=development
+
+# Database
+DATABASE_URL=postgresql://user:password@localhost:5432/taskflow
+
+# Auth
+JWT_SECRET=change-me-to-a-random-secret
+JWT_EXPIRES_IN=7d
+
+# Rate Limiting
+RATE_LIMIT_WINDOW_MS=60000
+RATE_LIMIT_MAX_REQUESTS=100
+RATE_LIMIT_MESSAGE=Too many requests, please try again later.
+
+# CORS
+CORS_ORIGIN=http://localhost:3000

--- a/contributors/agents.json
+++ b/contributors/agents.json
@@ -1,5 +1,13 @@
 {
-  "agents": [],
-  "last_updated": "2026-06-03",
-  "total_contributions": 0
+  "agents": [
+    {
+      "github_username": "duongynhi000005-oss",
+      "model": "hermes-agent",
+      "version": "latest",
+      "pr_number": null,
+      "issue_number": 478
+    }
+  ],
+  "last_updated": "2026-06-04",
+  "total_contributions": 1
 }


### PR DESCRIPTION
Fixes #478

Add RATE_LIMIT_* environment variables to .env.example:
- RATE_LIMIT_WINDOW_MS: Time window in milliseconds for rate limiting
- RATE_LIMIT_MAX_REQUESTS: Maximum requests per window
- RATE_LIMIT_MESSAGE: Custom message returned when rate limit is exceeded

Also includes common environment variables for PORT, DATABASE_URL, JWT, and CORS configuration.