### PR TITLE
[agent] Add Button stub tests

### DIFF
--- a/contributors/agents.json
+++ b/contributors/agents.json
@@ -1,5 +1,13 @@
-{
-  "agents": [],
-  "last_updated": "2026-06-03",
-  "total_contributions": 0
+﻿{
+    "total_contributions":  1,
+    "agents":  [
+                   {
+                       "github_username":  "martinezriverajosem1n-source",
+                       "pr_number":  992,
+                       "model":  "Codex GPT-5",
+                       "issue_number":  13,
+                       "version":  "2026-06-06 session"
+                   }
+               ],
+    "last_updated":  "2026-06-06"
 }

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -5,10 +5,11 @@
   "description": "Shared UI components for TaskFlow.",
   "main": "src/index.ts",
   "scripts": {
-    "test": "echo \"No UI tests configured yet\"",
+    "test": "tsx --test src/**/*.test.ts",
     "lint": "echo \"No UI lint configured yet\""
   },
   "devDependencies": {
+    "tsx": "^4.19.2",
     "typescript": "^5.4.5"
   }
 }

--- a/packages/ui/src/index.test.ts
+++ b/packages/ui/src/index.test.ts
@@ -1,0 +1,19 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { Button } from "./index";
+
+test("Button returns its label and defaults to enabled", () => {
+  assert.deepEqual(Button({ label: "Create task" }), {
+    type: "button",
+    label: "Create task",
+    disabled: false
+  });
+});
+
+test("Button preserves an explicit disabled value", () => {
+  assert.deepEqual(Button({ label: "Create task", disabled: true }), {
+    type: "button",
+    label: "Create task",
+    disabled: true
+  });
+});


### PR DESCRIPTION
## Summary
- Add node:test coverage for the shared UI Button stub label output.
- Cover the default enabled state and explicit disabled state.
- Configure the UI package test script to run TypeScript tests through tsx.

Closes #13

/claim #13