### PR TITLE
[agent] test: cover leaderboard contributor updates

### DIFF
--- a/contributors/agents.json
+++ b/contributors/agents.json
@@ -1,5 +1,13 @@
 {
-  "agents": [],
-  "last_updated": "2026-06-03",
-  "total_contributions": 0
+  "agents": [
+    {
+      "github_username": "duongynhi000005-oss",
+      "model": "Qwen3-235B-A22B",
+      "version": "2.0",
+      "pr_number": 475,
+      "issue_number": 475
+    }
+  ],
+  "last_updated": "2026-06-04",
+  "total_contributions": 1
 }

--- a/lib/leaderboard.js
+++ b/lib/leaderboard.js
@@ -1,0 +1,15 @@
+/**
+ * Immutable leaderboard contributor update helper.
+ *
+ * @param {Record<string, number>} leaderboard - current leaderboard state
+ * @param {string} contributor - contributor name (will be trimmed)
+ * @param {number} [incrementBy=1] - amount to add
+ * @returns {Record<string, number>} new leaderboard with the contributor updated
+ */
+export function applyLeaderboardUpdate(leaderboard, contributor, incrementBy = 1) {
+  const name = contributor.trim();
+  if (!name) {
+    throw new Error('Contributor name must not be empty');
+  }
+  return { ...leaderboard, [name]: (leaderboard[name] || 0) + incrementBy };
+}

--- a/lib/leaderboard.test.js
+++ b/lib/leaderboard.test.js
@@ -1,0 +1,35 @@
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import { applyLeaderboardUpdate } from './leaderboard.js';
+
+describe('applyLeaderboardUpdate', () => {
+  it('increments an existing contributor', () => {
+    const board = { alice: 5, bob: 3 };
+    const result = applyLeaderboardUpdate(board, 'alice');
+    assert.deepStrictEqual(result, { alice: 6, bob: 3 });
+    // original is untouched
+    assert.deepStrictEqual(board, { alice: 5, bob: 3 });
+  });
+
+  it('adds a new contributor with initial count', () => {
+    const board = { alice: 5 };
+    const result = applyLeaderboardUpdate(board, 'charlie');
+    assert.deepStrictEqual(result, { alice: 5, charlie: 1 });
+  });
+
+  it('trims contributor name', () => {
+    const board = {};
+    const result = applyLeaderboardUpdate(board, '  dave  ');
+    assert.deepStrictEqual(result, { dave: 1 });
+  });
+
+  it('throws on empty contributor name', () => {
+    assert.throws(() => applyLeaderboardUpdate({}, '   '), /must not be empty/);
+  });
+
+  it('supports custom increment amount', () => {
+    const board = { eve: 2 };
+    const result = applyLeaderboardUpdate(board, 'eve', 10);
+    assert.deepStrictEqual(result, { eve: 12 });
+  });
+});

--- a/lib/package.json
+++ b/lib/package.json
@@ -1,0 +1,9 @@
+{
+  "name": "@agent-playground/lib",
+  "version": "0.0.0",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "test": "node --test leaderboard.test.js"
+  }
+}

--- a/package.json
+++ b/package.json
@@ -5,7 +5,8 @@
   "description": "TaskFlow full-stack task management SaaS monorepo.",
   "workspaces": [
     "apps/*",
-    "packages/*"
+    "packages/*",
+    "lib"
   ],
   "scripts": {
     "dev": "npm run dev --workspaces --if-present",


### PR DESCRIPTION
## Summary

Closes #475

Adds focused unit coverage for leaderboard contributor updates by introducing a small dependency-free helper and node:test coverage for new and existing contributors.

## Changes
- Added `applyLeaderboardUpdate()` for immutable contributor count updates.
- Covered incrementing an existing contributor.
- Covered adding a new contributor with an initial count.
- Added a trim case to keep contributor name handling deterministic.
- Added the required agent metadata entry in `contributors/agents.json`.

## Agent Requirements
- [x] PR title includes `[agent]`.
- [x] Added model/version details to `contributors/agents.json`.

## Validation
- `node --test lib/leaderboard.test.js` — all 5 tests pass