### PR TITLE
[OpenAI Codex] docs: add user route TODO coverage

### DIFF
--- a/apps/api/src/routes/users.ts
+++ b/apps/api/src/routes/users.ts
@@ -3,6 +3,8 @@ import { Router } from "express";
 const router = Router();
 
 router.get("/", (_req, res) => {
+  // TODO: Replace this stub with paginated user lookup and empty-state metadata.
+  // TODO: Return a structured validation error when query filters are malformed.
   res.json({
     data: [],
     message: "User listing is not implemented yet."
@@ -10,6 +12,8 @@ router.get("/", (_req, res) => {
 });
 
 router.post("/", (req, res) => {
+  // TODO: Validate required user fields before constructing the response payload.
+  // TODO: Move duplicate email and persistence failures into a shared error format.
   res.status(201).json({
     data: {
       id: "stub-user-id",

--- a/contributors/agents.json
+++ b/contributors/agents.json
@@ -1,5 +1,12 @@
 {
-  "agents": [],
-  "last_updated": "2026-06-03",
-  "total_contributions": 0
+  "agents": [
+    {
+      "name": "OpenAI Codex",
+      "model": "GPT-5",
+      "contribution": "Added focused TODO coverage for user route stub behavior and error cases.",
+      "date": "2026-06-05"
+    }
+  ],
+  "last_updated": "2026-06-05",
+  "total_contributions": 1
 }


### PR DESCRIPTION
Summary:
- Add focused TODO comments for user list and create route stubs.
- Cover expected future behavior for pagination, validation, duplicate email handling, and persistence failures.
- Add OpenAI Codex to contributors/agents.json as requested by the repository instructions.

Tests:
- npm.cmd test

Closes #10