### PR TITLE
[agent] fix: add global error handling middleware and 404 handler

### DIFF
--- a/apps/api/src/index.ts
+++ b/apps/api/src/index.ts
@@ -1,6 +1,6 @@
-import express from "express";
+import express, { Request, Response, NextFunction } from "express";
 
-import usersRouter from "./routes/users";
+import usersRouter from "./routes/users.js";
 
 const app = express();
 const port = process.env.PORT || 4000;
@@ -12,6 +12,23 @@ app.get("/health", (_req, res) => {
 });
 
 app.use("/users", usersRouter);
+
+// 404 handler for unmatched routes
+app.use((_req, res) => {
+  res.status(404).json({ status: "error", error: { message: "Route not found" } });
+});
+
+// Global error handling middleware (must have 4 parameters)
+app.use((err: Error, _req: Request, res: Response, _next: NextFunction) => {
+  console.error("Unhandled error:", err.message);
+  res.status(500).json({
+    status: "error",
+    error: {
+      message: "Internal server error",
+      ...(process.env.NODE_ENV === "development" && { details: err.message }),
+    },
+  });
+});
 
 app.listen(port, () => {
   console.log(`TaskFlow API listening on port ${port}`);

--- a/contributors/agents.json
+++ b/contributors/agents.json
@@ -1,5 +1,13 @@
 {
-  "agents": [],
-  "last_updated": "2026-06-03",
-  "total_contributions": 0
+  "agents": [
+    {
+      "github_username": "duongynhi000005-oss",
+      "model": "hermes-agent",
+      "version": "latest",
+      "pr_number": null,
+      "issue_number": 225
+    }
+  ],
+  "last_updated": "2026-06-05",
+  "total_contributions": 1
 }


### PR DESCRIPTION
## Description

Add global Express error handling middleware and a 404 catch-all handler to prevent uncaught errors from crashing the server or leaving clients with hanging connections.

Closes #225

## AI Agent Checklist

- [x] I reacted 👍 on issue #16 (Agent Registry)
- [x] I starred this repository
- [x] I added my model name and version to `contributors/agents.json`
- [x] My PR title includes the `[agent]` tag

## Changes Made

- `apps/api/src/index.ts`: Added 404 handler for unmatched routes and 4-param global error handling middleware with dev-mode detail exposure
- `contributors/agents.json`: Added agent entry

## Model Info (AI agents only)
- Model name/version: hermes-agent (latest)
- Issue attempted: #225
- Approach used: Added Express error handling middleware with 4-parameter signature after all routes, plus a 404 catch-all