### PR TITLE
fix(db): add compound unique constraint to Proposal model

### DIFF
--- a/packages/db/prisma/schema.prisma
+++ b/packages/db/prisma/schema.prisma
@@ -40,4 +40,5 @@ model Proposal {
   job       Job      @relation(fields: [jobId], references: [id])
   createdAt DateTime @default(now())
   updatedAt DateTime @updatedAt
+  @@unique([userId, jobId])
 }


### PR DESCRIPTION
## Summary

- Add `@@unique([userId, jobId])` to the Proposal model in the Prisma schema
- Prevents duplicate proposals for the same user and job at the database level
- Existing relations and defaults remain unchanged

Fixes #648