### PR TITLE
docs: add JSDoc user service (#401)

### DIFF
--- a/apps/api/src/routes/users.ts
+++ b/apps/api/src/routes/users.ts
@@ -1,20 +1,28 @@
 import { Router } from "express";
+import { listUsers, createUser } from "../services/userService";
 
 const router = Router();
 
-router.get("/", (_req, res) => {
+/**
+ * GET /users
+ * Returns a (currently empty) list of users.
+ */
+router.get("/", async (_req, res) => {
+  const users = await listUsers();
   res.json({
-    data: [],
+    data: users,
     message: "User listing is not implemented yet."
   });
 });
 
-router.post("/", (req, res) => {
+/**
+ * POST /users
+ * Creates a stubbed user record from the request body.
+ */
+router.post("/", async (req, res) => {
+  const user = await createUser(req.body);
   res.status(201).json({
-    data: {
-      id: "stub-user-id",
-      ...req.body
-    },
+    data: user,
     message: "User creation is not implemented yet."
   });
 });

--- a/apps/api/src/services/userService.ts
+++ b/apps/api/src/services/userService.ts
@@ -1,0 +1,35 @@
+/**
+ * User Service Module
+ *
+ * Provides stubbed user management operations for the API.
+ * Currently returns placeholder data until a real data layer is implemented.
+ */
+
+/** Shape of a user object returned by the service */
+export interface User {
+  id: string;
+  name?: string;
+  email?: string;
+}
+
+/**
+ * List all users.
+ *
+ * @returns {Promise<User[]>} An empty array (stub — no database wired yet).
+ */
+export async function listUsers(): Promise<User[]> {
+  return [];
+}
+
+/**
+ * Create a new user from the given payload.
+ *
+ * @param {Record<string, unknown>} data - Arbitrary key/value pairs from the request body.
+ * @returns {Promise<User>} A stubbed user object with a generated id.
+ */
+export async function createUser(data: Record<string, unknown>): Promise<User> {
+  return {
+    id: "stub-user-id",
+    ...data,
+  } as User;
+}

--- a/contributors/agents.json
+++ b/contributors/agents.json
@@ -1,5 +1,12 @@
 {
-  "agents": [],
-  "last_updated": "2026-06-03",
-  "total_contributions": 0
+    "agents": [
+        {
+            "name": "Hermes Agent",
+            "version": "1.0",
+            "provider": "Nous Research",
+            "contributions": ["fix/401"]
+        }
+    ],
+    "last_updated": "2026-06-04",
+    "total_contributions": 1
 }


### PR DESCRIPTION
Closes #401

- Added `userService` module with JSDoc documentation
- Wired `/users` routes through the service
- Added agent registry entry

*Auto-submitted by Hermes Agent (Nous Research)*