### PR TITLE
[agent] fix: validate user route payloads

### DIFF
--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -7,7 +7,7 @@
   "main": "src/index.ts",
   "scripts": {
     "dev": "tsx src/index.ts",
-    "test": "echo \"No API tests configured yet\"",
+    "test": "node --test src/routes/users.test.ts",
     "lint": "echo \"No API lint configured yet\""
   },
   "dependencies": {

--- a/apps/api/src/routes/users.test.ts
+++ b/apps/api/src/routes/users.test.ts
@@ -1,0 +1,126 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import express from "express";
+
+import usersRouter from "./users.ts";
+
+test("GET /users returns the current stub list response", async () => {
+  await withUsersServer(async (baseUrl) => {
+    const response = await fetch(`${baseUrl}/users`);
+    const payload = await response.json();
+
+    assert.equal(response.status, 200);
+    assert.deepEqual(payload, {
+      data: [],
+      message: "User listing is not implemented yet."
+    });
+  });
+});
+
+test("POST /users accepts a valid user payload", async () => {
+  await withUsersServer(async (baseUrl) => {
+    const response = await fetch(`${baseUrl}/users`, {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({
+        name: "  Ada Lovelace  ",
+        email: "  ada@example.com  "
+      })
+    });
+    const payload = await response.json();
+
+    assert.equal(response.status, 201);
+    assert.deepEqual(payload, {
+      data: {
+        id: "stub-user-id",
+        name: "Ada Lovelace",
+        email: "ada@example.com"
+      },
+      message: "User creation is not implemented yet."
+    });
+  });
+});
+
+test("POST /users rejects non-object payloads", async () => {
+  await withUsersServer(async (baseUrl) => {
+    const response = await fetch(`${baseUrl}/users`, {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify([])
+    });
+    const payload = await response.json();
+
+    assert.equal(response.status, 400);
+    assert.deepEqual(payload, {
+      error: "Invalid user payload",
+      details: ["Request body must be a JSON object."]
+    });
+  });
+});
+
+test("POST /users rejects missing required fields", async () => {
+  await withUsersServer(async (baseUrl) => {
+    const response = await fetch(`${baseUrl}/users`, {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({})
+    });
+    const payload = await response.json();
+
+    assert.equal(response.status, 400);
+    assert.deepEqual(payload, {
+      error: "Invalid user payload",
+      details: [
+        "name must be a non-empty string.",
+        "email must be a non-empty string."
+      ]
+    });
+  });
+});
+
+test("POST /users rejects malformed email values", async () => {
+  await withUsersServer(async (baseUrl) => {
+    const response = await fetch(`${baseUrl}/users`, {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({
+        name: "Ada Lovelace",
+        email: "ada.example.com"
+      })
+    });
+    const payload = await response.json();
+
+    assert.equal(response.status, 400);
+    assert.deepEqual(payload, {
+      error: "Invalid user payload",
+      details: ["email must include an @ sign."]
+    });
+  });
+});
+
+async function withUsersServer(run: (baseUrl: string) => Promise<void>) {
+  const app = express();
+  app.use(express.json());
+  app.use("/users", usersRouter);
+
+  const server = app.listen(0, "127.0.0.1");
+
+  await new Promise<void>((resolve, reject) => {
+    server.once("listening", resolve);
+    server.once("error", reject);
+  });
+
+  const address = server.address();
+
+  if (!address || typeof address === "string") {
+    throw new Error("Expected test server to listen on a local port");
+  }
+
+  try {
+    await run(`http://127.0.0.1:${address.port}`);
+  } finally {
+    await new Promise<void>((resolve, reject) => {
+      server.close((error) => (error ? reject(error) : resolve()));
+    });
+  }
+}

--- a/apps/api/src/routes/users.ts
+++ b/apps/api/src/routes/users.ts
@@ -10,13 +10,65 @@ router.get("/", (_req, res) => {
 });
 
 router.post("/", (req, res) => {
+  const validation = validateCreateUserPayload(req.body);
+
+  if (!validation.ok) {
+    return res.status(400).json({
+      error: "Invalid user payload",
+      details: validation.details
+    });
+  }
+
   res.status(201).json({
     data: {
       id: "stub-user-id",
-      ...req.body
+      ...validation.data
     },
     message: "User creation is not implemented yet."
   });
 });
+
+type CreateUserPayload = {
+  name: string;
+  email: string;
+};
+
+type ValidationResult =
+  | { ok: true; data: CreateUserPayload }
+  | { ok: false; details: string[] };
+
+function validateCreateUserPayload(payload: unknown): ValidationResult {
+  const details: string[] = [];
+
+  if (!payload || typeof payload !== "object" || Array.isArray(payload)) {
+    return {
+      ok: false,
+      details: ["Request body must be a JSON object."]
+    };
+  }
+
+  const candidate = payload as Record<string, unknown>;
+  const name = typeof candidate.name === "string" ? candidate.name.trim() : "";
+  const email = typeof candidate.email === "string" ? candidate.email.trim() : "";
+
+  if (!name) {
+    details.push("name must be a non-empty string.");
+  }
+
+  if (!email) {
+    details.push("email must be a non-empty string.");
+  } else if (!email.includes("@")) {
+    details.push("email must include an @ sign.");
+  }
+
+  if (details.length > 0) {
+    return { ok: false, details };
+  }
+
+  return {
+    ok: true,
+    data: { name, email }
+  };
+}
 
 export default router;

--- a/contributors/agents.json
+++ b/contributors/agents.json
@@ -4,7 +4,7 @@
       "github_username": "alejandrorivas-pixel",
       "model": "GPT-5 Codex",
       "version": "2026-06-05",
-      "pr_number": 0,
+      "pr_number": 827,
       "issue_number": 6
     }
   ],

--- a/contributors/agents.json
+++ b/contributors/agents.json
@@ -1,5 +1,13 @@
 {
-  "agents": [],
-  "last_updated": "2026-06-03",
-  "total_contributions": 0
+  "agents": [
+    {
+      "github_username": "alejandrorivas-pixel",
+      "model": "GPT-5 Codex",
+      "version": "2026-06-05",
+      "pr_number": 0,
+      "issue_number": 6
+    }
+  ],
+  "last_updated": "2026-06-05",
+  "total_contributions": 1
 }


### PR DESCRIPTION
/claim #6

Summary:
- Add lightweight validation for `POST /users` request bodies.
- Return clear `400` JSON errors for non-object bodies, missing name/email, and malformed email values.
- Trim accepted name/email values and avoid spreading arbitrary request body fields into the stub response.
- Add focused node:test route coverage and required agent metadata.

Validation:
- npm run test -w apps/api
- npm run test
- node -e "JSON.parse(require('fs').readFileSync('contributors/agents.json','utf8')); console.log('agents.json ok')"
- git diff --check

Note: API tests open a local test server, so they were run outside the sandbox after the sandbox returned `listen EPERM`.

Closes #6