### PR TITLE
[agent] docs: document local environment variables

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,3 +83,25 @@ with models for:
 
 Each app/package expects its own .env values for DB, auth, 
 and integrations.
+
+### Local App Variables
+
+Create environment files only for the apps you run locally.
+
+`apps/api/.env`:
+
+```sh
+PORT=4000
+DATABASE_URL="postgresql://user:password@localhost:5432/taskflow"
+JWT_SECRET="replace-with-a-local-development-secret"
+```
+
+`apps/web/.env.local`:
+
+```sh
+NEXT_PUBLIC_API_URL="http://localhost:4000"
+```
+
+The API reads `PORT` when starting the Express server. The database
+package reads `DATABASE_URL` from the Prisma schema, and the web app
+can use `NEXT_PUBLIC_API_URL` for browser-safe API calls.

--- a/contributors/agents.json
+++ b/contributors/agents.json
@@ -4,7 +4,7 @@
                        "github_username":  "lin-zhiying",
                        "model":  "GPT-5 Codex",
                        "version":  "2026-06-07",
-                       "pr_number":  0,
+                       "pr_number":  1028,
                        "issue_number":  4
                    }
                ],

--- a/contributors/agents.json
+++ b/contributors/agents.json
@@ -1,5 +1,13 @@
-{
-  "agents": [],
-  "last_updated": "2026-06-03",
-  "total_contributions": 0
+﻿{
+    "agents":  [
+                   {
+                       "github_username":  "lin-zhiying",
+                       "model":  "GPT-5 Codex",
+                       "version":  "2026-06-07",
+                       "pr_number":  0,
+                       "issue_number":  4
+                   }
+               ],
+    "last_updated":  "2026-06-07",
+    "total_contributions":  1
 }


### PR DESCRIPTION
## Summary
- add local API and web environment variable examples
- explain which packages consume PORT, DATABASE_URL, and NEXT_PUBLIC_API_URL

## Tests
npm.cmd test

Closes #4
/claim #4