### PR TITLE
[agent] feat: add API error handling helper - Closes #7

### DIFF
--- a/apps/api/src/index.ts
+++ b/apps/api/src/index.ts
@@ -1,6 +1,7 @@
 import express from "express";
 
 import usersRouter from "./routes/users";
+import { errorHandler } from "./utils/errors";
 
 const app = express();
 const port = process.env.PORT || 4000;
@@ -12,6 +13,8 @@ app.get("/health", (_req, res) => {
 });
 
 app.use("/users", usersRouter);
+
+app.use(errorHandler);
 
 app.listen(port, () => {
   console.log(`TaskFlow API listening on port ${port}`);

--- a/apps/api/src/routes/users.ts
+++ b/apps/api/src/routes/users.ts
@@ -1,4 +1,5 @@
-import { Router } from "express";
+import { Router, Request, Response, NextFunction } from "express";
+import { createApiError } from "../utils/errors";
 
 const router = Router();
 
@@ -9,7 +10,10 @@ router.get("/", (_req, res) => {
   });
 });
 
-router.post("/", (req, res) => {
+router.post("/", (req: Request, res: Response, next: NextFunction) => {
+  if (!req.body || Object.keys(req.body).length === 0) {
+    return next(createApiError(400, "Request body is required"));
+  }
   res.status(201).json({
     data: {
       id: "stub-user-id",

--- a/apps/api/src/utils/errors.ts
+++ b/apps/api/src/utils/errors.ts
@@ -1,0 +1,26 @@
+import { Request, Response, NextFunction } from "express";
+
+export interface ApiError extends Error {
+  statusCode: number;
+}
+
+export function createApiError(statusCode: number, message: string): ApiError {
+  const error = new Error(message) as ApiError;
+  error.statusCode = statusCode;
+  return error;
+}
+
+export function errorHandler(
+  err: ApiError,
+  _req: Request,
+  res: Response,
+  _next: NextFunction
+) {
+  const statusCode = err.statusCode || 500;
+  res.status(statusCode).json({
+    error: {
+      status: statusCode,
+      message: err.message || "Internal Server Error",
+    },
+  });
+}

--- a/contributors/agents.json
+++ b/contributors/agents.json
@@ -1,5 +1,13 @@
 {
-  "agents": [],
-  "last_updated": "2026-06-03",
-  "total_contributions": 0
+  "agents": [
+    {
+      "model": "gpt-4o",
+      "version": "2024-06-01",
+      "issue": 320,
+      "pr": "fix/320",
+      "approach": "Created API error handling helper utility with createApiError and centralized error handler middleware. Added empty body validation to POST /users route."
+    }
+  ],
+  "last_updated": "2026-06-04",
+  "total_contributions": 1
 }


### PR DESCRIPTION
## Changes Made
- Created apps/api/src/utils/errors.ts with createApiError utility and centralized errorHandler middleware
- Updated apps/api/src/routes/users.ts to validate empty request body using error helper
- Registered error handler in apps/api/src/index.ts

## Model Info
- Model name: gpt-4o
- Issue attempted: #320
- Approach: Created reusable error utility with consistent error envelope

Closes #7