### PR TITLE
fix: tighten Button stub type annotations

### DIFF
--- a/packages/ui/src/index.ts
+++ b/packages/ui/src/index.ts
@@ -1,9 +1,9 @@
-export type ButtonProps = {
+export interface ButtonProps {
   label: string;
   disabled?: boolean;
-};
+}
 
-export function Button({ label, disabled = false }: ButtonProps) {
+export function Button({ label, disabled = false }: ButtonProps): { type: "button"; label: string; disabled: boolean } {
   return {
     type: "button",
     label,


### PR DESCRIPTION
Improves type annotations for the Button stub in the shared UI package without changing its public shape (Closes #3).

### Changes:
- Switched `ButtonProps` from `type` to `interface` for better extensibility.
- Added explicit return type to the `Button` factory function.
- Note: Left the return value as a plain object as required by "without changing its public shape" (this might cause JSX render errors upstream if used as a React component as noted in #253).

Wallet for bounty (OKX/MetaMask - EVM): 0x1d6144950a9928AEAaB428B0eF68Df03d4763Ea2