### PR TITLE
fix: prevent client-controlled ID override in POST /users (#690)

### DIFF
--- a/apps/api/src/routes/users.ts
+++ b/apps/api/src/routes/users.ts
@@ -12,8 +12,8 @@ router.get("/", (_req, res) => {
 router.post("/", (req, res) => {
   res.status(201).json({
     data: {
-      id: "stub-user-id",
-      ...req.body
+      ...req.body,
+      id: "stub-user-id"
     },
     message: "User creation is not implemented yet."
   });


### PR DESCRIPTION
Fixes #690

Move the spread of `req.body` before `id` assignment so that the server-controlled `id` always takes precedence over any client-supplied `id` field.