### PR TITLE
[agent] Add leaderboard update script and unit tests

### DIFF
--- a/contributors/agents.json
+++ b/contributors/agents.json
@@ -1,5 +1,13 @@
 {
-  "agents": [],
-  "last_updated": "2026-06-03",
-  "total_contributions": 0
+  "agents": [
+    {
+      "github_username": "duongynhi000005-oss",
+      "model": "hermes-agent",
+      "version": "latest",
+      "pr_number": 485,
+      "issue_number": 485
+    }
+  ],
+  "last_updated": "2026-06-04",
+  "total_contributions": 1
 }

--- a/scripts/update_leaderboard.cjs
+++ b/scripts/update_leaderboard.cjs
@@ -1,0 +1,87 @@
+#!/usr/bin/env node
+/**
+ * Leaderboard increment logic extracted for reuse and testing.
+ *
+ * Usage:
+ *   node scripts/update_leaderboard.cjs <username> [increment]
+ *
+ * When called from a workflow this file is imported and the
+ * exported helpers are used directly.
+ */
+
+const fs = require("fs");
+const path = require("path");
+
+const LEADERBOARD_PATH = path.resolve(__dirname, "..", "leaderboard.json");
+
+/**
+ * Read and parse the leaderboard JSON file.
+ * @param {string} [filePath] – override path (useful for tests)
+ * @returns {Record<string, number>}
+ */
+function readLeaderboard(filePath) {
+  const target = filePath || LEADERBOARD_PATH;
+  const raw = fs.readFileSync(target, "utf-8");
+  return JSON.parse(raw);
+}
+
+/**
+ * Increment a contributor's count on the leaderboard.
+ *
+ * @param {Record<string, number>} board – current leaderboard object
+ * @param {string} username              – GitHub username to increment
+ * @param {number} [increment=1]         – amount to add
+ * @returns {Record<string, number>}     – mutated board (same reference)
+ */
+function incrementContributor(board, username, increment = 1) {
+  if (typeof username !== "string" || username.trim() === "") {
+    throw new Error("username must be a non-empty string");
+  }
+  if (typeof increment !== "number" || increment < 1) {
+    throw new Error("increment must be a positive number");
+  }
+  board[username] = (board[username] || 0) + increment;
+  return board;
+}
+
+/**
+ * Write the leaderboard object back to disk.
+ * @param {Record<string, number>} board
+ * @param {string} [filePath]
+ */
+function writeLeaderboard(board, filePath) {
+  const target = filePath || LEADERBOARD_PATH;
+  fs.writeFileSync(target, JSON.stringify(board, null, 2) + "\n", "utf-8");
+}
+
+/**
+ * High-level helper: read → increment → write.
+ * @param {string} username
+ * @param {number} [increment=1]
+ * @param {string} [filePath]
+ */
+function updateLeaderboard(username, increment = 1, filePath) {
+  const board = readLeaderboard(filePath);
+  incrementContributor(board, username, increment);
+  writeLeaderboard(board, filePath);
+  return board;
+}
+
+module.exports = {
+  readLeaderboard,
+  incrementContributor,
+  writeLeaderboard,
+  updateLeaderboard,
+  LEADERBOARD_PATH,
+};
+
+// CLI entry-point
+if (require.main === module) {
+  const [, , username, incArg] = process.argv;
+  if (!username) {
+    console.error("Usage: node scripts/update_leaderboard.cjs <username> [increment]");
+    process.exit(1);
+  }
+  const result = updateLeaderboard(username, incArg ? Number(incArg) : 1);
+  console.log(`Leaderboard updated for ${username}:`, result[username]);
+}

--- a/scripts/update_leaderboard.test.cjs
+++ b/scripts/update_leaderboard.test.cjs
@@ -1,0 +1,140 @@
+const { describe, it, beforeEach, afterEach } = require("node:test");
+const assert = require("node:assert/strict");
+const fs = require("fs");
+const path = require("path");
+const os = require("os");
+
+const {
+  readLeaderboard,
+  incrementContributor,
+  writeLeaderboard,
+  updateLeaderboard,
+} = require("./update_leaderboard.cjs");
+
+// Helper: create a temporary leaderboard file for isolation
+function tmpFile(data) {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), "lb-test-"));
+  const file = path.join(dir, "leaderboard.json");
+  fs.writeFileSync(file, JSON.stringify(data, null, 2) + "\n");
+  return { dir, file };
+}
+
+function cleanup(dir) {
+  fs.rmSync(dir, { recursive: true, force: true });
+}
+
+// ── readLeaderboard ──────────────────────────────────────────────────
+
+describe("readLeaderboard", () => {
+  it("reads and parses an existing leaderboard file", () => {
+    const { dir, file } = tmpFile({ alice: 5, bob: 3 });
+    try {
+      const board = readLeaderboard(file);
+      assert.deepStrictEqual(board, { alice: 5, bob: 3 });
+    } finally {
+      cleanup(dir);
+    }
+  });
+
+  it("returns empty object for empty leaderboard", () => {
+    const { dir, file } = tmpFile({});
+    try {
+      const board = readLeaderboard(file);
+      assert.deepStrictEqual(board, {});
+    } finally {
+      cleanup(dir);
+    }
+  });
+});
+
+// ── incrementContributor ─────────────────────────────────────────────
+
+describe("incrementContributor", () => {
+  it("creates a new entry for a contributor not yet on the board", () => {
+    const board = { alice: 5 };
+    incrementContributor(board, "newuser");
+    assert.strictEqual(board["newuser"], 1);
+    assert.strictEqual(board["alice"], 5); // unchanged
+  });
+
+  it("increments an existing contributor by 1 (default)", () => {
+    const board = { alice: 5 };
+    incrementContributor(board, "alice");
+    assert.strictEqual(board["alice"], 6);
+  });
+
+  it("increments by a custom amount", () => {
+    const board = { bob: 2 };
+    incrementContributor(board, "bob", 4);
+    assert.strictEqual(board["bob"], 6);
+  });
+
+  it("throws on empty username", () => {
+    assert.throws(() => incrementContributor({}, ""), /non-empty string/);
+  });
+
+  it("throws on zero increment", () => {
+    assert.throws(() => incrementContributor({}, "x", 0), /positive number/);
+  });
+
+  it("throws on negative increment", () => {
+    assert.throws(() => incrementContributor({}, "x", -1), /positive number/);
+  });
+});
+
+// ── writeLeaderboard ─────────────────────────────────────────────────
+
+describe("writeLeaderboard", () => {
+  it("writes the board to disk and it can be read back", () => {
+    const { dir, file } = tmpFile({});
+    try {
+      writeLeaderboard({ foo: 10 }, file);
+      const roundtrip = readLeaderboard(file);
+      assert.deepStrictEqual(roundtrip, { foo: 10 });
+    } finally {
+      cleanup(dir);
+    }
+  });
+});
+
+// ── updateLeaderboard (integration) ──────────────────────────────────
+
+describe("updateLeaderboard", () => {
+  it("handles a new contributor end-to-end", () => {
+    const { dir, file } = tmpFile({ existing: 3 });
+    try {
+      const result = updateLeaderboard("brandnew", 1, file);
+      assert.strictEqual(result["brandnew"], 1);
+      assert.strictEqual(result["existing"], 3);
+      // verify file on disk
+      const fromDisk = readLeaderboard(file);
+      assert.deepStrictEqual(fromDisk, result);
+    } finally {
+      cleanup(dir);
+    }
+  });
+
+  it("handles an existing contributor end-to-end", () => {
+    const { dir, file } = tmpFile({ existing: 3 });
+    try {
+      updateLeaderboard("existing", 2, file);
+      const fromDisk = readLeaderboard(file);
+      assert.strictEqual(fromDisk["existing"], 5);
+    } finally {
+      cleanup(dir);
+    }
+  });
+
+  it("does not corrupt other entries", () => {
+    const { dir, file } = tmpFile({ a: 1, b: 2, c: 3 });
+    try {
+      updateLeaderboard("b", 10, file);
+      const board = readLeaderboard(file);
+      assert.strictEqual(board["a"], 1);
+      assert.strictEqual(board["b"], 12);
+      assert.strictEqual(board["c"], 3);
+    } finally {
+      cleanup(dir);
+    }
+  });
+});


### PR DESCRIPTION
## Summary

- Extract leaderboard increment logic into `scripts/update_leaderboard.cjs` so it can be tested and reused by the PR leaderboard workflow.
- Add 12 Node built-in unit tests covering new contributors, existing contributors, file I/O, and input validation.
- Register AI agent contribution in `contributors/agents.json` per the repository instructions.

## Verification

```
node --test scripts/update_leaderboard.test.cjs
```

All 12 tests pass.

Closes #485