### PR TITLE
test: add unit tests for user routes (Closes #464)

### DIFF
--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -7,7 +7,7 @@
   "main": "src/index.ts",
   "scripts": {
     "dev": "tsx src/index.ts",
-    "test": "echo \"No API tests configured yet\"",
+    "test": "vitest run",
     "lint": "echo \"No API lint configured yet\""
   },
   "dependencies": {
@@ -15,7 +15,10 @@
   },
   "devDependencies": {
     "@types/express": "^4.17.21",
+    "@types/supertest": "^6.0.2",
+    "supertest": "^7.0.0",
     "tsx": "^4.7.1",
-    "typescript": "^5.4.5"
+    "typescript": "^5.4.5",
+    "vitest": "^3.1.1"
   }
 }

--- a/apps/api/src/__tests__/users.test.ts
+++ b/apps/api/src/__tests__/users.test.ts
@@ -1,0 +1,35 @@
+import { describe, it, expect } from "vitest";
+import express from "express";
+import request from "supertest";
+import usersRouter from "../routes/users.js";
+
+const app = express();
+app.use(express.json());
+app.use("/users", usersRouter);
+
+describe("GET /users", () => {
+  it("returns 200 with empty data array", async () => {
+    const res = await request(app).get("/users");
+    expect(res.status).toBe(200);
+    expect(res.body.data).toEqual([]);
+  });
+
+  it("returns JSON content type", async () => {
+    const res = await request(app).get("/users");
+    expect(res.headers["content-type"]).toMatch(/json/);
+  });
+});
+
+describe("POST /users", () => {
+  it("returns 201 with posted body and stub id", async () => {
+    const res = await request(app).post("/users").send({ name: "Test" });
+    expect(res.status).toBe(201);
+    expect(res.body.data.name).toBe("Test");
+    expect(res.body.data.id).toBe("stub-user-id");
+  });
+
+  it("includes not-implemented message", async () => {
+    const res = await request(app).post("/users").send({ name: "Test" });
+    expect(res.body.message).toMatch(/not implemented/i);
+  });
+});

--- a/contributors/agents.json
+++ b/contributors/agents.json
@@ -1,5 +1,17 @@
 {
-  "agents": [],
-  "last_updated": "2026-06-03",
-  "total_contributions": 0
+  "agents": [
+    {
+      "username": "duongynhi000005-oss",
+      "contributions": [
+        {
+          "issue": 464,
+          "pr": "pending",
+          "type": "test",
+          "description": "Add unit tests for user routes"
+        }
+      ]
+    }
+  ],
+  "last_updated": "2026-06-04",
+  "total_contributions": 1
 }


### PR DESCRIPTION
## Summary

Add basic tests for the Express user route stubs covering list and create behavior.

### Changes
- Added vitest and supertest as dev dependencies to `apps/api`
- Created `apps/api/src/__tests__/users.test.ts` with 4 tests:
  - GET /users returns 200 with empty data array
  - GET /users returns JSON content type
  - POST /users returns 201 with posted body and stub id
  - POST /users includes not-implemented message

Closes #464