### PR TITLE
[agent] docs: add documented user service

### DIFF
--- a/apps/api/src/routes/users.ts
+++ b/apps/api/src/routes/users.ts
@@ -1,22 +1,15 @@
 import { Router } from "express";
 
+import { createUser, listUsers } from "../services/userService";
+
 const router = Router();
 
 router.get("/", (_req, res) => {
-  res.json({
-    data: [],
-    message: "User listing is not implemented yet."
-  });
+  res.json(listUsers());
 });
 
 router.post("/", (req, res) => {
-  res.status(201).json({
-    data: {
-      id: "stub-user-id",
-      ...req.body
-    },
-    message: "User creation is not implemented yet."
-  });
+  res.status(201).json(createUser(req.body));
 });
 
 export default router;

--- a/apps/api/src/services/userService.ts
+++ b/apps/api/src/services/userService.ts
@@ -1,0 +1,40 @@
+export type CreateUserInput = Record<string, unknown>;
+
+export interface StubUser {
+  id: string;
+  [key: string]: unknown;
+}
+
+export interface UserServiceMessage<TData> {
+  data: TData;
+  message: string;
+}
+
+/**
+ * Returns the current placeholder user collection.
+ *
+ * The API does not have persistent user storage yet, so callers receive an
+ * empty list while the response shape stays aligned with the future CRUD API.
+ */
+export function listUsers(): UserServiceMessage<StubUser[]> {
+  return {
+    data: [],
+    message: "User listing is not implemented yet."
+  };
+}
+
+/**
+ * Builds the placeholder response for a user creation request.
+ *
+ * The request payload is echoed with a stable stub id so route consumers can
+ * develop against the create-user contract before database writes are added.
+ */
+export function createUser(input: CreateUserInput): UserServiceMessage<StubUser> {
+  return {
+    data: {
+      id: "stub-user-id",
+      ...input
+    },
+    message: "User creation is not implemented yet."
+  };
+}

--- a/contributors/agents.json
+++ b/contributors/agents.json
@@ -4,7 +4,7 @@
       "github_username": "Vamshidhar-0814",
       "model": "GPT-5 Codex",
       "version": "2026-06-07",
-      "pr_number": 0,
+      "pr_number": 1059,
       "issue_number": 1
     }
   ],

--- a/contributors/agents.json
+++ b/contributors/agents.json
@@ -1,5 +1,13 @@
 {
-  "agents": [],
-  "last_updated": "2026-06-03",
-  "total_contributions": 0
+  "agents": [
+    {
+      "github_username": "Vamshidhar-0814",
+      "model": "GPT-5 Codex",
+      "version": "2026-06-07",
+      "pr_number": 0,
+      "issue_number": 1
+    }
+  ],
+  "last_updated": "2026-06-07",
+  "total_contributions": 1
 }


### PR DESCRIPTION
/claim #1

## Summary
- Added a focused user service module for the existing list/create placeholder behavior.
- Documented the exported service functions with concise JSDoc.
- Wired the current `/users` routes through the service without changing response shapes.
- Added required AI-agent metadata.

## Validation
- `npm test -- --if-present`
- `npx tsc --noEmit --module ESNext --moduleResolution Bundler --target ES2022 --esModuleInterop --strict --skipLibCheck apps/api/src/routes/users.ts apps/api/src/services/userService.ts`

Closes #1