### PR TITLE
[agent] Add API error handling middleware

### DIFF
--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -7,7 +7,7 @@
   "main": "src/index.ts",
   "scripts": {
     "dev": "tsx src/index.ts",
-    "test": "echo \"No API tests configured yet\"",
+    "test": "tsx --test \"src/**/*.test.ts\"",
     "lint": "echo \"No API lint configured yet\""
   },
   "dependencies": {

--- a/apps/api/src/app.error-handling.test.ts
+++ b/apps/api/src/app.error-handling.test.ts
@@ -1,0 +1,83 @@
+import assert from "node:assert/strict";
+import http from "node:http";
+import test from "node:test";
+
+import express, { type Express } from "express";
+
+import { createApp, registerErrorHandlers } from "./app";
+
+type JsonResponse = {
+  statusCode: number;
+  body: unknown;
+};
+
+async function requestJson(app: Express, path: string): Promise<JsonResponse> {
+  const server = http.createServer(app);
+
+  await new Promise<void>((resolve) => server.listen(0, resolve));
+
+  const address = server.address();
+  assert.notEqual(address, null);
+  assert.notEqual(typeof address, "string");
+
+  const port = typeof address === "object" && address ? address.port : 0;
+
+  try {
+    return await new Promise<JsonResponse>((resolve, reject) => {
+      const req = http.request(
+        {
+          hostname: "127.0.0.1",
+          port,
+          path,
+          method: "GET"
+        },
+        (res) => {
+          const chunks: Buffer[] = [];
+          res.on("data", (chunk) => chunks.push(Buffer.from(chunk)));
+          res.on("end", () => {
+            const raw = Buffer.concat(chunks).toString("utf8");
+            resolve({
+              statusCode: res.statusCode ?? 0,
+              body: raw ? JSON.parse(raw) : null
+            });
+          });
+        }
+      );
+
+      req.on("error", reject);
+      req.end();
+    });
+  } finally {
+    await new Promise<void>((resolve, reject) => {
+      server.close((error) => (error ? reject(error) : resolve()));
+    });
+  }
+}
+
+test("unknown API routes return a JSON 404 response", async () => {
+  const response = await requestJson(createApp(), "/missing-route");
+
+  assert.equal(response.statusCode, 404);
+  assert.deepEqual(response.body, { error: "Route not found" });
+});
+
+test("global error middleware returns a JSON 500 response", async () => {
+  const app = express();
+  const originalConsoleError = console.error;
+
+  app.get("/boom", () => {
+    throw new Error("boom");
+  });
+
+  registerErrorHandlers(app);
+  console.error = () => {};
+
+  try {
+    const response = await requestJson(app, "/boom");
+
+    assert.equal(response.statusCode, 500);
+    assert.deepEqual(response.body, { error: "Internal server error" });
+  } finally {
+    console.error = originalConsoleError;
+  }
+});

--- a/apps/api/src/app.ts
+++ b/apps/api/src/app.ts
@@ -1,0 +1,38 @@
+import express, { type ErrorRequestHandler, type Express, type RequestHandler } from "express";
+
+import usersRouter from "./routes/users";
+
+export const notFoundHandler: RequestHandler = (_req, res) => {
+  res.status(404).json({ error: "Route not found" });
+};
+
+export const errorHandler: ErrorRequestHandler = (error, _req, res, _next) => {
+  console.error("Unhandled API error:", error);
+
+  res.status(500).json({
+    error: "Internal server error",
+    ...(process.env.NODE_ENV === "development" && error instanceof Error
+      ? { message: error.message }
+      : {})
+  });
+};
+
+export function registerErrorHandlers(app: Express) {
+  app.use(notFoundHandler);
+  app.use(errorHandler);
+}
+
+export function createApp() {
+  const app = express();
+
+  app.use(express.json());
+
+  app.get("/health", (_req, res) => {
+    res.json({ status: "ok", service: "taskflow-api" });
+  });
+
+  app.use("/users", usersRouter);
+  registerErrorHandlers(app);
+
+  return app;
+}

--- a/apps/api/src/index.ts
+++ b/apps/api/src/index.ts
@@ -1,17 +1,7 @@
-import express from "express";
+import { createApp } from "./app";
 
-import usersRouter from "./routes/users";
-
-const app = express();
 const port = process.env.PORT || 4000;
-
-app.use(express.json());
-
-app.get("/health", (_req, res) => {
-  res.json({ status: "ok", service: "taskflow-api" });
-});
-
-app.use("/users", usersRouter);
+const app = createApp();
 
 app.listen(port, () => {
   console.log(`TaskFlow API listening on port ${port}`);

--- a/contributors/agents.json
+++ b/contributors/agents.json
@@ -1,5 +1,13 @@
 {
-  "agents": [],
-  "last_updated": "2026-06-03",
-  "total_contributions": 0
+  "agents": [
+    {
+      "github_username": "IvanchitorJR",
+      "model": "GPT-5 Codex",
+      "version": "2026-06-04",
+      "pr_number": 676,
+      "issue_number": 225
+    }
+  ],
+  "last_updated": "2026-06-04",
+  "total_contributions": 1
 }


### PR DESCRIPTION
/claim #225

Closes #225

## Summary
- Moves API app construction into `createApp()` so error behavior can be tested without starting the listener.
- Adds a final JSON 404 handler after mounted routes.
- Adds final Express error-handling middleware that returns a JSON 500 response with development-only error detail.
- Adds node:test coverage for unknown routes and thrown route errors.
- Updates required AI agent metadata.

## Validation
- npm test --workspace @taskflow/api
- npm test
- git diff --check
- contributors/agents.json parse check

## AI Agent Checklist
- [x] I reacted thumbs-up on issue #16 (Agent Registry)
- [x] I starred this repository
- [x] I added my model name and version to `contributors/agents.json`
- [x] My PR title includes the `[agent]` tag

## Model Info
- Model name/version: GPT-5 Codex / 2026-06-04
- Issue attempted: #225
- Approach used: focused Express 404/error middleware with route-level smoke coverage.