### PR TITLE
test: add leaderboard update unit tests (Closes #11)

### DIFF
--- a/contributors/agents.json
+++ b/contributors/agents.json
@@ -1,5 +1,13 @@
 {
-  "agents": [],
-  "last_updated": "2026-06-03",
-  "total_contributions": 0
+  "agents": [
+    {
+      "github_username": "jacksong2049-prog",
+      "model": "JackAI Hermes Agent",
+      "version": "2026-06-07",
+      "pr_number": null,
+      "issue_number": 11
+    }
+  ],
+  "last_updated": "2026-06-07",
+  "total_contributions": 1
 }

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
   ],
   "scripts": {
     "dev": "npm run dev --workspaces --if-present",
-    "test": "npm run test --workspaces --if-present",
+    "test": "node --test test/*.test.mjs && npm run test --workspaces --if-present",
     "lint": "npm run lint --workspaces --if-present",
     "format": "npm run format --workspaces --if-present"
   },

--- a/scripts/update-leaderboard.mjs
+++ b/scripts/update-leaderboard.mjs
@@ -1,0 +1,14 @@
+export function applyLeaderboardUpdate(leaderboard, contributor) {
+  if (!contributor || typeof contributor !== "string") {
+    throw new TypeError("contributor must be a non-empty string");
+  }
+  const name = contributor.trim();
+  if (!name) {
+    throw new TypeError("contributor must be a non-empty string");
+  }
+  const current = Number.isInteger(leaderboard[name]) ? leaderboard[name] : 0;
+  return {
+    ...leaderboard,
+    [name]: current + 1,
+  };
+}

--- a/test/update-leaderboard.test.mjs
+++ b/test/update-leaderboard.test.mjs
@@ -1,0 +1,48 @@
+import assert from "node:assert/strict";
+import { test, describe } from "node:test";
+import { applyLeaderboardUpdate } from "../scripts/update-leaderboard.mjs";
+
+describe("applyLeaderboardUpdate", () => {
+  test("increments an existing contributor count", () => {
+    const result = applyLeaderboardUpdate({ alice: 5, bob: 3 }, "alice");
+    assert.deepEqual(result, { alice: 6, bob: 3 });
+  });
+
+  test("adds a new contributor with count 1", () => {
+    const result = applyLeaderboardUpdate({ alice: 5 }, "charlie");
+    assert.deepEqual(result, { alice: 5, charlie: 1 });
+  });
+
+  test("trims whitespace from contributor name", () => {
+    const result = applyLeaderboardUpdate({}, "  alice  ");
+    assert.deepEqual(result, { alice: 1 });
+  });
+
+  test("handles multiple increments for the same contributor", () => {
+    let lb = {};
+    lb = applyLeaderboardUpdate(lb, "alice");
+    lb = applyLeaderboardUpdate(lb, "alice");
+    lb = applyLeaderboardUpdate(lb, "alice");
+    assert.deepEqual(lb, { alice: 3 });
+  });
+
+  test("throws on empty string contributor", () => {
+    assert.throws(() => applyLeaderboardUpdate({}, ""), TypeError);
+  });
+
+  test("throws on whitespace-only contributor", () => {
+    assert.throws(() => applyLeaderboardUpdate({}, "   "), TypeError);
+  });
+
+  test("throws on null/undefined contributor", () => {
+    assert.throws(() => applyLeaderboardUpdate({}, null), TypeError);
+    assert.throws(() => applyLeaderboardUpdate({}, undefined), TypeError);
+  });
+
+  test("does not mutate the original leaderboard", () => {
+    const original = { alice: 5 };
+    const result = applyLeaderboardUpdate(original, "bob");
+    assert.deepEqual(original, { alice: 5 });
+    assert.deepEqual(result, { alice: 5, bob: 1 });
+  });
+});


### PR DESCRIPTION
## Summary
Add unit tests for the leaderboard update script covering new and existing contributors.

## Changes
- **scripts/update-leaderboard.mjs** — pure helper function `applyLeaderboardUpdate(leaderboard, contributor)` that increments existing contributors or adds new ones
- **test/update-leaderboard.test.mjs** — 8 unit tests using `node:test`:
  - ✅ Increments existing contributor
  - ✅ Adds new contributor with count 1
  - ✅ Trims whitespace from names
  - ✅ Multiple increments accumulate correctly
  - ✅ Throws on empty/whitespace/null/undefined input
  - ✅ Does not mutate the original leaderboard object
- **package.json** — updated test script to run `node --test test/*.test.mjs` before workspace tests
- **contributors/agents.json** — registered agent metadata

## Testing
```bash
node --test test/update-leaderboard.test.mjs
```

Closes #11