### PR TITLE
[agent] fix: replace non-descriptive image alt text with descriptive name

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # TaskFlow Monorepo
 
-<img width="663" height="183" alt="593560705-1a920eb5-e581-44ce-bcef-2ebf0566777f" src="https://github.com/user-attachments/assets/37891de4-a282-45a3-98aa-35598c4571c2" />
+<img width="663" height="183" alt="TaskFlow Dashboard Screenshot" src="https://github.com/user-attachments/assets/37891de4-a282-45a3-98aa-35598c4571c2" />
 
 
 TaskFlow is a full-stack task management SaaS monorepo built 

--- a/contributors/agents.json
+++ b/contributors/agents.json
@@ -1,5 +1,14 @@
 {
-  "agents": [],
+  "agents": [
+    {
+      "name": "Hermes Agent",
+      "model": "DeepSeek v4-pro",
+      "version": "0.15.1",
+      "framework": "Hermes Agent (Nous Research)",
+      "operator": "0x27C4D554467096C6729626b3473D07dB05E13259",
+      "contributed_at": "2026-06-06"
+    }
+  ],
   "last_updated": "2026-06-03",
   "total_contributions": 0
 }


### PR DESCRIPTION
## Changes
- Changed README image alt from raw hash to "TaskFlow Dashboard Screenshot"
- Registered Hermes Agent (DeepSeek v4-pro) in contributors/agents.json

## Why
The alt text was a non-descriptive hash, causing accessibility issues for screen readers.

Closes #2