### PR TITLE
docs: add descriptive comments to Prisma schema models

### DIFF
--- a/packages/db/prisma/schema.prisma
+++ b/packages/db/prisma/schema.prisma
@@ -7,37 +7,92 @@ datasource db {
   url      = env("DATABASE_URL")
 }
 
+/// Represents a registered user in the TaskFlow platform.
+/// Users can post jobs and submit proposals to other users' jobs.
 model User {
+  /// Unique identifier for the user (CUID)
   id        String     @id @default(cuid())
+
+  /// User's email address, must be unique across the platform
   email     String     @unique
+
+  /// Optional display name for the user
   name      String?
+
+  /// Jobs created (owned) by this user
   jobs      Job[]
+
+  /// Proposals submitted by this user to various jobs
   proposals Proposal[]
+
+  /// Timestamp when the user account was created
   createdAt DateTime   @default(now())
+
+  /// Timestamp of the last update to the user record
   updatedAt DateTime   @updatedAt
 }
 
+/// Represents a job posting in the TaskFlow marketplace.
+/// A job is created by a user and can receive multiple proposals from other users.
 model Job {
+  /// Unique identifier for the job (CUID)
   id          String     @id @default(cuid())
+
+  /// Short title describing the job
   title       String
+
+  /// Detailed description of the job requirements and scope
   description String?
+
+  /// Current status of the job: "draft", "open", "in_progress", "completed", or "cancelled"
   status      String     @default("draft")
+
+  /// Foreign key referencing the user who owns this job
   ownerId     String
+
+  /// The user who created and owns this job
   owner       User       @relation(fields: [ownerId], references: [id])
+
+  /// All proposals submitted by users for this job
   proposals   Proposal[]
+
+  /// Timestamp when the job was posted
   createdAt   DateTime   @default(now())
+
+  /// Timestamp of the last update to the job
   updatedAt   DateTime   @updatedAt
 }
 
+/// Represents a proposal submitted by a user in response to a job posting.
+/// Proposals allow users to pitch their approach and pricing for a given job.
 model Proposal {
+  /// Unique identifier for the proposal (CUID)
   id        String   @id @default(cuid())
+
+  /// Brief summary of the proposer's approach or pitch
   summary   String
+
+  /// Proposed monetary amount for completing the job (optional)
   amount    Decimal?
+
+  /// Current status of the proposal: "pending", "accepted", "rejected", or "withdrawn"
   status    String   @default("pending")
+
+  /// Foreign key referencing the user who submitted this proposal
   userId    String
+
+  /// The user who submitted this proposal
   user      User     @relation(fields: [userId], references: [id])
+
+  /// Foreign key referencing the job this proposal is for
   jobId     String
+
+  /// The job that this proposal responds to
   job       Job      @relation(fields: [jobId], references: [id])
+
+  /// Timestamp when the proposal was submitted
   createdAt DateTime @default(now())
+
+  /// Timestamp of the last update to the proposal
   updatedAt DateTime @updatedAt
 }


### PR DESCRIPTION
## Summary

Add brief comments to all Prisma schema models explaining their role in the TaskFlow domain.

### Changes
- Added model-level comments for `User`, `Job`, and `Proposal` explaining their purpose
- Added field-level comments documenting each columns role, default values, and relationships
- Documented status field enum values (e.g., "draft", "open", "pending")

### Acceptance Criteria
- [x] Pull request is focused
- [x] Short summary included
- [x] Linked issue below

Closes #5