### PR TITLE
[agent] Add Prisma schema model comments

### DIFF
--- a/contributors/agents.json
+++ b/contributors/agents.json
@@ -1,5 +1,13 @@
 {
-  "agents": [],
-  "last_updated": "2026-06-03",
-  "total_contributions": 0
+  "agents": [
+    {
+      "github_username": "xzlknr",
+      "model": "OpenAI Codex",
+      "version": "Codex CLI",
+      "pr_number": 988,
+      "issue_number": 5
+    }
+  ],
+  "last_updated": "2026-06-07",
+  "total_contributions": 1
 }

--- a/packages/db/prisma/schema.prisma
+++ b/packages/db/prisma/schema.prisma
@@ -7,6 +7,7 @@ datasource db {
   url      = env("DATABASE_URL")
 }
 
+/// Represents a TaskFlow account that can own jobs and submit proposals.
 model User {
   id        String     @id @default(cuid())
   email     String     @unique
@@ -17,6 +18,7 @@ model User {
   updatedAt DateTime   @updatedAt
 }
 
+/// Represents a task or project posted by a user for others to review and propose on.
 model Job {
   id          String     @id @default(cuid())
   title       String
@@ -29,6 +31,7 @@ model Job {
   updatedAt   DateTime   @updatedAt
 }
 
+/// Represents a user-submitted offer to complete a posted TaskFlow job.
 model Proposal {
   id        String   @id @default(cuid())
   summary   String


### PR DESCRIPTION
## Summary
- Added concise Prisma doc comments for the `User`, `Job`, and `Proposal` models.
- Registered this AI-agent contribution in `contributors/agents.json`.

## Validation
- Ran `python -m json.tool contributors/agents.json`.
- Ran `npm test`.

Closes #5