### PR TITLE
fix: filter accepted user fields

### DIFF
--- a/apps/api/src/routes/users.ts
+++ b/apps/api/src/routes/users.ts
@@ -10,10 +10,13 @@ router.get("/", (_req, res) => {
 });
 
 router.post("/", (req, res) => {
+  const { name, email } = req.body;
+
   res.status(201).json({
     data: {
       id: "stub-user-id",
-      ...req.body
+      name,
+      email
     },
     message: "User creation is not implemented yet."
   });


### PR DESCRIPTION
## Summary

- filter the POST /users response to only include accepted `name` and `email` fields
- remove the `...req.body` spread so arbitrary request fields are not echoed back

## Validation

- `npm.cmd run test --workspace @taskflow/api`
- `npm.cmd run lint --workspace @taskflow/api`
- `git diff --check`

Closes #694