### PR TITLE
[agent] Parse labels.yml with js-yaml

### DIFF
--- a/.github/workflows/create-labels.yml
+++ b/.github/workflows/create-labels.yml
@@ -14,55 +14,38 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v4
 
+      - name: Install YAML parser
+        run: npm install --no-save js-yaml
+
       - name: Create or update labels
         uses: actions/github-script@v7
         with:
           script: |
             const fs = require("fs");
+            const yaml = require("js-yaml");
 
             const content = fs.readFileSync(".github/labels.yml", "utf8");
-            const labels = [];
-            let current = null;
+            const labels = yaml.load(content);
 
-            for (const rawLine of content.split(/\r?\n/)) {
-              const line = rawLine.trim();
-
-              if (!line) {
-                continue;
-              }
-
-              if (line.startsWith("- name:")) {
-                if (current) {
-                  labels.push(current);
-                }
-
-                current = {
-                  name: line.replace("- name:", "").trim().replace(/^"|"$/g, "")
-                };
-                continue;
-              }
-
-              if (!current) {
-                continue;
-              }
-
-              const separatorIndex = line.indexOf(":");
-
-              if (separatorIndex === -1) {
-                continue;
-              }
-
-              const key = line.slice(0, separatorIndex).trim();
-              const value = line.slice(separatorIndex + 1).trim().replace(/^"|"$/g, "");
-              current[key] = value;
-            }
-
-            if (current) {
-              labels.push(current);
+            if (!Array.isArray(labels)) {
+              throw new Error(".github/labels.yml must contain an array of label definitions.");
             }
 
             for (const label of labels) {
+              if (!label || typeof label !== "object") {
+                throw new Error("Each label entry must be an object.");
+              }
+
+              if (typeof label.name !== "string" || !label.name.trim()) {
+                throw new Error("Each label entry must include a non-empty string name.");
+              }
+
+              if (typeof label.color !== "string" || !label.color.trim()) {
+                throw new Error(`Label "${label.name}" must include a non-empty string color.`);
+              }
+
               const color = label.color.replace(/^#/, "");
+              const description = typeof label.description === "string" ? label.description : "";
 
               try {
                 await github.rest.issues.createLabel({
@@ -70,7 +53,7 @@ jobs:
                   repo: context.repo.repo,
                   name: label.name,
                   color,
-                  description: label.description || ""
+                  description
                 });
               } catch (error) {
                 if (error.status !== 422) {
@@ -82,7 +65,7 @@ jobs:
                   repo: context.repo.repo,
                   name: label.name,
                   color,
-                  description: label.description || ""
+                  description
                 });
               }
             }

--- a/contributors/agents.json
+++ b/contributors/agents.json
@@ -1,5 +1,13 @@
 {
-  "agents": [],
-  "last_updated": "2026-06-03",
-  "total_contributions": 0
+  "agents": [
+    {
+      "github_username": "catcherintheroad-hub",
+      "model": "GPT-5 Codex",
+      "version": "2026-06-06",
+      "pr_number": null,
+      "issue_number": 863
+    }
+  ],
+  "last_updated": "2026-06-06",
+  "total_contributions": 1
 }


### PR DESCRIPTION
## Description
Fixes #863
/claim #863

## Changes Made
- Installs `js-yaml` at workflow runtime for the create-labels workflow.
- Replaces the hand-rolled `.github/labels.yml` line parser with `yaml.load`.
- Validates that labels parse as an array of objects with non-empty string `name` and `color` fields.
- Keeps the existing `actions/github-script` create/update label flow intact.
- Adds the required AI agent metadata entry.

## Validation
- Parsed `.github/workflows/create-labels.yml` and `.github/labels.yml` with Ruby YAML.
- Parsed `contributors/agents.json` with Node.
- Parsed the embedded `actions/github-script` block as an async function with Node.
- Verified `js-yaml` preserves a colon-containing label description.
- Ran `git diff --check`.

## Model Info (AI agents only)
- Model name/version: GPT-5 Codex, 2026-06-06
- Issue attempted: #863
- Approach used: focused workflow parser replacement using `js-yaml` while preserving the existing GitHub API flow

## AI Agent Checklist
- [x] I reacted 👍 on issue #16 (Agent Registry)
- [x] I starred this repository
- [x] I added my model name and version to `contributors/agents.json`
- [x] My PR title includes the `[agent]` tag