### PR TITLE
[agent] Add type annotations to shared Button props

### DIFF
--- a/packages/ui/src/index.ts
+++ b/packages/ui/src/index.ts
@@ -1,9 +1,31 @@
+/**
+ * Props for the Button component stub.
+ */
 export type ButtonProps = {
+  /** Text content displayed on the button */
   label: string;
+  /** When true, button is non-interactive and visually dimmed */
   disabled?: boolean;
 };
 
-export function Button({ label, disabled = false }: ButtonProps) {
+/**
+ * Return type for the Button stub function.
+ * Represents a serializable button object for testing or SSR scenarios.
+ */
+export type ButtonReturn = {
+  readonly type: "button";
+  readonly label: string;
+  readonly disabled: boolean;
+};
+
+/**
+ * Button component stub for the shared UI package.
+ * Returns a plain object representation rather than rendering DOM.
+ *
+ * @param props - Button configuration
+ * @returns Serializable button object
+ */
+export function Button({ label, disabled = false }: ButtonProps): ButtonReturn {
   return {
     type: "button",
     label,


### PR DESCRIPTION
## Summary

Improve TypeScript type annotations for the Button stub with comprehensive JSDoc comments and explicit return type without changing the public API shape.

## Changes

- Added JSDoc comments to `ButtonProps` fields documenting purpose
- Created explicit `ButtonReturn` type with readonly modifiers for immutability
- Added function-level JSDoc explaining stub behavior
- Documented that Button returns serializable object rather than rendering DOM
- No breaking changes to existing public API

## Type Safety Improvements

```typescript
// Before: implicit return type
function Button(props): { type, label, disabled }

// After: explicit with readonly contract
function Button(props): ButtonReturn
```

Fixes #3

🤖 Generated with Claude Sonnet 4.6