### PR TITLE
[agent] fix: #13 - Add unit tests for UI Button stub

### DIFF
--- a/contributors/agents.json
+++ b/contributors/agents.json
@@ -1,5 +1,13 @@
 {
-  "agents": [],
-  "last_updated": "2026-06-03",
-  "total_contributions": 0
+  "agents": [
+    {
+      "github_username": "duongynhi000005-oss",
+      "model": "mimo-v2.5-pro",
+      "version": "latest",
+      "pr_number": null,
+      "issue_number": 371
+    }
+  ],
+  "last_updated": "2026-06-04",
+  "total_contributions": 1
 }

--- a/packages/ui/src/__tests__/Button.test.ts
+++ b/packages/ui/src/__tests__/Button.test.ts
@@ -1,0 +1,39 @@
+import { describe, it, expect } from "vitest";
+import { Button } from "../index";
+
+/**
+ * Unit tests for the shared Button stub component.
+ * Covers label rendering and disabled state behavior.
+ */
+
+describe("Button", () => {
+  it("should return an object with the correct label", () => {
+    const result = Button({ label: "Click Me" });
+    expect(result).toEqual({
+      type: "button",
+      label: "Click Me",
+      disabled: false,
+    });
+  });
+
+  it("should default disabled to false when not provided", () => {
+    const result = Button({ label: "Submit" });
+    expect(result.disabled).toBe(false);
+  });
+
+  it("should set disabled to true when explicitly passed", () => {
+    const result = Button({ label: "Disabled", disabled: true });
+    expect(result.disabled).toBe(true);
+    expect(result.label).toBe("Disabled");
+  });
+
+  it("should always have type as button", () => {
+    const result = Button({ label: "Test" });
+    expect(result.type).toBe("button");
+  });
+
+  it("should handle empty label", () => {
+    const result = Button({ label: "" });
+    expect(result.label).toBe("");
+  });
+});


### PR DESCRIPTION
## Summary

Added vitest unit tests for the shared Button stub component covering:
- Label rendering correctness
- Default disabled value (false)
- Explicit disabled override (true)
- Type field always set to "button"
- Empty label edge case

## Changes
- Created `packages/ui/src/__tests__/Button.test.ts`
- Updated `contributors/agents.json`

Closes #371

Fixes #13