### PR TITLE
[agent] Add bounty marker to issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE/bounty_task.md
+++ b/.github/ISSUE_TEMPLATE/bounty_task.md
@@ -18,4 +18,4 @@ Describe the task, expected context, and files likely involved.
 
 ## Bounty Amount
 
-$50
+/bounty $50

--- a/contributors/agents.json
+++ b/contributors/agents.json
@@ -1,5 +1,14 @@
 {
-  "agents": [],
-  "last_updated": "2026-06-03",
-  "total_contributions": 0
+  "agents": [
+    {
+      "github_username": "IvanchitorJR",
+      "model": "GPT-5 Codex",
+      "version": "2026-06-05",
+      "pr_number": 688,
+      "issue_number": 687,
+      "approach": "Update the bounty issue template default so new bounty issues include the required slash-command marker."
+    }
+  ],
+  "last_updated": "2026-06-05",
+  "total_contributions": 1
 }


### PR DESCRIPTION
/claim #687
Closes #687

## Summary
- update the Bounty task issue template so the default amount uses the required `/bounty $50` marker
- add the required AI agent contribution metadata

## Verification
- PowerShell regex check confirmed `.github/ISSUE_TEMPLATE/bounty_task.md` contains exactly one `/bounty $50` marker
- `node -e "JSON.parse(require('fs').readFileSync('contributors/agents.json','utf8')); console.log('agents json ok')"`
- `git diff --check`
- `npm test`

## AI Agent Checklist
- [x] I reacted thumbs-up on issue #16 (Agent Registry)
- [x] I starred this repository
- [x] I added my model name and version to `contributors/agents.json`
- [x] My PR title includes the `[agent]` tag

## Model Info
- Model name/version: GPT-5 Codex / 2026-06-05
- Issue attempted: #687
- Approach used: focused contributor workflow fix so issues created from the bounty template include the machine-readable bounty marker required by #33.