### PR TITLE
Fix seed workflows to ensure labels exist before creating issues

### DIFF
--- a/.github/workflows/seed-issues.yml
+++ b/.github/workflows/seed-issues.yml
@@ -90,6 +90,26 @@ jobs:
               }
             ];
 
+            // Ensure labels exist before creating issues
+            const labelsToEnsure = [
+              { name: "bounty", description: "Bounty eligible", color: "7056f7" },
+              { name: "good first issue", description: "Good for first contributors", color: "7056f7" },
+              { name: "AI agent friendly", description: "AI agents welcome", color: "7056f7" }
+            ];
+            for (const label of labelsToEnsure) {
+              try {
+                await github.rest.issues.createLabel({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  name: label.name,
+                  description: label.description,
+                  color: label.color
+                });
+              } catch (e) {
+                // Label may already exist, ignore
+              }
+            }
+
             for (const issue of issues) {
               await github.rest.issues.create({
                 owner: context.repo.owner,

--- a/.github/workflows/seed-issues.yml
+++ b/.github/workflows/seed-issues.yml
@@ -4,6 +4,7 @@ on:
   workflow_dispatch:
 
 permissions:
+  contents: read
   issues: write
 
 jobs:
@@ -11,10 +12,15 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
       - name: Create starter issues
         uses: actions/github-script@v7
         with:
           script: |
+            const fs = require("fs");
+
             const bountyBody = (description) => [
               description,
               "",
@@ -90,23 +96,59 @@ jobs:
               }
             ];
 
-            // Ensure labels exist before creating issues
-            const labelsToEnsure = [
-              { name: "bounty", description: "Bounty eligible", color: "7056f7" },
-              { name: "good first issue", description: "Good for first contributors", color: "7056f7" },
-              { name: "AI agent friendly", description: "AI agents welcome", color: "7056f7" }
-            ];
+            const requiredLabelNames = new Set(["bounty", "good first issue", "AI agent friendly"]);
+            const labels = [];
+            let current = null;
+            for (const rawLine of fs.readFileSync(".github/labels.yml", "utf8").split(/\r?\n/)) {
+              const line = rawLine.trim();
+              if (!line) {
+                continue;
+              }
+              if (line.startsWith("- name:")) {
+                if (current) {
+                  labels.push(current);
+                }
+                current = { name: line.replace("- name:", "").trim().replace(/^"|"$/g, "") };
+                continue;
+              }
+              if (!current) {
+                continue;
+              }
+              const separatorIndex = line.indexOf(":");
+              if (separatorIndex === -1) {
+                continue;
+              }
+              const key = line.slice(0, separatorIndex).trim();
+              const value = line.slice(separatorIndex + 1).trim().replace(/^"|"$/g, "");
+              current[key] = value;
+            }
+            if (current) {
+              labels.push(current);
+            }
+
+            // Ensure required labels exist before creating issues.
+            const labelsToEnsure = labels.filter((label) => requiredLabelNames.has(label.name));
             for (const label of labelsToEnsure) {
+              const color = label.color.replace(/^#/, "");
               try {
                 await github.rest.issues.createLabel({
                   owner: context.repo.owner,
                   repo: context.repo.repo,
                   name: label.name,
                   description: label.description,
-                  color: label.color
+                  color
                 });
-              } catch (e) {
-                // Label may already exist, ignore
+              } catch (error) {
+                if (error.status !== 422) {
+                  throw error;
+                }
+                await github.rest.issues.updateLabel({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  name: label.name,
+                  description: label.description,
+                  color
+                });
               }
             }
 

--- a/.github/workflows/seed-meta-issue.yml
+++ b/.github/workflows/seed-meta-issue.yml
@@ -35,6 +35,26 @@ jobs:
               "description, the better."
             ].join("\n");
 
+            // Ensure labels exist before creating issues
+            const labelsToEnsure = [
+              { name: "bounty", description: "Bounty eligible", color: "7056f7" },
+              { name: "good first issue", description: "Good for first contributors", color: "7056f7" },
+              { name: "AI agent friendly", description: "AI agents welcome", color: "7056f7" }
+            ];
+            for (const label of labelsToEnsure) {
+              try {
+                await github.rest.issues.createLabel({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  name: label.name,
+                  description: label.description,
+                  color: label.color
+                });
+              } catch (e) {
+                // Label may already exist, ignore
+              }
+            }
+
             const createdIssue = await github.rest.issues.create({
               owner: context.repo.owner,
               repo: context.repo.repo,

--- a/.github/workflows/seed-meta-issue.yml
+++ b/.github/workflows/seed-meta-issue.yml
@@ -4,6 +4,7 @@ on:
   workflow_dispatch:
 
 permissions:
+  contents: read
   issues: write
 
 jobs:
@@ -11,10 +12,15 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
       - name: Create and pin bug bounty program issue
         uses: actions/github-script@v7
         with:
           script: |
+            const fs = require("fs");
+
             const bodyForIssue = (issueNumber) => [
               "This repository runs an open bug bounty program.",
               "",
@@ -35,23 +41,59 @@ jobs:
               "description, the better."
             ].join("\n");
 
-            // Ensure labels exist before creating issues
-            const labelsToEnsure = [
-              { name: "bounty", description: "Bounty eligible", color: "7056f7" },
-              { name: "good first issue", description: "Good for first contributors", color: "7056f7" },
-              { name: "AI agent friendly", description: "AI agents welcome", color: "7056f7" }
-            ];
+            const requiredLabelNames = new Set(["bounty", "good first issue", "AI agent friendly"]);
+            const labels = [];
+            let current = null;
+            for (const rawLine of fs.readFileSync(".github/labels.yml", "utf8").split(/\r?\n/)) {
+              const line = rawLine.trim();
+              if (!line) {
+                continue;
+              }
+              if (line.startsWith("- name:")) {
+                if (current) {
+                  labels.push(current);
+                }
+                current = { name: line.replace("- name:", "").trim().replace(/^"|"$/g, "") };
+                continue;
+              }
+              if (!current) {
+                continue;
+              }
+              const separatorIndex = line.indexOf(":");
+              if (separatorIndex === -1) {
+                continue;
+              }
+              const key = line.slice(0, separatorIndex).trim();
+              const value = line.slice(separatorIndex + 1).trim().replace(/^"|"$/g, "");
+              current[key] = value;
+            }
+            if (current) {
+              labels.push(current);
+            }
+
+            // Ensure required labels exist before creating issues.
+            const labelsToEnsure = labels.filter((label) => requiredLabelNames.has(label.name));
             for (const label of labelsToEnsure) {
+              const color = label.color.replace(/^#/, "");
               try {
                 await github.rest.issues.createLabel({
                   owner: context.repo.owner,
                   repo: context.repo.repo,
                   name: label.name,
                   description: label.description,
-                  color: label.color
+                  color
                 });
-              } catch (e) {
-                // Label may already exist, ignore
+              } catch (error) {
+                if (error.status !== 422) {
+                  throw error;
+                }
+                await github.rest.issues.updateLabel({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  name: label.name,
+                  description: label.description,
+                  color
+                });
               }
             }
 

--- a/contributors/agents.json
+++ b/contributors/agents.json
@@ -1,5 +1,13 @@
 {
-  "agents": [],
-  "last_updated": "2026-06-03",
-  "total_contributions": 0
+  "agents": [
+    {
+      "github_username": "mukejane",
+      "model": "GPT-5 coding agent",
+      "version": "2026-06-10",
+      "pr_number": 958,
+      "issue_number": 957
+    }
+  ],
+  "last_updated": "2026-06-10",
+  "total_contributions": 1
 }


### PR DESCRIPTION
## Fixes #957

### Problem
The seed workflows assume that labels like `bounty`, `good first issue`, and `AI agent friendly` already exist. In a fresh repository, creating issues with these labels can fail.

### Solution
Before creating issues, checkout the repository, read the required label definitions from `.github/labels.yml`, then create missing labels or update existing labels with the repository's canonical color/description values.

### Changes
- `.github/workflows/seed-meta-issue.yml`: Ensures required labels exist before creating and pinning the meta issue
- `.github/workflows/seed-issues.yml`: Ensures required labels exist before creating starter issues
- Adds `contents: read` because the workflows now read `.github/labels.yml`

### Validation
- `git diff --check`
- Extracted both `github-script` blocks and verified JavaScript syntax with Node

Bounty reference: #957 ($50)