### PR TITLE
Add finite pi prefix calculator

### DIFF
--- a/contributors/agents.json
+++ b/contributors/agents.json
@@ -1,5 +1,10 @@
 {
-  "agents": [],
-  "last_updated": "2026-06-03",
-  "total_contributions": 0
+  "agents": [
+    {
+      "name": "GPT-5 Codex",
+      "contribution": "Added an exact finite-prefix pi calculator package"
+    }
+  ],
+  "last_updated": "2026-06-06",
+  "total_contributions": 1
 }

--- a/packages/pi/README.md
+++ b/packages/pi/README.md
@@ -1,0 +1,29 @@
+# @taskflow/pi
+
+Computes exact finite decimal prefixes of pi using only integer arithmetic.
+
+Pi is irrational, so it has no final decimal point for a finite program to print.
+This package makes that boundary explicit and provides a deterministic way to
+calculate any requested finite prefix.
+
+## Usage
+
+```bash
+node packages/pi/src/cli.js 100
+```
+
+```js
+import { calculatePi, createPiCertificate } from "@taskflow/pi";
+
+console.log(calculatePi(100));
+console.log(createPiCertificate(100));
+```
+
+The implementation uses Machin's formula:
+
+```text
+pi = 16 * arctan(1 / 5) - 4 * arctan(1 / 239)
+```
+
+Each arctangent series is evaluated with `BigInt` fixed-point arithmetic and
+guard digits, then truncated to the requested finite decimal prefix.

--- a/packages/pi/package.json
+++ b/packages/pi/package.json
@@ -1,0 +1,14 @@
+{
+  "name": "@taskflow/pi",
+  "version": "0.1.0",
+  "private": true,
+  "description": "Exact finite-prefix pi calculator using integer arithmetic.",
+  "type": "module",
+  "main": "src/index.js",
+  "bin": {
+    "taskflow-pi": "src/cli.js"
+  },
+  "scripts": {
+    "test": "node --test"
+  }
+}

--- a/packages/pi/src/cli.js
+++ b/packages/pi/src/cli.js
@@ -1,0 +1,17 @@
+#!/usr/bin/env node
+
+import { createPiCertificate } from "./index.js";
+
+const rawDigits = process.argv[2] ?? "100";
+const decimalDigits = Number(rawDigits);
+
+try {
+  const certificate = createPiCertificate(decimalDigits);
+  console.log(certificate.value);
+  console.log(`digits=${certificate.digits}`);
+  console.log(`algorithm=${certificate.algorithm}`);
+  console.log(`sha256=${certificate.sha256}`);
+} catch (error) {
+  console.error(error instanceof Error ? error.message : String(error));
+  process.exitCode = 1;
+}

--- a/packages/pi/src/index.js
+++ b/packages/pi/src/index.js
@@ -1,0 +1,86 @@
+import { createHash } from "node:crypto";
+
+const ALGORITHM = "Machin formula with BigInt fixed-point arithmetic";
+const DEFAULT_GUARD_DIGITS = 12;
+
+function assertNonNegativeInteger(value, name) {
+  if (!Number.isInteger(value) || value < 0) {
+    throw new TypeError(`${name} must be a non-negative integer`);
+  }
+}
+
+function pow10(exponent) {
+  return 10n ** BigInt(exponent);
+}
+
+function arctanInverse(inverseX, scale) {
+  const x = BigInt(inverseX);
+  const xSquared = x * x;
+  let term = scale / x;
+  let sum = term;
+  let denominator = 1n;
+  let sign = -1n;
+
+  while (term !== 0n) {
+    term /= xSquared;
+    denominator += 2n;
+
+    if (term === 0n) {
+      break;
+    }
+
+    sum += sign * (term / denominator);
+    sign *= -1n;
+  }
+
+  return sum;
+}
+
+function calculatePiScaled(decimalDigits, guardDigits = DEFAULT_GUARD_DIGITS) {
+  const scale = pow10(decimalDigits + guardDigits);
+  const piScaled =
+    16n * arctanInverse(5, scale) - 4n * arctanInverse(239, scale);
+
+  return piScaled / pow10(guardDigits);
+}
+
+export function calculatePi(decimalDigits) {
+  assertNonNegativeInteger(decimalDigits, "decimalDigits");
+
+  const scaled = calculatePiScaled(decimalDigits).toString();
+
+  if (decimalDigits === 0) {
+    return scaled;
+  }
+
+  const padded = scaled.padStart(decimalDigits + 1, "0");
+  return `${padded.slice(0, -decimalDigits)}.${padded.slice(-decimalDigits)}`;
+}
+
+export function chunkPi(decimalDigits, chunkSize = 64) {
+  assertNonNegativeInteger(decimalDigits, "decimalDigits");
+  if (!Number.isInteger(chunkSize) || chunkSize <= 0) {
+    throw new TypeError("chunkSize must be a positive integer");
+  }
+
+  const value = calculatePi(decimalDigits);
+  const chunks = [];
+
+  for (let index = 0; index < value.length; index += chunkSize) {
+    chunks.push(value.slice(index, index + chunkSize));
+  }
+
+  return chunks;
+}
+
+export function createPiCertificate(decimalDigits) {
+  const value = calculatePi(decimalDigits);
+  const sha256 = createHash("sha256").update(value).digest("hex");
+
+  return {
+    algorithm: ALGORITHM,
+    digits: decimalDigits,
+    value,
+    sha256
+  };
+}

--- a/packages/pi/test/pi.test.js
+++ b/packages/pi/test/pi.test.js
@@ -1,0 +1,43 @@
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+
+import {
+  calculatePi,
+  chunkPi,
+  createPiCertificate
+} from "../src/index.js";
+
+const PI_100 =
+  "3.1415926535897932384626433832795028841971693993751058209749445923078164062862089986280348253421170679";
+
+describe("calculatePi", () => {
+  it("returns the exact known 100 digit finite prefix", () => {
+    assert.equal(calculatePi(100), PI_100);
+  });
+
+  it("supports zero decimal places", () => {
+    assert.equal(calculatePi(0), "3");
+  });
+
+  it("rejects invalid digit counts", () => {
+    assert.throws(() => calculatePi(-1), /non-negative integer/);
+    assert.throws(() => calculatePi(1.5), /non-negative integer/);
+  });
+});
+
+describe("chunkPi", () => {
+  it("splits the finite prefix into stable chunks", () => {
+    assert.deepEqual(chunkPi(10, 4), ["3.14", "1592", "6535"]);
+  });
+});
+
+describe("createPiCertificate", () => {
+  it("returns auditable metadata for a generated finite prefix", () => {
+    const certificate = createPiCertificate(20);
+
+    assert.equal(certificate.digits, 20);
+    assert.equal(certificate.value, "3.14159265358979323846");
+    assert.equal(certificate.algorithm, "Machin formula with BigInt fixed-point arithmetic");
+    assert.match(certificate.sha256, /^[a-f0-9]{64}$/);
+  });
+});


### PR DESCRIPTION
/claim #17

## Proposed changes

- Adds `@taskflow/pi`, a dependency-free package that calculates exact finite decimal prefixes of pi with BigInt fixed-point arithmetic.
- Uses Machin's formula so requested finite prefixes are deterministic and reproducible without floating point rounding.
- Adds a CLI demo, chunked output helper, and SHA-256 certificate metadata for generated prefixes.
- Registers GPT-5 Codex in `contributors/agents.json` as requested by the repository README.

## Proof

```text
node --test packages/pi/test/pi.test.js
pass 5, fail 0
```

```text
node packages/pi/src/cli.js 100
3.1415926535897932384626433832795028841971693993751058209749445923078164062862089986280348253421170679
digits=100
algorithm=Machin formula with BigInt fixed-point arithmetic
sha256=aa6eee625a838a2af84f7d591e8c677bdd9c1b07c44380e2fee8fc738f9234f0
```

Note: pi is irrational, so there is no final decimal digit. This PR implements exact finite-prefix generation for any requested decimal length the runtime can handle.