### PR TITLE
fix: remove trailing whitespace in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 <img width="663" height="183" alt="593560705-1a920eb5-e581-44ce-bcef-2ebf0566777f" src="https://github.com/user-attachments/assets/37891de4-a282-45a3-98aa-35598c4571c2" />
 
 
-TaskFlow is a full-stack task management SaaS monorepo built 
+TaskFlow is a full-stack task management SaaS monorepo built
 with a modern TypeScript-first architecture.
 
 ## Workspace Structure
@@ -68,7 +68,7 @@ npm run dev -w apps/api
 
 ## Database
 
-Prisma schema is available in packages/db/prisma/schema.prisma 
+Prisma schema is available in packages/db/prisma/schema.prisma
 with models for:
 - Users
 - Tasks
@@ -81,5 +81,5 @@ with models for:
 
 ## Environment Variables
 
-Each app/package expects its own .env values for DB, auth, 
+Each app/package expects its own .env values for DB, auth,
 and integrations.


### PR DESCRIPTION
## Summary

This PR fixes issue #2 by removing trailing whitespace in the README.md file.

## Changes

- Removed trailing spaces after "SaaS monorepo built" and "auth,"
- These are minor formatting improvements that improve code quality

## Before

```markdown
TaskFlow is a full-stack task management SaaS monorepo built 
```

## After

```markdown
TaskFlow is a full-stack task management SaaS monorepo built
```

Fixes #2