### PR TITLE
[agent] Validate POST /users payload

### DIFF
--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -11,7 +11,8 @@
     "lint": "echo \"No API lint configured yet\""
   },
   "dependencies": {
-    "express": "^4.18.3"
+    "express": "^4.18.3",
+    "zod": "^3.23.8"
   },
   "devDependencies": {
     "@types/express": "^4.17.21",

--- a/apps/api/src/routes/users.ts
+++ b/apps/api/src/routes/users.ts
@@ -1,6 +1,14 @@
 import { Router } from "express";
+import { z } from "zod";
 
 const router = Router();
+
+const createUserSchema = z
+  .object({
+    email: z.string().email(),
+    name: z.string().min(1).optional()
+  })
+  .strict();
 
 router.get("/", (_req, res) => {
   res.json({
@@ -10,10 +18,20 @@ router.get("/", (_req, res) => {
 });
 
 router.post("/", (req, res) => {
+  const parsed = createUserSchema.safeParse(req.body);
+
+  if (!parsed.success) {
+    return res.status(400).json({
+      error: "Invalid user payload",
+      details: parsed.error.flatten()
+    });
+  }
+
   res.status(201).json({
     data: {
       id: "stub-user-id",
-      ...req.body
+      email: parsed.data.email,
+      name: parsed.data.name
     },
     message: "User creation is not implemented yet."
   });

--- a/contributors/agents.json
+++ b/contributors/agents.json
@@ -1,5 +1,13 @@
 {
-  "agents": [],
-  "last_updated": "2026-06-03",
-  "total_contributions": 0
+  "agents": [
+    {
+      "github_username": "modelsbridgeaicom-ship-it",
+      "model": "GPT-5 Codex",
+      "version": "2026-06-05",
+      "pr_number": 0,
+      "issue_number": 223
+    }
+  ],
+  "last_updated": "2026-06-05",
+  "total_contributions": 1
 }

--- a/contributors/agents.json
+++ b/contributors/agents.json
@@ -4,7 +4,7 @@
       "github_username": "modelsbridgeaicom-ship-it",
       "model": "GPT-5 Codex",
       "version": "2026-06-05",
-      "pr_number": 0,
+      "pr_number": 645,
       "issue_number": 223
     }
   ],


### PR DESCRIPTION
﻿Closes #223.

## Summary
- add strict Zod validation for POST /users payloads
- reject unknown fields such as role/isAdmin instead of echoing them back
- preserve the existing stub response for valid email/name payloads
- add required AI agent metadata for bounty review

## Validation
- npm test
- npx tsc --noEmit --target ES2022 --module ESNext --moduleResolution Bundler --esModuleInterop --skipLibCheck --strict apps/api/src/routes/users.ts
- started the API with tsx and verified a valid POST /users returns 201
- verified POST /users with { "email": "user@example.com", "role": "admin" } returns 400
- git diff --check



/claim #223

