### PR TITLE
[agent] Fix NodeNext API route import

### DIFF
--- a/apps/api/src/index.ts
+++ b/apps/api/src/index.ts
@@ -1,6 +1,6 @@
 import express from "express";
 
-import usersRouter from "./routes/users";
+import usersRouter from "./routes/users.js";
 
 const app = express();
 const port = process.env.PORT || 4000;

--- a/contributors/agents.json
+++ b/contributors/agents.json
@@ -1,5 +1,13 @@
 {
-  "agents": [],
-  "last_updated": "2026-06-03",
-  "total_contributions": 0
+  "agents": [
+    {
+      "github_username": "LukastGeorge",
+      "model": "Codex",
+      "version": "GPT-5",
+      "pr_number": null,
+      "issue_number": 637
+    }
+  ],
+  "last_updated": "2026-06-07",
+  "total_contributions": 1
 }

--- a/contributors/agents.json
+++ b/contributors/agents.json
@@ -4,7 +4,7 @@
       "github_username": "LukastGeorge",
       "model": "Codex",
       "version": "GPT-5",
-      "pr_number": null,
+      "pr_number": 1034,
       "issue_number": 637
     }
   ],


### PR DESCRIPTION
Closes #637

Summary:
- Updated the API users router import to use the runtime-valid .js extension required by NodeNext ESM resolution.
- Kept the change focused on the API entrypoint import.
- Added the required AI agent contribution metadata.

Validation:
- npx tsc --noEmit --module NodeNext --moduleResolution NodeNext --target ES2022 --esModuleInterop --skipLibCheck apps/api/src/index.ts
- npm test