### PR TITLE
[agent] Add homepage SEO metadata

### DIFF
--- a/apps/web/src/app/page.tsx
+++ b/apps/web/src/app/page.tsx
@@ -1,3 +1,10 @@
+import type { Metadata } from "next";
+
+export const metadata: Metadata = {
+  title: "TaskFlow | Task and Proposal Management",
+  description: "Plan tasks, coordinate jobs, and manage proposals from one workspace.",
+};
+
 export default function HomePage() {
   return (
     <main>


### PR DESCRIPTION
## Summary
- add a typed Next.js metadata export to the homepage
- set a descriptive title and description that match the existing TaskFlow copy

Closes #895

## Validation
- `npm test --workspace @taskflow/web`
- `npm test`
- parsed all tracked JSON files with Node
- `git diff --check`