### PR TITLE
[agent] Validate create user payload

### DIFF
--- a/apps/api/src/routes/users.ts
+++ b/apps/api/src/routes/users.ts
@@ -2,6 +2,49 @@ import { Router } from "express";
 
 const router = Router();
 
+type CreateUserPayload = {
+  email: string;
+  name: string;
+};
+
+type ValidationResult =
+  | { ok: true; data: CreateUserPayload }
+  | { ok: false; details: string[] };
+
+function isPlainObject(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function validateCreateUserPayload(body: unknown): ValidationResult {
+  if (!isPlainObject(body)) {
+    return {
+      ok: false,
+      details: ["Request body must be a JSON object."]
+    };
+  }
+
+  const name = typeof body.name === "string" ? body.name.trim() : "";
+  const email = typeof body.email === "string" ? body.email.trim() : "";
+  const details: string[] = [];
+
+  if (!name) {
+    details.push("name must be a non-empty string.");
+  }
+
+  if (!email) {
+    details.push("email must be a non-empty string.");
+  }
+
+  if (details.length > 0) {
+    return { ok: false, details };
+  }
+
+  return {
+    ok: true,
+    data: { email, name }
+  };
+}
+
 router.get("/", (_req, res) => {
   res.json({
     data: [],
@@ -10,10 +53,22 @@ router.get("/", (_req, res) => {
 });
 
 router.post("/", (req, res) => {
+  const validation = validateCreateUserPayload(req.body);
+
+  if (!validation.ok) {
+    return res.status(400).json({
+      error: {
+        code: "INVALID_USER_PAYLOAD",
+        message: "User creation requires a valid request body.",
+        details: validation.details
+      }
+    });
+  }
+
   res.status(201).json({
     data: {
       id: "stub-user-id",
-      ...req.body
+      ...validation.data
     },
     message: "User creation is not implemented yet."
   });

--- a/contributors/agents.json
+++ b/contributors/agents.json
@@ -1,5 +1,13 @@
 {
-  "agents": [],
-  "last_updated": "2026-06-03",
-  "total_contributions": 0
+  "agents": [
+    {
+      "github_username": "modelsbridgeaicom-ship-it",
+      "model": "GPT-5 Codex",
+      "version": "2026-06-07",
+      "pr_number": 971,
+      "issue_number": 6
+    }
+  ],
+  "last_updated": "2026-06-07",
+  "total_contributions": 1
 }


### PR DESCRIPTION
## Summary
- Add lightweight validation for POST /users request bodies.
- Reject non-object bodies and missing/blank name or email fields with a clear 400 response and details.
- Trim accepted name/email values while keeping the existing 201 stub response message and required AI agent metadata.

## Validation
- npm.cmd test -w apps/api
- npm.cmd run lint -w apps/api
- npm.cmd test --workspaces --if-present
- contributors/agents.json JSON parse check
- git diff --check

Closes #6
/claim #6
