### PR TITLE
[agent] feat: add unit tests for UI Button component

### DIFF
--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -4,11 +4,12 @@
   "private": true,
   "description": "Shared UI components for TaskFlow.",
   "main": "src/index.ts",
-  "scripts": {
-    "test": "echo \"No UI tests configured yet\"",
-    "lint": "echo \"No UI lint configured yet\""
-  },
   "devDependencies": {
-    "typescript": "^5.4.5"
+    "typescript": "^5.4.5",
+    "vitest": "^1.6.0"
+  },
+  "scripts": {
+    "test": "vitest run",
+    "lint": "echo \"No UI lint configured yet\""
   }
 }

--- a/packages/ui/src/__tests__/Button.test.ts
+++ b/packages/ui/src/__tests__/Button.test.ts
@@ -1,0 +1,29 @@
+import { describe, it, expect } from "vitest";
+import { Button } from "./index";
+
+describe("Button", () => {
+  it("returns a button descriptor with the given label", () => {
+    const result = Button({ label: "Click me" });
+    expect(result.label).toBe("Click me");
+  });
+
+  it("has type 'button' by default", () => {
+    const result = Button({ label: "Submit" });
+    expect(result.type).toBe("button");
+  });
+
+  it("is not disabled by default", () => {
+    const result = Button({ label: "Save" });
+    expect(result.disabled).toBe(false);
+  });
+
+  it("respects the disabled prop when set to true", () => {
+    const result = Button({ label: "Save", disabled: true });
+    expect(result.disabled).toBe(true);
+  });
+
+  it("respects the disabled prop when set to false", () => {
+    const result = Button({ label: "Save", disabled: false });
+    expect(result.disabled).toBe(false);
+  });
+});


### PR DESCRIPTION
## Description
Adds unit tests for the shared Button component using Vitest.

## Tests
- Returns descriptor with correct label
- Default type is 'button'
- Default disabled is false
- Respects disabled=true
- Respects disabled=false

## Setup
- Added vitest ^1.6.0 to UI package devDependencies
- Updated test script

Closes #13