### PR TITLE
test: add unit tests for user routes (list & create) (fixes #482)

### DIFF
--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -7,7 +7,7 @@
   "main": "src/index.ts",
   "scripts": {
     "dev": "tsx src/index.ts",
-    "test": "echo \"No API tests configured yet\"",
+    "test": "vitest run",
     "lint": "echo \"No API lint configured yet\""
   },
   "dependencies": {
@@ -15,7 +15,10 @@
   },
   "devDependencies": {
     "@types/express": "^4.17.21",
+    "@types/supertest": "^6.0.2",
+    "supertest": "^6.3.4",
     "tsx": "^4.7.1",
-    "typescript": "^5.4.5"
+    "typescript": "^5.4.5",
+    "vitest": "^1.6.0"
   }
 }

--- a/apps/api/tests/users.test.ts
+++ b/apps/api/tests/users.test.ts
@@ -1,0 +1,39 @@
+import { describe, it, expect } from "vitest";
+import express from "express";
+import request from "supertest";
+import usersRouter from "../src/routes/users";
+
+const app = express();
+app.use(express.json());
+app.use("/users", usersRouter);
+
+describe("User Routes", () => {
+  describe("GET /users", () => {
+    it("should return an empty data array with message", async () => {
+      const res = await request(app).get("/users");
+      expect(res.status).toBe(200);
+      expect(res.body).toHaveProperty("data");
+      expect(Array.isArray(res.body.data)).toBe(true);
+      expect(res.body.data).toHaveLength(0);
+      expect(res.body.message).toBe("User listing is not implemented yet.");
+    });
+  });
+
+  describe("POST /users", () => {
+    it("should create a stub user and return 201", async () => {
+      const payload = { name: "Alice", email: "alice@example.com" };
+      const res = await request(app).post("/users").send(payload);
+      expect(res.status).toBe(201);
+      expect(res.body.data).toHaveProperty("id", "stub-user-id");
+      expect(res.body.data.name).toBe("Alice");
+      expect(res.body.data.email).toBe("alice@example.com");
+      expect(res.body.message).toBe("User creation is not implemented yet.");
+    });
+
+    it("should accept an empty body", async () => {
+      const res = await request(app).post("/users").send({});
+      expect(res.status).toBe(201);
+      expect(res.body.data).toHaveProperty("id", "stub-user-id");
+    });
+  });
+});

--- a/contributors/agents.json
+++ b/contributors/agents.json
@@ -1,5 +1,24 @@
 {
-  "agents": [],
-  "last_updated": "2026-06-03",
-  "total_contributions": 0
+  "agents": [
+    {
+      "name": "hermes-agent",
+      "provider": "nous-research",
+      "contributions": [
+        {
+          "issue": 482,
+          "pr": null,
+          "title": "test: add unit tests for user routes (list & create)",
+          "type": "test",
+          "files": [
+            "apps/api/tests/users.test.ts",
+            "apps/api/package.json",
+            "contributors/agents.json"
+          ],
+          "timestamp": "2026-06-04T18:58:00Z"
+        }
+      ]
+    }
+  ],
+  "last_updated": "2026-06-04",
+  "total_contributions": 1
 }


### PR DESCRIPTION
Adds unit tests for user routes covering list and create endpoints.

Closes #482

Changes:
- New apps/api/tests/users.test.ts - vitest+supertest tests
- Updated apps/api/package.json - vitest, supertest deps
- Updated contributors/agents.json