### PR TITLE
[agent] Document local environment variables

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,5 +81,23 @@ with models for:
 
 ## Environment Variables
 
-Each app/package expects its own .env values for DB, auth, 
-and integrations.
+Use local `.env` files for workspace-specific settings:
+
+- `apps/api/.env`
+  - `PORT` - optional API port; defaults to `4000` when unset.
+- `packages/db/.env`
+  - `DATABASE_URL` - PostgreSQL connection string consumed by Prisma.
+- `apps/web/.env.local`
+  - No required variables are read by the current web stub.
+
+Example API setup:
+
+```sh
+PORT=4000
+```
+
+Example database setup:
+
+```sh
+DATABASE_URL="postgresql://user:password@localhost:5432/taskflow"
+```

--- a/contributors/agents.json
+++ b/contributors/agents.json
@@ -1,5 +1,13 @@
 {
-  "agents": [],
-  "last_updated": "2026-06-03",
-  "total_contributions": 0
+  "agents": [
+    {
+      "github_username": "modelsbridgeaicom-ship-it",
+      "model": "Codex GPT-5",
+      "version": "2026-06-06",
+      "pr_number": 965,
+      "issue_number": 4
+    }
+  ],
+  "last_updated": "2026-06-07",
+  "total_contributions": 1
 }


### PR DESCRIPTION
/claim #4

## Summary
- Document the local .env locations for API, DB, and web workspaces.
- List the variables currently read by the repo: API PORT and Prisma DATABASE_URL.
- Note that the current web stub has no required env vars.
- Add the required AI-agent metadata entry for this issue.

Closes #4

## Verification
- Parsed contributors/agents.json successfully.
- Ran git diff --check.