### PR TITLE
[agent] test: cover Button stub behavior

### DIFF
--- a/contributors/agents.json
+++ b/contributors/agents.json
@@ -4,7 +4,7 @@
       "github_username": "alejandrorivas-pixel",
       "model": "GPT-5 Codex",
       "version": "2026-06-05",
-      "pr_number": 0,
+      "pr_number": 821,
       "issue_number": 13
     }
   ],

--- a/contributors/agents.json
+++ b/contributors/agents.json
@@ -1,5 +1,13 @@
 {
-  "agents": [],
-  "last_updated": "2026-06-03",
-  "total_contributions": 0
+  "agents": [
+    {
+      "github_username": "alejandrorivas-pixel",
+      "model": "GPT-5 Codex",
+      "version": "2026-06-05",
+      "pr_number": 0,
+      "issue_number": 13
+    }
+  ],
+  "last_updated": "2026-06-05",
+  "total_contributions": 1
 }

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -3,9 +3,10 @@
   "version": "0.1.0",
   "private": true,
   "description": "Shared UI components for TaskFlow.",
+  "type": "module",
   "main": "src/index.ts",
   "scripts": {
-    "test": "echo \"No UI tests configured yet\"",
+    "test": "node --test src/index.test.ts",
     "lint": "echo \"No UI lint configured yet\""
   },
   "devDependencies": {

--- a/packages/ui/src/index.test.ts
+++ b/packages/ui/src/index.test.ts
@@ -1,0 +1,22 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+
+import { Button } from "./index.ts";
+
+test("Button preserves the provided label", () => {
+  const button = Button({ label: "Create task" });
+
+  assert.equal(button.label, "Create task");
+});
+
+test("Button defaults disabled to false", () => {
+  const button = Button({ label: "Create task" });
+
+  assert.equal(button.disabled, false);
+});
+
+test("Button preserves an explicit disabled value", () => {
+  const button = Button({ label: "Create task", disabled: true });
+
+  assert.equal(button.disabled, true);
+});


### PR DESCRIPTION
/claim #13

Summary:
- Add focused node:test coverage for the shared Button stub.
- Cover label preservation, the default disabled value, and explicit disabled=true.
- Wire the UI workspace test script to run the new test and add required agent metadata.

Validation:
- npm run test -w packages/ui
- npm run test
- node -e "JSON.parse(require('fs').readFileSync('contributors/agents.json','utf8')); console.log('agents.json ok')"
- git diff --check

Closes #13