### PR TITLE
[agent] Add Prisma status enums

### DIFF
--- a/contributors/agents.json
+++ b/contributors/agents.json
@@ -4,7 +4,7 @@
       "github_username": "xiaohaohhh123",
       "model": "GPT-5 Codex",
       "version": "2026-06-05",
-      "pr_number": 0,
+      "pr_number": 664,
       "issue_number": 657
     }
   ],

--- a/contributors/agents.json
+++ b/contributors/agents.json
@@ -1,5 +1,13 @@
 {
-  "agents": [],
-  "last_updated": "2026-06-03",
-  "total_contributions": 0
+  "agents": [
+    {
+      "github_username": "xiaohaohhh123",
+      "model": "GPT-5 Codex",
+      "version": "2026-06-05",
+      "pr_number": 0,
+      "issue_number": 657
+    }
+  ],
+  "last_updated": "2026-06-05",
+  "total_contributions": 1
 }

--- a/packages/db/prisma/schema.prisma
+++ b/packages/db/prisma/schema.prisma
@@ -7,6 +7,19 @@ datasource db {
   url      = env("DATABASE_URL")
 }
 
+enum JobStatus {
+  draft
+  published
+  closed
+}
+
+enum ProposalStatus {
+  pending
+  accepted
+  rejected
+  withdrawn
+}
+
 model User {
   id        String     @id @default(cuid())
   email     String     @unique
@@ -21,7 +34,7 @@ model Job {
   id          String     @id @default(cuid())
   title       String
   description String?
-  status      String     @default("draft")
+  status      JobStatus  @default(draft)
   ownerId     String
   owner       User       @relation(fields: [ownerId], references: [id])
   proposals   Proposal[]
@@ -33,7 +46,7 @@ model Proposal {
   id        String   @id @default(cuid())
   summary   String
   amount    Decimal?
-  status    String   @default("pending")
+  status    ProposalStatus @default(pending)
   userId    String
   user      User     @relation(fields: [userId], references: [id])
   jobId     String


### PR DESCRIPTION
## Description

Replaces free-form Prisma string status fields with narrow enums for job and proposal workflows while preserving the existing defaults.

Closes #657

## AI Agent Checklist

- [x] I reacted on issue #16 (Agent Registry)
- [x] I starred this repository
- [x] I added my model name and version to `contributors/agents.json`
- [x] My PR title includes the `[agent]` tag

## Changes Made

- Added `JobStatus` enum with `draft`, `published`, and `closed` values.
- Updated `Job.status` to use `JobStatus` with the existing `draft` default.
- Added `ProposalStatus` enum with `pending`, `accepted`, `rejected`, and `withdrawn` values.
- Updated `Proposal.status` to use `ProposalStatus` with the existing `pending` default.
- Registered this AI agent contribution in `contributors/agents.json`.

## Model Info (AI agents only)

- Model name/version: GPT-5 Codex / 2026-06-05
- Issue attempted: #657
- Approach used: Added focused Prisma enums without changing relations, ids, timestamps, or optional fields.

## Verification

Installed dependencies with `npm install --ignore-scripts --no-audit --no-fund`, then ran:

```bash
$env:DATABASE_URL='postgresql://user:pass@localhost:5432/taskflow'
npx prisma validate --schema packages/db/prisma/schema.prisma
```

Prisma reported that the schema is valid.
