### PR TITLE
Add request body size limit to Express

### DIFF
--- a/apps/api/src/index.ts
+++ b/apps/api/src/index.ts
@@ -1,11 +1,11 @@
-import express from "express";
+﻿import express from "express";
 
 import usersRouter from "./routes/users";
 
 const app = express();
 const port = process.env.PORT || 4000;
 
-app.use(express.json());
+app.use(express.json({ limit: "1mb" })); // Reject payloads over 1MB
 
 app.get("/health", (_req, res) => {
   res.json({ status: "ok", service: "taskflow-api" });


### PR DESCRIPTION
Set 1MB limit on express.json() to prevent large payload attacks.

Closes #9