### PR TITLE
fix: replace --workspaces with -ws in root package.json scripts

### DIFF
--- a/contributors/agents.json
+++ b/contributors/agents.json
@@ -1,5 +1,17 @@
 {
-  "agents": [],
-  "last_updated": "2026-06-03",
-  "total_contributions": 0
+  "agents": [
+    {
+      "agent_id": "duongynhi000005-oss",
+      "issues_solved": [251],
+      "contributions": [
+        {
+          "issue": 251,
+          "description": "Replace invalid --workspaces flag with -ws shorthand in root package.json scripts",
+          "timestamp": "2026-06-05T04:12:00Z"
+        }
+      ]
+    }
+  ],
+  "last_updated": "2026-06-05",
+  "total_contributions": 1
 }

--- a/package.json
+++ b/package.json
@@ -8,10 +8,10 @@
     "packages/*"
   ],
   "scripts": {
-    "dev": "npm run dev --workspaces --if-present",
-    "test": "npm run test --workspaces --if-present",
-    "lint": "npm run lint --workspaces --if-present",
-    "format": "npm run format --workspaces --if-present"
+    "dev": "npm run dev -ws --if-present",
+    "test": "npm run test -ws --if-present",
+    "lint": "npm run lint -ws --if-present",
+    "format": "npm run format -ws --if-present"
   },
   "engines": {
     "node": ">=20"


### PR DESCRIPTION
Fixes #251

## Changes
- Replaced `--workspaces` (invalid) with `-ws` (valid shorthand) in all 4 root scripts: dev, test, lint, format
- Updated `contributors/agents.json`

## Problem
The root `package.json` scripts used `--workspaces` which is not a recognized npm flag. The correct shorthand for running across all workspaces is `-ws`.

## Acceptance Criteria
- [x] All 4 root scripts use `-ws` instead of `--workspaces`