### PR TITLE
feat(users): add input validation to POST /users route (#312)

### DIFF
--- a/apps/api/src/routes/users.ts
+++ b/apps/api/src/routes/users.ts
@@ -1,6 +1,20 @@
-import { Router } from "express";
+import { Router, Request, Response, NextFunction } from "express";
 
 const router = Router();
+
+function validateUserData(req: Request, res: Response, next: NextFunction) {
+  const { name, email } = req.body;
+
+  if (!name || typeof name !== "string" || name.trim().length === 0) {
+    return res.status(400).json({ error: "name is required and must be a non-empty string" });
+  }
+
+  if (!email || typeof email !== "string" || !email.includes("@")) {
+    return res.status(400).json({ error: "email is required and must contain @" });
+  }
+
+  next();
+}
 
 router.get("/", (_req, res) => {
   res.json({
@@ -9,7 +23,7 @@ router.get("/", (_req, res) => {
   });
 });
 
-router.post("/", (req, res) => {
+router.post("/", validateUserData, (req, res) => {
   res.status(201).json({
     data: {
       id: "stub-user-id",

--- a/contributors/agents.json
+++ b/contributors/agents.json
@@ -1,5 +1,14 @@
 {
-  "agents": [],
-  "last_updated": "2026-06-03",
-  "total_contributions": 0
+  "agents": [
+    {
+      "name": "hermes-agent",
+      "type": "ai",
+      "issues_resolved": [
+        312
+      ],
+      "timestamp": "2026-06-04T17:06:00Z"
+    }
+  ],
+  "last_updated": "2026-06-04",
+  "total_contributions": 1
 }


### PR DESCRIPTION
Closes #312

Adds input validation middleware to the POST /users route to reject bad input with clear error responses.

Changes:
- Added `validateUserData` middleware:
  - `name` must be a non-empty string
  - `email` must be a string containing `@`
  - Returns 400 with descriptive message on invalid input
- Updated contributors/agents.json