### PR TITLE
Add root build script and next build to web workspace

### DIFF
--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -6,7 +6,8 @@
   "scripts": {
     "dev": "next dev",
     "test": "echo \"No web tests configured yet\"",
-    "lint": "next lint"
+    "lint": "next lint",
+    "build": "next build"
   },
   "dependencies": {
     "next": "^14.2.3",

--- a/package.json
+++ b/package.json
@@ -11,7 +11,8 @@
     "dev": "npm run dev --workspaces --if-present",
     "test": "npm run test --workspaces --if-present",
     "lint": "npm run lint --workspaces --if-present",
-    "format": "npm run format --workspaces --if-present"
+    "format": "npm run format --workspaces --if-present",
+    "build": "npm run build --workspaces --if-present"
   },
   "engines": {
     "node": ">=20"


### PR DESCRIPTION
## What this fixes

Closes #915

The monorepo had `dev`, `test`, `lint`, and `format` scripts at the root level but no `build` command. The `apps/web` workspace was also missing a `build` script, meaning `npm run build -w apps/web` would error out.

## Changes

- Added a root `build` script that runs `npm run build --workspaces --if-present`
- Added a `build` script to `apps/web/package.json` that runs `next build`
- No dependency or application behavior changes

## How to test

```bash
# From the monorepo root
npm run build
# Should invoke next build for the web workspace (other workspaces skip gracefully)
```

Or target the web workspace directly:

```bash
npm run build -w apps/web
```