### PR TITLE
feat(api): add request body size limit (Closes #462)

### DIFF
--- a/apps/api/src/index.ts
+++ b/apps/api/src/index.ts
@@ -5,13 +5,24 @@ import usersRouter from "./routes/users";
 const app = express();
 const port = process.env.PORT || 4000;
 
-app.use(express.json());
+app.use(express.json({ limit: "1mb" }));
 
 app.get("/health", (_req, res) => {
   res.json({ status: "ok", service: "taskflow-api" });
 });
 
 app.use("/users", usersRouter);
+
+// Error handler for payload too large
+app.use((err: any, _req: express.Request, res: express.Response, next: express.NextFunction) => {
+  if (err.type === "entity.too.large") {
+    return res.status(413).json({
+      error: "Payload too large",
+      message: "Request body must not exceed 1mb"
+    });
+  }
+  next(err);
+});
 
 app.listen(port, () => {
   console.log(`TaskFlow API listening on port ${port}`);

--- a/contributors/agents.json
+++ b/contributors/agents.json
@@ -1,5 +1,17 @@
 {
-  "agents": [],
-  "last_updated": "2026-06-03",
-  "total_contributions": 0
+  "agents": [
+    {
+      "username": "duongynhi000005-oss",
+      "contributions": [
+        {
+          "issue": 462,
+          "pr": "pending",
+          "type": "feature",
+          "description": "Add request body size limit"
+        }
+      ]
+    }
+  ],
+  "last_updated": "2026-06-04",
+  "total_contributions": 1
 }


### PR DESCRIPTION
## Summary

Configure a conservative JSON body size limit in the Express app.

### Changes
- Set `express.json({ limit: "1mb" })` as a conservative default for JSON request bodies
- Added error handler middleware that returns HTTP 413 with a descriptive error message when the limit is exceeded
- The 1mb limit prevents oversized payloads from consuming excessive server memory

### Behavior
- Requests with body ≤ 1mb: processed normally
- Requests with body > 1mb: `413 Payload too large` with JSON error response

### Example Error Response
```json
{
  "error": "Payload too large",
  "message": "Request body must not exceed 1mb"
}
```

Closes #462