### PR TITLE
[agent] Validate user creation input

### DIFF
--- a/apps/api/src/routes/users.ts
+++ b/apps/api/src/routes/users.ts
@@ -10,10 +10,13 @@ router.get("/", (_req, res) => {
 });
 
 router.post("/", (req, res) => {
+  const { email, name } = req.body;
+
   res.status(201).json({
     data: {
       id: "stub-user-id",
-      ...req.body
+      email,
+      name
     },
     message: "User creation is not implemented yet."
   });

--- a/contributors/agents.json
+++ b/contributors/agents.json
@@ -1,5 +1,13 @@
 {
-  "agents": [],
-  "last_updated": "2026-06-03",
-  "total_contributions": 0
+  "agents": [
+    {
+      "github_username": "16bd",
+      "model": "GPT-5 Codex",
+      "version": "2026-06-05",
+      "pr_number": null,
+      "issue_number": 694
+    }
+  ],
+  "last_updated": "2026-06-05",
+  "total_contributions": 1
 }


### PR DESCRIPTION
## Summary
- Restricts POST /users response data to expected user fields only.
- Prevents arbitrary request body fields from being reflected into the user payload.
- Adds the required AI agent registry entry for issue #694.

Closes #694

## Verification
- npm test
- git diff --check