### PR TITLE
fix: add lookup indexes for Prisma relation fields (#659)

### DIFF
--- a/packages/db/prisma/schema.prisma
+++ b/packages/db/prisma/schema.prisma
@@ -27,6 +27,8 @@ model Job {
   proposals   Proposal[]
   createdAt   DateTime   @default(now())
   updatedAt   DateTime   @updatedAt
+
+  @@index([ownerId])
 }
 
 model Proposal {
@@ -40,4 +42,7 @@ model Proposal {
   job       Job      @relation(fields: [jobId], references: [id])
   createdAt DateTime @default(now())
   updatedAt DateTime @updatedAt
+
+  @@index([userId])
+  @@index([jobId])
 }


### PR DESCRIPTION
Fixes #659

Add `@@index` for:
- `Job.ownerId` (owner dashboards and job lists)
- `Proposal.userId` (user's submitted proposals)
- `Proposal.jobId` (job owner's proposal review queue)

PostgreSQL foreign keys do not automatically create indexes on referencing columns. Without explicit indexes, common marketplace queries can degrade in performance as data grows.