### PR TITLE
feat: add vitest unit tests for user routes (Closes #460)

### DIFF
--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -7,7 +7,7 @@
   "main": "src/index.ts",
   "scripts": {
     "dev": "tsx src/index.ts",
-    "test": "echo \"No API tests configured yet\"",
+    "test": "vitest run",
     "lint": "echo \"No API lint configured yet\""
   },
   "dependencies": {
@@ -15,7 +15,10 @@
   },
   "devDependencies": {
     "@types/express": "^4.17.21",
+    "@types/supertest": "^6.0.2",
+    "supertest": "^7.0.0",
     "tsx": "^4.7.1",
-    "typescript": "^5.4.5"
+    "typescript": "^5.4.5",
+    "vitest": "^3.1.1"
   }
 }

--- a/apps/api/src/routes/users.test.ts
+++ b/apps/api/src/routes/users.test.ts
@@ -1,0 +1,43 @@
+import { describe, it, expect } from "vitest";
+
+import express from "express";
+import request from "supertest";
+import usersRouter from "./users.js";
+
+const app = express();
+app.use(express.json());
+app.use("/users", usersRouter);
+
+describe("GET /users", () => {
+  it("returns 200", async () => {
+    const res = await request(app).get("/users");
+    expect(res.status).toBe(200);
+  });
+
+  it("returns a data array", async () => {
+    const res = await request(app).get("/users");
+    expect(Array.isArray(res.body.data)).toBe(true);
+  });
+
+  it("includes a message field", async () => {
+    const res = await request(app).get("/users");
+    expect(res.body).toHaveProperty("message");
+  });
+});
+
+describe("POST /users", () => {
+  it("returns 201", async () => {
+    const res = await request(app).post("/users").send({ name: "Test" });
+    expect(res.status).toBe(201);
+  });
+
+  it("echoes the request body in data", async () => {
+    const res = await request(app).post("/users").send({ name: "Alice" });
+    expect(res.body.data.name).toBe("Alice");
+  });
+
+  it("includes a stub id in data", async () => {
+    const res = await request(app).post("/users").send({ name: "Bob" });
+    expect(res.body.data.id).toBe("stub-user-id");
+  });
+});

--- a/contributors/agents.json
+++ b/contributors/agents.json
@@ -1,5 +1,17 @@
 {
-  "agents": [],
-  "last_updated": "2026-06-03",
-  "total_contributions": 0
+  "agents": [
+    {
+      "username": "duongynhi000005-oss",
+      "contributions": [
+        {
+          "issue": 460,
+          "pr": "pending",
+          "type": "feature",
+          "description": "Add vitest unit tests for user routes"
+        }
+      ]
+    }
+  ],
+  "last_updated": "2026-06-04",
+  "total_contributions": 1
 }


### PR DESCRIPTION
## Summary

Wires up vitest as the test framework for  and adds a focused test suite for the user routes.

### Changes
- **Updated:**  — added , , and  to devDependencies; updated the  script to 
- **New:**  — 6 tests covering  (200 response, data array, message field) and  (201 status, body echo, stub id)

Closes #460