### PR TITLE
[agent] Add user route stub tests

### DIFF
--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -7,7 +7,7 @@
   "main": "src/index.ts",
   "scripts": {
     "dev": "tsx src/index.ts",
-    "test": "echo \"No API tests configured yet\"",
+    "test": "node --import tsx --test test/*.test.ts",
     "lint": "echo \"No API lint configured yet\""
   },
   "dependencies": {

--- a/apps/api/test/users.test.ts
+++ b/apps/api/test/users.test.ts
@@ -1,0 +1,87 @@
+import assert from "node:assert/strict";
+import { createServer, type Server } from "node:http";
+import type { AddressInfo } from "node:net";
+import test from "node:test";
+
+import express from "express";
+
+import usersRouter from "../src/routes/users";
+
+type TestServer = {
+  baseUrl: string;
+  close: () => Promise<void>;
+};
+
+async function createUsersTestServer(): Promise<TestServer> {
+  const app = express();
+  app.use(express.json());
+  app.use("/users", usersRouter);
+
+  const server: Server = createServer(app);
+
+  await new Promise<void>((resolve) => {
+    server.listen(0, "127.0.0.1", resolve);
+  });
+
+  const address = server.address() as AddressInfo;
+
+  return {
+    baseUrl: `http://127.0.0.1:${address.port}`,
+    close: () =>
+      new Promise<void>((resolve, reject) => {
+        server.close((error) => {
+          if (error) {
+            reject(error);
+            return;
+          }
+
+          resolve();
+        });
+      })
+  };
+}
+
+test("GET /users returns the list stub response", async () => {
+  const server = await createUsersTestServer();
+
+  try {
+    const response = await fetch(`${server.baseUrl}/users`);
+
+    assert.equal(response.status, 200);
+    assert.deepEqual(await response.json(), {
+      data: [],
+      message: "User listing is not implemented yet."
+    });
+  } finally {
+    await server.close();
+  }
+});
+
+test("POST /users returns the create stub response", async () => {
+  const server = await createUsersTestServer();
+  const payload = {
+    email: "ada@example.com",
+    name: "Ada Lovelace"
+  };
+
+  try {
+    const response = await fetch(`${server.baseUrl}/users`, {
+      body: JSON.stringify(payload),
+      headers: {
+        "content-type": "application/json"
+      },
+      method: "POST"
+    });
+
+    assert.equal(response.status, 201);
+    assert.deepEqual(await response.json(), {
+      data: {
+        id: "stub-user-id",
+        ...payload
+      },
+      message: "User creation is not implemented yet."
+    });
+  } finally {
+    await server.close();
+  }
+});

--- a/contributors/agents.json
+++ b/contributors/agents.json
@@ -1,5 +1,13 @@
 {
-  "agents": [],
-  "last_updated": "2026-06-03",
-  "total_contributions": 0
+  "agents": [
+    {
+      "github_username": "modelsbridgeaicom-ship-it",
+      "model": "GPT-5 Codex",
+      "version": "2026-06-07",
+      "pr_number": 979,
+      "issue_number": 12
+    }
+  ],
+  "last_updated": "2026-06-07",
+  "total_contributions": 1
 }


### PR DESCRIPTION
## Summary
- Add focused node:test coverage for the current Express user route stubs.
- Mount usersRouter on a throwaway Express app and cover GET /users list behavior plus POST /users create behavior.
- Replace the API placeholder test script with a runnable tsx-backed test command and update required AI agent metadata.

## Validation
- npm.cmd test -w apps/api
- npm.cmd run lint -w apps/api
- npm.cmd test --workspaces --if-present
- contributors/agents.json JSON parse check
- git diff --check

Note: this checkout initially had no node_modules installed, so npm.cmd test -w apps/api first failed because tsx was missing. After installing the repo-declared dependencies locally with npm.cmd install --ignore-scripts, the API and workspace tests passed. The generated local package-lock.json was removed and is not part of this PR.

Closes #12
/claim #12
