### PR TITLE
[agent] Add Prisma relation indexes

### DIFF
--- a/contributors/agents.json
+++ b/contributors/agents.json
@@ -1,5 +1,12 @@
 {
-  "agents": [],
-  "last_updated": "2026-06-03",
-  "total_contributions": 0
+  "agents": [
+    {
+      "model": "GPT-5 Codex",
+      "version": "2026-06-05",
+      "issue": "#659",
+      "contribution": "Added Prisma relation indexes for job and proposal lookup fields."
+    }
+  ],
+  "last_updated": "2026-06-05",
+  "total_contributions": 1
 }

--- a/packages/db/prisma/schema.prisma
+++ b/packages/db/prisma/schema.prisma
@@ -27,6 +27,8 @@ model Job {
   proposals   Proposal[]
   createdAt   DateTime   @default(now())
   updatedAt   DateTime   @updatedAt
+
+  @@index([ownerId])
 }
 
 model Proposal {
@@ -40,4 +42,7 @@ model Proposal {
   job       Job      @relation(fields: [jobId], references: [id])
   createdAt DateTime @default(now())
   updatedAt DateTime @updatedAt
+
+  @@index([userId])
+  @@index([jobId])
 }


### PR DESCRIPTION
Closes #659
/claim #659

## Summary
- add Prisma indexes for `Job.ownerId`, `Proposal.userId`, and `Proposal.jobId`
- keep existing ids, relations, defaults, and optional fields unchanged
- add the required AI agent metadata entry

## Testing
- `npm exec -w packages/db -- prisma format --schema prisma/schema.prisma`
- `DATABASE_URL=postgresql://user:pass@localhost:5432/taskflow npm exec -w packages/db -- prisma validate --schema prisma/schema.prisma`
- `npm test -w packages/db`
- `node -e "JSON.parse(require('fs').readFileSync('contributors/agents.json','utf8')); console.log('agents.json ok')"`
- `git diff --check`

## Model Info
- Model name/version: GPT-5 Codex / 2026-06-05
- Issue attempted: #659
- Approach used: narrow Prisma schema performance fix using relation lookup indexes for the core marketplace paths.
