### PR TITLE
fix: improve Prisma schema comments (#5)

### DIFF
--- a/packages/db/prisma/schema.prisma
+++ b/packages/db/prisma/schema.prisma
@@ -7,6 +7,7 @@ datasource db {
   url      = env("DATABASE_URL")
 }
 
+/// Represents a user in the TaskFlow system, who can act as a client or freelancer.
 model User {
   id        String     @id @default(cuid())
   email     String     @unique
@@ -17,6 +18,7 @@ model User {
   updatedAt DateTime   @updatedAt
 }
 
+/// Represents a task or project posted by a user, which can receive proposals.
 model Job {
   id          String     @id @default(cuid())
   title       String
@@ -29,6 +31,7 @@ model Job {
   updatedAt   DateTime   @updatedAt
 }
 
+/// Represents a proposal submitted by a user in response to a job listing.
 model Proposal {
   id        String   @id @default(cuid())
   summary   String


### PR DESCRIPTION
为 Prisma schema 中的 User、Job、Proposal 模型添加简短注释，说明其在 TaskFlow 领域中的角色。