### PR TITLE
[agent] Add API error response helper

### DIFF
--- a/apps/api/src/routes/users.ts
+++ b/apps/api/src/routes/users.ts
@@ -1,5 +1,7 @@
 import { Router } from "express";
 
+import { sendError } from "../utils/errorResponse";
+
 const router = Router();
 
 router.get("/", (_req, res) => {
@@ -10,6 +12,10 @@ router.get("/", (_req, res) => {
 });
 
 router.post("/", (req, res) => {
+  if (!req.body || Array.isArray(req.body) || typeof req.body !== "object") {
+    return sendError(res, 400, "User payload must be a JSON object.");
+  }
+
   res.status(201).json({
     data: {
       id: "stub-user-id",

--- a/apps/api/src/utils/errorResponse.ts
+++ b/apps/api/src/utils/errorResponse.ts
@@ -1,0 +1,19 @@
+import type { Response } from "express";
+
+type ErrorResponseOptions = {
+  details?: unknown;
+};
+
+export function sendError(
+  res: Response,
+  statusCode: number,
+  message: string,
+  options: ErrorResponseOptions = {}
+) {
+  return res.status(statusCode).json({
+    error: {
+      message,
+      ...(options.details === undefined ? {} : { details: options.details })
+    }
+  });
+}

--- a/contributors/agents.json
+++ b/contributors/agents.json
@@ -1,5 +1,13 @@
 {
-  "agents": [],
-  "last_updated": "2026-06-03",
-  "total_contributions": 0
+  "agents": [
+    {
+      "github_username": "yumusuisuian-creator",
+      "model": "GPT-5",
+      "version": "Codex",
+      "pr_number": 912,
+      "issue_number": 7
+    }
+  ],
+  "last_updated": "2026-06-06",
+  "total_contributions": 1
 }


### PR DESCRIPTION
## Summary
- Add a shared Express `sendError` response helper for API routes.
- Use it from `POST /users` when the request body is missing, an array, or not a JSON object.
- Register this GPT-5 Codex contribution in `contributors/agents.json`.

## Validation
- `npm run test -w apps/api`
- `npm run lint -w apps/api`
- `npm exec -w apps/api tsc -- --noEmit --module ESNext --moduleResolution bundler --target ES2022 src/index.ts`

Notes:
- The API test and lint scripts currently echo placeholder messages in this repo.
- The TypeScript check passes with bundler module resolution, which matches the repo's extensionless imports and `tsx` style.

/claim #7
