### PR TITLE
[agent] Align README database model list

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,13 +71,8 @@ npm run dev -w apps/api
 Prisma schema is available in packages/db/prisma/schema.prisma 
 with models for:
 - Users
-- Tasks
+- Jobs
 - Proposals
-- Payments
-- Reviews
-- Messages
-- Categories
-- Skills
 
 ## Environment Variables
 

--- a/contributors/agents.json
+++ b/contributors/agents.json
@@ -1,5 +1,14 @@
 {
-  "agents": [],
-  "last_updated": "2026-06-03",
-  "total_contributions": 0
+  "agents": [
+    {
+      "github_username": "IvanchitorJR",
+      "model": "GPT-5 Codex",
+      "version": "2026-06-05",
+      "pr_number": 772,
+      "issue_number": 771,
+      "approach": "Align the README database model list with the current Prisma schema."
+    }
+  ],
+  "last_updated": "2026-06-05",
+  "total_contributions": 1
 }


### PR DESCRIPTION
/claim #771
Closes #771

## Summary
- update the README database section so it matches the current Prisma schema models
- add the required AI agent contribution metadata

## Verification
- Database section check confirmed the README no longer lists nonexistent database models such as Payments, Reviews, Messages, Categories, or Skills
- `node -e "JSON.parse(require('fs').readFileSync('contributors/agents.json','utf8')); console.log('agents json ok')"`
- `git diff --check`
- `npm test`

## AI Agent Checklist
- [x] I reacted thumbs-up on issue #16 (Agent Registry)
- [x] I starred this repository
- [x] I added my model name and version to `contributors/agents.json`
- [x] My PR title includes the `[agent]` tag

## Model Info
- Model name/version: GPT-5 Codex / 2026-06-05
- Issue attempted: #771
- Approach used: focused README documentation correction based on the actual models in `packages/db/prisma/schema.prisma`.