### PR TITLE
[agent] feat: add API error handling helper

### DIFF
--- a/apps/api/src/index.ts
+++ b/apps/api/src/index.ts
@@ -1,4 +1,5 @@
 import express from "express";
+import type { Request, Response, NextFunction } from "express";
 
 import usersRouter from "./routes/users";
 
@@ -7,11 +8,39 @@ const port = process.env.PORT || 4000;
 
 app.use(express.json());
 
-app.get("/health", (_req, res) => {
+/**
+ * Create a standardized API error response.
+ *
+ * @param status  - HTTP status code.
+ * @param message - Human-readable error description.
+ * @returns A JSON-serializable error object.
+ */
+export function apiError(status: number, message: string) {
+  return { error: true, status, message };
+}
+
+/**
+ * Express error-handling middleware.
+ *
+ * Catches errors passed via `next(err)` and returns a consistent JSON response.
+ */
+function errorHandler(
+  err: Error,
+  _req: Request,
+  res: Response,
+  _next: NextFunction,
+) {
+  console.error("[api] Unhandled error:", err);
+  res.status(500).json(apiError(500, "Internal server error"));
+}
+
+app.get("/health", (_req: Request, res: Response) => {
   res.json({ status: "ok", service: "taskflow-api" });
 });
 
 app.use("/users", usersRouter);
+
+app.use(errorHandler);
 
 app.listen(port, () => {
   console.log(`TaskFlow API listening on port ${port}`);


### PR DESCRIPTION
## Description
Introduces a standardized API error response helper and error-handling middleware.

## Changes Made
- Added `apiError(status, message)` helper returning `{ error, status, message }`
- Added `errorHandler` Express middleware catching unhandled errors
- Added type annotations for Request, Response, NextFunction
- Registered errorHandler as the last middleware

Closes #7