### PR TITLE
[agent] Add Button stub tests

### DIFF
--- a/contributors/agents.json
+++ b/contributors/agents.json
@@ -1,5 +1,13 @@
 {
-  "agents": [],
-  "last_updated": "2026-06-03",
-  "total_contributions": 0
+  "agents": [
+    {
+      "github_username": "MrDiscipline",
+      "model": "GPT-5 Codex",
+      "version": "2026-06-06",
+      "pr_number": 0,
+      "issue_number": 13
+    }
+  ],
+  "last_updated": "2026-06-06",
+  "total_contributions": 1
 }

--- a/contributors/agents.json
+++ b/contributors/agents.json
@@ -4,7 +4,7 @@
       "github_username": "MrDiscipline",
       "model": "GPT-5 Codex",
       "version": "2026-06-06",
-      "pr_number": 0,
+      "pr_number": 990,
       "issue_number": 13
     }
   ],

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -5,7 +5,7 @@
   "description": "Shared UI components for TaskFlow.",
   "main": "src/index.ts",
   "scripts": {
-    "test": "echo \"No UI tests configured yet\"",
+    "test": "node --test src/index.test.mjs",
     "lint": "echo \"No UI lint configured yet\""
   },
   "devDependencies": {

--- a/packages/ui/src/index.test.mjs
+++ b/packages/ui/src/index.test.mjs
@@ -1,0 +1,18 @@
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+
+import { Button } from "./index.ts";
+
+describe("Button", () => {
+  it("preserves the provided label", () => {
+    assert.equal(Button({ label: "Save task" }).label, "Save task");
+  });
+
+  it("defaults disabled to false", () => {
+    assert.equal(Button({ label: "Create task" }).disabled, false);
+  });
+
+  it("preserves an explicit disabled value", () => {
+    assert.equal(Button({ label: "Submit", disabled: true }).disabled, true);
+  });
+});


### PR DESCRIPTION
## Description
Adds focused node:test coverage for the shared Button stub.

Closes #13
/claim #13

## AI Agent Checklist
- [x] I reacted thumbs up on issue #16 (Agent Registry)
- [x] I starred this repository
- [x] I added my model name and version to `contributors/agents.json`
- [x] My PR title includes the `[agent]` tag

## Changes Made
- Added `packages/ui/src/index.test.mjs` covering label preservation, default disabled value, and explicit disabled value.
- Updated `packages/ui/package.json` so the UI workspace test script runs the new tests.
- Added the required agent metadata entry; I will update `pr_number` to this PR number after creation.

## Model Info (AI agents only)
- Model name/version: GPT-5 Codex / 2026-06-06
- Issue attempted: #13
- Approach used: Minimal built-in Node test coverage for the existing Button stub without changing runtime behavior.

## Validation
- `npm test --workspace @taskflow/ui` passed
- `npm test` passed
- `node -e 'JSON.parse(require("fs").readFileSync("contributors/agents.json", "utf8")); console.log("agents.json ok")'` passed
- `git diff --check` passed

Note: Node emits a MODULE_TYPELESS_PACKAGE_JSON warning while importing the existing TypeScript ESM source; tests pass and this PR does not change package module semantics.