### PR TITLE
Add prisma generate and postinstall scripts to db workspace

### DIFF
--- a/packages/db/package.json
+++ b/packages/db/package.json
@@ -4,6 +4,8 @@
   "private": true,
   "description": "Prisma schema and database utilities for TaskFlow.",
   "scripts": {
+    "generate": "prisma generate",
+    "postinstall": "prisma generate",
     "test": "echo \"No database tests configured yet\"",
     "lint": "echo \"No database lint configured yet\""
   },


### PR DESCRIPTION
## What this fixes

Closes #908

The `packages/db` workspace depends on Prisma and `@prisma/client`, but after installing the workspace the Prisma client was never generated. Anyone cloning the repo would get import errors for `PrismaClient` without manually running the generate step.

## Changes

- Added a `generate` script that runs `prisma generate`
- Added a `postinstall` hook so the client is built automatically after `npm install`
- Existing scripts (`test`, `lint`) are preserved

## How to test

```bash
cd packages/db && npm install
# postinstall should trigger prisma generate automatically
```

Check that `node_modules/.prisma/client/index.d.ts` exists after install.