### PR TITLE
[agent] Serialize leaderboard workflow updates

### DIFF
--- a/.github/workflows/auto-process.yml
+++ b/.github/workflows/auto-process.yml
@@ -7,7 +7,7 @@ permissions:
   contents: write
 concurrency:
   group: leaderboard-json-update
-  cancel-in-progress: false
+  cancel-in-progress: true
 jobs:
   update-leaderboard:
     runs-on: ubuntu-latest


### PR DESCRIPTION
/claim #843

Summary:
- Serialize leaderboard workflow updates by cancelling older in-progress runs in the shared concurrency group.
- Keep the change scoped to `.github/workflows/auto-process.yml` as requested.

Validation:
- `git diff --check`

Fixes #843