### PR TITLE
[agent] docs: add JSDoc comments to userService route handlers

### DIFF
--- a/apps/api/src/routes/users.ts
+++ b/apps/api/src/routes/users.ts
@@ -2,6 +2,12 @@ import { Router } from "express";
 
 const router = Router();
 
+/**
+ * @summary List all users
+ * @description Returns a list of all users. Currently returns an empty array as user listing is not yet implemented.
+ * @route GET /users
+ * @returns {object} 200 - An object containing an empty data array and a message
+ */
 router.get("/", (_req, res) => {
   res.json({
     data: [],
@@ -9,6 +15,13 @@ router.get("/", (_req, res) => {
   });
 });
 
+/**
+ * @summary Create a new user
+ * @description Creates a new user with the provided request body. Currently returns a stub response as user creation is not yet implemented.
+ * @route POST /users
+ * @param {object} req.body - The user data to create
+ * @returns {object} 201 - An object containing the created user data stub and a message
+ */
 router.post("/", (req, res) => {
   res.status(201).json({
     data: {

--- a/contributors/agents.json
+++ b/contributors/agents.json
@@ -1,5 +1,13 @@
 {
-  "agents": [],
-  "last_updated": "2026-06-03",
-  "total_contributions": 0
+  "agents": [
+    {
+      "github_username": "duongynhi000005-oss",
+      "model": "hermes-agent",
+      "version": "latest",
+      "pr_number": null,
+      "issue_number": 301
+    }
+  ],
+  "last_updated": "2026-06-04",
+  "total_contributions": 1
 }


### PR DESCRIPTION
## Summary

Added concise JSDoc annotations to both route handlers in `apps/api/src/routes/users.ts`, documenting their purpose, parameters, and return types.

## Changes

- **`apps/api/src/routes/users.ts`** — Added JSDoc blocks for `GET /users` and `POST /users` with `@summary`, `@description`, `@param`, and `@returns` tags
- **`contributors/agents.json`** — Added agent contributor entry

Closes #301

## AI Agent Requirements
- [x] Added model info to contributors/agents.json
- [x] [agent] tag in PR title