### PR TITLE
Use YAML parser in label creation workflow

### DIFF
--- a/.github/workflows/create-labels.yml
+++ b/.github/workflows/create-labels.yml
@@ -14,63 +14,45 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v4
 
+      - name: Install YAML parser
+        run: npm install --no-save js-yaml
+
       - name: Create or update labels
         uses: actions/github-script@v7
         with:
           script: |
             const fs = require("fs");
+            const path = require("path");
+            const yaml = require(path.join(process.env.GITHUB_WORKSPACE, "node_modules", "js-yaml"));
 
             const content = fs.readFileSync(".github/labels.yml", "utf8");
-            const labels = [];
-            let current = null;
 
-            for (const rawLine of content.split(/\r?\n/)) {
-              const line = rawLine.trim();
+            const labels = yaml.load(content);
 
-              if (!line) {
-                continue;
-              }
-
-              if (line.startsWith("- name:")) {
-                if (current) {
-                  labels.push(current);
-                }
-
-                current = {
-                  name: line.replace("- name:", "").trim().replace(/^"|"$/g, "")
-                };
-                continue;
-              }
-
-              if (!current) {
-                continue;
-              }
-
-              const separatorIndex = line.indexOf(":");
-
-              if (separatorIndex === -1) {
-                continue;
-              }
-
-              const key = line.slice(0, separatorIndex).trim();
-              const value = line.slice(separatorIndex + 1).trim().replace(/^"|"$/g, "");
-              current[key] = value;
-            }
-
-            if (current) {
-              labels.push(current);
+            if (!Array.isArray(labels)) {
+              throw new Error(".github/labels.yml must contain a list of labels");
             }
 
             for (const label of labels) {
-              const color = label.color.replace(/^#/, "");
+              if (!label || typeof label !== "object") {
+                throw new Error("Each label entry must be an object");
+              }
+
+              if (!label.name || !label.color) {
+                throw new Error("Each label entry must include name and color");
+              }
+
+              const name = String(label.name);
+              const color = String(label.color).replace(/^#/, "");
+              const description = label.description ? String(label.description) : "";
 
               try {
                 await github.rest.issues.createLabel({
                   owner: context.repo.owner,
                   repo: context.repo.repo,
-                  name: label.name,
+                  name,
                   color,
-                  description: label.description || ""
+                  description
                 });
               } catch (error) {
                 if (error.status !== 422) {
@@ -80,9 +62,9 @@ jobs:
                 await github.rest.issues.updateLabel({
                   owner: context.repo.owner,
                   repo: context.repo.repo,
-                  name: label.name,
+                  name,
                   color,
-                  description: label.description || ""
+                  description
                 });
               }
             }


### PR DESCRIPTION
## Summary
- replace the hand-rolled labels.yml parser with js-yaml in the create-labels workflow
- validate that the parsed labels file is an array of label objects with required name/color fields
- keep existing create/update behavior while preserving YAML scalar handling for descriptions and names

## Validation
- node parser check against the current .github/labels.yml and a quoted colon-containing description sample
- git diff --check

Closes #863
/claim #863