### PR TITLE
Add graceful shutdown to API server

### DIFF
--- a/apps/api/src/index.ts
+++ b/apps/api/src/index.ts
@@ -13,6 +13,25 @@ app.get("/health", (_req, res) => {
 
 app.use("/users", usersRouter);
 
-app.listen(port, () => {
+const server = app.listen(port, () => {
   console.log(`TaskFlow API listening on port ${port}`);
 });
+
+const shutdownTimeout = setTimeout(() => {
+  console.error("Forcing shutdown after timeout");
+  process.exit(1);
+}, 10000);
+shutdownTimeout.unref();
+
+function gracefulShutdown(signal: string) {
+  console.log(`Received ${signal}, shutting down gracefully...`);
+  shutdownTimeout.ref();
+
+  server.close(() => {
+    console.log("HTTP server closed");
+    process.exit(0);
+  });
+}
+
+process.on("SIGTERM", () => gracefulShutdown("SIGTERM"));
+process.on("SIGINT", () => gracefulShutdown("SIGINT"));


### PR DESCRIPTION
## What this fixes

Closes #906

The API server at `apps/api/src/index.ts` started with `app.listen()` but discarded the returned `http.Server` instance and had no signal handlers. In container environments a SIGTERM would abruptly terminate the process, potentially dropping in-flight requests.

## Changes

- Store the `http.Server` returned by `app.listen()`
- Register SIGTERM and SIGINT handlers
- On signal: call `server.close()` to stop accepting new connections and let in-flight requests drain
- Force exit after 10 seconds if clean shutdown hangs (prevents zombie processes in containers)

## How to test

1. Start the server: `cd apps/api && npm run dev`
2. Send SIGTERM: `kill -TERM <pid>`
3. Verify the log shows "Received SIGTERM, shutting down gracefully..." followed by "HTTP server closed"