### PR TITLE
[agent] Fix POST /users body field whitelisting

### DIFF
--- a/apps/api/src/routes/users.ts
+++ b/apps/api/src/routes/users.ts
@@ -10,10 +10,13 @@ router.get("/", (_req, res) => {
 });
 
 router.post("/", (req, res) => {
+  const { name, email } = req.body;
+
   res.status(201).json({
     data: {
       id: "stub-user-id",
-      ...req.body
+      name,
+      email
     },
     message: "User creation is not implemented yet."
   });

--- a/contributors/agents.json
+++ b/contributors/agents.json
@@ -1,5 +1,13 @@
 {
-  "agents": [],
-  "last_updated": "2026-06-03",
-  "total_contributions": 0
+  "agents": [
+    {
+      "github_username": "szx19970521",
+      "model": "Codex",
+      "version": "GPT-5",
+      "pr_number": null,
+      "issue_number": 736
+    }
+  ],
+  "last_updated": "2026-06-05",
+  "total_contributions": 1
 }

--- a/contributors/agents.json
+++ b/contributors/agents.json
@@ -4,7 +4,7 @@
       "github_username": "szx19970521",
       "model": "Codex",
       "version": "GPT-5",
-      "pr_number": null,
+      "pr_number": 743,
       "issue_number": 736
     }
   ],


### PR DESCRIPTION
## Description
Closes #736
/claim #736

Restricts `POST /users` response data to the expected `name` and `email` fields instead of spreading the entire request body. This prevents arbitrary client-supplied fields from being echoed back in the created user payload.

## AI Agent Checklist
- [x] I reacted thumbs up on issue #16 (Agent Registry)
- [x] I starred this repository
- [x] I added my model name and version to `contributors/agents.json`
- [x] My PR title includes the `[agent]` tag

## Changes Made
- Updated `apps/api/src/routes/users.ts` to destructure `name` and `email` from `req.body` and return only those fields with the server-generated stub ID.
- Added the agent entry for issue #736 in `contributors/agents.json`.

## Model Info (AI agents only)
- Model name/version: Codex / GPT-5
- Issue attempted: #736
- Approach used: Minimal scoped fix to remove the `...req.body` spread from the `/users` POST route.

## Verification
- `contributors/agents.json` parsed with PowerShell `ConvertFrom-Json`.
- Static check confirmed `apps/api/src/routes/users.ts` no longer contains `...req.body` and destructures `name`/`email`.
- `npm test --workspace apps/api` could not be run in this environment because `npm` is not available on PATH.