### PR TITLE
[agent] Add graceful shutdown handler

### DIFF
--- a/apps/api/src/index.ts
+++ b/apps/api/src/index.ts
@@ -13,6 +13,34 @@ app.get("/health", (_req, res) => {
 
 app.use("/users", usersRouter);
 
-app.listen(port, () => {
+const server = app.listen(port, () => {
   console.log(`TaskFlow API listening on port ${port}`);
 });
+
+/**
+ * Graceful shutdown handler.
+ * Handles SIGTERM and SIGINT signals to cleanly close the server
+ * and allow in-flight requests to complete before exiting.
+ */
+function gracefulShutdown(signal: string) {
+  console.log(`\nReceived ${signal}. Starting graceful shutdown...`);
+
+  server.close((err) => {
+    if (err) {
+      console.error("Error during server shutdown:", err);
+      process.exit(1);
+    }
+
+    console.log("Server closed. All connections drained.");
+    process.exit(0);
+  });
+
+  // Force exit after 10 seconds if connections haven't drained
+  setTimeout(() => {
+    console.error("Forced shutdown after timeout. Exiting.");
+    process.exit(1);
+  }, 10_000).unref();
+}
+
+process.on("SIGTERM", () => gracefulShutdown("SIGTERM"));
+process.on("SIGINT", () => gracefulShutdown("SIGINT"));

--- a/contributors/agents.json
+++ b/contributors/agents.json
@@ -1,5 +1,19 @@
 {
-  "agents": [],
-  "last_updated": "2026-06-03",
-  "total_contributions": 0
+  "agents": [
+    {
+      "name": "hermes-agent",
+      "model": "mimo-v2-5-pro",
+      "provider": "xiaomi",
+      "contributions": [
+        {
+          "issue": 485,
+          "pr": null,
+          "description": "Add graceful shutdown handler",
+          "timestamp": "2026-06-04T15:35:00Z"
+        }
+      ]
+    }
+  ],
+  "last_updated": "2026-06-04",
+  "total_contributions": 1
 }


### PR DESCRIPTION
Fixes #485

## Summary
- Add graceful shutdown handler to the Express API
- Handle SIGTERM and SIGINT signals for clean server shutdown
- Drain in-flight connections before exiting
- Force exit after 10-second timeout to prevent hanging
- Register agent contribution in contributors/agents.json

## Changes Made
- apps/api/src/index.ts - Refactored to capture server instance and add shutdown logic
- contributors/agents.json - Agent registration

## Model Info
- Model: mimo-v2-5-pro (xiaomi)
- Agent: hermes-agent