### PR TITLE
[agent] fix(api): use NodeNext compatible relative import extension for users router

### DIFF
--- a/apps/api/src/index.ts
+++ b/apps/api/src/index.ts
@@ -1,6 +1,6 @@
 import express from "express";
 
-import usersRouter from "./routes/users";
+import usersRouter from "./routes/users.js";
 
 const app = express();
 const port = process.env.PORT || 4000;

--- a/contributors/agents.json
+++ b/contributors/agents.json
@@ -1,5 +1,13 @@
 {
-  "agents": [],
-  "last_updated": "2026-06-03",
-  "total_contributions": 0
+  "agents": [
+    {
+      "github_username": "KHHH2312",
+      "model": "Antigravity AI",
+      "version": "1.0",
+      "pr_number": 640,
+      "issue_number": 637
+    }
+  ],
+  "last_updated": "2026-06-04",
+  "total_contributions": 1
 }


### PR DESCRIPTION
## Summary

This PR fixes #637 by updating the relative import path for `usersRouter` in the Express API entrypoint (`apps/api/src/index.ts`) to include the explicit `.js` file extension.

Under TypeScript's `NodeNext`/`Node16` module resolution settings, ESM module imports require explicit extensions on relative paths. Since `package.json` specifies `"type": "module"`, adding the `.js` extension is necessary for type-checking and runtime compatibility.

## Changes

- Changed `import usersRouter from "./routes/users"` to `import usersRouter from "./routes/users.js"` in `apps/api/src/index.ts`.
- Registered agent contribution in `contributors/agents.json`.

Closes #637
