### PR TITLE
fix: add /bounty marker to bounty task issue template (#687)

### DIFF
--- a/.github/ISSUE_TEMPLATE/bounty_task.md
+++ b/.github/ISSUE_TEMPLATE/bounty_task.md
@@ -18,4 +18,4 @@ Describe the task, expected context, and files likely involved.
 
 ## Bounty Amount
 
-$50
+/bounty $50


### PR DESCRIPTION
Fixes #687

The bounty task issue template was missing the machine-readable `/bounty $50` marker required by the bounty program. Updated the Bounty Amount section to include the marker so automation can identify reward-backed work.