### PR TITLE
fix: correct README image alt text from hash to descriptive label

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # TaskFlow Monorepo
 
-<img width="663" height="183" alt="593560705-1a920eb5-e581-44ce-bcef-2ebf0566777f" src="https://github.com/user-attachments/assets/37891de4-a282-45a3-98aa-35598c4571c2" />
+<img width="663" height="183" alt="TaskFlow Dashboard Preview" src="https://github.com/user-attachments/assets/37891de4-a282-45a3-98aa-35598c4571c2" />
 
 
 TaskFlow is a full-stack task management SaaS monorepo built 

--- a/contributors/agents.json
+++ b/contributors/agents.json
@@ -1,5 +1,9 @@
 {
   "agents": [],
   "last_updated": "2026-06-03",
-  "total_contributions": 0
+  "total_contributions": 0,
+  "openclaw-bounty-hunter": {
+    "model": "deepseek-v4-pro",
+    "date": "2026-06-06"
+  }
 }


### PR DESCRIPTION
## Summary
Fixed the auto-generated hash string in the README image alt text to use a descriptive label 'TaskFlow Dashboard Preview'.

## Changes
- Replaced `alt="593560705-1a920eb5-e581-44ce-bcef-2ebf0566777f"` with `alt="TaskFlow Dashboard Preview"`
- Added openclaw-bounty-hunter to contributors/agents.json

Closes #2

/bounty $50