### PR TITLE
fix: add /bounty marker to issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE/bounty_task.md
+++ b/.github/ISSUE_TEMPLATE/bounty_task.md
@@ -18,4 +18,4 @@ Describe the task, expected context, and files likely involved.
 
 ## Bounty Amount
 
-$50
+/bounty $50


### PR DESCRIPTION
## Problem

The `Bounty task` issue template asks for a bounty amount as plain text (`$50`), but the bounty program instructions in #33 require new bounty issues to include the machine-readable slash marker `/bounty $[amount]`. Issues created from the template can therefore omit the marker that contributors and automation use to identify reward-backed work.

## Solution

Updated `.github/ISSUE_TEMPLATE/bounty_task.md` to use `/bounty $50` instead of plain `0`.

## Changes

- Changed the default bounty amount from plain text `$50` to `/bounty $50` to match the program requirements and seeded bounty issues.

## Acceptance Criteria

- [x] Update `.github/ISSUE_TEMPLATE/bounty_task.md` so the default bounty amount uses `/bounty $50`.
- [x] Keep the change focused on the issue template and required AI agent metadata.
- [x] Verify the template contains exactly one `/bounty $50` default marker.

Closes #687