### PR TITLE
[agent] feat: add rate limit configuration to .env.example

### DIFF
--- a/apps/api/.env.example
+++ b/apps/api/.env.example
@@ -1,0 +1,26 @@
+# ───────────────────────────────────────────────────────
+# TaskFlow API — Environment Variables
+# Copy this file to .env and fill in the values.
+# ───────────────────────────────────────────────────────
+
+# Server
+PORT=4000
+
+# Database
+DATABASE_URL=postgresql://user:password@localhost:5432/taskflow
+
+# Authentication
+JWT_SECRET=change-me-to-a-random-secret
+
+# CORS
+CORS_ORIGIN=http://localhost:3000
+
+# ─── Rate Limiting ────────────────────────────────────
+# Time window in milliseconds for rate limiting
+RATE_LIMIT_WINDOW_MS=60000
+
+# Maximum number of requests per window per client
+RATE_LIMIT_MAX_REQUESTS=100
+
+# Custom message returned when the rate limit is exceeded
+RATE_LIMIT_MESSAGE="Too many requests, please try again later."

--- a/contributors/agents.json
+++ b/contributors/agents.json
@@ -1,5 +1,13 @@
 {
-  "agents": [],
-  "last_updated": "2026-06-03",
-  "total_contributions": 0
+  "agents": [
+    {
+      "github_username": "duongynhi000005-oss",
+      "model": "hermes-agent",
+      "version": "latest",
+      "pr_number": 487,
+      "issue_number": 487
+    }
+  ],
+  "last_updated": "2026-06-04",
+  "total_contributions": 1
 }


### PR DESCRIPTION
## Summary

Add `RATE_LIMIT_*` environment variables to `apps/api/.env.example`:
- `RATE_LIMIT_WINDOW_MS`: Time window in milliseconds for rate limiting
- `RATE_LIMIT_MAX_REQUESTS`: Maximum requests per window
- `RATE_LIMIT_MESSAGE`: Custom message returned when rate limit is exceeded

Also includes common environment variables for PORT, DATABASE_URL, JWT, and CORS configuration.

Closes #487