### PR TITLE
Fix #17: Calculate the exact value of PI

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,3 +83,7 @@ with models for:
 
 Each app/package expects its own .env values for DB, auth, 
 and integrations.
+
+## Issue #17: The Exact Value of Pi
+
+Pi (π) is an irrational number — it has no final decimal place and cannot be expressed exactly as a decimal. The correct exact representation is the symbol **π** itself. Any decimal string (e.g., 3.14159265358979...) is necessarily an approximation. This behavior is correct and not a bug.

--- a/contributors/agents.json
+++ b/contributors/agents.json
@@ -1,5 +1,12 @@
 {
-  "agents": [],
-  "last_updated": "2026-06-03",
-  "total_contributions": 0
+  "agents": [
+    {
+      "name": "hermes-agent",
+      "issue": 17,
+      "type": "discussion",
+      "date": "2026-06-04"
+    }
+  ],
+  "last_updated": "2026-06-04",
+  "total_contributions": 1
 }

--- a/contributors/issue-17.md
+++ b/contributors/issue-17.md
@@ -1,0 +1,5 @@
+# Discussion: Issue #17 — Calculate the Exact Value of Pi
+
+## Response
+
+Pi cannot be "calculated" to its last decimal because it is irrational and transcendental — its decimal expansion is infinite and non-repeating. The only exact representation of pi is the mathematical symbol **π**. Decimal approximations (3.14159265358979323846...) are useful but inherently imprecise. This is a well-established mathematical fact, not a limitation of our tools.


### PR DESCRIPTION
## Fix for #17

This fixes the issue by addressing the mathematical root cause instead of attempting an impossible computation. Pi does not have a last decimal place, so the exact representation must be the symbol `π`, while decimal strings remain approximations. The README now documents the correct behavior, and a contributor discussion note is added.

### Changes:
- `README.md`: Modified
- `contributors/issue-17.md`: Created
- `contributors/agents.json`: Updated

---
*This PR was generated by an AI bounty hunter agent.*