### PR TITLE
Make manual seed workflows idempotent

### DIFF
--- a/.github/workflows/seed-issues.yml
+++ b/.github/workflows/seed-issues.yml
@@ -90,7 +90,24 @@ jobs:
               }
             ];
 
+            const existingIssues = await github.paginate(github.rest.issues.listForRepo, {
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              state: "all",
+              per_page: 100
+            });
+            const existingIssueTitles = new Set(
+              existingIssues
+                .filter((issue) => !issue.pull_request)
+                .map((issue) => issue.title)
+            );
+
             for (const issue of issues) {
+              if (existingIssueTitles.has(issue.title)) {
+                core.info(`Skipping existing starter issue: ${issue.title}`);
+                continue;
+              }
+
               await github.rest.issues.create({
                 owner: context.repo.owner,
                 repo: context.repo.repo,
@@ -98,4 +115,5 @@ jobs:
                 body: issue.body,
                 labels: ["good first issue", "bounty", "AI agent friendly"]
               });
+              existingIssueTitles.add(issue.title);
             }

--- a/.github/workflows/seed-meta-issue.yml
+++ b/.github/workflows/seed-meta-issue.yml
@@ -35,19 +35,41 @@ jobs:
               "description, the better."
             ].join("\n");
 
-            const createdIssue = await github.rest.issues.create({
+            const metaIssueTitles = new Set([
+              "Bug Bounty Program - How to Participate",
+              "Bug Bounty Program — How to Participate",
+              "Bug Bounty Program â€” How to Participate"
+            ]);
+
+            const existingIssues = await github.paginate(github.rest.issues.listForRepo, {
               owner: context.repo.owner,
               repo: context.repo.repo,
-              title: "Bug Bounty Program — How to Participate",
-              body: bodyForIssue("[NUMBER]"),
-              labels: ["bounty", "good first issue", "AI agent friendly"]
+              state: "all",
+              per_page: 100
             });
+            const existingMetaIssue = existingIssues.find(
+              (issue) => !issue.pull_request && metaIssueTitles.has(issue.title)
+            );
+
+            let metaIssue = existingMetaIssue;
+            if (metaIssue) {
+              core.info(`Updating existing bug bounty program issue #${metaIssue.number}`);
+            } else {
+              const createdIssue = await github.rest.issues.create({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                title: "Bug Bounty Program - How to Participate",
+                body: bodyForIssue("[NUMBER]"),
+                labels: ["bounty", "good first issue", "AI agent friendly"]
+              });
+              metaIssue = createdIssue.data;
+            }
 
             await github.rest.issues.update({
               owner: context.repo.owner,
               repo: context.repo.repo,
-              issue_number: createdIssue.data.number,
-              body: bodyForIssue(createdIssue.data.number)
+              issue_number: metaIssue.number,
+              body: bodyForIssue(metaIssue.number)
             });
 
             try {
@@ -62,9 +84,9 @@ jobs:
                   }
                 `,
                 {
-                  issueId: createdIssue.data.node_id
+                  issueId: metaIssue.node_id
                 }
               );
             } catch (error) {
-              core.warning(`Created issue #${createdIssue.data.number}, but pinning failed: ${error.message}`);
+              core.warning(`Seeded issue #${metaIssue.number}, but pinning failed: ${error.message}`);
             }


### PR DESCRIPTION
/claim #805

## Related scoped bounty
/claim #875

PR #809 was opened before issue #875 existed, but it already implements the seed workflow idempotency requested by #875. Please include this PR in the #875 reward review set if existing pre-issue coverage is eligible.

## Summary
- Makes `.github/workflows/seed-issues.yml` idempotent by loading existing issues and skipping starter issue titles that already exist.
- Makes `.github/workflows/seed-meta-issue.yml` reuse the existing Bug Bounty Program issue, update its body with the correct issue number, and pin the reused issue instead of creating duplicates.
- Preserves existing labels, bounty body text, and pinning behavior while keeping the change scoped to the seed workflows.

## Validation
- `git diff --check`
- Parsed both embedded `actions/github-script` blocks with `node` as async functions.
- PR #809 is open, non-draft, mergeable/clean, with `update-leaderboard` passing.

No application code or bounty automation outside the two seed workflows was changed.