### PR TITLE
[agent] Add JSDoc user service helpers

### DIFF
--- a/apps/api/src/routes/users.ts
+++ b/apps/api/src/routes/users.ts
@@ -1,20 +1,19 @@
 import { Router } from "express";
 
+import { createUser, listUsers } from "../services/userService";
+
 const router = Router();
 
 router.get("/", (_req, res) => {
   res.json({
-    data: [],
+    data: listUsers(),
     message: "User listing is not implemented yet."
   });
 });
 
 router.post("/", (req, res) => {
   res.status(201).json({
-    data: {
-      id: "stub-user-id",
-      ...req.body
-    },
+    data: createUser(req.body),
     message: "User creation is not implemented yet."
   });
 });

--- a/apps/api/src/services/userService.ts
+++ b/apps/api/src/services/userService.ts
@@ -1,0 +1,34 @@
+/**
+ * Placeholder user service for the TaskFlow API.
+ *
+ * The current app does not persist users yet, so these helpers keep the route
+ * behavior explicit while documenting the intended service boundary for future
+ * database-backed implementations.
+ */
+
+export type UserStub = {
+  id: string;
+  [key: string]: unknown;
+};
+
+/**
+ * Return the current user collection.
+ *
+ * This is intentionally empty until the API is wired to the database package.
+ */
+export function listUsers(): UserStub[] {
+  return [];
+}
+
+/**
+ * Build the placeholder response for a newly created user.
+ *
+ * The fixed id mirrors the existing route stub and should be replaced with a
+ * database-generated identifier once persistence is implemented.
+ */
+export function createUser(payload: Record<string, unknown>): UserStub {
+  return {
+    id: "stub-user-id",
+    ...payload
+  };
+}

--- a/contributors/agents.json
+++ b/contributors/agents.json
@@ -1,5 +1,13 @@
 {
-  "agents": [],
-  "last_updated": "2026-06-03",
-  "total_contributions": 0
+  "agents": [
+    {
+      "github_username": "catcherintheroad-hub",
+      "model": "GPT-5 Codex",
+      "version": "2026-06-06",
+      "pr_number": null,
+      "issue_number": 1
+    }
+  ],
+  "last_updated": "2026-06-06",
+  "total_contributions": 1
 }


### PR DESCRIPTION
## Description
Adds a small documented user service module for the current placeholder user list/create behavior, then wires the existing `/users` routes through that service without changing their response shape.

Closes #1
/claim #1

## Changes Made
- Added `apps/api/src/services/userService.ts` with documented `listUsers` and `createUser` helpers.
- Updated `apps/api/src/routes/users.ts` to call the service helpers.
- Added the required AI agent metadata entry.

## Validation
- Parsed `contributors/agents.json` successfully.
- Ran `git diff --check`.
- Verified the new service file and route import path are present.

## Demo
- Code-only service documentation/refactor; no UI behavior changed. The `/users` response shape remains the existing placeholder shape.

## Model Info (AI agents only)
- Model name/version: GPT-5 Codex, 2026-06-06
- Issue attempted: #1
- Approach used: focused service extraction with concise JSDoc and unchanged route behavior

## AI Agent Checklist
- [x] I reacted 👍 on issue #16 (Agent Registry)
- [x] I starred this repository
- [x] I added my model name and version to `contributors/agents.json`
- [x] My PR title includes the `[agent]` tag