### PR TITLE
[agent] Add rate limiter middleware

### DIFF
--- a/apps/api/src/index.ts
+++ b/apps/api/src/index.ts
@@ -1,11 +1,13 @@
 import express from "express";
 
+import { rateLimiter } from "./middleware/rateLimiter";
 import usersRouter from "./routes/users";
 
 const app = express();
 const port = process.env.PORT || 4000;
 
 app.use(express.json());
+app.use(rateLimiter());
 
 app.get("/health", (_req, res) => {
   res.json({ status: "ok", service: "taskflow-api" });

--- a/apps/api/src/middleware/rateLimiter.ts
+++ b/apps/api/src/middleware/rateLimiter.ts
@@ -1,0 +1,58 @@
+import { Request, Response, NextFunction } from "express";
+
+interface RateLimitEntry {
+  count: number;
+  resetTime: number;
+}
+
+/**
+ * Simple in-memory rate limiter middleware.
+ *
+ * @param windowMs - Time window in milliseconds (default: 60000 = 1 minute)
+ * @param maxRequests - Maximum requests per window (default: 100)
+ */
+export function rateLimiter(windowMs: number = 60_000, maxRequests: number = 100) {
+  const clients = new Map<string, RateLimitEntry>();
+
+  // Periodically clean up expired entries to prevent memory leaks
+  const cleanupInterval = setInterval(() => {
+    const now = Date.now();
+    for (const [key, entry] of clients) {
+      if (now > entry.resetTime) {
+        clients.delete(key);
+      }
+    }
+  }, windowMs);
+
+  // Allow the cleanup timer to not keep the process alive
+  cleanupInterval.unref();
+
+  return (req: Request, res: Response, next: NextFunction) => {
+    const clientIp = req.ip || req.socket.remoteAddress || "unknown";
+    const now = Date.now();
+
+    let entry = clients.get(clientIp);
+
+    if (!entry || now > entry.resetTime) {
+      entry = { count: 1, resetTime: now + windowMs };
+      clients.set(clientIp, entry);
+    } else {
+      entry.count++;
+    }
+
+    // Set rate limit headers
+    res.setHeader("X-RateLimit-Limit", maxRequests);
+    res.setHeader("X-RateLimit-Remaining", Math.max(0, maxRequests - entry.count));
+    res.setHeader("X-RateLimit-Reset", Math.ceil(entry.resetTime / 1000));
+
+    if (entry.count > maxRequests) {
+      res.setHeader("Retry-After", Math.ceil((entry.resetTime - now) / 1000));
+      return res.status(429).json({
+        error: "Too many requests",
+        message: `Rate limit exceeded. Try again in ${Math.ceil((entry.resetTime - now) / 1000)} seconds.`,
+      });
+    }
+
+    next();
+  };
+}

--- a/contributors/agents.json
+++ b/contributors/agents.json
@@ -1,5 +1,19 @@
 {
-  "agents": [],
-  "last_updated": "2026-06-03",
-  "total_contributions": 0
+  "agents": [
+    {
+      "name": "hermes-agent",
+      "model": "mimo-v2-5-pro",
+      "provider": "xiaomi",
+      "contributions": [
+        {
+          "issue": 490,
+          "pr": null,
+          "description": "Add rate limiter middleware",
+          "timestamp": "2026-06-04T15:37:00Z"
+        }
+      ]
+    }
+  ],
+  "last_updated": "2026-06-04",
+  "total_contributions": 1
 }


### PR DESCRIPTION
Fixes #490

## Summary
- Add in-memory rate limiter middleware to the Express API
- Configurable time window and maximum requests per window
- Returns 429 status with Retry-After header when limit exceeded
- Sets X-RateLimit-Limit, X-RateLimit-Remaining, and X-RateLimit-Reset headers
- Includes automatic cleanup of expired entries to prevent memory leaks
- Register agent contribution in contributors/agents.json

## Changes Made
- apps/api/src/middleware/rateLimiter.ts - New rate limiter middleware
- apps/api/src/index.ts - Import and apply rate limiter globally
- contributors/agents.json - Agent registration

## Model Info
- Model: mimo-v2-5-pro (xiaomi)
- Agent: hermes-agent