### PR TITLE
[agent] feat: add API error response helper with async handler

### DIFF
--- a/apps/api/src/index.ts
+++ b/apps/api/src/index.ts
@@ -1,6 +1,7 @@
 import express from "express";
 
 import usersRouter from "./routes/users";
+import { errorHandler } from "./utils/errorHandler";
 
 const app = express();
 const port = process.env.PORT || 4000;
@@ -12,6 +13,8 @@ app.get("/health", (_req, res) => {
 });
 
 app.use("/users", usersRouter);
+
+app.use(errorHandler);
 
 app.listen(port, () => {
   console.log(`TaskFlow API listening on port ${port}`);

--- a/apps/api/src/routes/users.ts
+++ b/apps/api/src/routes/users.ts
@@ -1,22 +1,35 @@
 import { Router } from "express";
+import { asyncHandler, AppError } from "../utils/errorHandler";
 
 const router = Router();
 
-router.get("/", (_req, res) => {
-  res.json({
-    data: [],
-    message: "User listing is not implemented yet."
-  });
-});
+router.get(
+  "/",
+  asyncHandler(async (_req, res) => {
+    res.json({
+      data: [],
+      message: "User listing is not implemented yet.",
+    });
+  }),
+);
 
-router.post("/", (req, res) => {
-  res.status(201).json({
-    data: {
-      id: "stub-user-id",
-      ...req.body
-    },
-    message: "User creation is not implemented yet."
-  });
-});
+router.post(
+  "/",
+  asyncHandler(async (req, res) => {
+    const { name, email } = req.body;
+
+    if (!name || !email) {
+      throw new AppError("name and email are required", 400);
+    }
+
+    res.status(201).json({
+      data: {
+        id: "stub-user-id",
+        ...req.body,
+      },
+      message: "User creation is not implemented yet.",
+    });
+  }),
+);
 
 export default router;

--- a/apps/api/src/utils/errorHandler.ts
+++ b/apps/api/src/utils/errorHandler.ts
@@ -1,0 +1,78 @@
+import { Request, Response, NextFunction } from "express";
+
+/**
+ * Error response shape used across the API.
+ */
+export interface ApiErrorResponse {
+  error: {
+    message: string;
+    status: number;
+    details?: unknown;
+  };
+}
+
+/**
+ * Custom application error that carries an HTTP status code.
+ */
+export class AppError extends Error {
+  public readonly status: number;
+  public readonly details?: unknown;
+
+  constructor(message: string, status = 500, details?: unknown) {
+    super(message);
+    this.name = "AppError";
+    this.status = status;
+    this.details = details;
+  }
+}
+
+/**
+ * Wraps an async route handler so thrown / rejected errors are forwarded
+ * to Express error-handling middleware via `next()`.
+ *
+ * @example
+ * router.get("/", asyncHandler(async (req, res) => { … }));
+ */
+export function asyncHandler(
+  fn: (req: Request, res: Response, next: NextFunction) => Promise<void>,
+) {
+  return (req: Request, res: Response, next: NextFunction) => {
+    Promise.resolve(fn(req, res, next)).catch(next);
+  };
+}
+
+/**
+ * Global Express error-handling middleware.
+ *
+ * Produces a consistent JSON error response for every unhandled error.
+ * Attach with `app.use(errorHandler)` **after** all routes.
+ *
+ * @example
+ * app.use(errorHandler);
+ */
+export function errorHandler(
+  err: Error,
+  _req: Request,
+  res: Response,
+  _next: NextFunction,
+): void {
+  if (err instanceof AppError) {
+    res.status(err.status).json({
+      error: {
+        message: err.message,
+        status: err.status,
+        details: err.details,
+      },
+    } satisfies ApiErrorResponse);
+    return;
+  }
+
+  // Unexpected / unknown error
+  console.error("Unhandled error:", err);
+  res.status(500).json({
+    error: {
+      message: "Internal Server Error",
+      status: 500,
+    },
+  } satisfies ApiErrorResponse);
+}


### PR DESCRIPTION
## Changes
- Created  with:
  -  — typed HTTP error class with status code
  -  — wraps async route handlers, forwarding errors to Express
  -  — global middleware producing consistent JSON error responses
- Integrated into  with input validation example
- Registered global error handler in 

## Example usage


Closes #7