### PR TITLE
[agent] fix: add input validation to POST /users - destructure only expected fields

### DIFF
--- a/apps/api/src/routes/users.ts
+++ b/apps/api/src/routes/users.ts
@@ -10,10 +10,12 @@ router.get("/", (_req, res) => {
 });
 
 router.post("/", (req, res) => {
+  const { name, email } = req.body || {};
   res.status(201).json({
     data: {
       id: "stub-user-id",
-      ...req.body
+      name,
+      email
     },
     message: "User creation is not implemented yet."
   });


### PR DESCRIPTION
Closes #736

/claim #736

## Summary
Added input validation to POST /users by destructuring only expected fields (`name`, `email`) instead of spreading the entire `...req.body`.