### PR TITLE
[agent] Normalize health check response envelope

### DIFF
--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -7,7 +7,7 @@
   "main": "src/index.ts",
   "scripts": {
     "dev": "tsx src/index.ts",
-    "test": "echo \"No API tests configured yet\"",
+    "test": "tsx --test \"src/**/*.test.ts\"",
     "lint": "echo \"No API lint configured yet\""
   },
   "dependencies": {

--- a/apps/api/src/app.test.ts
+++ b/apps/api/src/app.test.ts
@@ -1,0 +1,59 @@
+import assert from "node:assert/strict";
+import http from "node:http";
+import test from "node:test";
+
+import { createApp } from "./app";
+
+async function getJson(path: string) {
+  const server = http.createServer(createApp());
+
+  await new Promise<void>((resolve) => server.listen(0, resolve));
+
+  const address = server.address();
+  assert.notEqual(address, null);
+  assert.notEqual(typeof address, "string");
+
+  const port = typeof address === "object" && address ? address.port : 0;
+
+  try {
+    return await new Promise<{ statusCode: number; body: unknown }>((resolve, reject) => {
+      const req = http.request(
+        {
+          hostname: "127.0.0.1",
+          port,
+          path,
+          method: "GET"
+        },
+        (res) => {
+          const chunks: Buffer[] = [];
+          res.on("data", (chunk) => chunks.push(Buffer.from(chunk)));
+          res.on("end", () => {
+            resolve({
+              statusCode: res.statusCode ?? 0,
+              body: JSON.parse(Buffer.concat(chunks).toString("utf8"))
+            });
+          });
+        }
+      );
+
+      req.on("error", reject);
+      req.end();
+    });
+  } finally {
+    await new Promise<void>((resolve, reject) => {
+      server.close((error) => (error ? reject(error) : resolve()));
+    });
+  }
+}
+
+test("GET /health returns the standard status/data envelope", async () => {
+  const response = await getJson("/health");
+
+  assert.equal(response.statusCode, 200);
+  assert.deepEqual(response.body, {
+    status: "ok",
+    data: {
+      service: "taskflow-api"
+    }
+  });
+});

--- a/apps/api/src/app.ts
+++ b/apps/api/src/app.ts
@@ -1,0 +1,22 @@
+import express from "express";
+
+import usersRouter from "./routes/users";
+
+export function createApp() {
+  const app = express();
+
+  app.use(express.json());
+
+  app.get("/health", (_req, res) => {
+    res.json({
+      status: "ok",
+      data: {
+        service: "taskflow-api"
+      }
+    });
+  });
+
+  app.use("/users", usersRouter);
+
+  return app;
+}

--- a/apps/api/src/index.ts
+++ b/apps/api/src/index.ts
@@ -1,17 +1,7 @@
-import express from "express";
+import { createApp } from "./app";
 
-import usersRouter from "./routes/users";
-
-const app = express();
 const port = process.env.PORT || 4000;
-
-app.use(express.json());
-
-app.get("/health", (_req, res) => {
-  res.json({ status: "ok", service: "taskflow-api" });
-});
-
-app.use("/users", usersRouter);
+const app = createApp();
 
 app.listen(port, () => {
   console.log(`TaskFlow API listening on port ${port}`);

--- a/contributors/agents.json
+++ b/contributors/agents.json
@@ -1,5 +1,13 @@
 {
-  "agents": [],
-  "last_updated": "2026-06-03",
-  "total_contributions": 0
+  "agents": [
+    {
+      "github_username": "IvanchitorJR",
+      "model": "GPT-5 Codex",
+      "version": "2026-06-04",
+      "pr_number": 652,
+      "issue_number": 8
+    }
+  ],
+  "last_updated": "2026-06-04",
+  "total_contributions": 1
 }


### PR DESCRIPTION
Closes #8

## Summary
- Moves Express app construction into createApp() so routes can be tested without starting a listener.
- Normalizes GET /health to the standard { status, data } envelope.
- Adds node:test coverage for the health check response.
- Updates required AI agent metadata.

## Validation
- npm test --workspace @taskflow/api
- npm test
- git diff --check
- contributors/agents.json parse check