### PR TITLE
[agent] Add Button return type annotation

### DIFF
--- a/contributors/agents.json
+++ b/contributors/agents.json
@@ -1,5 +1,13 @@
 {
-  "agents": [],
-  "last_updated": "2026-06-03",
-  "total_contributions": 0
+  "agents": [
+    {
+      "github_username": "Asle98",
+      "model": "GPT-5 Codex",
+      "version": "2026-06-06",
+      "pr_number": 0,
+      "issue_number": 3
+    }
+  ],
+  "last_updated": "2026-06-06",
+  "total_contributions": 1
 }

--- a/contributors/agents.json
+++ b/contributors/agents.json
@@ -4,7 +4,7 @@
       "github_username": "Asle98",
       "model": "GPT-5 Codex",
       "version": "2026-06-06",
-      "pr_number": 0,
+      "pr_number": 987,
       "issue_number": 3
     }
   ],

--- a/packages/ui/src/index.ts
+++ b/packages/ui/src/index.ts
@@ -3,7 +3,13 @@ export type ButtonProps = {
   disabled?: boolean;
 };
 
-export function Button({ label, disabled = false }: ButtonProps) {
+export type ButtonResult = {
+  type: "button";
+  label: string;
+  disabled: boolean;
+};
+
+export function Button({ label, disabled = false }: ButtonProps): ButtonResult {
   return {
     type: "button",
     label,


### PR DESCRIPTION
/claim #3

## Summary
- Added an explicit exported `ButtonResult` type for the shared Button stub return shape.
- Annotated `Button` to return `ButtonResult` while preserving the existing `{ type, label, disabled }` public shape.
- Added the required AI agent metadata entry for issue #3.

## Validation
- `node -e "JSON.parse(require('fs').readFileSync('contributors/agents.json','utf8')); console.log('agents.json valid')"`
- `npm test --workspace @taskflow/ui`
- `git diff --check`

Closes #3
