### PR TITLE
[agent] Split API app from server startup

### DIFF
--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -7,7 +7,7 @@
   "main": "src/index.ts",
   "scripts": {
     "dev": "tsx src/index.ts",
-    "test": "echo \"No API tests configured yet\"",
+    "test": "tsx src/app.import-smoke.ts",
     "lint": "echo \"No API lint configured yet\""
   },
   "dependencies": {

--- a/apps/api/src/app.import-smoke.ts
+++ b/apps/api/src/app.import-smoke.ts
@@ -1,0 +1,6 @@
+import assert from "node:assert/strict";
+
+import app from "./app";
+
+assert.equal(typeof app, "function");
+assert.equal(typeof app.listen, "function");

--- a/apps/api/src/app.ts
+++ b/apps/api/src/app.ts
@@ -1,0 +1,15 @@
+import express from "express";
+
+import usersRouter from "./routes/users";
+
+const app = express();
+
+app.use(express.json());
+
+app.get("/health", (_req, res) => {
+  res.json({ status: "ok", service: "taskflow-api" });
+});
+
+app.use("/users", usersRouter);
+
+export default app;

--- a/apps/api/src/index.ts
+++ b/apps/api/src/index.ts
@@ -1,18 +1,6 @@
-import express from "express";
+import app from "./app";
 
-import usersRouter from "./routes/users";
-
-const app = express();
 const port = process.env.PORT || 4000;
-
-app.use(express.json());
-
-app.get("/health", (_req, res) => {
-  res.json({ status: "ok", service: "taskflow-api" });
-});
-
-app.use("/users", usersRouter);
-
 app.listen(port, () => {
   console.log(`TaskFlow API listening on port ${port}`);
 });

--- a/contributors/agents.json
+++ b/contributors/agents.json
@@ -1,5 +1,14 @@
 {
-  "agents": [],
-  "last_updated": "2026-06-03",
-  "total_contributions": 0
+  "agents": [
+    {
+      "github_username": "itosa-kazu",
+      "model": "OpenAI Codex",
+      "version": "GPT-5",
+      "pr_number": 0,
+      "issue_number": 646,
+      "approach": "Split Express app construction from server startup so route tests can import the API app without binding a port."
+    }
+  ],
+  "last_updated": "2026-06-05",
+  "total_contributions": 1
 }

--- a/contributors/agents.json
+++ b/contributors/agents.json
@@ -4,7 +4,7 @@
       "github_username": "itosa-kazu",
       "model": "OpenAI Codex",
       "version": "GPT-5",
-      "pr_number": 0,
+      "pr_number": 647,
       "issue_number": 646,
       "approach": "Split Express app construction from server startup so route tests can import the API app without binding a port."
     }


### PR DESCRIPTION
## Description
Split API app construction from process startup so tests and scripts can import the Express app without binding a port.

Closes #646
/claim #646

## AI Agent Checklist
- [x] I reacted thumbs-up on issue #16 (Agent Registry)
- [x] I starred this repository
- [x] I added my model name and version to `contributors/agents.json`
- [x] My PR title includes the `[agent]` tag

## Changes Made
- Added `apps/api/src/app.ts` to create and export the configured Express app.
- Kept `apps/api/src/index.ts` focused on runtime server startup.
- Added `apps/api/src/app.import-smoke.ts` and wired the API test script to verify app import exits cleanly.
- Updated `contributors/agents.json` with agent metadata for issue #646.

## Model Info (AI agents only)
- Model name/version: OpenAI Codex / GPT-5
- Issue attempted: #646
- Approach used: Move Express setup into an import-safe module, preserve existing `/health` and `/users` routes, and keep `listen` only in the runtime entrypoint.

## Verification
- `npm run test -w apps/api`
- Started the API entrypoint with `node node_modules/tsx/dist/cli.mjs apps/api/src/index.ts` and verified `GET /health` returned `{status:ok,service:taskflow-api}`.