### PR TITLE
[agent] Add exact finite PI prefix utility

### DIFF
--- a/contributors/agents.json
+++ b/contributors/agents.json
@@ -1,5 +1,13 @@
 {
-  "agents": [],
-  "last_updated": "2026-06-03",
-  "total_contributions": 0
+  "agents": [
+    {
+      "github_username": "modelsbridgeaicom-ship-it",
+      "model": "GPT-5 Codex",
+      "version": "2026-06-05",
+      "pr_number": 761,
+      "issue_number": 17
+    }
+  ],
+  "last_updated": "2026-06-05",
+  "total_contributions": 1
 }

--- a/packages/pi/README.md
+++ b/packages/pi/README.md
@@ -1,0 +1,36 @@
+# PI Prefix Utility
+
+This workspace package computes exact finite decimal prefixes of PI using
+integer-only Machin arctangent arithmetic.
+
+PI has no final decimal digit because it is irrational. This package does not
+claim to emit the infinite expansion. It emits exact finite prefixes for a
+requested number of fractional digits and provides a small certificate so the
+output can be audited without pasting long digit strings into a pull request.
+
+## Commands
+
+Print the first 20 fractional digits:
+
+```sh
+npm run demo -w packages/pi -- 20
+```
+
+Print the same prefix through the chunked path:
+
+```sh
+npm run demo -w packages/pi -- 20 5
+```
+
+Print a review certificate with digit count, chunk count, first/last digits, and
+a SHA-256 hash of the complete finite prefix:
+
+```sh
+npm run demo -w packages/pi -- 100 25 --certificate
+```
+
+Run the tests:
+
+```sh
+npm run test -w packages/pi
+```

--- a/packages/pi/package.json
+++ b/packages/pi/package.json
@@ -1,0 +1,16 @@
+{
+  "name": "@agent-playground/pi-prefix",
+  "version": "0.1.0",
+  "private": true,
+  "description": "Integer-only utilities for exact finite decimal prefixes of pi.",
+  "type": "module",
+  "main": "src/index.ts",
+  "scripts": {
+    "demo": "tsx src/cli.ts",
+    "test": "tsx --test src/index.test.ts"
+  },
+  "devDependencies": {
+    "tsx": "^4.7.1",
+    "typescript": "^5.4.5"
+  }
+}

--- a/packages/pi/src/cli.ts
+++ b/packages/pi/src/cli.ts
@@ -1,0 +1,13 @@
+import { calculatePiPrefix, explainPiExactnessLimit, piPrefixChunks } from "./index.js";
+
+const digits = Number.parseInt(process.argv[2] ?? "100", 10);
+const chunkSizeArg = process.argv[3];
+const chunkSize = chunkSizeArg === undefined ? undefined : Number.parseInt(chunkSizeArg, 10);
+
+if (chunkSize === undefined) {
+  console.log(calculatePiPrefix(digits));
+} else {
+  console.log([...piPrefixChunks(digits, chunkSize)].join(""));
+}
+
+console.error(explainPiExactnessLimit());

--- a/packages/pi/src/cli.ts
+++ b/packages/pi/src/cli.ts
@@ -1,10 +1,21 @@
-import { calculatePiPrefix, explainPiExactnessLimit, piPrefixChunks } from "./index.js";
+import {
+  calculatePiPrefix,
+  createPiPrefixCertificate,
+  explainPiExactnessLimit,
+  piPrefixChunks
+} from "./index.js";
 
-const digits = Number.parseInt(process.argv[2] ?? "100", 10);
-const chunkSizeArg = process.argv[3];
+const args = process.argv.slice(2);
+const certificateMode = args.includes("--certificate");
+const positionalArgs = args.filter((arg) => arg !== "--certificate");
+
+const digits = Number.parseInt(positionalArgs[0] ?? "100", 10);
+const chunkSizeArg = positionalArgs[1];
 const chunkSize = chunkSizeArg === undefined ? undefined : Number.parseInt(chunkSizeArg, 10);
 
-if (chunkSize === undefined) {
+if (certificateMode) {
+  console.log(JSON.stringify(createPiPrefixCertificate(digits, chunkSize), null, 2));
+} else if (chunkSize === undefined) {
   console.log(calculatePiPrefix(digits));
 } else {
   console.log([...piPrefixChunks(digits, chunkSize)].join(""));

--- a/packages/pi/src/index.test.ts
+++ b/packages/pi/src/index.test.ts
@@ -3,6 +3,7 @@ import { describe, it } from "node:test";
 import {
   KNOWN_PI_100_DIGITS,
   calculatePiPrefix,
+  createPiPrefixCertificate,
   explainPiExactnessLimit,
   piPrefixChunks
 } from "./index.js";
@@ -28,6 +29,24 @@ describe("piPrefixChunks", () => {
 
   it("rejects invalid chunk sizes", () => {
     assert.throws(() => [...piPrefixChunks(10, 0)], /greater than 0/);
+  });
+});
+
+describe("createPiPrefixCertificate", () => {
+  it("returns auditable metadata for a finite prefix", () => {
+    assert.deepEqual(createPiPrefixCertificate(12, 5), {
+      chunkCount: 4,
+      chunkSize: 5,
+      digits: 12,
+      firstDigits: "3.141592653589",
+      lastDigits: "3.141592653589",
+      prefixLength: 14,
+      sha256: "1f0960c3ef5338a9e9f3784e332a1cca423a5fb1bbff501e8a2bad94f28b1d20"
+    });
+  });
+
+  it("rejects invalid certificate chunk sizes", () => {
+    assert.throws(() => createPiPrefixCertificate(10, 0), /greater than 0/);
   });
 });
 

--- a/packages/pi/src/index.test.ts
+++ b/packages/pi/src/index.test.ts
@@ -1,0 +1,38 @@
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+import {
+  KNOWN_PI_100_DIGITS,
+  calculatePiPrefix,
+  explainPiExactnessLimit,
+  piPrefixChunks
+} from "./index.js";
+
+describe("calculatePiPrefix", () => {
+  it("returns exact finite prefixes using integer arithmetic", () => {
+    assert.equal(calculatePiPrefix(0), "3");
+    assert.equal(calculatePiPrefix(5), "3.14159");
+    assert.equal(calculatePiPrefix(100), KNOWN_PI_100_DIGITS);
+  });
+
+  it("rejects invalid precision values", () => {
+    assert.throws(() => calculatePiPrefix(-1), /non-negative integer/);
+    assert.throws(() => calculatePiPrefix(1.5), /non-negative integer/);
+    assert.throws(() => calculatePiPrefix(100_001), /100000 or less/);
+  });
+});
+
+describe("piPrefixChunks", () => {
+  it("streams the finite prefix in stable chunks", () => {
+    assert.deepEqual([...piPrefixChunks(12, 5)], ["3.", "14159", "26535", "89"]);
+  });
+
+  it("rejects invalid chunk sizes", () => {
+    assert.throws(() => [...piPrefixChunks(10, 0)], /greater than 0/);
+  });
+});
+
+describe("explainPiExactnessLimit", () => {
+  it("documents why a final decimal digit cannot be produced", () => {
+    assert.match(explainPiExactnessLimit(), /never terminates/);
+  });
+});

--- a/packages/pi/src/index.ts
+++ b/packages/pi/src/index.ts
@@ -1,0 +1,90 @@
+export const KNOWN_PI_100_DIGITS =
+  "3.1415926535897932384626433832795028841971693993751058209749445923078164062862089986280348253421170679";
+
+const DEFAULT_GUARD_DIGITS = 12;
+const MAX_DIGITS = 100_000;
+
+export type PiPrefixOptions = {
+  guardDigits?: number;
+};
+
+export function calculatePiPrefix(digits: number, options: PiPrefixOptions = {}): string {
+  assertNonNegativeInteger(digits, "digits");
+  if (digits > MAX_DIGITS) {
+    throw new RangeError(`digits must be ${MAX_DIGITS} or less`);
+  }
+
+  const guardDigits = options.guardDigits ?? DEFAULT_GUARD_DIGITS;
+  assertNonNegativeInteger(guardDigits, "guardDigits");
+
+  const precision = digits + guardDigits;
+  const scale = 10n ** BigInt(precision);
+  const piScaled =
+    16n * arctanOneOver(5n, scale) - 4n * arctanOneOver(239n, scale);
+  const trimmed = piScaled / (10n ** BigInt(guardDigits));
+  const raw = trimmed.toString().padStart(digits + 1, "0");
+
+  if (digits === 0) {
+    return raw;
+  }
+
+  return `${raw.slice(0, 1)}.${raw.slice(1).padEnd(digits, "0")}`;
+}
+
+export function* piPrefixChunks(
+  digits: number,
+  chunkSize = 50,
+  options: PiPrefixOptions = {}
+): Generator<string> {
+  assertNonNegativeInteger(chunkSize, "chunkSize");
+  if (chunkSize === 0) {
+    throw new RangeError("chunkSize must be greater than 0");
+  }
+
+  const prefix = calculatePiPrefix(digits, options);
+  if (digits === 0) {
+    yield prefix;
+    return;
+  }
+
+  const [integerPart, fractionalPart = ""] = prefix.split(".");
+  yield `${integerPart}.`;
+
+  for (let offset = 0; offset < fractionalPart.length; offset += chunkSize) {
+    yield fractionalPart.slice(offset, offset + chunkSize);
+  }
+}
+
+export function explainPiExactnessLimit(): string {
+  return [
+    "Pi is irrational, so its decimal expansion never terminates.",
+    "A finite program can emit exact finite prefixes on demand, but there is no final decimal digit to return."
+  ].join(" ");
+}
+
+function arctanOneOver(inverseX: bigint, scale: bigint): bigint {
+  const inverseSquare = inverseX * inverseX;
+  let powerTerm = scale / inverseX;
+  let sum = powerTerm;
+  let denominator = 3n;
+  let sign = -1n;
+
+  while (true) {
+    powerTerm /= inverseSquare;
+    const scaledTerm = powerTerm / denominator;
+
+    if (scaledTerm === 0n) {
+      return sum;
+    }
+
+    sum += sign * scaledTerm;
+    sign = -sign;
+    denominator += 2n;
+  }
+}
+
+function assertNonNegativeInteger(value: number, name: string): void {
+  if (!Number.isInteger(value) || value < 0) {
+    throw new RangeError(`${name} must be a non-negative integer`);
+  }
+}

--- a/packages/pi/src/index.ts
+++ b/packages/pi/src/index.ts
@@ -1,3 +1,5 @@
+import { createHash } from "node:crypto";
+
 export const KNOWN_PI_100_DIGITS =
   "3.1415926535897932384626433832795028841971693993751058209749445923078164062862089986280348253421170679";
 
@@ -6,6 +8,16 @@ const MAX_DIGITS = 100_000;
 
 export type PiPrefixOptions = {
   guardDigits?: number;
+};
+
+export type PiPrefixCertificate = {
+  chunkCount: number;
+  chunkSize: number;
+  digits: number;
+  firstDigits: string;
+  lastDigits: string;
+  prefixLength: number;
+  sha256: string;
 };
 
 export function calculatePiPrefix(digits: number, options: PiPrefixOptions = {}): string {
@@ -53,6 +65,32 @@ export function* piPrefixChunks(
   for (let offset = 0; offset < fractionalPart.length; offset += chunkSize) {
     yield fractionalPart.slice(offset, offset + chunkSize);
   }
+}
+
+export function createPiPrefixCertificate(
+  digits: number,
+  chunkSize = 50,
+  options: PiPrefixOptions = {}
+): PiPrefixCertificate {
+  assertNonNegativeInteger(chunkSize, "chunkSize");
+  if (chunkSize === 0) {
+    throw new RangeError("chunkSize must be greater than 0");
+  }
+
+  const prefix = calculatePiPrefix(digits, options);
+  const fractionalDigits = digits === 0 ? "" : prefix.split(".")[1] ?? "";
+  const chunkCount =
+    digits === 0 ? 1 : 1 + Math.ceil(fractionalDigits.length / chunkSize);
+
+  return {
+    chunkCount,
+    chunkSize,
+    digits,
+    firstDigits: prefix.slice(0, 32),
+    lastDigits: prefix.slice(-32),
+    prefixLength: prefix.length,
+    sha256: createHash("sha256").update(prefix).digest("hex")
+  };
 }
 
 export function explainPiExactnessLimit(): string {


### PR DESCRIPTION
/claim #17

## Summary
- add a focused `@agent-playground/pi-prefix` workspace package
- compute exact finite decimal prefixes of pi using integer-only Machin arctangent arithmetic
- add a chunked output helper and CLI demo for long finite prefixes
- document why pi cannot have a final decimal digit
- register the AI agent metadata for issue #17

## Validation
- `npm run test -w packages/pi`
- `npm run demo -w packages/pi -- 20 5`
- `npm test -- --workspaces --if-present`
- `git diff --check`

Closes #17