### PR TITLE
[agent] Add leaderboard update tests

### DIFF
--- a/contributors/agents.json
+++ b/contributors/agents.json
@@ -1,5 +1,13 @@
 {
-  "agents": [],
-  "last_updated": "2026-06-03",
-  "total_contributions": 0
+  "agents": [
+    {
+      "github_username": "modelsbridgeaicom-ship-it",
+      "model": "GPT-5 Codex",
+      "version": "2026-06-07",
+      "pr_number": 975,
+      "issue_number": 11
+    }
+  ],
+  "last_updated": "2026-06-07",
+  "total_contributions": 1
 }

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
   ],
   "scripts": {
     "dev": "npm run dev --workspaces --if-present",
-    "test": "npm run test --workspaces --if-present",
+    "test": "node --test test/*.test.mjs && npm run test --workspaces --if-present",
     "lint": "npm run lint --workspaces --if-present",
     "format": "npm run format --workspaces --if-present"
   },

--- a/scripts/update-leaderboard.mjs
+++ b/scripts/update-leaderboard.mjs
@@ -1,0 +1,36 @@
+function normalizeContributor(contributor) {
+  if (typeof contributor !== "string") {
+    throw new TypeError("contributor must be a non-empty string");
+  }
+
+  const username = contributor.trim();
+  if (!username) {
+    throw new TypeError("contributor must be a non-empty string");
+  }
+
+  return username;
+}
+
+export function applyLeaderboardUpdate(leaderboard, contribution) {
+  const username = normalizeContributor(contribution.contributor);
+  const prNumber = contribution.prNumber ?? null;
+  const currentEntry = leaderboard[username] ?? {
+    contributions: 0,
+    pullRequests: []
+  };
+
+  if (prNumber !== null && currentEntry.pullRequests.includes(prNumber)) {
+    return { ...leaderboard, [username]: currentEntry };
+  }
+
+  return {
+    ...leaderboard,
+    [username]: {
+      contributions: currentEntry.contributions + 1,
+      pullRequests:
+        prNumber === null
+          ? currentEntry.pullRequests
+          : [...currentEntry.pullRequests, prNumber]
+    }
+  };
+}

--- a/test/update-leaderboard.test.mjs
+++ b/test/update-leaderboard.test.mjs
@@ -1,0 +1,81 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { applyLeaderboardUpdate } from "../scripts/update-leaderboard.mjs";
+
+test("adds a new contributor with an initial contribution", () => {
+  const result = applyLeaderboardUpdate({}, {
+    contributor: "modelsbridgeaicom-ship-it",
+    prNumber: 971
+  });
+
+  assert.deepEqual(result, {
+    "modelsbridgeaicom-ship-it": {
+      contributions: 1,
+      pullRequests: [971]
+    }
+  });
+});
+
+test("increments an existing contributor without changing other entries", () => {
+  const result = applyLeaderboardUpdate(
+    {
+      "modelsbridgeaicom-ship-it": {
+        contributions: 1,
+        pullRequests: [970]
+      },
+      "xevrion-v2": {
+        contributions: 3,
+        pullRequests: [1, 2, 3]
+      }
+    },
+    {
+      contributor: "modelsbridgeaicom-ship-it",
+      prNumber: 971
+    }
+  );
+
+  assert.deepEqual(result, {
+    "modelsbridgeaicom-ship-it": {
+      contributions: 2,
+      pullRequests: [970, 971]
+    },
+    "xevrion-v2": {
+      contributions: 3,
+      pullRequests: [1, 2, 3]
+    }
+  });
+});
+
+test("does not count the same pull request twice", () => {
+  const leaderboard = {
+    "modelsbridgeaicom-ship-it": {
+      contributions: 1,
+      pullRequests: [971]
+    }
+  };
+
+  assert.deepEqual(
+    applyLeaderboardUpdate(leaderboard, {
+      contributor: "modelsbridgeaicom-ship-it",
+      prNumber: 971
+    }),
+    leaderboard
+  );
+});
+
+test("trims contributor names before updating", () => {
+  const result = applyLeaderboardUpdate({}, {
+    contributor: "  modelsbridgeaicom-ship-it  ",
+    prNumber: 971
+  });
+
+  assert.deepEqual(Object.keys(result), ["modelsbridgeaicom-ship-it"]);
+});
+
+test("rejects blank contributor names", () => {
+  assert.throws(
+    () => applyLeaderboardUpdate({}, { contributor: "   ", prNumber: 971 }),
+    /contributor must be a non-empty string/
+  );
+});


### PR DESCRIPTION
## Summary
- Add a dependency-free leaderboard update helper.
- Add node:test coverage for new contributors, existing contributors, duplicate PR guarding, name trimming, and invalid contributor input.
- Wire the root test script to run the focused leaderboard tests before workspace tests and update required AI agent metadata.

## Validation
- node --test test/*.test.mjs
- npm.cmd test
- contributors/agents.json JSON parse check
- git diff --check

Note: npm.cmd run lint --workspaces --if-present was attempted, but this checkout does not have the web workspace dependency needed for next lint (`next` is not installed). The failure is unrelated to the leaderboard helper/tests, so it is not counted as a passing validation gate.

Closes #11
/claim #11
