### PR TITLE
[agent] Add Prisma status enums

### DIFF
--- a/contributors/agents.json
+++ b/contributors/agents.json
@@ -1,5 +1,12 @@
 {
-  "agents": [],
-  "last_updated": "2026-06-03",
-  "total_contributions": 0
+  "agents": [
+    {
+      "model": "GPT-5 Codex",
+      "version": "2026-06-05",
+      "issue": "#657",
+      "contribution": "Added Prisma enums for job and proposal status values."
+    }
+  ],
+  "last_updated": "2026-06-05",
+  "total_contributions": 1
 }

--- a/packages/db/prisma/schema.prisma
+++ b/packages/db/prisma/schema.prisma
@@ -7,6 +7,21 @@ datasource db {
   url      = env("DATABASE_URL")
 }
 
+enum JobStatus {
+  DRAFT       @map("draft")
+  OPEN        @map("open")
+  IN_PROGRESS @map("in_progress")
+  COMPLETED   @map("completed")
+  CANCELLED   @map("cancelled")
+}
+
+enum ProposalStatus {
+  PENDING   @map("pending")
+  ACCEPTED  @map("accepted")
+  REJECTED  @map("rejected")
+  WITHDRAWN @map("withdrawn")
+}
+
 model User {
   id        String     @id @default(cuid())
   email     String     @unique
@@ -21,7 +36,7 @@ model Job {
   id          String     @id @default(cuid())
   title       String
   description String?
-  status      String     @default("draft")
+  status      JobStatus  @default(DRAFT)
   ownerId     String
   owner       User       @relation(fields: [ownerId], references: [id])
   proposals   Proposal[]
@@ -30,14 +45,14 @@ model Job {
 }
 
 model Proposal {
-  id        String   @id @default(cuid())
+  id        String         @id @default(cuid())
   summary   String
   amount    Decimal?
-  status    String   @default("pending")
+  status    ProposalStatus @default(PENDING)
   userId    String
-  user      User     @relation(fields: [userId], references: [id])
+  user      User           @relation(fields: [userId], references: [id])
   jobId     String
-  job       Job      @relation(fields: [jobId], references: [id])
-  createdAt DateTime @default(now())
-  updatedAt DateTime @updatedAt
+  job       Job            @relation(fields: [jobId], references: [id])
+  createdAt DateTime       @default(now())
+  updatedAt DateTime       @updatedAt
 }


### PR DESCRIPTION
Closes #657
/claim #657

## Summary
- add `JobStatus` and `ProposalStatus` Prisma enums for workflow state fields
- preserve the existing `draft` and `pending` defaults through mapped enum values
- add the required AI agent metadata entry

## Testing
- `npm exec -w packages/db -- prisma format --schema prisma/schema.prisma`
- `DATABASE_URL=postgresql://user:pass@localhost:5432/taskflow npm exec -w packages/db -- prisma validate --schema prisma/schema.prisma`
- `npm test -w packages/db`
- `node -e "JSON.parse(require('fs').readFileSync('contributors/agents.json','utf8')); console.log('agents.json ok')"`
- `git diff --check`

## Model Info
- Model name/version: GPT-5 Codex / 2026-06-05
- Issue attempted: #657
- Approach used: narrow Prisma schema constraint using enums with mapped database values, keeping relations and defaults unchanged.
