### PR TITLE
[OpenAI Codex] docs: add JSDoc to user service

### DIFF
--- a/apps/api/src/routes/users.ts
+++ b/apps/api/src/routes/users.ts
@@ -1,20 +1,19 @@
 import { Router } from "express";
 
+import { createUser, listUsers } from "../services/userService";
+
 const router = Router();
 
 router.get("/", (_req, res) => {
   res.json({
-    data: [],
+    data: listUsers(),
     message: "User listing is not implemented yet."
   });
 });
 
 router.post("/", (req, res) => {
   res.status(201).json({
-    data: {
-      id: "stub-user-id",
-      ...req.body
-    },
+    data: createUser(req.body),
     message: "User creation is not implemented yet."
   });
 });

--- a/apps/api/src/services/userService.ts
+++ b/apps/api/src/services/userService.ts
@@ -1,0 +1,24 @@
+export type UserPayload = Record<string, unknown>;
+
+/**
+ * Return the current user collection.
+ *
+ * This placeholder keeps the route contract stable until database-backed
+ * user lookup is implemented.
+ */
+export function listUsers(): UserPayload[] {
+  return [];
+}
+
+/**
+ * Build a newly created user response from the provided payload.
+ *
+ * This stub mirrors the eventual service boundary by assigning a stable
+ * placeholder id while preserving the submitted request fields.
+ */
+export function createUser(payload: UserPayload): UserPayload {
+  return {
+    id: "stub-user-id",
+    ...payload
+  };
+}

--- a/contributors/agents.json
+++ b/contributors/agents.json
@@ -1,5 +1,12 @@
 {
-  "agents": [],
-  "last_updated": "2026-06-03",
-  "total_contributions": 0
+  "agents": [
+    {
+      "name": "OpenAI Codex",
+      "model": "GPT-5",
+      "contribution": "Added documented user service helpers and routed users through the service layer.",
+      "date": "2026-06-05"
+    }
+  ],
+  "last_updated": "2026-06-05",
+  "total_contributions": 1
 }


### PR DESCRIPTION
Summary:
- Add documented user service helpers for listing and creating users.
- Route user endpoints through the service layer while preserving the existing stub responses.
- Add OpenAI Codex to contributors/agents.json as requested by the repository instructions.

Tests:
- npm.cmd test

Closes #1