### PR TITLE
fix(api): normalize health check response shape (Closes #461)

### DIFF
--- a/apps/api/src/index.ts
+++ b/apps/api/src/index.ts
@@ -5,10 +5,20 @@ import usersRouter from "./routes/users";
 const app = express();
 const port = process.env.PORT || 4000;
 
+const startTime = Date.now();
+
 app.use(express.json());
 
 app.get("/health", (_req, res) => {
-  res.json({ status: "ok", service: "taskflow-api" });
+  const uptimeSeconds = (Date.now() - startTime) / 1000;
+  res.json({
+    status: "ok",
+    data: {
+      service: "taskflow-api",
+      uptime: uptimeSeconds,
+      timestamp: new Date().toISOString()
+    }
+  });
 });
 
 app.use("/users", usersRouter);

--- a/contributors/agents.json
+++ b/contributors/agents.json
@@ -1,5 +1,17 @@
 {
-  "agents": [],
-  "last_updated": "2026-06-03",
-  "total_contributions": 0
+  "agents": [
+    {
+      "username": "duongynhi000005-oss",
+      "contributions": [
+        {
+          "issue": 461,
+          "pr": "pending",
+          "type": "fix",
+          "description": "Normalize health check response shape"
+        }
+      ]
+    }
+  ],
+  "last_updated": "2026-06-04",
+  "total_contributions": 1
 }


### PR DESCRIPTION
## Summary

Normalize the health check endpoint to use a consistent response envelope with `status` and `data` fields.

### Changes
- Wrapped health check details in a `data` object
- Added `uptime` (process uptime in seconds) and `timestamp` (ISO 8601)
- Preserved the `status: "ok"` top-level field for backward compatibility

### Response Shape
```json
{
  "status": "ok",
  "data": {
    "service": "taskflow-api",
    "uptime": 123.456,
    "timestamp": "2026-06-04T12:00:00.000Z"
  }
}
```

Closes #461