### PR TITLE
[agent] Fix shared UI Button React contract

### DIFF
--- a/contributors/agents.json
+++ b/contributors/agents.json
@@ -1,5 +1,12 @@
 {
-  "agents": [],
-  "last_updated": "2026-06-03",
-  "total_contributions": 0
+  "agents": [
+    {
+      "agent": "OpenAI Codex",
+      "model": "GPT-5",
+      "issues": ["#220", "#253"],
+      "contribution": "Fixed the shared UI Button component to return a real React element and declared the React package contract."
+    }
+  ],
+  "last_updated": "2026-06-05",
+  "total_contributions": 1
 }

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -5,10 +5,18 @@
   "description": "Shared UI components for TaskFlow.",
   "main": "src/index.ts",
   "scripts": {
-    "test": "echo \"No UI tests configured yet\"",
+    "test": "tsc --noEmit",
     "lint": "echo \"No UI lint configured yet\""
   },
+  "peerDependencies": {
+    "react": "^18.0.0",
+    "react-dom": "^18.0.0"
+  },
   "devDependencies": {
+    "@types/react": "^18.3.1",
+    "@types/react-dom": "^18.3.0",
+    "react": "^18.3.1",
+    "react-dom": "^18.3.1",
     "typescript": "^5.4.5"
   }
 }

--- a/packages/ui/src/index.ts
+++ b/packages/ui/src/index.ts
@@ -1,12 +1,22 @@
+import { createElement, type ButtonHTMLAttributes, type ReactElement } from "react";
+
 export type ButtonProps = {
   label: string;
-  disabled?: boolean;
-};
+} & Omit<ButtonHTMLAttributes<HTMLButtonElement>, "children">;
 
-export function Button({ label, disabled = false }: ButtonProps) {
-  return {
-    type: "button",
-    label,
-    disabled
-  };
+export function Button({
+  label,
+  disabled = false,
+  type = "button",
+  ...buttonProps
+}: ButtonProps): ReactElement {
+  return createElement(
+    "button",
+    {
+      ...buttonProps,
+      disabled,
+      type
+    },
+    label
+  );
 }

--- a/packages/ui/tsconfig.json
+++ b/packages/ui/tsconfig.json
@@ -1,0 +1,14 @@
+{
+  "compilerOptions": {
+    "declaration": true,
+    "esModuleInterop": true,
+    "jsx": "react-jsx",
+    "lib": ["ES2022", "DOM"],
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
+    "noEmit": true,
+    "strict": true,
+    "target": "ES2022"
+  },
+  "include": ["src/**/*.ts"]
+}


### PR DESCRIPTION
/claim #220
/claim #253

## Summary
- make the shared UI `Button` return a real React button element instead of a plain object
- preserve the existing `label` and `disabled` API while allowing standard button attributes
- declare React and React DOM as peer dependencies for the UI package and add local dev/type dependencies
- add a UI TypeScript verification config and wire `npm test -w packages/ui` to `tsc --noEmit`
- register the AI agent metadata for issues #220 and #253

## Validation
- `npm run test -w packages/ui`
- `npm test`
- `contributors/agents.json` and `packages/ui/package.json` JSON parse check
- `git diff --check`

Closes #220
Closes #253
