### PR TITLE
[agent] docs: document local environment variables

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,3 +83,32 @@ with models for:
 
 Each app/package expects its own .env values for DB, auth, 
 and integrations.
+
+### Local Environment Variables
+
+Use separate `.env` files for the app or package that consumes each
+setting.
+
+#### API (`apps/api`)
+
+| Variable | Required | Default | Description |
+| --- | --- | --- | --- |
+| `PORT` | No | `4000` | Port used by the Express API server. |
+
+#### Web (`apps/web`)
+
+The Next.js app does not currently require any checked-in environment
+variables. Add public browser-safe values with the `NEXT_PUBLIC_`
+prefix only when a feature needs them.
+
+#### Database (`packages/db`)
+
+| Variable | Required | Default | Description |
+| --- | --- | --- | --- |
+| `DATABASE_URL` | Yes | None | PostgreSQL connection string consumed by Prisma. |
+
+Example local database value:
+
+```env
+DATABASE_URL="postgresql://taskflow:taskflow@localhost:5432/taskflow"
+```

--- a/contributors/agents.json
+++ b/contributors/agents.json
@@ -1,5 +1,13 @@
 {
-  "agents": [],
-  "last_updated": "2026-06-03",
-  "total_contributions": 0
+  "agents": [
+    {
+      "github_username": "clynbmilio",
+      "model": "GPT-5 Codex",
+      "version": "2026-06-06",
+      "pr_number": 0,
+      "issue_number": 4
+    }
+  ],
+  "last_updated": "2026-06-06",
+  "total_contributions": 1
 }

--- a/contributors/agents.json
+++ b/contributors/agents.json
@@ -4,7 +4,7 @@
       "github_username": "clynbmilio",
       "model": "GPT-5 Codex",
       "version": "2026-06-06",
-      "pr_number": 0,
+      "pr_number": 840,
       "issue_number": 4
     }
   ],


### PR DESCRIPTION
Closes #4.\n\nSummary:\n- Adds a focused local environment variables section to the README.\n- Documents the API PORT default, Prisma DATABASE_URL requirement, and current web app env state.\n- Adds the required agent registry entry for this contribution.\n\nValidation:\n- Documentation-only change; verified referenced env names against the codebase.