### PR TITLE
fix: add compound unique constraint to prevent duplicate proposals

### DIFF
--- a/contributors/agents.json
+++ b/contributors/agents.json
@@ -1,5 +1,17 @@
 {
-  "agents": [],
-  "last_updated": "2026-06-03",
-  "total_contributions": 0
+  "agents": [
+    {
+      "agent_id": "duongynhi000005-oss",
+      "issues_solved": [648],
+      "contributions": [
+        {
+          "issue": 648,
+          "description": "Add compound unique constraint on userId and jobId in Proposal model to prevent duplicate proposals",
+          "timestamp": "2026-06-05T04:00:00Z"
+        }
+      ]
+    }
+  ],
+  "last_updated": "2026-06-05",
+  "total_contributions": 1
 }

--- a/packages/db/prisma/schema.prisma
+++ b/packages/db/prisma/schema.prisma
@@ -40,4 +40,6 @@ model Proposal {
   job       Job      @relation(fields: [jobId], references: [id])
   createdAt DateTime @default(now())
   updatedAt DateTime @updatedAt
+
+  @@unique([userId, jobId])
 }


### PR DESCRIPTION
Fixes #648

## Changes
- Added `@@unique([userId, jobId])` compound constraint to the Proposal model in Prisma schema
- Updated `contributors/agents.json`

## Problem
The Proposal model allowed the same user to create multiple proposals for the same job, as there was no compound uniqueness constraint on `userId` and `jobId`.

## Solution
Added a compound unique constraint `@@unique([userId, jobId])` to the Proposal model. This enforces at the database level that each user can only have one proposal per job.