### PR TITLE
fix: add ESLint config and deps to prevent interactive setup in web lint

### DIFF
--- a/apps/web/.eslintrc.json
+++ b/apps/web/.eslintrc.json
@@ -1,0 +1,10 @@
+{
+  "extends": ["next/core-web-vitals"],
+  "parserOptions": {
+    "ecmaVersion": "latest",
+    "sourceType": "module"
+  },
+  "rules": {
+    "@next/next/no-img-element": "off"
+  }
+}

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -17,6 +17,8 @@
     "@types/node": "^20.12.7",
     "@types/react": "^18.3.1",
     "@types/react-dom": "^18.3.0",
+    "eslint": "^8.57.0",
+    "eslint-config-next": "^14.2.3",
     "typescript": "^5.4.5"
   }
 }

--- a/contributors/agents.json
+++ b/contributors/agents.json
@@ -1,5 +1,17 @@
 {
-  "agents": [],
-  "last_updated": "2026-06-03",
-  "total_contributions": 0
+  "agents": [
+    {
+      "agent_id": "duongynhi000005-oss",
+      "issues_solved": [655],
+      "contributions": [
+        {
+          "issue": 655,
+          "description": "Add ESLint configuration and dependencies to prevent interactive setup prompts in web workspace",
+          "timestamp": "2026-06-05T04:00:00Z"
+        }
+      ]
+    }
+  ],
+  "last_updated": "2026-06-05",
+  "total_contributions": 1
 }


### PR DESCRIPTION
Fixes #655

## Changes
- Added `.eslintrc.json` with `next/core-web-vitals` configuration
- Added `eslint` and `eslint-config-next` as dev dependencies in `apps/web/package.json`
- Updated `contributors/agents.json`

## Problem
Running `npm run lint -w apps/web` triggered an interactive ESLint setup wizard because no configuration file or ESLint dependencies existed. This broke CI and non-interactive runs.

## Solution
Added a committed ESLint configuration file and the required dependencies so `next lint` runs non-interactively and produces deterministic output.