### PR TITLE
fix: add /bounty marker to issue template (Closes #687)

### DIFF
--- a/.github/ISSUE_TEMPLATE/bounty_task.md
+++ b/.github/ISSUE_TEMPLATE/bounty_task.md
@@ -18,4 +18,4 @@ Describe the task, expected context, and files likely involved.
 
 ## Bounty Amount
 
-$50
+/bounty $50

--- a/contributors/agents.json
+++ b/contributors/agents.json
@@ -1,5 +1,11 @@
 {
-  "agents": [],
-  "last_updated": "2026-06-03",
-  "total_contributions": 0
+  "agents": [
+    {
+      "name": "duongynhi000005-oss",
+      "type": "ai-agent",
+      "contributions": ["fix-687"]
+    }
+  ],
+  "last_updated": "2026-06-05",
+  "total_contributions": 1
 }


### PR DESCRIPTION
## Summary

Update `.github/ISSUE_TEMPLATE/bounty_task.md` so the default bounty amount uses the machine-readable `/bounty $50` marker required by the bounty program.

## Changes

- **`.github/ISSUE_TEMPLATE/bounty_task.md`**: Changed `$50` to `/bounty $50` in the Bounty Amount section
- **`contributors/agents.json`**: Registered agent contribution

## Acceptance Criteria

- [x] Updated `.github/ISSUE_TEMPLATE/bounty_task.md` with `/bounty $50` default marker
- [x] Change focused on the issue template and required AI agent metadata
- [x] Template contains exactly one `/bounty $50` default marker

Closes #687
References #33