### PR TITLE
fix: parse label workflow yaml with js-yaml

### DIFF
--- a/.github/workflows/create-labels.yml
+++ b/.github/workflows/create-labels.yml
@@ -14,63 +14,43 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v4
 
+      - name: Install workflow dependencies
+        run: npm install --no-save --no-package-lock --ignore-scripts js-yaml@4.1.0
+
       - name: Create or update labels
         uses: actions/github-script@v7
         with:
           script: |
             const fs = require("fs");
+            const yaml = require("js-yaml");
 
             const content = fs.readFileSync(".github/labels.yml", "utf8");
-            const labels = [];
-            let current = null;
+            const labels = yaml.load(content) || [];
 
-            for (const rawLine of content.split(/\r?\n/)) {
-              const line = rawLine.trim();
-
-              if (!line) {
-                continue;
-              }
-
-              if (line.startsWith("- name:")) {
-                if (current) {
-                  labels.push(current);
-                }
-
-                current = {
-                  name: line.replace("- name:", "").trim().replace(/^"|"$/g, "")
-                };
-                continue;
-              }
-
-              if (!current) {
-                continue;
-              }
-
-              const separatorIndex = line.indexOf(":");
-
-              if (separatorIndex === -1) {
-                continue;
-              }
-
-              const key = line.slice(0, separatorIndex).trim();
-              const value = line.slice(separatorIndex + 1).trim().replace(/^"|"$/g, "");
-              current[key] = value;
-            }
-
-            if (current) {
-              labels.push(current);
+            if (!Array.isArray(labels)) {
+              throw new Error(".github/labels.yml must contain a list of labels");
             }
 
             for (const label of labels) {
-              const color = label.color.replace(/^#/, "");
+              if (!label || typeof label !== "object") {
+                throw new Error("Each label entry must be an object");
+              }
+
+              if (!label.name || !label.color) {
+                throw new Error("Each label must include name and color fields");
+              }
+
+              const name = String(label.name);
+              const color = String(label.color).replace(/^#/, "");
+              const description = label.description ? String(label.description) : "";
 
               try {
                 await github.rest.issues.createLabel({
                   owner: context.repo.owner,
                   repo: context.repo.repo,
-                  name: label.name,
+                  name,
                   color,
-                  description: label.description || ""
+                  description
                 });
               } catch (error) {
                 if (error.status !== 422) {
@@ -80,9 +60,9 @@ jobs:
                 await github.rest.issues.updateLabel({
                   owner: context.repo.owner,
                   repo: context.repo.repo,
-                  name: label.name,
+                  name,
                   color,
-                  description: label.description || ""
+                  description
                 });
               }
             }


### PR DESCRIPTION
## Summary
- Replaced the hand-rolled `.github/labels.yml` parser with `js-yaml` so label descriptions containing colons are preserved correctly.
- Added a pinned, script-disabled workflow dependency install for `js-yaml@4.1.0`.
- Added basic label document and field validation/coercion before calling the GitHub labels API.

## Verification
- `node` syntax check of the embedded `github-script` body inside an async wrapper.
- Confirmed `js-yaml` preserves a sample description containing a colon: `Bug: something is broken`.
- `git diff --check`
- Added-line security scan: 0 findings.
- Independent reviewer: passed; no blocking security concerns or logic errors.

Closes #839
/claim #839
