### PR TITLE
fix: add CORS middleware to Express API (#692)

### DIFF
--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -11,11 +11,13 @@
     "lint": "echo \"No API lint configured yet\""
   },
   "dependencies": {
-    "express": "^4.18.3"
+    "express": "^4.18.3",
+    "cors": "^2.8.5"
   },
   "devDependencies": {
     "@types/express": "^4.17.21",
     "tsx": "^4.7.1",
-    "typescript": "^5.4.5"
+    "typescript": "^5.4.5",
+    "@types/cors": "^2.8.17"
   }
 }

--- a/apps/api/src/index.ts
+++ b/apps/api/src/index.ts
@@ -1,3 +1,4 @@
+import cors from "cors";
 import express from "express";
 
 import usersRouter from "./routes/users";
@@ -5,6 +6,7 @@ import usersRouter from "./routes/users";
 const app = express();
 const port = process.env.PORT || 4000;
 
+app.use(cors());
 app.use(express.json());
 
 app.get("/health", (_req, res) => {


### PR DESCRIPTION
Fixes #692

Add `cors` package and `app.use(cors())` to allow cross-origin requests from the web frontend. Also adds `@types/cors` to devDependencies.