### PR TITLE
[agent] Add pagination to user list endpoint

### DIFF
--- a/apps/api/src/routes/users.ts
+++ b/apps/api/src/routes/users.ts
@@ -1,21 +1,48 @@
-import { Router } from "express";
+import { Router, Request, Response } from "express";
 
 const router = Router();
 
-router.get("/", (_req, res) => {
+/**
+ * GET /users?page=1&limit=20
+ *
+ * Returns a paginated user list. Query parameters:
+ * - page:  page number (default 1, minimum 1)
+ * - limit: items per page (default 20, min 1, max 100)
+ */
+router.get("/", (req: Request, res: Response) => {
+  const page = Math.max(1, parseInt(req.query.page as string, 10) || 1);
+  const limit = Math.min(
+    100,
+    Math.max(1, parseInt(req.query.limit as string, 10) || 20),
+  );
+  const offset = (page - 1) * limit;
+
+  // Placeholder data — in production this would query the database
+  const totalItems = 0;
+  const totalPages = Math.ceil(totalItems / limit) || 1;
+
   res.json({
     data: [],
-    message: "User listing is not implemented yet."
+    pagination: {
+      page,
+      limit,
+      offset,
+      totalItems,
+      totalPages,
+      hasNextPage: page < totalPages,
+      hasPreviousPage: page > 1,
+    },
+    message: "User listing is not implemented yet.",
   });
 });
 
-router.post("/", (req, res) => {
+router.post("/", (req: Request, res: Response) => {
   res.status(201).json({
     data: {
       id: "stub-user-id",
-      ...req.body
+      ...req.body,
     },
-    message: "User creation is not implemented yet."
+    message: "User creation is not implemented yet.",
   });
 });
 

--- a/contributors/agents.json
+++ b/contributors/agents.json
@@ -1,5 +1,13 @@
 {
-  "agents": [],
-  "last_updated": "2026-06-03",
-  "total_contributions": 0
+  "agents": [
+    {
+      "github_username": "duongynhi000005-oss",
+      "model": "hermes-agent",
+      "version": "latest",
+      "pr_number": null,
+      "issue_number": 483
+    }
+  ],
+  "last_updated": "2026-06-04",
+  "total_contributions": 1
 }


### PR DESCRIPTION
## Summary

Add pagination support to the `GET /users` endpoint with query parameters:
- `page` — page number (default 1, minimum 1)
- `limit` — items per page (default 20, minimum 1, maximum 100)

Response includes a `pagination` object with:
- `page`, `limit`, `offset`
- `totalItems`, `totalPages`
- `hasNextPage`, `hasPreviousPage`

## Changes Made

- `apps/api/src/routes/users.ts` — Add pagination query params and response metadata
- `contributors/agents.json` — Agent registration

## Model Info (AI agents only)
- Model name/version: hermes-agent
- Issue attempted: #483
- Approach used: Query parameter parsing with bounds clamping and pagination metadata

Closes #483