### PR TITLE
[agent] Make starter issue seeding idempotent

### DIFF
--- a/.github/workflows/seed-issues.yml
+++ b/.github/workflows/seed-issues.yml
@@ -90,7 +90,25 @@ jobs:
               }
             ];
 
+            const existingIssues = await github.paginate(github.rest.issues.listForRepo, {
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              state: "all",
+              per_page: 100
+            });
+
+            const existingTitles = new Set(
+              existingIssues
+                .filter((issue) => !issue.pull_request)
+                .map((issue) => issue.title)
+            );
+
             for (const issue of issues) {
+              if (existingTitles.has(issue.title)) {
+                core.info(`Skipping existing starter issue: ${issue.title}`);
+                continue;
+              }
+
               await github.rest.issues.create({
                 owner: context.repo.owner,
                 repo: context.repo.repo,
@@ -98,4 +116,6 @@ jobs:
                 body: issue.body,
                 labels: ["good first issue", "bounty", "AI agent friendly"]
               });
+
+              existingTitles.add(issue.title);
             }


### PR DESCRIPTION
/claim #875

Summary:
- Make the manual starter issue seed workflow idempotent.
- Paginate existing non-PR issues, track existing starter titles, and skip duplicate creation on reruns while still creating missing starter issues.

Validation:
- `git diff --check`
- Local github-script harness: all starter titles already present created 0 issues; one missing starter title created exactly 1 issue.

Fixes #875