### PR TITLE
[agent] Add request logging middleware

### DIFF
--- a/apps/api/src/index.ts
+++ b/apps/api/src/index.ts
@@ -1,11 +1,13 @@
 import express from "express";
 
+import { requestLogger } from "./middleware/logger";
 import usersRouter from "./routes/users";
 
 const app = express();
 const port = process.env.PORT || 4000;
 
 app.use(express.json());
+app.use(requestLogger);
 
 app.get("/health", (_req, res) => {
   res.json({ status: "ok", service: "taskflow-api" });

--- a/apps/api/src/middleware/logger.ts
+++ b/apps/api/src/middleware/logger.ts
@@ -1,0 +1,22 @@
+import { Request, Response, NextFunction } from "express";
+
+/**
+ * Request logging middleware.
+ * Logs method, URL, status code, and response time for every request.
+ */
+export function requestLogger(req: Request, res: Response, next: NextFunction) {
+  const start = Date.now();
+
+  res.on("finish", () => {
+    const duration = Date.now() - start;
+    const timestamp = new Date().toISOString();
+    const { method, originalUrl } = req;
+    const { statusCode } = res;
+
+    console.log(
+      `[${timestamp}] ${method} ${originalUrl} ${statusCode} - ${duration}ms`
+    );
+  });
+
+  next();
+}

--- a/contributors/agents.json
+++ b/contributors/agents.json
@@ -1,5 +1,19 @@
 {
-  "agents": [],
-  "last_updated": "2026-06-03",
-  "total_contributions": 0
+  "agents": [
+    {
+      "name": "hermes-agent",
+      "model": "mimo-v2-5-pro",
+      "provider": "xiaomi",
+      "contributions": [
+        {
+          "issue": 484,
+          "pr": null,
+          "description": "Add request logging middleware",
+          "timestamp": "2026-06-04T15:33:00Z"
+        }
+      ]
+    }
+  ],
+  "last_updated": "2026-06-04",
+  "total_contributions": 1
 }


### PR DESCRIPTION
Fixes #484

## Summary
- Add request logging middleware to the Express API
- Logs HTTP method, URL, status code, and response duration for every request
- Register agent contribution in contributors/agents.json

## Changes Made
-  — New request logging middleware
-  — Import and apply logger middleware
-  — Agent registration

## Model Info
- Model: mimo-v2-5-pro (xiaomi)
- Agent: hermes-agent