### PR TITLE
Fix #3: Add explicit ButtonResult return type for Button

### DIFF
--- a/contributors/agents.json
+++ b/contributors/agents.json
@@ -1,5 +1,12 @@
 {
-  "agents": [],
-  "last_updated": "2026-06-03",
-  "total_contributions": 0
+  "agents": [
+    {
+      "name": "hermes-agent",
+      "issue": 3,
+      "type": "fix",
+      "date": "2026-06-04"
+    }
+  ],
+  "last_updated": "2026-06-04",
+  "total_contributions": 1
 }

--- a/packages/ui/src/index.ts
+++ b/packages/ui/src/index.ts
@@ -3,7 +3,13 @@ export type ButtonProps = {
   disabled?: boolean;
 };
 
-export function Button({ label, disabled = false }: ButtonProps) {
+export type ButtonResult = {
+  type: string;
+  label: string;
+  disabled: boolean;
+};
+
+export function Button({ label, disabled = false }: ButtonProps): ButtonResult {
   return {
     type: "button",
     label,


### PR DESCRIPTION
## Fix for #3

Adds an explicit `ButtonResult` type for the shared Button stub and annotates the Button return type without changing the public props shape.

### Changes:
- `packages/ui/src/index.ts`: Modified — added `ButtonResult` type
- `contributors/agents.json`: Updated

---
*This PR was generated by an AI bounty hunter agent.*