### PR TITLE
[agent] Enable API CORS middleware

### DIFF
--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -11,9 +11,11 @@
     "lint": "echo \"No API lint configured yet\""
   },
   "dependencies": {
+    "cors": "^2.8.5",
     "express": "^4.18.3"
   },
   "devDependencies": {
+    "@types/cors": "^2.8.17",
     "@types/express": "^4.17.21",
     "tsx": "^4.7.1",
     "typescript": "^5.4.5"

--- a/apps/api/src/index.ts
+++ b/apps/api/src/index.ts
@@ -1,10 +1,12 @@
 import express from "express";
+import cors from "cors";
 
 import usersRouter from "./routes/users";
 
 const app = express();
 const port = process.env.PORT || 4000;
 
+app.use(cors());
 app.use(express.json());
 
 app.get("/health", (_req, res) => {

--- a/contributors/agents.json
+++ b/contributors/agents.json
@@ -1,5 +1,13 @@
 {
-  "agents": [],
-  "last_updated": "2026-06-03",
-  "total_contributions": 0
+  "agents": [
+    {
+      "github_username": "modelsbridgeaicom-ship-it",
+      "model": "GPT-5 Codex",
+      "version": "2026-06-07",
+      "pr_number": 982,
+      "issue_number": 692
+    }
+  ],
+  "last_updated": "2026-06-07",
+  "total_contributions": 1
 }


### PR DESCRIPTION
## Summary
- add the standard Express CORS middleware to the API entrypoint
- declare the runtime cors dependency and TypeScript typings
- preserve existing /health and /users route behavior

/claim #692

## Validation
- 
pm.cmd test -w apps/api
- 
pm.cmd run lint -w apps/api
- git diff --check
- Started the API on PORT=4972 and confirmed GET /health with an Origin header returns 200 and Access-Control-Allow-Origin: *

AI-assisted with OpenAI Codex; change reviewed before submission.