### PR TITLE
[agent] Add unique proposal constraint

### DIFF
--- a/contributors/agents.json
+++ b/contributors/agents.json
@@ -1,5 +1,13 @@
 {
-  "agents": [],
-  "last_updated": "2026-06-03",
-  "total_contributions": 0
+  "agents": [
+    {
+      "github_username": "16bd",
+      "model": "GPT-5 Codex",
+      "version": "2026-06-05",
+      "pr_number": null,
+      "issue_number": 722
+    }
+  ],
+  "last_updated": "2026-06-05",
+  "total_contributions": 1
 }

--- a/packages/db/prisma/schema.prisma
+++ b/packages/db/prisma/schema.prisma
@@ -40,4 +40,6 @@ model Proposal {
   job       Job      @relation(fields: [jobId], references: [id])
   createdAt DateTime @default(now())
   updatedAt DateTime @updatedAt
+
+  @@unique([userId, jobId])
 }


### PR DESCRIPTION
## Summary
- Adds a Prisma compound unique constraint on Proposal(userId, jobId).
- Keeps existing Proposal relations, defaults, and fields unchanged.
- Adds the required AI agent registry entry for issue #722.

Closes #722

## Verification
- npm test
- git diff --check