### PR TITLE
Add centralized API error handling middleware

### DIFF
--- a/apps/api/src/index.ts
+++ b/apps/api/src/index.ts
@@ -13,6 +13,16 @@ app.get("/health", (_req, res) => {
 
 app.use("/users", usersRouter);
 
+// Centralized error handling middleware
+app.use((err, _req, res, _next) => {
+  console.error("Unhandled error:", err.message);
+  res.status(err.status || 500).json({
+    status: "error",
+    data: null,
+    message: err.message || "Internal server error"
+  });
+});
+
 app.listen(port, () => {
   console.log(`TaskFlow API listening on port ${port}`);
 });


### PR DESCRIPTION
Catch-all Express error handler returning consistent JSON envelope {status, data, message}.

Closes #7