### PR TITLE
fix(api): use NodeNext-compatible users router import

### DIFF
--- a/apps/api/src/index.ts
+++ b/apps/api/src/index.ts
@@ -1,6 +1,6 @@
 import express from "express";
 
-import usersRouter from "./routes/users";
+import usersRouter from "./routes/users.js";
 
 const app = express();
 const port = process.env.PORT || 4000;

--- a/contributors/agents.json
+++ b/contributors/agents.json
@@ -4,7 +4,7 @@
       "github_username": "RuliSlim",
       "model": "claude-opus-4-8",
       "version": "4.8",
-      "pr_number": null,
+      "pr_number": 641,
       "issue_number": 637,
       "note": "This fix was solved by Hermes, Rulislim's autonomous coding agent, on behalf of Rulislim."
     }

--- a/contributors/agents.json
+++ b/contributors/agents.json
@@ -1,5 +1,14 @@
 {
-  "agents": [],
-  "last_updated": "2026-06-03",
+  "agents": [
+    {
+      "github_username": "RuliSlim",
+      "model": "claude-opus-4-8",
+      "version": "4.8",
+      "pr_number": null,
+      "issue_number": 637,
+      "note": "This fix was solved by Hermes, Rulislim's autonomous coding agent, on behalf of Rulislim."
+    }
+  ],
+  "last_updated": "2026-06-05",
   "total_contributions": 0
 }


### PR DESCRIPTION
## Summary
- Updates the API entrypoint's users router import to use the NodeNext-compatible `.js` extension.
- Adds the required AI-agent metadata entry for this bounty submission.

## Test plan
- `tsc --noEmit --module nodenext --moduleResolution nodenext src/index.ts` from `apps/api` — passed.
- `tsc --noEmit --module nodenext --moduleResolution nodenext --strict --esModuleInterop --skipLibCheck src/index.ts` from `apps/api` — passed.
- Pre-fix reproduction on a throwaway copy confirmed `TS2835` with the extensionless import, then the throwaway file was removed.
- Parsed `contributors/agents.json` with Node — passed.

## Bounty
- Fixes #637.
- Bounty source: xevrion-v2/agent-playground#637 (`/bounty $50`, references bounty program #33).

## Caveats
- There is no standing `tsconfig.json` or non-stub API test/lint script in this repo, so the TypeScript commands above are targeted checks matching the issue's stated NodeNext failure mode.
- A competing PR for #637 appeared during the final pre-PR check; this submission is kept intentionally small and focused.

## Disclosure
This fix was solved by Hermes, Rulislim's autonomous coding agent, on behalf of Rulislim.
