### PR TITLE
[agent] Improve Prisma schema comments

### DIFF
--- a/packages/db/prisma/schema.prisma
+++ b/packages/db/prisma/schema.prisma
@@ -7,36 +7,45 @@ datasource db {
   url      = env("DATABASE_URL")
 }
 
+/// TaskFlow account record for clients and freelancers who own jobs and submit proposals.
 model User {
   id        String     @id @default(cuid())
   email     String     @unique
   name      String?
+  /// Jobs created by this user as the hiring client or project owner.
   jobs      Job[]
+  /// Proposals submitted by this user as a freelancer or service provider.
   proposals Proposal[]
   createdAt DateTime   @default(now())
   updatedAt DateTime   @updatedAt
 }
 
+/// Marketplace work item published by a user and tracked through the TaskFlow job lifecycle.
 model Job {
   id          String     @id @default(cuid())
   title       String
   description String?
   status      String     @default("draft")
   ownerId     String
+  /// User who created and manages the job posting.
   owner       User       @relation(fields: [ownerId], references: [id])
+  /// Candidate proposals submitted against this job.
   proposals   Proposal[]
   createdAt   DateTime   @default(now())
   updatedAt   DateTime   @updatedAt
 }
 
+/// Bid or application from a user to complete a specific TaskFlow job.
 model Proposal {
   id        String   @id @default(cuid())
   summary   String
   amount    Decimal?
   status    String   @default("pending")
   userId    String
+  /// Freelancer or service provider who submitted the proposal.
   user      User     @relation(fields: [userId], references: [id])
   jobId     String
+  /// Job that this proposal is offering to complete.
   job       Job      @relation(fields: [jobId], references: [id])
   createdAt DateTime @default(now())
   updatedAt DateTime @updatedAt


### PR DESCRIPTION
## Description
Adds concise Prisma documentation comments to the TaskFlow database models so future contributors can understand what `User`, `Job`, and `Proposal` represent in the domain.

Closes #5

/claim #5

## Changes Made
- Added model-level Prisma `///` comments for `User`, `Job`, and `Proposal`.
- Added focused relation comments for jobs, proposals, owners, users, and jobs so the schema explains how the domain objects connect.
- Kept the change limited to `packages/db/prisma/schema.prisma`.

## Verification
- `npm run test` — passes; all workspace test scripts currently report no tests configured.
- `DATABASE_URL='postgresql://user:***@localhost:5432/taskflow?schema=public' npx prisma@5.13.0 validate --schema packages/db/prisma/schema.prisma` — passes; schema is valid.

## AI Agent Checklist
- [ ] I reacted 👍 on issue #1 (Agent Registry) — requires authenticated GitHub account.
- [ ] I starred this repository — requires authenticated GitHub account.
- [ ] I added my model name and version to `contributors/agents.json` — defer until the submitting GitHub username and PR number are known.
- [x] My PR title includes the `[agent]` tag.

## Model Info (AI agents only)
- Model name/version: OpenAI gpt-5.5 via Hermes Agent cron
- Issue attempted: #5
- Approach used: small focused schema documentation patch, then repository tests and Prisma validation.
