### PR TITLE
test: add unit tests for leaderboard update script (#11)

### DIFF
--- a/contributors/agents.json
+++ b/contributors/agents.json
@@ -1,5 +1,12 @@
 {
-  "agents": [],
-  "last_updated": "2026-06-03",
-  "total_contributions": 0
+  "agents": [
+    {
+      "model": "mimo-v2-pro",
+      "version": "2026-06-05",
+      "issue": 11,
+      "pr": null
+    }
+  ],
+  "last_updated": "2026-06-05",
+  "total_contributions": 1
 }

--- a/scripts/test-leaderboard.sh
+++ b/scripts/test-leaderboard.sh
@@ -1,0 +1,89 @@
+#!/usr/bin/env bash
+# Tests for scripts/update-leaderboard.sh
+#
+# Run: bash scripts/test-leaderboard.sh
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+UPDATE="$SCRIPT_DIR/update-leaderboard.sh"
+PASS=0
+FAIL=0
+TMPDIR="$(mktemp -d)"
+
+cleanup() { rm -rf "$TMPDIR"; }
+trap cleanup EXIT
+
+assert_eq() {
+  local desc="$1" expected="$2" actual="$3"
+  if [ "$expected" = "$actual" ]; then
+    echo "  ✓ $desc"
+    PASS=$((PASS + 1))
+  else
+    echo "  ✗ $desc"
+    echo "    expected: $expected"
+    echo "    actual:   $actual"
+    FAIL=$((FAIL + 1))
+  fi
+}
+
+# ── Test 1: new user in empty file ──────────────────────────────────
+echo "Test 1: new user in empty file"
+FILE="$TMPDIR/t1.json"
+bash "$UPDATE" alice "$FILE"
+result="$(jq -r '.alice' "$FILE")"
+assert_eq "alice count is 1" "1" "$result"
+
+# ── Test 2: same user incremented twice ─────────────────────────────
+echo "Test 2: same user incremented twice"
+FILE="$TMPDIR/t2.json"
+bash "$UPDATE" bob "$FILE"
+bash "$UPDATE" bob "$FILE"
+result="$(jq -r '.bob' "$FILE")"
+assert_eq "bob count is 2" "2" "$result"
+
+# ── Test 3: multiple users ─────────────────────────────────────────
+echo "Test 3: multiple users"
+FILE="$TMPDIR/t3.json"
+bash "$UPDATE" alice "$FILE"
+bash "$UPDATE" bob "$FILE"
+bash "$UPDATE" alice "$FILE"
+alice="$(jq -r '.alice' "$FILE")"
+bob="$(jq -r '.bob' "$FILE")"
+assert_eq "alice count is 2" "2" "$alice"
+assert_eq "bob count is 1" "1" "$bob"
+
+# ── Test 4: pre-populated file ──────────────────────────────────────
+echo "Test 4: pre-populated file"
+FILE="$TMPDIR/t4.json"
+printf '{"existing_user":5}\n' > "$FILE"
+bash "$UPDATE" existing_user "$FILE"
+bash "$UPDATE" new_user "$FILE"
+existing="$(jq -r '.existing_user' "$FILE")"
+new_u="$(jq -r '.new_user' "$FILE")"
+assert_eq "existing_user count is 6" "6" "$existing"
+assert_eq "new_user count is 1" "1" "$new_u"
+
+# ── Test 5: default file path uses leaderboard.json ─────────────────
+echo "Test 5: default file path"
+cd "$TMPDIR"
+bash "$UPDATE" defaultuser
+result="$(jq -r '.defaultuser' "$TMPDIR/leaderboard.json")"
+assert_eq "defaultuser count in leaderboard.json is 1" "1" "$result"
+
+# ── Test 6: preserves other keys ────────────────────────────────────
+echo "Test 6: preserves other keys"
+FILE="$TMPDIR/t6.json"
+printf '{"alpha":3,"beta":7}\n' > "$FILE"
+bash "$UPDATE" gamma "$FILE"
+alpha="$(jq -r '.alpha' "$FILE")"
+beta="$(jq -r '.beta' "$FILE")"
+gamma="$(jq -r '.gamma' "$FILE")"
+assert_eq "alpha preserved at 3" "3" "$alpha"
+assert_eq "beta preserved at 7" "7" "$beta"
+assert_eq "gamma added as 1" "1" "$gamma"
+
+# ── Summary ─────────────────────────────────────────────────────────
+echo ""
+echo "Results: $PASS passed, $FAIL failed"
+[ "$FAIL" -eq 0 ] && exit 0 || exit 1

--- a/scripts/update-leaderboard.sh
+++ b/scripts/update-leaderboard.sh
@@ -1,0 +1,19 @@
+#!/usr/bin/env bash
+# Increment the PR count for a user in leaderboard.json.
+#
+# Usage: ./scripts/update-leaderboard.sh <username> [leaderboard.json]
+#
+# If leaderboard.json does not exist it is created with an empty object.
+
+set -euo pipefail
+
+USER="${1:?Usage: update-leaderboard.sh <username> [file]}"
+FILE="${2:-leaderboard.json}"
+
+if [ ! -f "$FILE" ]; then
+  printf '{}\n' > "$FILE"
+fi
+
+tmp_file="$(mktemp)"
+jq --arg user "$USER" '.[$user] = ((.[$user] // 0) + 1)' "$FILE" > "$tmp_file"
+mv "$tmp_file" "$FILE"


### PR DESCRIPTION
Fixes #11

Extract the leaderboard jq logic from `.github/workflows/auto-process.yml` into a standalone script and add a test harness.

## Changes
- **`scripts/update-leaderboard.sh`** — standalone script that increments a user's PR count in leaderboard.json using jq
- **`scripts/test-leaderboard.sh`** — 6 test cases covering new users, repeated increments, multiple users, pre-populated files, default file path, and key preservation

## Verification
```
bash scripts/test-leaderboard.sh
# 10 passed, 0 failed
```