### PR TITLE
[agent] Fix user creation payload filtering

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,8 @@ node_modules/
 dist/
 build/
 coverage/
+**/.tmp-test/
+*.tsbuildinfo
 
 # Logs
 *.log

--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -7,7 +7,7 @@
   "main": "src/index.ts",
   "scripts": {
     "dev": "tsx src/index.ts",
-    "test": "echo \"No API tests configured yet\"",
+    "test": "tsc --outDir .tmp-test --rootDir src --module NodeNext --moduleResolution NodeNext --target ES2022 --esModuleInterop --skipLibCheck src/routes/users.ts src/routes/users.test.ts && node .tmp-test/routes/users.test.js",
     "lint": "echo \"No API lint configured yet\""
   },
   "dependencies": {

--- a/apps/api/src/routes/users.test.ts
+++ b/apps/api/src/routes/users.test.ts
@@ -1,0 +1,52 @@
+import assert from "node:assert/strict";
+import express from "express";
+
+import usersRouter from "./users.js";
+
+const app = express();
+app.use(express.json());
+app.use("/users", usersRouter);
+
+const server = app.listen(0);
+const address = server.address();
+
+if (!address || typeof address === "string") {
+  throw new Error("Expected test server to listen on a local TCP port");
+}
+
+const baseUrl = `http://127.0.0.1:${address.port}`;
+
+try {
+  const response = await fetch(`${baseUrl}/users`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({
+      id: "malicious-id",
+      name: "Ada Lovelace",
+      email: "ada@example.com",
+      admin: true
+    })
+  });
+
+  assert.equal(response.status, 201);
+
+  const body = await response.json();
+  assert.deepEqual(body.data, {
+    id: "stub-user-id",
+    name: "Ada Lovelace",
+    email: "ada@example.com"
+  });
+  assert.equal("admin" in body.data, false);
+
+  console.log("users route payload filtering checks passed");
+} finally {
+  await new Promise<void>((resolve, reject) => {
+    server.close((error) => {
+      if (error) {
+        reject(error);
+      } else {
+        resolve();
+      }
+    });
+  });
+}

--- a/apps/api/src/routes/users.ts
+++ b/apps/api/src/routes/users.ts
@@ -10,10 +10,13 @@ router.get("/", (_req, res) => {
 });
 
 router.post("/", (req, res) => {
+  const { name, email } = req.body ?? {};
+
   res.status(201).json({
     data: {
       id: "stub-user-id",
-      ...req.body
+      ...(name !== undefined ? { name } : {}),
+      ...(email !== undefined ? { email } : {})
     },
     message: "User creation is not implemented yet."
   });

--- a/contributors/agents.json
+++ b/contributors/agents.json
@@ -4,7 +4,7 @@
       "github_username": "IvanchitorJR",
       "model": "GPT-5 Codex",
       "version": "2026-06-05",
-      "pr_number": 0,
+      "pr_number": 778,
       "issue_number": 694
     }
   ],

--- a/contributors/agents.json
+++ b/contributors/agents.json
@@ -1,5 +1,13 @@
 {
-  "agents": [],
-  "last_updated": "2026-06-03",
-  "total_contributions": 0
+  "agents": [
+    {
+      "github_username": "IvanchitorJR",
+      "model": "GPT-5 Codex",
+      "version": "2026-06-05",
+      "pr_number": 0,
+      "issue_number": 694
+    }
+  ],
+  "last_updated": "2026-06-05",
+  "total_contributions": 1
 }


### PR DESCRIPTION
## Summary
- restrict POST /users responses to the stub id plus expected name and email fields
- prevent client payloads from overriding id or reflecting arbitrary fields such as admin
- add an API route verification script that compiles with TypeScript and exercises the route over HTTP
- register the AI agent contribution metadata

## Verification
- npm test -w apps/api
- npm test

Closes #694