### PR TITLE
[agent] docs: add user service JSDoc

### DIFF
--- a/apps/api/src/routes/users.ts
+++ b/apps/api/src/routes/users.ts
@@ -1,20 +1,18 @@
 import { Router } from "express";
+import { createUser, listUsers } from "../services/userService";
 
 const router = Router();
 
 router.get("/", (_req, res) => {
   res.json({
-    data: [],
+    data: listUsers(),
     message: "User listing is not implemented yet."
   });
 });
 
 router.post("/", (req, res) => {
   res.status(201).json({
-    data: {
-      id: "stub-user-id",
-      ...req.body
-    },
+    data: createUser(req.body),
     message: "User creation is not implemented yet."
   });
 });

--- a/apps/api/src/services/userService.ts
+++ b/apps/api/src/services/userService.ts
@@ -1,0 +1,29 @@
+export type StubUser = {
+  id: string;
+  [key: string]: unknown;
+};
+
+export type CreateUserInput = Record<string, unknown>;
+
+/**
+ * Returns the current user collection placeholder.
+ *
+ * The API does not have persistence wired yet, so this deliberately returns an
+ * empty list while preserving the future service boundary for route handlers.
+ */
+export function listUsers(): StubUser[] {
+  return [];
+}
+
+/**
+ * Builds the placeholder user creation response.
+ *
+ * Until database-backed creation exists, the request payload is echoed with a
+ * stable stub id so callers can exercise the route contract.
+ */
+export function createUser(payload: CreateUserInput): StubUser {
+  return {
+    id: "stub-user-id",
+    ...payload
+  };
+}

--- a/contributors/agents.json
+++ b/contributors/agents.json
@@ -4,7 +4,7 @@
       "github_username": "alejandrorivas-pixel",
       "model": "GPT-5 Codex",
       "version": "2026-06-05",
-      "pr_number": 0,
+      "pr_number": 812,
       "issue_number": 1
     }
   ],

--- a/contributors/agents.json
+++ b/contributors/agents.json
@@ -1,5 +1,13 @@
 {
-  "agents": [],
-  "last_updated": "2026-06-03",
-  "total_contributions": 0
+  "agents": [
+    {
+      "github_username": "alejandrorivas-pixel",
+      "model": "GPT-5 Codex",
+      "version": "2026-06-05",
+      "pr_number": 0,
+      "issue_number": 1
+    }
+  ],
+  "last_updated": "2026-06-05",
+  "total_contributions": 1
 }


### PR DESCRIPTION
/claim #1

Summary:
- Add a focused user service module for the existing list/create placeholder behavior.
- Document the service functions with concise JSDoc so future contributors can understand the intended stub behavior.
- Wire the current user routes through the service without changing response shape.
- Add the required agent metadata entry.

Validation:
- node -e "JSON.parse(require('fs').readFileSync('contributors/agents.json','utf8')); console.log('agents.json ok')"
- npm run test
- git diff --check

Closes #1