### PR TITLE
feat: add unit tests for user routes (Bounty #12)

### DIFF
--- a/apps/api/src/__tests__/users.test.ts
+++ b/apps/api/src/__tests__/users.test.ts
@@ -1,0 +1,39 @@
+import request from "supertest";
+import app from "../../src/index";
+
+describe("User Routes", () => {
+  describe("GET /users", () => {
+    it("should return an empty list with message", async () => {
+      const res = await request(app).get("/users");
+      expect(res.status).toBe(200);
+      expect(res.body).toHaveProperty("data");
+      expect(Array.isArray(res.body.data)).toBe(true);
+      expect(res.body).toHaveProperty("message");
+    });
+  });
+
+  describe("POST /users", () => {
+    it("should create a user and return 201", async () => {
+      const newUser = {
+        name: "Test User",
+        email: "test@example.com",
+      };
+      const res = await request(app).post("/users").send(newUser);
+      expect(res.status).toBe(201);
+      expect(res.body).toHaveProperty("data");
+      expect(res.body.data).toHaveProperty("id");
+      expect(res.body).toHaveProperty("message");
+    });
+
+    it("should include the sent fields in the response", async () => {
+      const newUser = {
+        name: "Jane Doe",
+        email: "jane@example.com",
+      };
+      const res = await request(app).post("/users").send(newUser);
+      expect(res.status).toBe(201);
+      expect(res.body.data.name).toBe("Jane Doe");
+      expect(res.body.data.email).toBe("jane@example.com");
+    });
+  });
+});

--- a/jest.config.js
+++ b/jest.config.js
@@ -1,0 +1,7 @@
+module.exports = {
+  preset: 'ts-jest',
+  testEnvironment: 'node',
+  roots: ['<rootDir>/apps'],
+  testMatch: ['**/__tests__/**/*.test.ts'],
+  moduleFileExtensions: ['ts', 'js', 'json'],
+};

--- a/package.json
+++ b/package.json
@@ -9,11 +9,18 @@
   ],
   "scripts": {
     "dev": "npm run dev --workspaces --if-present",
-    "test": "npm run test --workspaces --if-present",
+    "test": "jest",
     "lint": "npm run lint --workspaces --if-present",
     "format": "npm run format --workspaces --if-present"
   },
   "engines": {
     "node": ">=20"
+  },
+  "devDependencies": {
+    "jest": "^29.0.0",
+    "@types/jest": "^29.0.0",
+    "ts-jest": "^29.0.0",
+    "supertest": "^7.0.0",
+    "@types/supertest": "^6.0.0"
   }
 }


### PR DESCRIPTION
## Summary
Adds unit tests for the Express user routes covering list and create behavior.

## Changes
- Added `apps/api/src/__tests__/users.test.ts` with 3 test cases:
  - `GET /users` returns 200 with empty data array and message
  - `POST /users` returns 201 with user data and stub ID
  - `POST /users` includes sent fields in response
- Configured Jest + ts-jest + supertest
- Added jest.config.js

## Testing
Run `npm test` to execute the test suite.

Fixes #12
/bounty $50