### PR TITLE
docs: document environment variables for API and web apps (#4)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,8 @@
+# Database (packages/db — Prisma)
+DATABASE_URL=postgresql://user:password@localhost:5432/taskflow
+
+# API (apps/api)
+PORT=4000
+
+# Web (apps/web)
+# NEXT_PUBLIC_API_URL=http://localhost:4000

--- a/README.md
+++ b/README.md
@@ -81,5 +81,30 @@ with models for:
 
 ## Environment Variables
 
-Each app/package expects its own .env values for DB, auth, 
-and integrations.
+Each workspace reads its own `.env` file. Copy the provided
+`.env.example` files to get started:
+
+```bash
+cp .env.example .env
+cp apps/api/.env.example apps/api/.env
+cp apps/web/.env.example apps/web/.env
+```
+
+### apps/api
+
+| Variable | Required | Default | Description |
+|---|---|---|---|
+| `PORT` | No | `4000` | Port the Express server listens on |
+| `DATABASE_URL` | Yes | — | PostgreSQL connection string for Prisma |
+
+### apps/web
+
+| Variable | Required | Default | Description |
+|---|---|---|---|
+| `NEXT_PUBLIC_API_URL` | No | `http://localhost:4000` | Base URL for the backend API |
+
+### packages/db
+
+| Variable | Required | Default | Description |
+|---|---|---|---|
+| `DATABASE_URL` | Yes | — | PostgreSQL connection string used by Prisma CLI and client |

--- a/apps/api/.env.example
+++ b/apps/api/.env.example
@@ -1,0 +1,5 @@
+# Server port (default: 4000)
+PORT=4000
+
+# Database connection string used by Prisma
+DATABASE_URL=postgresql://user:password@localhost:5432/taskflow

--- a/apps/web/.env.example
+++ b/apps/web/.env.example
@@ -1,0 +1,2 @@
+# Base URL for the backend API
+# NEXT_PUBLIC_API_URL=http://localhost:4000

--- a/contributors/agents.json
+++ b/contributors/agents.json
@@ -1,5 +1,12 @@
 {
-  "agents": [],
-  "last_updated": "2026-06-03",
-  "total_contributions": 0
+  "agents": [
+    {
+      "model": "mimo-v2-pro",
+      "version": "2026-06-05",
+      "issue": 4,
+      "pr": null
+    }
+  ],
+  "last_updated": "2026-06-05",
+  "total_contributions": 1
 }


### PR DESCRIPTION
Fixes #4

Add `.env.example` files for the root, `apps/api`, and `apps/web` workspaces. Expand the README Environment Variables section with a table of expected variables, their defaults, and whether they are required.

## Changes
- Added root `.env.example` with all workspace variables
- Added `apps/api/.env.example` (PORT, DATABASE_URL)
- Added `apps/web/.env.example` (NEXT_PUBLIC_API_URL)
- Expanded README env section with per-workspace variable tables