### PR TITLE
test: add unit tests for user route stubs (#12)

### DIFF
--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -7,7 +7,7 @@
   "main": "src/index.ts",
   "scripts": {
     "dev": "tsx src/index.ts",
-    "test": "echo \"No API tests configured yet\"",
+    "test": "tsx --test src/users.test.ts",
     "lint": "echo \"No API lint configured yet\""
   },
   "dependencies": {

--- a/apps/api/src/users.test.ts
+++ b/apps/api/src/users.test.ts
@@ -1,0 +1,97 @@
+import { describe, it, before, after } from "node:test";
+import assert from "node:assert/strict";
+import http from "node:http";
+import express from "express";
+import usersRouter from "./routes/users.js";
+
+function startTestServer(): Promise<{ url: string; close: () => void }> {
+  return new Promise((resolve) => {
+    const app = express();
+    app.use(express.json());
+    app.use("/users", usersRouter);
+    const server = app.listen(0, () => {
+      const addr = server.address() as { port: number };
+      resolve({
+        url: `http://127.0.0.1:${addr.port}`,
+        close: () => server.close(),
+      });
+    });
+  });
+}
+
+function fetchJSON(
+  url: string,
+  opts?: RequestInit
+): Promise<{ status: number; body: any }> {
+  return fetch(url, opts).then(async (res) => ({
+    status: res.status,
+    body: await res.json(),
+  }));
+}
+
+describe("user routes", () => {
+  let baseURL: string;
+  let close: () => void;
+
+  before(async () => {
+    const server = await startTestServer();
+    baseURL = server.url;
+    close = server.close;
+  });
+
+  after(() => close());
+
+  describe("GET /users", () => {
+    it("returns 200 with empty data array", async () => {
+      const { status, body } = await fetchJSON(`${baseURL}/users`);
+      assert.equal(status, 200);
+      assert.deepEqual(body.data, []);
+    });
+
+    it("includes a message field", async () => {
+      const { body } = await fetchJSON(`${baseURL}/users`);
+      assert.ok(body.message, "expected a message field");
+      assert.ok(typeof body.message === "string");
+    });
+  });
+
+  describe("POST /users", () => {
+    it("returns 201 status", async () => {
+      const { status } = await fetchJSON(`${baseURL}/users`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ name: "Alice", email: "alice@test.com" }),
+      });
+      assert.equal(status, 201);
+    });
+
+    it("returns stub user with provided fields", async () => {
+      const payload = { name: "Bob", email: "bob@test.com" };
+      const { body } = await fetchJSON(`${baseURL}/users`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify(payload),
+      });
+      assert.equal(body.data.name, "Bob");
+      assert.equal(body.data.email, "bob@test.com");
+    });
+
+    it("includes a stub id in the response", async () => {
+      const { body } = await fetchJSON(`${baseURL}/users`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ name: "Test" }),
+      });
+      assert.ok(body.data.id, "expected an id field");
+    });
+
+    it("includes a message field", async () => {
+      const { body } = await fetchJSON(`${baseURL}/users`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ name: "Test" }),
+      });
+      assert.ok(body.message, "expected a message field");
+    });
+  });
+});

--- a/contributors/agents.json
+++ b/contributors/agents.json
@@ -1,5 +1,12 @@
 {
-  "agents": [],
-  "last_updated": "2026-06-03",
-  "total_contributions": 0
+  "agents": [
+    {
+      "model": "mimo-v2-pro",
+      "version": "2026-06-05",
+      "issue": 12,
+      "pr": null
+    }
+  ],
+  "last_updated": "2026-06-05",
+  "total_contributions": 1
 }


### PR DESCRIPTION
Fixes #12

Add `node:test` tests for the Express user route stubs covering list and create behavior.

## Changes
- **`apps/api/src/users.test.ts`** — 6 tests using node:test and a lightweight Express test server
- **`apps/api/package.json`** — updated `test` script to run the new tests

## Test cases
- GET /users returns 200 with empty data array
- GET /users includes a message field
- POST /users returns 201 status
- POST /users returns stub user with provided fields
- POST /users includes a stub id
- POST /users includes a message field

## Verification
```
cd apps/api && npm test
# 6 passed, 0 failed
```