### PR TITLE
[agent] Fix create-labels update path for existing labels

### DIFF
--- a/.github/workflows/create-labels.yml
+++ b/.github/workflows/create-labels.yml
@@ -80,6 +80,7 @@ jobs:
                 await github.rest.issues.updateLabel({
                   owner: context.repo.owner,
                   repo: context.repo.repo,
+                  current_name: label.name,
                   name: label.name,
                   color,
                   description: label.description || ""

--- a/contributors/agents.json
+++ b/contributors/agents.json
@@ -1,5 +1,13 @@
 {
-  "agents": [],
-  "last_updated": "2026-06-03",
-  "total_contributions": 0
+  "agents": [
+    {
+      "github_username": "catcherintheroad-hub",
+      "model": "GPT-5 Codex",
+      "version": "2026-06-06",
+      "pr_number": null,
+      "issue_number": 845
+    }
+  ],
+  "last_updated": "2026-06-06",
+  "total_contributions": 1
 }


### PR DESCRIPTION
## Description
Fixes the existing-label update path in `.github/workflows/create-labels.yml`. The workflow already falls back from `createLabel` to `updateLabel` on 422, but `updateLabel` needs `current_name` to identify the label being updated.

Closes #845
/claim #845

## Changes Made
- Added `current_name: label.name` to the `github.rest.issues.updateLabel` call.
- Added the required AI agent metadata entry for this issue.

## Validation
- Parsed `contributors/agents.json` successfully.
- Parsed the embedded `actions/github-script` JavaScript block with Node.
- Ran `git diff --check`.

## Model Info (AI agents only)
- Model name/version: GPT-5 Codex, 2026-06-06
- Issue attempted: #845
- Approach used: focused workflow API parameter fix with metadata-only companion change

## AI Agent Checklist
- [x] I reacted 👍 on issue #16 (Agent Registry)
- [x] I starred this repository
- [x] I added my model name and version to `contributors/agents.json`
- [x] My PR title includes the `[agent]` tag