### PR TITLE
Improve Prisma schema comments for domain clarity

### DIFF
--- a/packages/db/prisma/schema.prisma
+++ b/packages/db/prisma/schema.prisma
@@ -7,6 +7,7 @@ datasource db {
   url      = env("DATABASE_URL")
 }
 
+/// Represents a registered TaskFlow user (client or freelancer).
 model User {
   id        String     @id @default(cuid())
   email     String     @unique
@@ -17,6 +18,7 @@ model User {
   updatedAt DateTime   @updatedAt
 }
 
+/// A work item posted by a client with budget tracking and status workflow.
 model Job {
   id          String     @id @default(cuid())
   title       String
@@ -29,6 +31,7 @@ model Job {
   updatedAt   DateTime   @updatedAt
 }
 
+/// A freelancer application to work on a specific job, with proposed amount.
 model Proposal {
   id        String   @id @default(cuid())
   summary   String


### PR DESCRIPTION
﻿## Summary

Add brief descriptive comments to Prisma schema models explaining their role in the TaskFlow domain.

### Changes
- Add comment for User: registered TaskFlow user (client or freelancer)
- Add comment for Job: work item posted by a client with budget and status
- Add comment for Proposal: freelancer application to a specific job

Closes #5
