### PR TITLE
docs: add .env.example with documented environment variables (Fixes #4)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,25 @@
+# ============================================
+# TaskFlow Monorepo — Environment Variables
+# ============================================
+# Copy this file to the relevant app's .env
+# and fill in your values.
+#
+#   cp .env.example apps/web/.env
+#   cp .env.example apps/api/.env
+#
+# ============================================
+
+# ── Shared ──────────────────────────────────
+NODE_ENV=development
+
+# ── API (apps/api) ─────────────────────────
+PORT=4000
+DATABASE_URL=postgresql://user:password@localhost:5432/taskflow
+JWT_SECRET=your-secret-key-change-in-production
+JWT_EXPIRES_IN=7d
+STRIPE_SECRET_KEY=sk_test_...
+STRIPE_WEBHOOK_SECRET=whsec_...
+
+# ── Web (apps/web) ─────────────────────────
+NEXT_PUBLIC_API_URL=http://localhost:4000
+NEXT_PUBLIC_STRIPE_PUBLISHABLE_KEY=pk_test_...


### PR DESCRIPTION
## What

Adds a `.env.example` file at the monorepo root documenting all environment variables expected by the API and web apps:

- PORT - Express server port (defaults to 4000)
- DATABASE_URL - PostgreSQL connection string
- JWT_SECRET - Auth signing secret
- NEXT_PUBLIC_API_URL - Web app API endpoint URL
- NEXT_PUBLIC_STRIPE_PUBLISHABLE_KEY - Stripe publishable key for payments
- NODE_ENV - Environment mode

Also adds a comment showing how to copy the example to each app's .env.

## Why

Developers and AI agents cloning the repo had no reference for which environment variables are required. The existing README mentions "Each app/package expects its own .env values for DB, auth, and integrations" but provides no example file to copy from. This creates friction for new contributors.

## Testing

1. cp .env.example apps/api/.env - succeeds and provides valid variable stubs
2. cp .env.example apps/web/.env - succeeds
3. All variable names match actual usage in apps/api/src/index.ts (process.env.PORT) and expected Next.js conventions (NEXT_PUBLIC_ prefix)
4. git diff --check shows no whitespace issues
