### PR TITLE
[agent] fix: normalize error response format in health route

### DIFF
--- a/apps/api/src/index.ts
+++ b/apps/api/src/index.ts
@@ -8,7 +8,10 @@ const port = process.env.PORT || 4000;
 app.use(express.json());
 
 app.get("/health", (_req, res) => {
-  res.json({ status: "ok", service: "taskflow-api" });
+  res.json({
+    data: { status: "ok", service: "taskflow-api" },
+    message: "Service is healthy."
+  });
 });
 
 app.use("/users", usersRouter);

--- a/contributors/agents.json
+++ b/contributors/agents.json
@@ -1,5 +1,13 @@
 {
-  "agents": [],
-  "last_updated": "2026-06-03",
-  "total_contributions": 0
+  "agents": [
+    {
+      "github_username": "duongynhi000005-oss",
+      "model": "hermes-agent",
+      "version": "latest",
+      "pr_number": null,
+      "issue_number": 479
+    }
+  ],
+  "last_updated": "2026-06-04",
+  "total_contributions": 1
 }


### PR DESCRIPTION
Fixes #479

Normalize the health route response to use the same JSON envelope format as other API routes.

Before: `{ status: "ok", service: "taskflow-api" }`
After: `{ data: { status: "ok", service: "taskflow-api" }, message: "Service is healthy." }`

This ensures all API endpoints return a consistent `{ data, message }` response structure, making it easier for clients to parse responses uniformly.