### PR TITLE
fix: destructure only expected fields in POST /users (#694)

### DIFF
--- a/apps/api/src/routes/users.ts
+++ b/apps/api/src/routes/users.ts
@@ -10,10 +10,12 @@ router.get("/", (_req, res) => {
 });
 
 router.post("/", (req, res) => {
+  const { name, email } = req.body;
   res.status(201).json({
     data: {
       id: "stub-user-id",
-      ...req.body
+      name,
+      email
     },
     message: "User creation is not implemented yet."
   });


### PR DESCRIPTION
Fixes #694

Only destructure `name` and `email` from `req.body` instead of spreading all client-provided fields. This prevents clients from injecting arbitrary data into the user object.