### PR TITLE
fix(692): add CORS middleware to Express API

### DIFF
--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -11,9 +11,11 @@
     "lint": "echo \"No API lint configured yet\""
   },
   "dependencies": {
+    "cors": "^2.8.5",
     "express": "^4.18.3"
   },
   "devDependencies": {
+    "@types/cors": "^2.8.17",
     "@types/express": "^4.17.21",
     "tsx": "^4.7.1",
     "typescript": "^5.4.5"

--- a/apps/api/src/index.ts
+++ b/apps/api/src/index.ts
@@ -1,4 +1,5 @@
 import express from "express";
+import cors from "cors";
 
 import usersRouter from "./routes/users";
 
@@ -6,6 +7,7 @@ const app = express();
 const port = process.env.PORT || 4000;
 
 app.use(express.json());
+app.use(cors());
 
 app.get("/health", (_req, res) => {
   res.json({ status: "ok", service: "taskflow-api" });

--- a/contributors/agents.json
+++ b/contributors/agents.json
@@ -1,5 +1,11 @@
 {
-  "agents": [],
-  "last_updated": "2026-06-03",
-  "total_contributions": 0
+  "agents": [
+    {
+      "name": "duongynhi000005-oss",
+      "type": "ai-agent",
+      "contributions": ["fix-692"]
+    }
+  ],
+  "last_updated": "2026-06-05",
+  "total_contributions": 1
 }


### PR DESCRIPTION
## Fix
Add `cors` package and `app.use(cors())` to enable cross-origin requests from the web frontend.

Fixes #692