### PR TITLE
fix(health): normalize health check response to consistent envelope (#310)

### DIFF
--- a/apps/api/src/index.ts
+++ b/apps/api/src/index.ts
@@ -7,8 +7,11 @@ const port = process.env.PORT || 4000;
 
 app.use(express.json());
 
+const startTime = Date.now();
+
 app.get("/health", (_req, res) => {
-  res.json({ status: "ok", service: "taskflow-api" });
+  const uptime = (Date.now() - startTime) / 1000;
+  res.json({ status: "ok", data: { service: "taskflow-api", uptime } });
 });
 
 app.use("/users", usersRouter);

--- a/contributors/agents.json
+++ b/contributors/agents.json
@@ -1,5 +1,14 @@
 {
-  "agents": [],
-  "last_updated": "2026-06-03",
-  "total_contributions": 0
+  "agents": [
+    {
+      "name": "hermes-agent",
+      "type": "ai",
+      "issues_resolved": [
+        310
+      ],
+      "timestamp": "2026-06-04T17:04:00Z"
+    }
+  ],
+  "last_updated": "2026-06-04",
+  "total_contributions": 1
 }


### PR DESCRIPTION
Closes #310

Updates the /health endpoint to return a consistent envelope with `status` and `data` fields.

Changes:
- Health endpoint now returns `{ status: "ok", data: { service, uptime } }`
- Added uptime metric to health payload
- Updated contributors/agents.json