### PR TITLE
[agent] Add Button stub unit tests

### DIFF
--- a/contributors/agents.json
+++ b/contributors/agents.json
@@ -2,8 +2,8 @@
   "agents": [
     {
       "github_username": "LukastGeorge",
-      "model": "Codex",
-      "version": "GPT-5",
+      "model": "GPT-5",
+      "version": "Codex",
       "pr_number": 1037,
       "issue_number": 13
     }

--- a/contributors/agents.json
+++ b/contributors/agents.json
@@ -1,5 +1,13 @@
 {
-  "agents": [],
-  "last_updated": "2026-06-03",
-  "total_contributions": 0
+  "agents": [
+    {
+      "github_username": "LukastGeorge",
+      "model": "Codex",
+      "version": "GPT-5",
+      "pr_number": null,
+      "issue_number": 13
+    }
+  ],
+  "last_updated": "2026-06-07",
+  "total_contributions": 1
 }

--- a/contributors/agents.json
+++ b/contributors/agents.json
@@ -4,7 +4,7 @@
       "github_username": "LukastGeorge",
       "model": "Codex",
       "version": "GPT-5",
-      "pr_number": null,
+      "pr_number": 1037,
       "issue_number": 13
     }
   ],

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -5,10 +5,11 @@
   "description": "Shared UI components for TaskFlow.",
   "main": "src/index.ts",
   "scripts": {
-    "test": "echo \"No UI tests configured yet\"",
+    "test": "tsx --test src/index.test.ts",
     "lint": "echo \"No UI lint configured yet\""
   },
   "devDependencies": {
+    "tsx": "^4.7.1",
     "typescript": "^5.4.5"
   }
 }

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -5,7 +5,7 @@
   "description": "Shared UI components for TaskFlow.",
   "main": "src/index.ts",
   "scripts": {
-    "test": "tsx --test src/index.test.ts",
+    "test": "node --import tsx --test \"src/**/*.test.ts\"",
     "lint": "echo \"No UI lint configured yet\""
   },
   "devDependencies": {

--- a/packages/ui/src/index.test.ts
+++ b/packages/ui/src/index.test.ts
@@ -1,0 +1,19 @@
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+
+import { Button } from "./index";
+
+describe("Button", () => {
+  it("preserves the label and defaults disabled to false", () => {
+    assert.deepEqual(Button({ label: "Save" }), {
+      type: "button",
+      label: "Save",
+      disabled: false
+    });
+  });
+
+  it("preserves an explicit disabled value", () => {
+    assert.equal(Button({ label: "Submit", disabled: true }).disabled, true);
+    assert.equal(Button({ label: "Cancel", disabled: false }).disabled, false);
+  });
+});


### PR DESCRIPTION
Closes #13

Summary:
- Added focused node:test coverage for the shared Button stub.
- Covered label preservation, the default disabled value, and explicit disabled true/false values.
- Updated the UI workspace test script and required AI agent contribution metadata.

Validation:
- npm test -w packages/ui
- npm test