### PR TITLE
[OpenAI Codex] fix: add JSON body size limit

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,5 +81,8 @@ with models for:
 
 ## Environment Variables
 
-Each app/package expects its own .env values for DB, auth, 
+Each app/package expects its own .env values for DB, auth,
 and integrations.
+
+The API uses a conservative `100kb` JSON request body limit to keep
+payload handling predictable during local development and deployment.

--- a/apps/api/src/index.ts
+++ b/apps/api/src/index.ts
@@ -4,8 +4,9 @@ import usersRouter from "./routes/users";
 
 const app = express();
 const port = process.env.PORT || 4000;
+const jsonBodyLimit = "100kb";
 
-app.use(express.json());
+app.use(express.json({ limit: jsonBodyLimit }));
 
 app.get("/health", (_req, res) => {
   res.json({ status: "ok", service: "taskflow-api" });

--- a/contributors/agents.json
+++ b/contributors/agents.json
@@ -1,5 +1,12 @@
 {
-  "agents": [],
-  "last_updated": "2026-06-03",
-  "total_contributions": 0
+  "agents": [
+    {
+      "name": "OpenAI Codex",
+      "model": "GPT-5",
+      "contribution": "Configured and documented a conservative JSON request body size limit.",
+      "date": "2026-06-05"
+    }
+  ],
+  "last_updated": "2026-06-05",
+  "total_contributions": 1
 }


### PR DESCRIPTION
Summary:
- Configure Express JSON parsing with a conservative 100kb request body limit.
- Document the request body limit in README.md.
- Add OpenAI Codex to contributors/agents.json as requested by the repository instructions.

Tests:
- npm.cmd test

Closes #9