### PR TITLE
[agent] Add JSDoc-backed user service

### DIFF
--- a/apps/api/src/routes/users.ts
+++ b/apps/api/src/routes/users.ts
@@ -1,20 +1,18 @@
 import { Router } from "express";
+import { createUser, listUsers } from "../services/userService";
 
 const router = Router();
 
 router.get("/", (_req, res) => {
   res.json({
-    data: [],
+    data: listUsers(),
     message: "User listing is not implemented yet."
   });
 });
 
 router.post("/", (req, res) => {
   res.status(201).json({
-    data: {
-      id: "stub-user-id",
-      ...req.body
-    },
+    data: createUser(req.body),
     message: "User creation is not implemented yet."
   });
 });

--- a/apps/api/src/services/userService.ts
+++ b/apps/api/src/services/userService.ts
@@ -1,0 +1,30 @@
+export interface CreateUserInput {
+  [key: string]: unknown;
+}
+
+export interface UserRecord extends CreateUserInput {
+  id: string;
+}
+
+/**
+ * Returns the current placeholder user list.
+ *
+ * The service intentionally preserves the existing stubbed behavior while the
+ * backing data store is not implemented.
+ */
+export function listUsers(): UserRecord[] {
+  return [];
+}
+
+/**
+ * Builds the placeholder user creation response from the incoming request body.
+ *
+ * @param input - Request payload submitted to the create-user endpoint.
+ * @returns A stub user record with the stable placeholder id and submitted data.
+ */
+export function createUser(input: CreateUserInput): UserRecord {
+  return {
+    id: "stub-user-id",
+    ...input
+  };
+}

--- a/contributors/agents.json
+++ b/contributors/agents.json
@@ -1,5 +1,13 @@
 {
-  "agents": [],
-  "last_updated": "2026-06-03",
-  "total_contributions": 0
+    "total_contributions":  1,
+    "agents":  [
+                   {
+                       "github_username":  "martinezriverajosem1n-source",
+                       "pr_number":  956,
+                       "model":  "Codex GPT-5",
+                       "issue_number":  1,
+                       "version":  "2026-06-06 session"
+                   }
+               ],
+    "last_updated":  "2026-06-06"
 }


### PR DESCRIPTION
/claim #1

## Summary
- Adds a focused `userService` module for the existing placeholder user list/create behavior.
- Documents the exported service types and functions with concise JSDoc.
- Wires the `/users` routes through the service without changing the response shape.

Closes #1

## Verification
- Source-only TypeScript refactor; no runtime behavior changed.
- Checked the touched files for focused scope.