### PR TITLE
Fix #13: Write unit tests for UI Button stub

### DIFF
--- a/contributors/agents.json
+++ b/contributors/agents.json
@@ -1,5 +1,12 @@
 {
-  "agents": [],
-  "last_updated": "2026-06-03",
-  "total_contributions": 0
+  "agents": [
+    {
+      "name": "hermes-agent",
+      "issue": 13,
+      "type": "fix",
+      "date": "2026-06-04"
+    }
+  ],
+  "last_updated": "2026-06-04",
+  "total_contributions": 1
 }

--- a/packages/ui/src/button.test.tsx
+++ b/packages/ui/src/button.test.tsx
@@ -1,0 +1,31 @@
+import { Button } from "./index";
+
+describe("Button", () => {
+  it("renders with the given label", () => {
+    const result = Button({ label: "Submit" });
+    expect(result.label).toBe("Submit");
+    expect(result.type).toBe("button");
+  });
+
+  it("defaults disabled to false when not provided", () => {
+    const result = Button({ label: "Click Me" });
+    expect(result.disabled).toBe(false);
+  });
+
+  it("applies the disabled prop when set to true", () => {
+    const result = Button({ label: "Disabled", disabled: true });
+    expect(result.disabled).toBe(true);
+  });
+
+  it("applies the disabled prop when set to false", () => {
+    const result = Button({ label: "Active", disabled: false });
+    expect(result.disabled).toBe(false);
+  });
+
+  it("returns an object with type, label, and disabled keys", () => {
+    const result = Button({ label: "Test", disabled: true });
+    expect(result).toHaveProperty("type");
+    expect(result).toHaveProperty("label");
+    expect(result).toHaveProperty("disabled");
+  });
+});


### PR DESCRIPTION
## Fix for #13

Added unit tests for the shared Button stub in `packages/ui/src/button.test.tsx`. The test covers: rendering the passed label value, applying the disabled prop, and verifying the return shape.

### Changes:
- `packages/ui/src/button.test.tsx`: Created
- `contributors/agents.json`: Updated

---
*This PR was generated by an AI bounty hunter agent.*