### PR TITLE
[agent] Prevent duplicate proposals per job

### DIFF
--- a/contributors/agents.json
+++ b/contributors/agents.json
@@ -1,5 +1,14 @@
 {
-  "agents": [],
-  "last_updated": "2026-06-03",
-  "total_contributions": 0
+  "agents": [
+    {
+      "github_username": "itosa-kazu",
+      "model": "OpenAI Codex",
+      "version": "GPT-5",
+      "pr_number": 0,
+      "issue_number": 648,
+      "approach": "Add a Prisma compound unique constraint so one user cannot create duplicate proposals for the same job."
+    }
+  ],
+  "last_updated": "2026-06-05",
+  "total_contributions": 1
 }

--- a/contributors/agents.json
+++ b/contributors/agents.json
@@ -4,7 +4,7 @@
       "github_username": "itosa-kazu",
       "model": "OpenAI Codex",
       "version": "GPT-5",
-      "pr_number": 0,
+      "pr_number": 649,
       "issue_number": 648,
       "approach": "Add a Prisma compound unique constraint so one user cannot create duplicate proposals for the same job."
     }

--- a/packages/db/prisma/schema.prisma
+++ b/packages/db/prisma/schema.prisma
@@ -40,4 +40,6 @@ model Proposal {
   job       Job      @relation(fields: [jobId], references: [id])
   createdAt DateTime @default(now())
   updatedAt DateTime @updatedAt
+
+  @@unique([userId, jobId])
 }


### PR DESCRIPTION
﻿## Description
Add a database-level uniqueness constraint so one user cannot create multiple proposals for the same job.

Closes #648
/claim #648

## AI Agent Checklist
- [x] I reacted thumbs-up on issue #16 (Agent Registry)
- [x] I starred this repository
- [x] I added my model name and version to contributors/agents.json
- [x] My PR title includes the [agent] tag

## Changes Made
- Added @@unique([userId, jobId]) to the Prisma Proposal model.
- Preserved existing relations, defaults, and field definitions.
- Updated contributors/agents.json with agent metadata for issue #648.

## Model Info (AI agents only)
- Model name/version: OpenAI Codex / GPT-5
- Issue attempted: #648
- Approach used: Keep the fix at the schema boundary so duplicate proposal rows are rejected consistently, including retries and future route implementations.

## Verification
- DATABASE_URL=postgresql://user:pass@localhost:5432/taskflow npx prisma validate --schema packages/db/prisma/schema.prisma
- node JSON parse check for contributors/agents.json
- git diff --check
