### PR TITLE
fix: add Prisma enums for Job and Proposal status fields

### DIFF
--- a/contributors/agents.json
+++ b/contributors/agents.json
@@ -1,5 +1,17 @@
 {
-  "agents": [],
-  "last_updated": "2026-06-03",
-  "total_contributions": 0
+  "agents": [
+    {
+      "agent_id": "duongynhi000005-oss",
+      "issues_solved": [657],
+      "contributions": [
+        {
+          "issue": 657,
+          "description": "Add Prisma enums for Job and Proposal status fields to enforce valid values at database level",
+          "timestamp": "2026-06-05T04:00:00Z"
+        }
+      ]
+    }
+  ],
+  "last_updated": "2026-06-05",
+  "total_contributions": 1
 }

--- a/packages/db/prisma/schema.prisma
+++ b/packages/db/prisma/schema.prisma
@@ -7,6 +7,21 @@ datasource db {
   url      = env("DATABASE_URL")
 }
 
+enum JobStatus {
+  draft
+  published
+  in_progress
+  completed
+  cancelled
+}
+
+enum ProposalStatus {
+  pending
+  accepted
+  rejected
+  withdrawn
+}
+
 model User {
   id        String     @id @default(cuid())
   email     String     @unique
@@ -18,26 +33,26 @@ model User {
 }
 
 model Job {
-  id          String     @id @default(cuid())
+  id          String         @id @default(cuid())
   title       String
   description String?
-  status      String     @default("draft")
+  status      JobStatus      @default(draft)
   ownerId     String
-  owner       User       @relation(fields: [ownerId], references: [id])
+  owner       User           @relation(fields: [ownerId], references: [id])
   proposals   Proposal[]
-  createdAt   DateTime   @default(now())
-  updatedAt   DateTime   @updatedAt
+  createdAt   DateTime       @default(now())
+  updatedAt   DateTime       @updatedAt
 }
 
 model Proposal {
-  id        String   @id @default(cuid())
+  id        String          @id @default(cuid())
   summary   String
   amount    Decimal?
-  status    String   @default("pending")
+  status    ProposalStatus  @default(pending)
   userId    String
-  user      User     @relation(fields: [userId], references: [id])
+  user      User            @relation(fields: [userId], references: [id])
   jobId     String
-  job       Job      @relation(fields: [jobId], references: [id])
-  createdAt DateTime @default(now())
-  updatedAt DateTime @updatedAt
+  job       Job             @relation(fields: [jobId], references: [id])
+  createdAt DateTime        @default(now())
+  updatedAt DateTime        @updatedAt
 }


### PR DESCRIPTION
Fixes #657

## Changes
- Added `JobStatus` enum: `draft`, `published`, `in_progress`, `completed`, `cancelled`
- Added `ProposalStatus` enum: `pending`, `accepted`, `rejected`, `withdrawn`
- Changed `Job.status` from `String @default("draft")` to `JobStatus @default(draft)`
- Changed `Proposal.status` from `String @default("pending")` to `ProposalStatus @default(pending)`
- Updated `contributors/agents.json`

## Problem
Status fields were stored as free-form strings, allowing invalid values like `draftt` or `pendng` to be persisted.

## Solution
Replaced String types with Prisma enums that enforce valid status values at the database level.