### PR TITLE
[agent] feat: improve Button type annotations

### DIFF
--- a/packages/ui/src/index.ts
+++ b/packages/ui/src/index.ts
@@ -1,11 +1,27 @@
-export type ButtonProps = {
+/**
+ * Props for the shared Button component.
+ */
+export interface ButtonProps {
+  /** The text displayed inside the button. */
   label: string;
+  /** When true, the button is non-interactive and visually dimmed. */
   disabled?: boolean;
-};
+}
 
+/**
+ * Renders a UI button descriptor.
+ *
+ * @param props - The button configuration.
+ * @returns An object describing the button for the rendering layer.
+ *
+ * @example
+ * ```tsx
+ * <Button label="Submit" disabled={false} />
+ * ```
+ */
 export function Button({ label, disabled = false }: ButtonProps) {
   return {
-    type: "button",
+    type: "button" as const,
     label,
     disabled
   };


### PR DESCRIPTION
## Description
Improves type annotations for the shared Button component without changing its public shape.

## Changes Made
- Converted `ButtonProps` from type alias to interface (better docs & extensibility)
- Added JSDoc comments to all ButtonProps fields
- Added JSDoc with @param, @returns, and @example to Button function
- Added `as const` assertion for stricter return type
- Public API shape unchanged

Closes #3