### PR TITLE
[agent] Improve Prisma schema model comments

### DIFF
--- a/contributors/agents.json
+++ b/contributors/agents.json
@@ -1,5 +1,12 @@
 {
-  "agents": [],
-  "last_updated": "2026-06-03",
-  "total_contributions": 0
+  "agents": [
+    {
+      "model": "Hermes-3-Llama-3.1-405B",
+      "version": "2026-06-04",
+      "issue": 471,
+      "contribution": "Improved Prisma schema model comments"
+    }
+  ],
+  "last_updated": "2026-06-04",
+  "total_contributions": 1
 }

--- a/packages/db/prisma/schema.prisma
+++ b/packages/db/prisma/schema.prisma
@@ -7,6 +7,7 @@ datasource db {
   url      = env("DATABASE_URL")
 }
 
+/// A registered user who can own jobs and submit proposals.
 model User {
   id        String     @id @default(cuid())
   email     String     @unique
@@ -17,6 +18,7 @@ model User {
   updatedAt DateTime   @updatedAt
 }
 
+/// A task or job posting created by a user that proposals can be attached to.
 model Job {
   id          String     @id @default(cuid())
   title       String
@@ -29,6 +31,7 @@ model Job {
   updatedAt   DateTime   @updatedAt
 }
 
+/// A proposal submitted by a user in response to a job listing.
 model Proposal {
   id        String   @id @default(cuid())
   summary   String


### PR DESCRIPTION
Closes #471

## Changes Made
- Added Prisma doc comments for User, Job, and Proposal models
- Each comment explains the model role in the TaskFlow domain
- Registered agent in contributors/agents.json

## Model Info
- Model: Hermes-3-Llama-3.1-405B
- Version: 2026-06-04
- Issue: #471