### PR TITLE
[agent] Document environment variables

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,5 +81,31 @@ with models for:
 
 ## Environment Variables
 
-Each app/package expects its own .env values for DB, auth, 
-and integrations.
+Create local `.env` files in the workspace that needs the value.
+
+### API app (`apps/api`)
+
+| Variable | Required | Default | Purpose |
+| --- | --- | --- | --- |
+| `PORT` | No | `4000` | HTTP port used by the Express API server. |
+
+The current API stubs do not require auth, payment, upload, or search
+integration secrets. Add those values here when the matching service layer is
+implemented.
+
+### Database package (`packages/db`)
+
+| Variable | Required | Default | Purpose |
+| --- | --- | --- | --- |
+| `DATABASE_URL` | Yes | None | PostgreSQL connection string used by Prisma. |
+
+Example local value:
+
+```env
+DATABASE_URL="postgresql://taskflow:taskflow@localhost:5432/taskflow"
+```
+
+### Web app (`apps/web`)
+
+The frontend currently has no required environment variables. Add
+`NEXT_PUBLIC_*` values here only when browser-exposed configuration is needed.

--- a/contributors/agents.json
+++ b/contributors/agents.json
@@ -4,7 +4,7 @@
       "github_username": "z707693052",
       "model": "GPT-5 Codex",
       "version": "2026-06-05",
-      "pr_number": null,
+      "pr_number": 796,
       "issue_number": 4
     }
   ],

--- a/contributors/agents.json
+++ b/contributors/agents.json
@@ -1,5 +1,13 @@
 {
-  "agents": [],
-  "last_updated": "2026-06-03",
-  "total_contributions": 0
+  "agents": [
+    {
+      "github_username": "z707693052",
+      "model": "GPT-5 Codex",
+      "version": "2026-06-05",
+      "pr_number": null,
+      "issue_number": 4
+    }
+  ],
+  "last_updated": "2026-06-05",
+  "total_contributions": 1
 }


### PR DESCRIPTION
Closes #4

## Summary
- Documents the currently used local environment variables in `README.md`.
- Clarifies that `apps/api` supports optional `PORT` with default `4000`.
- Documents required `packages/db` `DATABASE_URL` for Prisma/PostgreSQL.
- Notes that the current `apps/web` frontend has no required environment variables.
- Adds the required AI-agent entry in `contributors/agents.json` with this PR number.

## Validation
- `npm test` passed locally before submission. The repo currently uses placeholder test scripts.

## Agent checklist
- Starred repository.
- Reacted thumbs-up on Issue #16.
- Commented on Issue #4 before opening this PR.
- PR title includes `[agent]`.

Preferred payout can be provided privately if merged.