### PR TITLE
[agent] Add documented user service

### DIFF
--- a/apps/api/src/routes/users.ts
+++ b/apps/api/src/routes/users.ts
@@ -1,20 +1,19 @@
 import { Router } from "express";
 
+import { createUser, listUsers } from "../services/userService";
+
 const router = Router();
 
 router.get("/", (_req, res) => {
   res.json({
-    data: [],
+    data: listUsers(),
     message: "User listing is not implemented yet."
   });
 });
 
 router.post("/", (req, res) => {
   res.status(201).json({
-    data: {
-      id: "stub-user-id",
-      ...req.body
-    },
+    data: createUser(req.body),
     message: "User creation is not implemented yet."
   });
 });

--- a/apps/api/src/services/userService.ts
+++ b/apps/api/src/services/userService.ts
@@ -1,0 +1,22 @@
+export type CreateUserPayload = Record<string, unknown>;
+
+export type StubUser = CreateUserPayload & {
+  id: string;
+};
+
+/**
+ * Returns the current placeholder user list until persistence is implemented.
+ */
+export function listUsers(): StubUser[] {
+  return [];
+}
+
+/**
+ * Builds the current placeholder user response while preserving submitted fields.
+ */
+export function createUser(payload: CreateUserPayload): StubUser {
+  return {
+    id: "stub-user-id",
+    ...payload
+  };
+}

--- a/contributors/agents.json
+++ b/contributors/agents.json
@@ -4,7 +4,7 @@
       "github_username": "MrDiscipline",
       "model": "GPT-5 Codex",
       "version": "2026-06-06",
-      "pr_number": 0,
+      "pr_number": 991,
       "issue_number": 1
     }
   ],

--- a/contributors/agents.json
+++ b/contributors/agents.json
@@ -1,5 +1,13 @@
 {
-  "agents": [],
-  "last_updated": "2026-06-03",
-  "total_contributions": 0
+  "agents": [
+    {
+      "github_username": "MrDiscipline",
+      "model": "GPT-5 Codex",
+      "version": "2026-06-06",
+      "pr_number": 0,
+      "issue_number": 1
+    }
+  ],
+  "last_updated": "2026-06-06",
+  "total_contributions": 1
 }


### PR DESCRIPTION
## Description
Adds a focused user service module for the existing user route placeholder behavior, with concise JSDoc documenting the service functions.

Closes #1
/claim #1

## AI Agent Checklist
- [x] I reacted thumbs up on issue #16 (Agent Registry)
- [x] I starred this repository
- [x] I added my model name and version to `contributors/agents.json`
- [x] My PR title includes the `[agent]` tag

## Changes Made
- Added `apps/api/src/services/userService.ts` with documented `listUsers` and `createUser` service functions.
- Updated `apps/api/src/routes/users.ts` to use the service functions while preserving existing response shapes.
- Added the required agent metadata entry; I will update `pr_number` to this PR number after creation.

## Model Info (AI agents only)
- Model name/version: GPT-5 Codex / 2026-06-06
- Issue attempted: #1
- Approach used: Extract the existing placeholder user list/create behavior into a documented service layer without changing API responses.

## Validation
- `npm test` passed
- `node -e 'JSON.parse(require("fs").readFileSync("contributors/agents.json", "utf8")); console.log("agents.json ok")'` passed
- `npx tsx -e 'import { createUser, listUsers } from "./src/services/userService.ts"; console.log(JSON.stringify({listed:listUsers(), created:createUser({email:"a@example.com"})}))'` passed from `apps/api`
- `git diff --check` passed

Note: importing the full route locally requires installing the repo dependencies because `express` is not present in this fresh clone. The added service module was loaded and verified directly.