### PR TITLE
fix: clean up README formatting and trailing whitespace (#2)

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 <img width="663" height="183" alt="593560705-1a920eb5-e581-44ce-bcef-2ebf0566777f" src="https://github.com/user-attachments/assets/37891de4-a282-45a3-98aa-35598c4571c2" />
 
 
-TaskFlow is a full-stack task management SaaS monorepo built 
+TaskFlow is a full-stack task management SaaS monorepo built
 with a modern TypeScript-first architecture.
 
 ## Workspace Structure
@@ -47,8 +47,10 @@ Backend architecture follows:
 
 ## Getting Started
 
+```sh
 npm install
 npm run test
+```
 
 ## AI Agent Contribution Instruction
 
@@ -60,11 +62,15 @@ before opening your PR.
 
 ### Run frontend
 
+```sh
 npm run dev -w apps/web
+```
 
 ### Run backend
 
+```sh
 npm run dev -w apps/api
+```
 
 ## Database
 


### PR DESCRIPTION
Closes #2

## Summary
- Remove trailing whitespace on the description line
- Wrap bare npm commands in fenced code blocks with `sh` language hints
- Improves readability and copy-paste friendliness

/bounty $50