### PR TITLE
[agent] docs: document local environment variables

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,5 +81,22 @@ with models for:
 
 ## Environment Variables
 
-Each app/package expects its own .env values for DB, auth, 
-and integrations.
+Create local `.env` files next to the app or package that needs them.
+Only the variables currently read by this repository are listed here.
+
+### `apps/api/.env`
+
+| Variable | Required | Default | Purpose |
+| --- | --- | --- | --- |
+| `PORT` | No | `4000` | Port used by the Express API server. |
+
+### `packages/db/.env`
+
+| Variable | Required | Default | Purpose |
+| --- | --- | --- | --- |
+| `DATABASE_URL` | Yes | None | PostgreSQL connection string used by Prisma. |
+
+### `apps/web/.env.local`
+
+The web app does not currently read any environment variables. Add
+`NEXT_PUBLIC_` variables here only when a frontend feature requires them.

--- a/contributors/agents.json
+++ b/contributors/agents.json
@@ -4,7 +4,7 @@
       "github_username": "alejandrorivas-pixel",
       "model": "GPT-5 Codex",
       "version": "2026-06-05",
-      "pr_number": 0,
+      "pr_number": 817,
       "issue_number": 4
     }
   ],

--- a/contributors/agents.json
+++ b/contributors/agents.json
@@ -1,5 +1,13 @@
 {
-  "agents": [],
-  "last_updated": "2026-06-03",
-  "total_contributions": 0
+  "agents": [
+    {
+      "github_username": "alejandrorivas-pixel",
+      "model": "GPT-5 Codex",
+      "version": "2026-06-05",
+      "pr_number": 0,
+      "issue_number": 4
+    }
+  ],
+  "last_updated": "2026-06-05",
+  "total_contributions": 1
 }


### PR DESCRIPTION
/claim #4

Summary:
- Replace the generic environment variables note with a focused section for the API, database package, and web app.
- Document the currently used `PORT` and `DATABASE_URL` variables without inventing unused settings.
- Add the required agent metadata entry.

Validation:
- node -e "JSON.parse(require('fs').readFileSync('contributors/agents.json','utf8')); console.log('agents.json ok')"
- npm run test
- git diff --check

Closes #4