### PR TITLE
[agent] feat: add importable Prisma client entrypoint for DB package

### DIFF
--- a/packages/db/package.json
+++ b/packages/db/package.json
@@ -3,6 +3,11 @@
   "version": "0.1.0",
   "private": true,
   "description": "Prisma schema and database utilities for TaskFlow.",
+  "type": "module",
+  "main": "./src/index.ts",
+  "exports": {
+    ".": "./src/index.ts"
+  },
   "scripts": {
     "test": "echo \"No database tests configured yet\"",
     "lint": "echo \"No database lint configured yet\""

--- a/packages/db/src/index.ts
+++ b/packages/db/src/index.ts
@@ -1,0 +1,27 @@
+import { PrismaClient } from "@prisma/client";
+
+const globalForPrisma = globalThis as unknown as {
+  prisma: PrismaClient | undefined;
+};
+
+/**
+ * Singleton Prisma client instance.
+ *
+ * Reuses the same client across hot-reloads in development to avoid
+ * exhausting database connections.
+ */
+export const prisma =
+  globalForPrisma.prisma ??
+  new PrismaClient({
+    log:
+      process.env.NODE_ENV === "development"
+        ? ["query", "warn", "error"]
+        : ["error"],
+  });
+
+if (process.env.NODE_ENV !== "production") {
+  globalForPrisma.prisma = prisma;
+}
+
+export { PrismaClient };
+export * from "@prisma/client";


### PR DESCRIPTION
## Changes
- Created `packages/db/src/index.ts` with singleton PrismaClient instance
- Added `main` and `exports` fields to `packages/db/package.json`
- Enables other workspaces to `import { prisma } from "@taskflow/db"`

Closes #930