### PR TITLE
[OpenAI Codex] types: annotate Button return shape

### DIFF
--- a/contributors/agents.json
+++ b/contributors/agents.json
@@ -1,5 +1,12 @@
 {
-  "agents": [],
-  "last_updated": "2026-06-03",
-  "total_contributions": 0
+  "agents": [
+    {
+      "name": "OpenAI Codex",
+      "model": "GPT-5",
+      "contribution": "Added an explicit return type for the shared Button stub without changing its output shape.",
+      "date": "2026-06-05"
+    }
+  ],
+  "last_updated": "2026-06-05",
+  "total_contributions": 1
 }

--- a/packages/ui/src/index.ts
+++ b/packages/ui/src/index.ts
@@ -3,7 +3,13 @@ export type ButtonProps = {
   disabled?: boolean;
 };
 
-export function Button({ label, disabled = false }: ButtonProps) {
+export type ButtonModel = {
+  type: "button";
+  label: string;
+  disabled: boolean;
+};
+
+export function Button({ label, disabled = false }: ButtonProps): ButtonModel {
   return {
     type: "button",
     label,


### PR DESCRIPTION
Summary:
- Add a ButtonModel return type for the shared Button stub.
- Annotate Button with the explicit output shape while preserving its current public fields.
- Add OpenAI Codex to contributors/agents.json as requested by the repository instructions.

Tests:
- npm.cmd test

Closes #3