### PR TITLE
docs: add JSDoc to user service route handlers

### DIFF
--- a/apps/api/src/routes/users.ts
+++ b/apps/api/src/routes/users.ts
@@ -2,6 +2,11 @@ import { Router } from "express";
 
 const router = Router();
 
+/**
+ * GET /users
+ * Returns a list of all users. Currently returns an empty stub
+ * until full user listing is implemented.
+ */
 router.get("/", (_req, res) => {
   res.json({
     data: [],
@@ -9,6 +14,11 @@ router.get("/", (_req, res) => {
   });
 });
 
+/**
+ * POST /users
+ * Creates a new user. Currently returns a stub with the request body
+ * merged into a placeholder ID until full creation is implemented.
+ */
 router.post("/", (req, res) => {
   res.status(201).json({
     data: {


### PR DESCRIPTION
Closes #1

Added JSDoc comments to GET /users and POST /users route handlers in apps/api/src/routes/users.ts