### PR TITLE
test: add unit tests for Button stub (Closes #463)

### DIFF
--- a/contributors/agents.json
+++ b/contributors/agents.json
@@ -1,5 +1,17 @@
 {
-  "agents": [],
-  "last_updated": "2026-06-03",
-  "total_contributions": 0
+  "agents": [
+    {
+      "username": "duongynhi000005-oss",
+      "contributions": [
+        {
+          "issue": 463,
+          "pr": "pending",
+          "type": "test",
+          "description": "Add unit tests for Button stub component"
+        }
+      ]
+    }
+  ],
+  "last_updated": "2026-06-04",
+  "total_contributions": 1
 }

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -5,10 +5,11 @@
   "description": "Shared UI components for TaskFlow.",
   "main": "src/index.ts",
   "scripts": {
-    "test": "echo \"No UI tests configured yet\"",
+    "test": "vitest run",
     "lint": "echo \"No UI lint configured yet\""
   },
   "devDependencies": {
-    "typescript": "^5.4.5"
+    "typescript": "^5.4.5",
+    "vitest": "^3.1.1"
   }
 }

--- a/packages/ui/src/__tests__/button.test.ts
+++ b/packages/ui/src/__tests__/button.test.ts
@@ -1,0 +1,24 @@
+import { describe, it, expect } from "vitest";
+import { Button } from "../index.js";
+
+describe("Button", () => {
+  it("returns correct button object with label", () => {
+    const result = Button({ label: "Click me" });
+    expect(result.label).toBe("Click me");
+  });
+
+  it("default disabled is false", () => {
+    const result = Button({ label: "Submit" });
+    expect(result.disabled).toBe(false);
+  });
+
+  it("explicit disabled=true works", () => {
+    const result = Button({ label: "Disabled", disabled: true });
+    expect(result.disabled).toBe(true);
+  });
+
+  it("preserves type field", () => {
+    const result = Button({ label: "Test" });
+    expect(result.type).toBe("button");
+  });
+});


### PR DESCRIPTION
## Summary

Add unit tests for the shared Button stub component covering label and disabled values.

### Changes
- Added vitest as dev dependency to `packages/ui`
- Created `packages/ui/src/__tests__/button.test.ts` with 4 tests:
  - Returns correct button object with label
  - Default disabled is false
  - Explicit disabled=true works
  - Preserves type field

Closes #463