### PR TITLE
[agent] Add API 404 and error handling middleware

### DIFF
--- a/apps/api/src/index.ts
+++ b/apps/api/src/index.ts
@@ -1,4 +1,4 @@
-import express from "express";
+import express, { type NextFunction, type Request, type Response } from "express";
 
 import usersRouter from "./routes/users";
 
@@ -12,6 +12,25 @@ app.get("/health", (_req, res) => {
 });
 
 app.use("/users", usersRouter);
+
+app.use((_req, res) => {
+  res.status(404).json({ error: "Route not found" });
+});
+
+app.use((err: unknown, _req: Request, res: Response, next: NextFunction) => {
+  if (res.headersSent) {
+    next(err);
+    return;
+  }
+
+  const message = err instanceof Error ? err.message : "Unknown error";
+
+  console.error("Unhandled error:", err);
+  res.status(500).json({
+    error: "Internal server error",
+    ...(process.env.NODE_ENV === "development" ? { message } : {})
+  });
+});
 
 app.listen(port, () => {
   console.log(`TaskFlow API listening on port ${port}`);

--- a/contributors/agents.json
+++ b/contributors/agents.json
@@ -4,7 +4,7 @@
       "github_username": "modelsbridgeaicom-ship-it",
       "model": "GPT-5 Codex",
       "version": "2026-06-05",
-      "pr_number": 0,
+      "pr_number": 644,
       "issue_number": 225
     }
   ],

--- a/contributors/agents.json
+++ b/contributors/agents.json
@@ -1,5 +1,13 @@
 {
-  "agents": [],
-  "last_updated": "2026-06-03",
-  "total_contributions": 0
+  "agents": [
+    {
+      "github_username": "modelsbridgeaicom-ship-it",
+      "model": "GPT-5 Codex",
+      "version": "2026-06-05",
+      "pr_number": 0,
+      "issue_number": 225
+    }
+  ],
+  "last_updated": "2026-06-05",
+  "total_contributions": 1
 }


### PR DESCRIPTION
﻿Closes #225.

## Summary
- add a 404 JSON handler after mounted API routes
- add final Express error-handling middleware with development-only error messages
- preserve existing /health and /users behavior
- add required AI agent metadata for bounty review

## Validation
- npm test
- npx tsc --noEmit --target ES2022 --module ESNext --moduleResolution Bundler --esModuleInterop --skipLibCheck --strict apps/api/src/index.ts
- started the API with tsx and verified /health returns 200
- verified /missing-route returns 404 with { "error": "Route not found" }
- git diff --check



/claim #225

