### PR TITLE
[agent] feat: add request body size limit

### DIFF
--- a/apps/api/src/index.ts
+++ b/apps/api/src/index.ts
@@ -5,7 +5,8 @@ import usersRouter from "./routes/users";
 const app = express();
 const port = process.env.PORT || 4000;
 
-app.use(express.json());
+// Parse JSON request bodies with a conservative size limit (100 KB).
+app.use(express.json({ limit: "100kb" }));
 
 app.get("/health", (_req, res) => {
   res.json({ status: "ok", service: "taskflow-api" });


### PR DESCRIPTION
## Description
Configures a conservative JSON body size limit to prevent oversized payload attacks.

## Changes Made
- Changed `express.json()` to `express.json({ limit: "100kb" })`
- Added comment explaining the limit

Closes #9