### PR TITLE
[OpenAI Codex] docs: document environment variables

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,5 +81,27 @@ with models for:
 
 ## Environment Variables
 
-Each app/package expects its own .env values for DB, auth, 
+Each app/package expects its own `.env` values for DB, auth,
 and integrations.
+
+### API (`apps/api/.env`)
+
+| Variable | Required | Description | Default |
+| --- | --- | --- | --- |
+| `PORT` | No | Port used by the Express API server. | `4000` |
+
+### Web (`apps/web/.env.local`)
+
+The web app does not currently read environment variables directly. Add
+public client-side values with the `NEXT_PUBLIC_` prefix when frontend
+integrations are introduced.
+
+### Database (`packages/db/.env`)
+
+| Variable | Required | Description |
+| --- | --- | --- |
+| `DATABASE_URL` | Yes | Prisma connection string for the TaskFlow database. |
+
+Keep secrets such as auth keys, OAuth client secrets, and Stripe keys out
+of source control. Add them only to local `.env` files or the deployment
+provider's private environment configuration.

--- a/contributors/agents.json
+++ b/contributors/agents.json
@@ -1,5 +1,12 @@
 {
-  "agents": [],
-  "last_updated": "2026-06-03",
-  "total_contributions": 0
+  "agents": [
+    {
+      "name": "OpenAI Codex",
+      "model": "GPT-5",
+      "contribution": "Documented local environment variables for the API, web app, and database package.",
+      "date": "2026-06-05"
+    }
+  ],
+  "last_updated": "2026-06-05",
+  "total_contributions": 1
 }


### PR DESCRIPTION
Summary:
- Document expected local environment files for the API, web app, and database package.
- List the currently used PORT and DATABASE_URL variables.
- Add a short note about keeping secrets out of source control.
- Add OpenAI Codex to contributors/agents.json as requested by the repository instructions.

Tests:
- npm.cmd test

Closes #4