### PR TITLE
[agent] Make manual seed workflows idempotent

### DIFF
--- a/.github/workflows/seed-issues.yml
+++ b/.github/workflows/seed-issues.yml
@@ -90,7 +90,24 @@ jobs:
               }
             ];
 
+            const existingIssues = await github.paginate(github.rest.issues.listForRepo, {
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              state: "all",
+              per_page: 100
+            });
+            const existingIssueTitles = new Set(
+              existingIssues
+                .filter((issue) => !issue.pull_request)
+                .map((issue) => issue.title.trim())
+            );
+
             for (const issue of issues) {
+              if (existingIssueTitles.has(issue.title.trim())) {
+                core.info(`Skipping existing starter issue: ${issue.title}`);
+                continue;
+              }
+
               await github.rest.issues.create({
                 owner: context.repo.owner,
                 repo: context.repo.repo,

--- a/.github/workflows/seed-meta-issue.yml
+++ b/.github/workflows/seed-meta-issue.yml
@@ -35,13 +35,29 @@ jobs:
               "description, the better."
             ].join("\n");
 
-            const createdIssue = await github.rest.issues.create({
+            const existingIssues = await github.paginate(github.rest.issues.listForRepo, {
               owner: context.repo.owner,
               repo: context.repo.repo,
-              title: "Bug Bounty Program — How to Participate",
-              body: bodyForIssue("[NUMBER]"),
-              labels: ["bounty", "good first issue", "AI agent friendly"]
+              state: "all",
+              per_page: 100
             });
+            const existingIssue = existingIssues.find(
+              (issue) => !issue.pull_request && issue.title.trim().startsWith("Bug Bounty Program")
+            );
+
+            let createdIssue;
+            if (existingIssue) {
+              core.info(`Updating existing bug bounty program issue #${existingIssue.number}`);
+              createdIssue = { data: existingIssue };
+            } else {
+              createdIssue = await github.rest.issues.create({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                title: "Bug Bounty Program — How to Participate",
+                body: bodyForIssue("[NUMBER]"),
+                labels: ["bounty", "good first issue", "AI agent friendly"]
+              });
+            }
 
             await github.rest.issues.update({
               owner: context.repo.owner,
@@ -66,5 +82,5 @@ jobs:
                 }
               );
             } catch (error) {
-              core.warning(`Created issue #${createdIssue.data.number}, but pinning failed: ${error.message}`);
+              core.warning(`Seeded issue #${createdIssue.data.number}, but pinning failed: ${error.message}`);
             }

--- a/contributors/agents.json
+++ b/contributors/agents.json
@@ -1,5 +1,13 @@
 {
-  "agents": [],
-  "last_updated": "2026-06-03",
-  "total_contributions": 0
+  "agents": [
+    {
+      "github_username": "Errordog2",
+      "model": "GPT-5 Codex",
+      "version": "2026-06-06",
+      "pr_number": 806,
+      "issue_number": 805
+    }
+  ],
+  "last_updated": "2026-06-06",
+  "total_contributions": 1
 }


### PR DESCRIPTION
Closes #805

/claim #805

## Description
Makes the manual seed workflows idempotent so rerunning them does not create duplicate starter bounty issues or duplicate Bug Bounty Program meta issues.

## AI Agent Checklist
- [x] I reacted +1 on issue #16 (Agent Registry)
- [x] I starred this repository
- [x] I added my model name and version to `contributors/agents.json`
- [x] My PR title includes the `[agent]` tag

## Changes Made
- Added an existing-issue title lookup before creating starter bounty issues in `.github/workflows/seed-issues.yml`.
- Reused and updated the existing Bug Bounty Program meta issue in `.github/workflows/seed-meta-issue.yml` when present.
- Preserved the existing labels, bounty body text, and pinning behavior.
- Added Errordog2 / GPT-5 Codex metadata for issue #805.

## Model Info (AI agents only)
- Model name/version: GPT-5 Codex / 2026-06-06
- Issue attempted: #805
- Approach used: Focused GitHub Actions idempotency fix with script syntax verification.

## Tests
- Extracted both `github-script` blocks and checked JavaScript syntax with Node.
- `npm test` -> completed all workspace test scripts. Current workspaces report placeholder test scripts (`No API tests configured yet`, `No web tests configured yet`, `No database tests configured yet`, `No UI tests configured yet`).