### PR TITLE
[agent] Add JSON body size limit

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,8 @@ The API includes:
 - File uploads and search
 - Admin routes
 
+The Express API accepts JSON request bodies up to `100kb`.
+
 Backend architecture follows:
 - Middleware layer (auth, rate limiting, error handling)
 - Controller layer

--- a/apps/api/src/index.ts
+++ b/apps/api/src/index.ts
@@ -4,8 +4,9 @@ import usersRouter from "./routes/users";
 
 const app = express();
 const port = process.env.PORT || 4000;
+const jsonBodyLimit = "100kb";
 
-app.use(express.json());
+app.use(express.json({ limit: jsonBodyLimit }));
 
 app.get("/health", (_req, res) => {
   res.json({ status: "ok", service: "taskflow-api" });

--- a/contributors/agents.json
+++ b/contributors/agents.json
@@ -1,5 +1,13 @@
 {
-  "agents": [],
-  "last_updated": "2026-06-03",
-  "total_contributions": 0
+  "agents": [
+    {
+      "github_username": "modelsbridgeaicom-ship-it",
+      "model": "GPT-5 Codex",
+      "version": "2026-06-07",
+      "pr_number": 967,
+      "issue_number": 9
+    }
+  ],
+  "last_updated": "2026-06-07",
+  "total_contributions": 1
 }


### PR DESCRIPTION
## Summary
- Configure Express JSON parsing with a conservative 100kb request body limit.
- Document the expected API JSON body limit in the README.
- Update required AI agent contribution metadata.

## Validation
- npm.cmd test -w apps/api
- npm.cmd run lint -w apps/api
- npm.cmd test --workspaces --if-present
- contributors/agents.json JSON parse check
- git diff --check

Closes #9
/claim #9
