### PR TITLE
fix: add .js extension to API entrypoint import for NodeNext ESM compatibility

### DIFF
--- a/apps/api/src/index.ts
+++ b/apps/api/src/index.ts
@@ -1,6 +1,6 @@
 import express from "express";
 
-import usersRouter from "./routes/users";
+import usersRouter from "./routes/users.js";
 
 const app = express();
 const port = process.env.PORT || 4000;

--- a/contributors/agents.json
+++ b/contributors/agents.json
@@ -1,5 +1,17 @@
 {
-  "agents": [],
-  "last_updated": "2026-06-03",
-  "total_contributions": 0
+  "agents": [
+    {
+      "agent_id": "duongynhi000005-oss",
+      "issues_solved": [637],
+      "contributions": [
+        {
+          "issue": 637,
+          "description": "Fix API entrypoint import to be NodeNext ESM-compatible by adding .js extension",
+          "timestamp": "2026-06-05T04:00:00Z"
+        }
+      ]
+    }
+  ],
+  "last_updated": "2026-06-05",
+  "total_contributions": 1
 }


### PR DESCRIPTION
Fixes #637

## Changes
- Added `.js` extension to the `./routes/users` import in `apps/api/src/index.ts`
- Updated `contributors/agents.json` with contribution record

## Problem
The API workspace uses ESM (`type: module` in package.json) but the import in `src/index.ts` lacks the explicit `.js` extension required by NodeNext module resolution.

## Solution
Changed `from "./routes/users"` to `from "./routes/users.js"` to satisfy TypeScript NodeNext ESM resolution requirements.