### PR TITLE
[agent] test: add unit tests for user routes (Closes #302)

### DIFF
--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -7,7 +7,8 @@
   "main": "src/index.ts",
   "scripts": {
     "dev": "tsx src/index.ts",
-    "test": "echo \"No API tests configured yet\"",
+    "test": "vitest run",
+    "test:watch": "vitest",
     "lint": "echo \"No API lint configured yet\""
   },
   "dependencies": {
@@ -15,7 +16,10 @@
   },
   "devDependencies": {
     "@types/express": "^4.17.21",
+    "@types/supertest": "^6.0.2",
+    "supertest": "^6.3.4",
     "tsx": "^4.7.1",
-    "typescript": "^5.4.5"
+    "typescript": "^5.4.5",
+    "vitest": "^1.6.0"
   }
 }

--- a/apps/api/src/__tests__/users.test.ts
+++ b/apps/api/src/__tests__/users.test.ts
@@ -1,0 +1,47 @@
+import { describe, it, expect, beforeAll, afterAll } from "vitest";
+import request from "supertest";
+import express from "express";
+import usersRouter from "../routes/users";
+
+const app = express();
+app.use(express.json());
+app.use("/users", usersRouter);
+
+describe("User Routes", () => {
+  describe("GET /users", () => {
+    it("should return 200 with empty data array and not-implemented message", async () => {
+      const res = await request(app).get("/users");
+      expect(res.status).toBe(200);
+      expect(res.body).toHaveProperty("data");
+      expect(Array.isArray(res.body.data)).toBe(true);
+      expect(res.body.data).toHaveLength(0);
+      expect(res.body).toHaveProperty("message");
+      expect(res.body.message).toContain("not implemented");
+    });
+
+    it("should return JSON content type", async () => {
+      const res = await request(app).get("/users");
+      expect(res.headers["content-type"]).toMatch(/json/);
+    });
+  });
+
+  describe("POST /users", () => {
+    it("should return 201 with stub data including request body fields", async () => {
+      const userData = { name: "Test User", email: "test@example.com" };
+      const res = await request(app).post("/users").send(userData);
+      expect(res.status).toBe(201);
+      expect(res.body).toHaveProperty("data");
+      expect(res.body.data).toHaveProperty("id", "stub-user-id");
+      expect(res.body.data).toHaveProperty("name", "Test User");
+      expect(res.body.data).toHaveProperty("email", "test@example.com");
+      expect(res.body).toHaveProperty("message");
+    });
+
+    it("should handle empty body correctly", async () => {
+      const res = await request(app).post("/users").send({});
+      expect(res.status).toBe(201);
+      expect(res.body).toHaveProperty("data");
+      expect(res.body.data).toHaveProperty("id", "stub-user-id");
+    });
+  });
+});

--- a/contributors/agents.json
+++ b/contributors/agents.json
@@ -1,5 +1,13 @@
 {
-  "agents": [],
-  "last_updated": "2026-06-03",
-  "total_contributions": 0
+  "agents": [
+    {
+      "github_username": "duongynhi000005-oss",
+      "model": "hermes-agent",
+      "version": "latest",
+      "pr_number": null,
+      "issue_number": 302
+    }
+  ],
+  "last_updated": "2026-06-04",
+  "total_contributions": 1
 }


### PR DESCRIPTION
## Summary

Adds unit tests for the Express user route stubs covering list (GET) and create (POST) behavior.

## Changes

- apps/api/src/__tests__/users.test.ts - New test file with 4 test cases
- apps/api/package.json - Added vitest, supertest, @types/supertest

Closes #302

## AI Agent Requirements
- [x] Added model info to contributors/agents.json
- [x] [agent] tag in PR title