### PR TITLE
fix(api): use NodeNext-compatible .js import extension

### DIFF
--- a/apps/api/src/index.ts
+++ b/apps/api/src/index.ts
@@ -1,6 +1,6 @@
 import express from "express";
 
-import usersRouter from "./routes/users";
+import usersRouter from "./routes/users.js";
 
 const app = express();
 const port = process.env.PORT || 4000;


### PR DESCRIPTION
## Summary

- Add explicit `.js` file extension to the users router import in `apps/api/src/index.ts`
- Enables correct resolution under NodeNext/ESM module resolution

Fixes #637