### PR TITLE
[agent] Add Button result type annotations

### DIFF
--- a/contributors/agents.json
+++ b/contributors/agents.json
@@ -1,5 +1,13 @@
 {
-  "agents": [],
-  "last_updated": "2026-06-03",
-  "total_contributions": 0
+  "agents": [
+    {
+      "github_username": "modelsbridgeaicom-ship-it",
+      "model": "Codex GPT-5",
+      "version": "2026-06-06",
+      "pr_number": 964,
+      "issue_number": 3
+    }
+  ],
+  "last_updated": "2026-06-07",
+  "total_contributions": 1
 }

--- a/packages/ui/src/index.ts
+++ b/packages/ui/src/index.ts
@@ -1,9 +1,17 @@
+export type ButtonType = "button";
+
 export type ButtonProps = {
   label: string;
   disabled?: boolean;
 };
 
-export function Button({ label, disabled = false }: ButtonProps) {
+export type ButtonResult = {
+  type: ButtonType;
+  label: string;
+  disabled: boolean;
+};
+
+export function Button({ label, disabled = false }: ButtonProps): ButtonResult {
   return {
     type: "button",
     label,


### PR DESCRIPTION
/claim #3

## Summary
- Add explicit exported types for the Button stub result shape.
- Annotate the Button return type without changing the returned fields or behavior.
- Add the required AI-agent metadata entry for this issue.

Closes #3

## Verification
- Parsed contributors/agents.json successfully.
- Ran git diff --check.
- Ran npm.cmd test -w packages/ui.