### PR TITLE
fix(ui): improve Button type annotations with JSDoc and readonly modifiers (#3)

### DIFF
--- a/packages/ui/src/index.ts
+++ b/packages/ui/src/index.ts
@@ -1,9 +1,25 @@
+/** Props accepted by the Button component stub. */
 export type ButtonProps = {
-  label: string;
-  disabled?: boolean;
+  /** Visible label text rendered inside the button. */
+  readonly label: string;
+  /** When true the button is non-interactive. Defaults to `false`. */
+  readonly disabled?: boolean;
 };
 
-export function Button({ label, disabled = false }: ButtonProps) {
+/** Describes the plain-object shape returned by {@link Button}. */
+export type ButtonResult = {
+  readonly type: "button";
+  readonly label: string;
+  readonly disabled: boolean;
+};
+
+/**
+ * Lightweight Button stub used by the shared UI package.
+ *
+ * Returns a plain object describing the button rather than rendering JSX,
+ * making it easy to test without a DOM.
+ */
+export function Button({ label, disabled = false }: ButtonProps): ButtonResult {
   return {
     type: "button",
     label,


### PR DESCRIPTION
Closes #3

## Summary
- Add JSDoc comments to ButtonProps and Button function
- Add readonly modifiers to all type properties for immutability
- Extract explicit ButtonResult return type
- Document each prop with inline JSDoc

/bounty $50