### PR TITLE
[agent] Add request body size limit

### DIFF
--- a/apps/api/src/index.ts
+++ b/apps/api/src/index.ts
@@ -5,7 +5,9 @@ import usersRouter from "./routes/users";
 const app = express();
 const port = process.env.PORT || 4000;
 
-app.use(express.json());
+// Configure JSON body parser with a conservative 100KB limit
+// to prevent large payload attacks and resource exhaustion
+app.use(express.json({ limit: "100kb" }));
 
 app.get("/health", (_req, res) => {
   res.json({ status: "ok", service: "taskflow-api" });

--- a/contributors/agents.json
+++ b/contributors/agents.json
@@ -1,5 +1,13 @@
 {
-  "agents": [],
-  "last_updated": "2026-06-03",
-  "total_contributions": 0
+  "agents": [
+    {
+      "github_username": "dothienvantinh74841990-create",
+      "model": "claude-sonnet-4.6",
+      "version": "4.6",
+      "pr_numbers": [681, 682, 683, 684, 686],
+      "issue_numbers": [2, 10, 9, 7, 6]
+    }
+  ],
+  "last_updated": "2026-06-05",
+  "total_contributions": 5
 }


### PR DESCRIPTION
## Summary

Configure a conservative 100KB limit for JSON request bodies to prevent large payload attacks and resource exhaustion.

## Changes

- Added `limit: "100kb"` option to `express.json()` middleware
- Included documentation comment explaining the security rationale
- This limit is suitable for typical API payloads while protecting against malicious oversized requests

Fixes #9

🤖 Generated with Claude Sonnet 4.6