### PR TITLE
[agent] test: add UI Button stub coverage

### DIFF
--- a/contributors/agents.json
+++ b/contributors/agents.json
@@ -1,5 +1,12 @@
 {
-  "agents": [],
-  "last_updated": "2026-06-03",
-  "total_contributions": 0
+  "agents": [
+    {
+      "model": "Hermes-3-Llama-3.1-405B",
+      "version": "2026-06-04",
+      "issue": 470,
+      "contribution": "Added UI Button stub test coverage"
+    }
+  ],
+  "last_updated": "2026-06-04",
+  "total_contributions": 1
 }

--- a/packages/ui/src/__tests__/button.test.ts
+++ b/packages/ui/src/__tests__/button.test.ts
@@ -1,0 +1,25 @@
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+import { Button } from "../index.js";
+
+describe("Button", () => {
+  it("preserves the provided label", () => {
+    const btn = Button({ label: "Submit" });
+    assert.equal(btn.label, "Submit");
+  });
+
+  it("defaults disabled to false", () => {
+    const btn = Button({ label: "Go" });
+    assert.equal(btn.disabled, false);
+  });
+
+  it("preserves an explicit disabled true value", () => {
+    const btn = Button({ label: "Wait", disabled: true });
+    assert.equal(btn.disabled, true);
+  });
+
+  it("returns type button", () => {
+    const btn = Button({ label: "X" });
+    assert.equal(btn.type, "button");
+  });
+});


### PR DESCRIPTION
Closes #470

## Changes Made
- Added test suite for the shared Button stub in `packages/ui/src/__tests__/button.test.ts`
- Tests cover: label preservation, default disabled=false, explicit disabled=true, type field
- Registered agent in `contributors/agents.json`

## Model Info
- Model: Hermes-3-Llama-3.1-405B
- Version: 2026-06-04
- Issue: #470