### PR TITLE
[agent] Add API error response helper

### DIFF
--- a/apps/api/src/routes/users.ts
+++ b/apps/api/src/routes/users.ts
@@ -1,6 +1,12 @@
 import { Router } from "express";
 
+import { sendApiError } from "../utils/apiError";
+
 const router = Router();
+
+function isPlainObject(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
 
 router.get("/", (_req, res) => {
   res.json({
@@ -10,6 +16,15 @@ router.get("/", (_req, res) => {
 });
 
 router.post("/", (req, res) => {
+  if (!isPlainObject(req.body)) {
+    return sendApiError(
+      res,
+      400,
+      "INVALID_USER_PAYLOAD",
+      "User creation requires a JSON object body."
+    );
+  }
+
   res.status(201).json({
     data: {
       id: "stub-user-id",

--- a/apps/api/src/utils/apiError.ts
+++ b/apps/api/src/utils/apiError.ts
@@ -1,0 +1,22 @@
+import type { Response } from "express";
+
+export type ApiErrorBody = {
+  error: {
+    code: string;
+    message: string;
+  };
+};
+
+export function sendApiError(
+  res: Response,
+  statusCode: number,
+  code: string,
+  message: string
+) {
+  return res.status(statusCode).json({
+    error: {
+      code,
+      message
+    }
+  } satisfies ApiErrorBody);
+}

--- a/contributors/agents.json
+++ b/contributors/agents.json
@@ -1,5 +1,13 @@
 {
-  "agents": [],
-  "last_updated": "2026-06-03",
-  "total_contributions": 0
+  "agents": [
+    {
+      "github_username": "modelsbridgeaicom-ship-it",
+      "model": "GPT-5 Codex",
+      "version": "2026-06-07",
+      "pr_number": 970,
+      "issue_number": 7
+    }
+  ],
+  "last_updated": "2026-06-07",
+  "total_contributions": 1
 }


### PR DESCRIPTION
## Summary
- Add a small shared API error response helper for Express routes.
- Use the helper from POST /users when the request body is not a JSON object.
- Keep the existing successful user creation stub response unchanged and update required AI agent metadata.

## Validation
- npm.cmd test -w apps/api
- npm.cmd run lint -w apps/api
- npm.cmd test --workspaces --if-present
- contributors/agents.json JSON parse check
- git diff --check

Note: an ad-hoc TypeScript no-emit command was attempted, but this repo has no tsconfig or installed dependencies in the checkout, and the temporary NodeNext config also rejects existing extensionless imports in current source files. I did not count that as a passing validation gate.

Closes #7
/claim #7
