### PR TITLE
fix: use /bounty marker in bounty task template (Closes #687)

### DIFF
--- a/.github/ISSUE_TEMPLATE/bounty_task.md
+++ b/.github/ISSUE_TEMPLATE/bounty_task.md
@@ -18,4 +18,4 @@ Describe the task, expected context, and files likely involved.
 
 ## Bounty Amount
 
-$50
+/bounty $50


### PR DESCRIPTION
## Summary

Updates the `Bounty task` issue template (`.github/ISSUE_TEMPLATE/bounty_task.md`) to use the machine-readable `/bounty $50` marker instead of plain `$50`.

## Problem

The template's "Bounty Amount" section used `$50` as a plain text default, but the bounty program instructions (ref #33) require the `/bounty $[amount]` slash marker for automation and contributor identification.

## Fix

Changed the bounty amount default from `$50` to `/bounty $50` in the template. This is a one-line change that keeps the template compatible with existing workflows while adding the required machine-readable marker.

## Testing

- Template YAML frontmatter preserved
- Only the bounty amount line was modified
- Default marker format matches seeded bounty issues and program instructions

Closes #687