### PR TITLE
[agent] Add API error response helper

### DIFF
--- a/apps/api/src/http/errors.ts
+++ b/apps/api/src/http/errors.ts
@@ -1,0 +1,14 @@
+import { Response } from "express";
+
+export function sendApiError(
+  res: Response,
+  status: number,
+  message: string,
+  details?: unknown
+) {
+  res.status(status).json({
+    error: true,
+    message,
+    ...(details ? { details } : {}),
+  });
+}

--- a/contributors/agents.json
+++ b/contributors/agents.json
@@ -1,5 +1,12 @@
 {
-  "agents": [],
-  "last_updated": "2026-06-03",
-  "total_contributions": 0
+  "agents": [
+    {
+      "model": "Hermes-3-Llama-3.1-405B",
+      "version": "2026-06-04",
+      "issue": 473,
+      "contribution": "Added API error response helper"
+    }
+  ],
+  "last_updated": "2026-06-04",
+  "total_contributions": 1
 }


### PR DESCRIPTION
Closes #473

## Changes Made
- Added `sendApiError` helper in `apps/api/src/http/errors.ts`
- Reusable error response function for consistent API error formatting
- Registered agent in contributors/agents.json

## Model Info
- Model: Hermes-3-Llama-3.1-405B
- Version: 2026-06-04
- Issue: #473