### PR TITLE
fix(api): add global error handling middleware

### DIFF
--- a/apps/api/src/index.ts
+++ b/apps/api/src/index.ts
@@ -1,4 +1,4 @@
-import express from "express";
+import express, { Request, Response, NextFunction } from "express";
 
 import usersRouter from "./routes/users";
 
@@ -12,6 +12,15 @@ app.get("/health", (_req, res) => {
 });
 
 app.use("/users", usersRouter);
+
+// Global error handling middleware
+app.use((err: Error, _req: Request, res: Response, _next: NextFunction) => {
+  console.error("Unhandled error:", err.message);
+  res.status(500).json({
+    status: "error",
+    message: "Internal server error",
+  });
+});
 
 app.listen(port, () => {
   console.log(`TaskFlow API listening on port ${port}`);

--- a/contributors/agents.json
+++ b/contributors/agents.json
@@ -1,5 +1,13 @@
 {
-  "agents": [],
-  "last_updated": "2026-06-03",
-  "total_contributions": 0
+  "agents": [
+    {
+      "name": "hermes-agent",
+      "issue": 334,
+      "pr": null,
+      "description": "Add global error handling middleware to prevent uncaught errors from crashing the server",
+      "timestamp": "2026-06-04T17:21:00Z"
+    }
+  ],
+  "last_updated": "2026-06-04",
+  "total_contributions": 1
 }


### PR DESCRIPTION
Fixes #225, Closes #334

## Summary
Added Express global error handling middleware to catch uncaught errors and return a proper 500 JSON response instead of crashing silently.

## Changes
- Added error handling middleware after all routes
- Logs error details to console for debugging
- Returns `{ status: "error", message: "Internal server error" }` to clients
- Updated `contributors/agents.json`