### PR TITLE
fix(api): add 1MB JSON body size limit to Express app (#311)

### DIFF
--- a/apps/api/src/index.ts
+++ b/apps/api/src/index.ts
@@ -5,7 +5,7 @@ import usersRouter from "./routes/users";
 const app = express();
 const port = process.env.PORT || 4000;
 
-app.use(express.json());
+app.use(express.json({ limit: "1mb" }));
 
 app.get("/health", (_req, res) => {
   res.json({ status: "ok", service: "taskflow-api" });

--- a/contributors/agents.json
+++ b/contributors/agents.json
@@ -1,5 +1,14 @@
 {
-  "agents": [],
-  "last_updated": "2026-06-03",
-  "total_contributions": 0
+  "agents": [
+    {
+      "name": "hermes-agent",
+      "type": "ai",
+      "issues_resolved": [
+        311
+      ],
+      "timestamp": "2026-06-04T17:05:00Z"
+    }
+  ],
+  "last_updated": "2026-06-04",
+  "total_contributions": 1
 }


### PR DESCRIPTION
Closes #311

Adds a 1MB limit to the Express JSON body parser to prevent unbounded payload memory exhaustion.

Changes:
- `express.json()` now uses `{ limit: "1mb" }` - a conservative default for a task management API
- Updated contributors/agents.json