### PR TITLE
[agent] Add Button stub tests

### DIFF
--- a/contributors/agents.json
+++ b/contributors/agents.json
@@ -1,5 +1,13 @@
 {
-  "agents": [],
-  "last_updated": "2026-06-03",
-  "total_contributions": 0
+  "agents": [
+    {
+      "github_username": "modelsbridgeaicom-ship-it",
+      "model": "GPT-5 Codex",
+      "version": "2026-06-07",
+      "pr_number": 974,
+      "issue_number": 13
+    }
+  ],
+  "last_updated": "2026-06-07",
+  "total_contributions": 1
 }

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -5,7 +5,7 @@
   "description": "Shared UI components for TaskFlow.",
   "main": "src/index.ts",
   "scripts": {
-    "test": "echo \"No UI tests configured yet\"",
+    "test": "node --experimental-strip-types --test src/index.test.ts",
     "lint": "echo \"No UI lint configured yet\""
   },
   "devDependencies": {

--- a/packages/ui/src/index.test.ts
+++ b/packages/ui/src/index.test.ts
@@ -1,0 +1,26 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { Button } from "./index.ts";
+
+test("Button preserves the provided label and defaults to enabled", () => {
+  assert.deepEqual(Button({ label: "Save" }), {
+    type: "button",
+    label: "Save",
+    disabled: false
+  });
+});
+
+test("Button respects explicit disabled values", () => {
+  assert.deepEqual(Button({ label: "Delete", disabled: true }), {
+    type: "button",
+    label: "Delete",
+    disabled: true
+  });
+
+  assert.deepEqual(Button({ label: "Edit", disabled: false }), {
+    type: "button",
+    label: "Edit",
+    disabled: false
+  });
+});


### PR DESCRIPTION
## Summary
- Add node:test coverage for the shared Button stub.
- Cover label preservation plus default, explicit true, and explicit false disabled values.
- Replace the UI package placeholder test script with a runnable test command and update required AI agent metadata.

## Validation
- npm.cmd test -w packages/ui
- npm.cmd run lint -w packages/ui
- npm.cmd test --workspaces --if-present
- contributors/agents.json JSON parse check
- git diff --check

Note: Node reports MODULE_TYPELESS_PACKAGE_JSON while running TypeScript tests because the UI package does not declare a module type. The tests still pass; this PR avoids changing package module semantics just to silence the warning.

Closes #13
/claim #13
