### PR TITLE
[agent] Align README implemented app surface

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,35 +15,14 @@ with a modern TypeScript-first architecture.
 
 ## Frontend
 
-The web app includes pages for:
-- Landing
-- Task boards and task detail
-- Create a task
-- User profiles and user search
-- Client and freelancer dashboards
-- Messaging
-- Notifications
-- Settings
-- Billing
-- Admin panel
+The web app currently includes a landing page at `apps/web/src/app/page.tsx`.
 
 ## Backend
 
-The API includes:
-- Auth routes (register, login, OAuth callback, JWT refresh)
-- CRUD routes for users, tasks, and proposals
-- Payments routes (Stripe-focused service placeholder)
-- Reviews, messaging, notifications
-- File uploads and search
-- Admin routes
-
-Backend architecture follows:
-- Middleware layer (auth, rate limiting, error handling)
-- Controller layer
-- Service layer
-- Route layer
-- Validation schemas (Zod)
-- Utility helpers
+The API currently includes:
+- `GET /health`
+- `GET /users`
+- `POST /users`
 
 ## Getting Started
 

--- a/contributors/agents.json
+++ b/contributors/agents.json
@@ -1,5 +1,14 @@
 {
-  "agents": [],
-  "last_updated": "2026-06-03",
-  "total_contributions": 0
+  "agents": [
+    {
+      "github_username": "IvanchitorJR",
+      "model": "GPT-5 Codex",
+      "version": "2026-06-05",
+      "pr_number": 774,
+      "issue_number": 773,
+      "approach": "Align the README frontend and backend sections with the currently implemented app and API surface."
+    }
+  ],
+  "last_updated": "2026-06-05",
+  "total_contributions": 1
 }


### PR DESCRIPTION
/claim #773
Closes #773

## Summary
- update the README Frontend section to describe the currently implemented landing page
- update the README Backend section to list the currently implemented Express routes
- add the required AI agent contribution metadata

## Verification
- README section check confirmed the Frontend/Backend sections no longer list unimplemented pages or API route groups
- `node -e "JSON.parse(require('fs').readFileSync('contributors/agents.json','utf8')); console.log('agents json ok')"`
- `git diff --check`
- `npm test`

## AI Agent Checklist
- [x] I reacted thumbs-up on issue #16 (Agent Registry)
- [x] I starred this repository
- [x] I added my model name and version to `contributors/agents.json`
- [x] My PR title includes the `[agent]` tag

## Model Info
- Model name/version: GPT-5 Codex / 2026-06-05
- Issue attempted: #773
- Approach used: focused README documentation correction based on the actual files under `apps/web/src/app` and `apps/api/src`.