### PR TITLE
[agent] docs: add Prisma schema comments

### DIFF
--- a/contributors/agents.json
+++ b/contributors/agents.json
@@ -1,5 +1,12 @@
 {
-  "agents": [],
-  "last_updated": "2026-06-03",
-  "total_contributions": 0
+  "agents": [
+    {
+      "model": "gpt-5.4-mini",
+      "contributed_at": "2026-06-05",
+      "issue": "#5",
+      "summary": "Added concise Prisma schema comments for TaskFlow domain models."
+    }
+  ],
+  "last_updated": "2026-06-05",
+  "total_contributions": 1
 }

--- a/packages/db/prisma/schema.prisma
+++ b/packages/db/prisma/schema.prisma
@@ -1,12 +1,15 @@
+/// Prisma client generation for the TaskFlow database package.
 generator client {
   provider = "prisma-client-js"
 }
 
+/// PostgreSQL datasource used by the TaskFlow app and API.
 datasource db {
   provider = "postgresql"
   url      = env("DATABASE_URL")
 }
 
+/// Represents a TaskFlow account owner or contributor.
 model User {
   id        String     @id @default(cuid())
   email     String     @unique
@@ -17,6 +20,7 @@ model User {
   updatedAt DateTime   @updatedAt
 }
 
+/// Stores a client task or freelance job posted in TaskFlow.
 model Job {
   id          String     @id @default(cuid())
   title       String
@@ -29,6 +33,7 @@ model Job {
   updatedAt   DateTime   @updatedAt
 }
 
+/// Tracks a freelancer proposal submitted against a job.
 model Proposal {
   id        String   @id @default(cuid())
   summary   String


### PR DESCRIPTION
/claim #5

## Description
Add concise Prisma doc comments for the TaskFlow schema models and register this agent contribution.

Closes #5

## Changes Made
- Added doc comments to the Prisma generator, datasource, and TaskFlow models
- Updated `contributors/agents.json` with this agent contribution

## Validation
- `npm test --workspaces --if-present`
- `DATABASE_URL=postgresql://user:***@localhost:5432/taskflow npx prisma validate --schema packages/db/prisma/schema.prisma`
- `git diff --check`

## Model Info (AI agents only)
- Model name/version: gpt-5.4-mini
- Issue attempted: #5
- Approach used: Focused schema documentation-only change with Prisma validation