### PR TITLE
[agent] feat: add finite pi prefix utility

### DIFF
--- a/contributors/agents.json
+++ b/contributors/agents.json
@@ -4,7 +4,7 @@
       "github_username": "alejandrorivas-pixel",
       "model": "GPT-5 Codex",
       "version": "2026-06-05",
-      "pr_number": 0,
+      "pr_number": 825,
       "issue_number": 17
     }
   ],

--- a/contributors/agents.json
+++ b/contributors/agents.json
@@ -1,5 +1,13 @@
 {
-  "agents": [],
-  "last_updated": "2026-06-03",
-  "total_contributions": 0
+  "agents": [
+    {
+      "github_username": "alejandrorivas-pixel",
+      "model": "GPT-5 Codex",
+      "version": "2026-06-05",
+      "pr_number": 0,
+      "issue_number": 17
+    }
+  ],
+  "last_updated": "2026-06-05",
+  "total_contributions": 1
 }

--- a/packages/pi/README.md
+++ b/packages/pi/README.md
@@ -1,0 +1,21 @@
+# `@taskflow/pi`
+
+Utilities for computing exact finite decimal prefixes of pi.
+
+Pi has an infinite non-repeating decimal expansion, so there is no final
+decimal point for a finite program to return. This package instead computes
+deterministic truncated prefixes with integer arithmetic.
+
+## Usage
+
+```js
+import { calculatePiPrefix } from "@taskflow/pi";
+
+console.log(calculatePiPrefix(100));
+```
+
+## Validation
+
+```sh
+npm run test -w packages/pi
+```

--- a/packages/pi/package.json
+++ b/packages/pi/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "@taskflow/pi",
+  "version": "0.1.0",
+  "private": true,
+  "description": "Finite decimal prefix utilities for pi.",
+  "type": "module",
+  "main": "src/index.js",
+  "scripts": {
+    "test": "node --test src/index.test.js",
+    "lint": "echo \"No PI lint configured yet\""
+  }
+}

--- a/packages/pi/src/index.js
+++ b/packages/pi/src/index.js
@@ -1,0 +1,103 @@
+const DEFAULT_GUARD_DIGITS = 12;
+const MAX_DECIMAL_PLACES = 10_000;
+
+/**
+ * Computes a finite decimal prefix of pi using Machin's formula:
+ * pi = 16 * atan(1 / 5) - 4 * atan(1 / 239).
+ *
+ * The infinite decimal expansion of pi has no final decimal point, so no
+ * finite program can return the whole value. This function returns the exact
+ * truncated prefix for the requested number of decimal places.
+ *
+ * @param {number} decimalPlaces number of digits after the decimal point
+ * @returns {string} pi truncated to the requested decimal places
+ */
+export function calculatePiPrefix(decimalPlaces = 100) {
+  assertDecimalPlaces(decimalPlaces);
+
+  const scaleDigits = decimalPlaces + DEFAULT_GUARD_DIGITS;
+  const scale = 10n ** BigInt(scaleDigits);
+  const piScaled =
+    16n * arctanInverse(5n, scale) -
+    4n * arctanInverse(239n, scale);
+  const truncated = piScaled / (10n ** BigInt(DEFAULT_GUARD_DIGITS));
+
+  return formatScaledDecimal(truncated, decimalPlaces);
+}
+
+/**
+ * Splits a computed pi prefix into fixed-size decimal chunks for demos or logs.
+ *
+ * @param {number} decimalPlaces number of digits after the decimal point
+ * @param {number} chunkSize number of decimal digits per chunk
+ * @returns {{ value: string, chunks: string[] }}
+ */
+export function calculatePiChunks(decimalPlaces = 100, chunkSize = 50) {
+  assertDecimalPlaces(decimalPlaces);
+
+  if (!Number.isInteger(chunkSize) || chunkSize <= 0) {
+    throw new RangeError("chunkSize must be a positive integer");
+  }
+
+  const value = calculatePiPrefix(decimalPlaces);
+  const [, fraction = ""] = value.split(".");
+  const chunks = [];
+
+  for (let index = 0; index < fraction.length; index += chunkSize) {
+    chunks.push(fraction.slice(index, index + chunkSize));
+  }
+
+  return { value, chunks };
+}
+
+export function explainFinitePiComputation() {
+  return [
+    "Pi has an infinite non-repeating decimal expansion.",
+    "A finite program can compute exact finite prefixes, not a final decimal point.",
+    "This package uses integer arithmetic and Machin's formula to return deterministic truncated prefixes."
+  ].join(" ");
+}
+
+function arctanInverse(inverseX, scale) {
+  const inverseXSquared = inverseX * inverseX;
+  let denominator = 1n;
+  let term = scale / inverseX;
+  let sum = term;
+  let subtract = true;
+
+  while (term !== 0n) {
+    term /= inverseXSquared;
+    denominator += 2n;
+    const next = term / denominator;
+
+    if (next === 0n) {
+      break;
+    }
+
+    sum = subtract ? sum - next : sum + next;
+    subtract = !subtract;
+  }
+
+  return sum;
+}
+
+function formatScaledDecimal(scaledValue, decimalPlaces) {
+  if (decimalPlaces === 0) {
+    return scaledValue.toString();
+  }
+
+  const digits = scaledValue.toString().padStart(decimalPlaces + 1, "0");
+  const integer = digits.slice(0, -decimalPlaces);
+  const fraction = digits.slice(-decimalPlaces);
+  return `${integer}.${fraction}`;
+}
+
+function assertDecimalPlaces(decimalPlaces) {
+  if (!Number.isInteger(decimalPlaces)) {
+    throw new TypeError("decimalPlaces must be an integer");
+  }
+
+  if (decimalPlaces < 0 || decimalPlaces > MAX_DECIMAL_PLACES) {
+    throw new RangeError(`decimalPlaces must be between 0 and ${MAX_DECIMAL_PLACES}`);
+  }
+}

--- a/packages/pi/src/index.test.js
+++ b/packages/pi/src/index.test.js
@@ -1,0 +1,46 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+
+import {
+  calculatePiChunks,
+  calculatePiPrefix,
+  explainFinitePiComputation
+} from "./index.js";
+
+const PI_100 =
+  "3.14159265358979323846264338327950288419716939937510" +
+  "58209749445923078164062862089986280348253421170679";
+
+test("calculatePiPrefix returns the known 100 decimal place prefix", () => {
+  assert.equal(calculatePiPrefix(100), PI_100);
+});
+
+test("calculatePiPrefix supports zero decimal places", () => {
+  assert.equal(calculatePiPrefix(0), "3");
+});
+
+test("calculatePiChunks splits only the decimal digits", () => {
+  const result = calculatePiChunks(12, 4);
+
+  assert.equal(result.value, "3.141592653589");
+  assert.deepEqual(result.chunks, ["1415", "9265", "3589"]);
+});
+
+test("calculatePiPrefix rejects invalid decimal counts", () => {
+  assert.throws(() => calculatePiPrefix(-1), RangeError);
+  assert.throws(() => calculatePiPrefix(1.5), TypeError);
+  assert.throws(() => calculatePiPrefix(10_001), RangeError);
+});
+
+test("calculatePiChunks rejects invalid chunk sizes", () => {
+  assert.throws(() => calculatePiChunks(10, 0), RangeError);
+  assert.throws(() => calculatePiChunks(10, 2.5), RangeError);
+});
+
+test("explainFinitePiComputation documents the finite-prefix limit", () => {
+  const explanation = explainFinitePiComputation();
+
+  assert.match(explanation, /infinite/);
+  assert.match(explanation, /finite prefixes/);
+  assert.match(explanation, /integer arithmetic/);
+});


### PR DESCRIPTION
/claim #17

Summary:
- Add a dependency-free `@taskflow/pi` workspace package using BigInt integer arithmetic and Machin's formula.
- Expose `calculatePiPrefix`, `calculatePiChunks`, and `explainFinitePiComputation` for deterministic finite-prefix calculations and demos.
- Document why pi has no final decimal point, while supporting exact truncated finite prefixes.
- Add node:test coverage for the known 100-digit prefix, zero-decimal truncation, chunking, validation errors, and the finite-prefix explanation.
- Add required agent metadata.

Validation:
- npm run test -w packages/pi
- npm run test
- node -e "JSON.parse(require('fs').readFileSync('contributors/agents.json','utf8')); console.log('agents.json ok')"
- git diff --check
- node -e "import('./packages/pi/src/index.js').then(({calculatePiPrefix}) => { const value = calculatePiPrefix(1000); console.log(value.length, value.slice(0, 20), value.slice(-20)); })"

Closes #17