### PR TITLE
fix: separate app creation from server startup in API entrypoint

### DIFF
--- a/apps/api/src/index.ts
+++ b/apps/api/src/index.ts
@@ -1,18 +1,29 @@
 import express from "express";
 
-import usersRouter from "./routes/users";
+import usersRouter from "./routes/users.js";
 
-const app = express();
-const port = process.env.PORT || 4000;
+export function createApp() {
+  const app = express();
 
-app.use(express.json());
+  app.use(express.json());
 
-app.get("/health", (_req, res) => {
-  res.json({ status: "ok", service: "taskflow-api" });
-});
+  app.get("/health", (_req, res) => {
+    res.json({ status: "ok", service: "taskflow-api" });
+  });
 
-app.use("/users", usersRouter);
+  app.use("/users", usersRouter);
 
-app.listen(port, () => {
-  console.log(`TaskFlow API listening on port ${port}`);
-});
+  return app;
+}
+
+// Only start listening when this file is the entry point, not when imported from tests
+const isMainModule = import.meta.url === `file://${process.argv[1]}`;
+
+if (isMainModule) {
+  const app = createApp();
+  const port = process.env.PORT || 4000;
+
+  app.listen(port, () => {
+    console.log(`TaskFlow API listening on port ${port}`);
+  });
+}

--- a/contributors/agents.json
+++ b/contributors/agents.json
@@ -1,5 +1,17 @@
 {
-  "agents": [],
-  "last_updated": "2026-06-03",
-  "total_contributions": 0
+  "agents": [
+    {
+      "agent_id": "duongynhi000005-oss",
+      "issues_solved": [646],
+      "contributions": [
+        {
+          "issue": 646,
+          "description": "Refactor API entrypoint to separate app creation from server startup for testability",
+          "timestamp": "2026-06-05T04:00:00Z"
+        }
+      ]
+    }
+  ],
+  "last_updated": "2026-06-05",
+  "total_contributions": 1
 }


### PR DESCRIPTION
Fixes #646

## Changes
- Refactored `apps/api/src/index.ts` to export a `createApp()` factory function
- Server only starts when the file is the main entry point, not when imported
- Added `.js` extension to import for NodeNext ESM compatibility
- Updated `contributors/agents.json`

## Problem
The API entrypoint called `app.listen()` at module top level, making it impossible to import from tests without triggering side effects.

## Solution
Extracted app configuration into an exported `createApp()` function and used `import.meta.url` to only start the server when run directly.