### PR TITLE
[agent] Document Prisma model roles

### DIFF
--- a/contributors/agents.json
+++ b/contributors/agents.json
@@ -1,5 +1,13 @@
 {
-  "agents": [],
-  "last_updated": "2026-06-03",
-  "total_contributions": 0
+  "agents": [
+    {
+      "github_username": "modelsbridgeaicom-ship-it",
+      "model": "GPT-5 Codex",
+      "version": "2026-06-07",
+      "pr_number": 968,
+      "issue_number": 5
+    }
+  ],
+  "last_updated": "2026-06-07",
+  "total_contributions": 1
 }

--- a/packages/db/prisma/schema.prisma
+++ b/packages/db/prisma/schema.prisma
@@ -7,6 +7,7 @@ datasource db {
   url      = env("DATABASE_URL")
 }
 
+/// Represents a TaskFlow account that owns jobs and submits proposals.
 model User {
   id        String     @id @default(cuid())
   email     String     @unique
@@ -17,6 +18,7 @@ model User {
   updatedAt DateTime   @updatedAt
 }
 
+/// Represents a task listing created by a user for others to propose on.
 model Job {
   id          String     @id @default(cuid())
   title       String
@@ -29,6 +31,7 @@ model Job {
   updatedAt   DateTime   @updatedAt
 }
 
+/// Represents a user's offer to complete a specific TaskFlow job.
 model Proposal {
   id        String   @id @default(cuid())
   summary   String


### PR DESCRIPTION
## Summary
- Add concise Prisma model comments for the TaskFlow User, Job, and Proposal domain roles.
- Keep all schema fields and runtime behavior unchanged.
- Update required AI agent contribution metadata.

## Validation
- DATABASE_URL=postgresql://user:password@localhost:5432/taskflow npx.cmd -p prisma@5.13.0 prisma validate --schema packages/db/prisma/schema.prisma
- npm.cmd test -w packages/db
- npm.cmd run lint -w packages/db
- npm.cmd test --workspaces --if-present
- contributors/agents.json JSON parse check
- git diff --check

Closes #5
/claim #5
