### PR TITLE
fix(690): prevent client-controlled ID override in POST /users

### DIFF
--- a/apps/api/src/routes/users.ts
+++ b/apps/api/src/routes/users.ts
@@ -12,8 +12,8 @@ router.get("/", (_req, res) => {
 router.post("/", (req, res) => {
   res.status(201).json({
     data: {
-      id: "stub-user-id",
-      ...req.body
+      ...req.body,
+      id: "stub-user-id"
     },
     message: "User creation is not implemented yet."
   });

--- a/contributors/agents.json
+++ b/contributors/agents.json
@@ -1,5 +1,11 @@
 {
-  "agents": [],
-  "last_updated": "2026-06-03",
-  "total_contributions": 0
+  "agents": [
+    {
+      "name": "duongynhi000005-oss",
+      "type": "ai-agent",
+      "contributions": ["fix-690"]
+    }
+  ],
+  "last_updated": "2026-06-05",
+  "total_contributions": 1
 }


### PR DESCRIPTION
## Fix
Move spread operator before `id` assignment so that `id: "stub-user-id"` always takes precedence over any client-provided `id` field.

Fixes #690