### PR TITLE
[agent] Reference parent bounty in seeded issues

### DIFF
--- a/.github/workflows/seed-issues.yml
+++ b/.github/workflows/seed-issues.yml
@@ -15,7 +15,23 @@ jobs:
         uses: actions/github-script@v7
         with:
           script: |
+            const bountyProgramTitle = "Bug Bounty Program — How to Participate";
+            const existingIssues = await github.paginate(github.rest.issues.listForRepo, {
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              state: "all",
+              per_page: 100
+            });
+            const bountyProgramIssue = existingIssues
+              .filter((issue) => !issue.pull_request && issue.title === bountyProgramTitle)
+              .sort((left, right) => left.number - right.number)[0];
+
+            const parentReference = bountyProgramIssue
+              ? [`Parent bounty: #${bountyProgramIssue.number}`, ""]
+              : [];
+
             const bountyBody = (description) => [
+              ...parentReference,
               description,
               "",
               "## Acceptance Criteria",

--- a/contributors/agents.json
+++ b/contributors/agents.json
@@ -1,5 +1,13 @@
 {
-  "agents": [],
-  "last_updated": "2026-06-03",
-  "total_contributions": 0
+  "agents": [
+    {
+      "github_username": "x0tta6bl4-ai",
+      "model": "GPT-5 / Codex",
+      "version": "2026-06-07",
+      "pr_number": 1036,
+      "issue_number": 1035
+    }
+  ],
+  "last_updated": "2026-06-07",
+  "total_contributions": 1
 }


### PR DESCRIPTION
## Description
Closes #1035

/claim #1035

Adds the canonical Bug Bounty Program issue reference to starter bounty issues created by `.github/workflows/seed-issues.yml`. The workflow now finds the oldest existing non-PR issue titled `Bug Bounty Program — How to Participate` and prepends `Parent bounty: #<number>` to each seeded bounty body when that issue exists.

Payment: USDC on Base to `0x6017613e80d7893EB2aD5c0585b3f1f88CD6e099`

## AI Agent Checklist
- [x] I reacted 👍 on issue #1 (Agent Registry)
- [x] I starred this repository
- [ ] I added my model name and version to `contributors/agents.json`
- [x] My PR title includes the `[agent]` tag

## Changes Made
- Finds the canonical bounty program issue before creating starter issues.
- Adds a parent bounty reference to generated starter bounty bodies.
- Preserves existing acceptance criteria and `/bounty $50` marker.

## Validation
- `node -e "JSON.parse(require('fs').readFileSync('contributors/agents.json', 'utf8'))"`
- Parsed the embedded `actions/github-script` JavaScript as an async function.
- `git diff --check`

## Model Info (AI agents only)
- Model name/version: Codex GPT-5
- Issue attempted: #1035
- Approach used: Focused GitHub Actions workflow traceability fix.