### PR TITLE
[agent] Add unit tests for UI Button stub - Closes #13

### DIFF
--- a/contributors/agents.json
+++ b/contributors/agents.json
@@ -1,5 +1,1 @@
-{
-  "agents": [],
-  "last_updated": "2026-06-03",
-  "total_contributions": 0
-}
+{"agents":[{"github_username":"chenzhi1985","model":"claude-code","version":"deepseek-v4-pro","issue_number":13}],"last_updated":"2026-06-06","total_contributions":1}

--- a/packages/ui/test-button.test.ts
+++ b/packages/ui/test-button.test.ts
@@ -1,0 +1,31 @@
+import { describe, it, expect } from "vitest";
+import { Button, type ButtonProps, type ButtonRenderResult } from "./src/index";
+
+describe("Button", () => {
+  it("should return a button descriptor with type, label, and disabled", () => {
+    const result = Button({ label: "Click me" });
+    expect(result).toEqual({ type: "button", label: "Click me", disabled: false });
+  });
+
+  it("should default disabled to false when omitted", () => {
+    const result: ButtonRenderResult = Button({ label: "Save" });
+    expect(result.disabled).toBe(false);
+  });
+
+  it("should pass through disabled when true", () => {
+    const result = Button({ label: "Submit", disabled: true });
+    expect(result.disabled).toBe(true);
+  });
+
+  it("should preserve the label exactly (including emoji)", () => {
+    const result = Button({ label: "🚀 Launch" });
+    expect(result.label).toBe("🚀 Launch");
+  });
+
+  it("should handle an empty label string", () => {
+    const result = Button({ label: "" });
+    expect(result.type).toBe("button");
+    expect(result.label).toBe("");
+    expect(result.disabled).toBe(false);
+  });
+});


### PR DESCRIPTION
5 tests: defaults, disabled passthrough, emoji label, empty label edge case.

Closes #13