### PR TITLE
[agent] Add user route tests

### DIFF
--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -7,7 +7,7 @@
   "main": "src/index.ts",
   "scripts": {
     "dev": "tsx src/index.ts",
-    "test": "echo \"No API tests configured yet\"",
+    "test": "tsx --test src/**/*.test.ts",
     "lint": "echo \"No API lint configured yet\""
   },
   "dependencies": {

--- a/apps/api/src/routes/users.test.ts
+++ b/apps/api/src/routes/users.test.ts
@@ -1,0 +1,80 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import express from "express";
+import usersRouter from "./users";
+
+function createTestServer() {
+  const app = express();
+
+  app.use(express.json());
+  app.use("/users", usersRouter);
+
+  const server = app.listen(0);
+
+  return new Promise<{ baseUrl: string; close: () => Promise<void> }>((resolve, reject) => {
+    server.once("error", reject);
+    server.once("listening", () => {
+      const address = server.address();
+
+      if (!address || typeof address === "string") {
+        reject(new Error("Expected server to listen on a TCP port"));
+        return;
+      }
+
+      resolve({
+        baseUrl: `http://127.0.0.1:${address.port}`,
+        close: () =>
+          new Promise((closeResolve, closeReject) => {
+            server.close((error) => (error ? closeReject(error) : closeResolve()));
+          })
+      });
+    });
+  });
+}
+
+test("GET /users returns the placeholder user list", async () => {
+  const server = await createTestServer();
+
+  try {
+    const response = await fetch(`${server.baseUrl}/users`);
+    const payload = await response.json();
+
+    assert.equal(response.status, 200);
+    assert.deepEqual(payload, {
+      data: [],
+      message: "User listing is not implemented yet."
+    });
+  } finally {
+    await server.close();
+  }
+});
+
+test("POST /users returns a created stub user", async () => {
+  const server = await createTestServer();
+
+  try {
+    const response = await fetch(`${server.baseUrl}/users`, {
+      method: "POST",
+      headers: {
+        "content-type": "application/json"
+      },
+      body: JSON.stringify({
+        email: "client@example.com",
+        name: "TaskFlow Client"
+      })
+    });
+    const payload = await response.json();
+
+    assert.equal(response.status, 201);
+    assert.deepEqual(payload, {
+      data: {
+        id: "stub-user-id",
+        email: "client@example.com",
+        name: "TaskFlow Client"
+      },
+      message: "User creation is not implemented yet."
+    });
+  } finally {
+    await server.close();
+  }
+});

--- a/contributors/agents.json
+++ b/contributors/agents.json
@@ -1,5 +1,13 @@
 {
-  "agents": [],
-  "last_updated": "2026-06-03",
-  "total_contributions": 0
+    "total_contributions":  1,
+    "agents":  [
+                   {
+                       "github_username":  "martinezriverajosem1n-source",
+                       "pr_number":  995,
+                       "model":  "Codex GPT-5",
+                       "issue_number":  12,
+                       "version":  "2026-06-06 session"
+                   }
+               ],
+    "last_updated":  "2026-06-06"
 }


### PR DESCRIPTION
## Summary
- Add node:test coverage for the Express user route stubs.
- Cover GET /users list behavior and POST /users create behavior.
- Update the API package test script to run TypeScript tests through the existing 	sx dev dependency.

## Verification
- Ran a bundled Node equivalent check for the expected list/create response shapes.

Closes #12

/claim #12