### PR TITLE
fix: add input validation to POST /users route (#6)

### DIFF
--- a/apps/api/src/routes/users.ts
+++ b/apps/api/src/routes/users.ts
@@ -10,10 +10,28 @@ router.get("/", (_req, res) => {
 });
 
 router.post("/", (req, res) => {
+  const { name, email } = req.body ?? {};
+
+  const errors: string[] = [];
+
+  if (typeof name !== "string" || name.trim().length === 0) {
+    errors.push("name is required and must be a non-empty string.");
+  }
+
+  if (typeof email !== "string" || !email.includes("@")) {
+    errors.push("email is required and must be a valid email address.");
+  }
+
+  if (errors.length > 0) {
+    res.status(400).json({ errors });
+    return;
+  }
+
   res.status(201).json({
     data: {
       id: "stub-user-id",
-      ...req.body
+      name: name.trim(),
+      email: email.trim(),
     },
     message: "User creation is not implemented yet."
   });


### PR DESCRIPTION
## Summary
Adds lightweight input validation to the POST /users route so invalid request shapes return a clear 400 error response instead of blindly echoing arbitrary payloads.

## Changes
- Destructure `name` and `email` from request body instead of spreading the entire body
- Validate `name` is a non-empty string
- Validate `email` is a string containing `@`
- Return `400` with descriptive error messages on validation failure

Closes #6