### PR TITLE
docs: document environment variables (#4)

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,5 +81,27 @@ with models for:
 
 ## Environment Variables
 
-Each app/package expects its own .env values for DB, auth, 
-and integrations.
+Each app/package has its own `.env.example` file. Copy it to `.env` and fill in the values:
+
+```bash
+cp apps/api/.env.example apps/api/.env
+cp apps/web/.env.example apps/web/.env
+```
+
+### API (`apps/api/.env`)
+
+| Variable | Description | Default |
+|----------|-------------|---------|
+| `PORT` | Server port | `4000` |
+| `DATABASE_URL` | Prisma DB connection string | — |
+| `JWT_SECRET` | Secret for signing JWT tokens | — |
+| `STRIPE_SECRET_KEY` | Stripe API key for payments | — |
+| `CORS_ORIGIN` | Allowed CORS origin | `*` |
+| `RATE_LIMIT_WINDOW_MS` | Rate limit window (ms) | `60000` |
+| `RATE_LIMIT_MAX` | Max requests per window | `100` |
+
+### Web (`apps/web/.env`)
+
+| Variable | Description | Default |
+|----------|-------------|---------|
+| `NEXT_PUBLIC_API_URL` | Backend API base URL | `http://localhost:4000` |

--- a/apps/api/.env.example
+++ b/apps/api/.env.example
@@ -1,0 +1,26 @@
+# TaskFlow API Environment Variables
+
+## Required
+
+# Server port (default: 4000)
+PORT=4000
+
+# Database connection string (Prisma)
+DATABASE_URL="postgresql://user:password@localhost:5432/taskflow"
+
+# JWT secret for auth tokens
+JWT_SECRET="change-me-to-a-random-secret"
+
+# Stripe secret key (for payment routes)
+STRIPE_SECRET_KEY="sk_test_..."
+
+## Optional
+
+# CORS origin (default: *)
+CORS_ORIGIN="http://localhost:3000"
+
+# Rate limit window in ms (default: 60000)
+RATE_LIMIT_WINDOW_MS=60000
+
+# Max requests per window (default: 100)
+RATE_LIMIT_MAX=100

--- a/apps/web/.env.example
+++ b/apps/web/.env.example
@@ -1,0 +1,11 @@
+# TaskFlow Web Environment Variables
+
+## Required
+
+# API base URL
+NEXT_PUBLIC_API_URL="http://localhost:4000"
+
+## Optional
+
+# Analytics key (if enabled)
+NEXT_PUBLIC_ANALYTICS_KEY=""

--- a/contributors/agents.json
+++ b/contributors/agents.json
@@ -1,5 +1,12 @@
 {
-  "agents": [],
-  "last_updated": "2026-06-03",
-  "total_contributions": 0
+    "agents": [
+        {
+            "name": "Hermes Agent",
+            "version": "1.0",
+            "provider": "Nous Research",
+            "contributions": ["fix/4"]
+        }
+    ],
+    "last_updated": "2026-06-04",
+    "total_contributions": 1
 }


### PR DESCRIPTION
Closes #4

- Added `.env.example` files for both `apps/api` and `apps/web`
- Expanded the Environment Variables section in README with a table of all variables, descriptions, and defaults
- Added setup instructions for copying `.env.example` to `.env`
- Added agent registry entry

*Auto-submitted by Hermes Agent (Nous Research)*