### PR TITLE
[agent] Add validation for user creation route

### DIFF
--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -7,7 +7,7 @@
   "main": "src/index.ts",
   "scripts": {
     "dev": "tsx src/index.ts",
-    "test": "echo \"No API tests configured yet\"",
+    "test": "tsx --test \"src/**/*.test.ts\"",
     "lint": "echo \"No API lint configured yet\""
   },
   "dependencies": {

--- a/apps/api/src/routes/users.test.ts
+++ b/apps/api/src/routes/users.test.ts
@@ -1,0 +1,116 @@
+import assert from "node:assert/strict";
+import http from "node:http";
+import test from "node:test";
+
+import express from "express";
+
+import usersRouter, { validateCreateUserPayload } from "./users";
+
+type JsonResponse = {
+  statusCode: number;
+  body: any;
+};
+
+async function postUser(payload: unknown): Promise<JsonResponse> {
+  const app = express();
+  app.use(express.json());
+  app.use("/users", usersRouter);
+
+  const server = http.createServer(app);
+
+  await new Promise<void>((resolve) => server.listen(0, resolve));
+
+  const address = server.address();
+  assert.notEqual(address, null);
+  assert.notEqual(typeof address, "string");
+
+  const port = typeof address === "object" && address ? address.port : 0;
+  const body = JSON.stringify(payload);
+
+  try {
+    return await new Promise<JsonResponse>((resolve, reject) => {
+      const req = http.request(
+        {
+          hostname: "127.0.0.1",
+          port,
+          path: "/users",
+          method: "POST",
+          headers: {
+            "content-type": "application/json",
+            "content-length": Buffer.byteLength(body)
+          }
+        },
+        (res) => {
+          const chunks: Buffer[] = [];
+          res.on("data", (chunk) => chunks.push(Buffer.from(chunk)));
+          res.on("end", () => {
+            const raw = Buffer.concat(chunks).toString("utf8");
+            resolve({
+              statusCode: res.statusCode ?? 0,
+              body: raw ? JSON.parse(raw) : null
+            });
+          });
+        }
+      );
+
+      req.on("error", reject);
+      req.end(body);
+    });
+  } finally {
+    await new Promise<void>((resolve, reject) => {
+      server.close((error) => (error ? reject(error) : resolve()));
+    });
+  }
+}
+
+test("validateCreateUserPayload accepts and normalizes valid payloads", () => {
+  const result = validateCreateUserPayload({
+    name: "  Ada Lovelace  ",
+    email: "ADA@Example.COM"
+  });
+
+  assert.equal(result.ok, true);
+
+  if (result.ok) {
+    assert.deepEqual(result.value, {
+      name: "Ada Lovelace",
+      email: "ada@example.com"
+    });
+  }
+});
+
+test("POST /users returns a clear error for invalid request shapes", async () => {
+  const response = await postUser({ email: "invalid-email" });
+
+  assert.equal(response.statusCode, 400);
+  assert.equal(response.body.error.code, "INVALID_USER_PAYLOAD");
+  assert.deepEqual(
+    response.body.error.details.map((detail: { field: string }) => detail.field),
+    ["name", "email"]
+  );
+});
+
+test("POST /users rejects unexpected fields instead of mass-assigning them", async () => {
+  const response = await postUser({
+    name: "Grace Hopper",
+    email: "grace@example.com",
+    role: "admin"
+  });
+
+  assert.equal(response.statusCode, 400);
+  assert.equal(response.body.error.details[0].field, "role");
+});
+
+test("POST /users returns only the validated user fields", async () => {
+  const response = await postUser({
+    name: "Grace Hopper",
+    email: "GRACE@EXAMPLE.COM"
+  });
+
+  assert.equal(response.statusCode, 201);
+  assert.deepEqual(response.body.data, {
+    id: "stub-user-id",
+    name: "Grace Hopper",
+    email: "grace@example.com"
+  });
+});

--- a/apps/api/src/routes/users.ts
+++ b/apps/api/src/routes/users.ts
@@ -2,6 +2,66 @@ import { Router } from "express";
 
 const router = Router();
 
+type CreateUserPayload = {
+  name: string;
+  email: string;
+};
+
+type ValidationResult =
+  | { ok: true; value: CreateUserPayload }
+  | { ok: false; errors: Array<{ field: string; message: string }> };
+
+const allowedCreateUserFields = new Set(["name", "email"]);
+const emailPattern = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+export function validateCreateUserPayload(body: unknown): ValidationResult {
+  if (!isRecord(body)) {
+    return {
+      ok: false,
+      errors: [{ field: "body", message: "Request body must be a JSON object." }]
+    };
+  }
+
+  const errors: Array<{ field: string; message: string }> = [];
+
+  for (const field of Object.keys(body)) {
+    if (!allowedCreateUserFields.has(field)) {
+      errors.push({ field, message: "Field is not allowed." });
+    }
+  }
+
+  const rawName = body.name;
+  const rawEmail = body.email;
+
+  if (typeof rawName !== "string" || rawName.trim().length === 0) {
+    errors.push({ field: "name", message: "Name is required." });
+  } else if (rawName.trim().length > 120) {
+    errors.push({ field: "name", message: "Name must be 120 characters or fewer." });
+  }
+
+  if (typeof rawEmail !== "string" || rawEmail.trim().length === 0) {
+    errors.push({ field: "email", message: "Email is required." });
+  } else if (!emailPattern.test(rawEmail.trim())) {
+    errors.push({ field: "email", message: "Email must be valid." });
+  }
+
+  if (errors.length > 0) {
+    return { ok: false, errors };
+  }
+
+  return {
+    ok: true,
+    value: {
+      name: String(rawName).trim(),
+      email: String(rawEmail).trim().toLowerCase()
+    }
+  };
+}
+
 router.get("/", (_req, res) => {
   res.json({
     data: [],
@@ -10,10 +70,22 @@ router.get("/", (_req, res) => {
 });
 
 router.post("/", (req, res) => {
+  const result = validateCreateUserPayload(req.body);
+
+  if (!result.ok) {
+    return res.status(400).json({
+      error: {
+        code: "INVALID_USER_PAYLOAD",
+        message: "User payload failed validation.",
+        details: result.errors
+      }
+    });
+  }
+
   res.status(201).json({
     data: {
       id: "stub-user-id",
-      ...req.body
+      ...result.value
     },
     message: "User creation is not implemented yet."
   });

--- a/contributors/agents.json
+++ b/contributors/agents.json
@@ -1,5 +1,13 @@
 {
-  "agents": [],
-  "last_updated": "2026-06-03",
-  "total_contributions": 0
+  "agents": [
+    {
+      "github_username": "ivandejesus1806",
+      "model": "GPT-5 Codex",
+      "version": "2026-06-04",
+      "pr_number": 650,
+      "issue_number": 6
+    }
+  ],
+  "last_updated": "2026-06-04",
+  "total_contributions": 1
 }


### PR DESCRIPTION
Closes #6

## Summary
- Adds lightweight validation for `POST /users` payloads.
- Requires `name` and `email`, normalizes accepted fields, and rejects unknown fields instead of spreading arbitrary request body data into the response.
- Adds node:test coverage for valid payloads, invalid shapes, and mass-assignment prevention.
- Updates `contributors/agents.json` for the required AI agent metadata.

## Validation
- `npm test --workspace @taskflow/api`
- `npm test`
- `git diff --check`
- `node -e "JSON.parse(require('fs').readFileSync('contributors/agents.json','utf8')); console.log('agents.json ok')"`