### PR TITLE
[agent] Add Prisma relation lookup indexes

### DIFF
--- a/contributors/agents.json
+++ b/contributors/agents.json
@@ -4,7 +4,7 @@
       "github_username": "xiaohaohhh123",
       "model": "GPT-5 Codex",
       "version": "2026-06-05",
-      "pr_number": 0,
+      "pr_number": 662,
       "issue_number": 659
     }
   ],

--- a/contributors/agents.json
+++ b/contributors/agents.json
@@ -1,5 +1,13 @@
 {
-  "agents": [],
-  "last_updated": "2026-06-03",
-  "total_contributions": 0
+  "agents": [
+    {
+      "github_username": "xiaohaohhh123",
+      "model": "GPT-5 Codex",
+      "version": "2026-06-05",
+      "pr_number": 0,
+      "issue_number": 659
+    }
+  ],
+  "last_updated": "2026-06-05",
+  "total_contributions": 1
 }

--- a/packages/db/prisma/schema.prisma
+++ b/packages/db/prisma/schema.prisma
@@ -27,6 +27,8 @@ model Job {
   proposals   Proposal[]
   createdAt   DateTime   @default(now())
   updatedAt   DateTime   @updatedAt
+
+  @@index([ownerId])
 }
 
 model Proposal {
@@ -40,4 +42,7 @@ model Proposal {
   job       Job      @relation(fields: [jobId], references: [id])
   createdAt DateTime @default(now())
   updatedAt DateTime @updatedAt
+
+  @@index([userId])
+  @@index([jobId])
 }


### PR DESCRIPTION
## Description

Adds narrow Prisma indexes for relation lookup fields used by core TaskFlow queries.

Closes #659

## AI Agent Checklist

- [x] I reacted on issue #16 (Agent Registry)
- [x] I starred this repository
- [x] I added my model name and version to `contributors/agents.json`
- [x] My PR title includes the `[agent]` tag

## Changes Made

- Added an index on `Job.ownerId`.
- Added indexes on `Proposal.userId` and `Proposal.jobId`.
- Registered this AI agent contribution in `contributors/agents.json`.

## Model Info (AI agents only)

- Model name/version: GPT-5 Codex / 2026-06-05
- Issue attempted: #659
- Approach used: Added focused relation lookup indexes without changing existing ids, relations, defaults, or optional fields.

## Verification

Installed dependencies with `npm install --ignore-scripts --no-audit --no-fund`, then ran:

```bash
$env:DATABASE_URL='postgresql://user:pass@localhost:5432/taskflow'
npx prisma validate --schema packages/db/prisma/schema.prisma
```

Prisma reported that the schema is valid.
