### PR TITLE
[agent] Add type annotations to shared Button props - Closes #3

### DIFF
--- a/contributors/agents.json
+++ b/contributors/agents.json
@@ -1,5 +1,1 @@
-{
-  "agents": [],
-  "last_updated": "2026-06-03",
-  "total_contributions": 0
-}
+{"agents":[{"github_username":"chenzhi1985","model":"claude-code","version":"deepseek-v4-pro","issue_number":3}],"last_updated":"2026-06-06","total_contributions":1}

--- a/packages/ui/src/index.ts
+++ b/packages/ui/src/index.ts
@@ -1,9 +1,29 @@
+/** Props for the shared Button component */
 export type ButtonProps = {
+  /** Accessible text displayed inside the button */
   label: string;
+  /** When true the button is non-interactive */
   disabled?: boolean;
 };
 
-export function Button({ label, disabled = false }: ButtonProps) {
+/** Rendered button shape returned by the Button stub */
+export interface ButtonRenderResult {
+  type: "button";
+  label: string;
+  disabled: boolean;
+}
+
+/**
+ * Shared Button stub component.
+ *
+ * Returns a plain object describing the button — intended as a
+ * cross-platform abstraction that framework-specific adapters can
+ * render into native elements (DOM, React Native, etc.).
+ *
+ * @param props — {@link ButtonProps}
+ * @returns A {@link ButtonRenderResult} descriptor object
+ */
+export function Button({ label, disabled = false }: ButtonProps): ButtonRenderResult {
   return {
     type: "button",
     label,


### PR DESCRIPTION
Add JSDoc, explicit return type (ButtonRenderResult), and property-level docs.

Closes #3