### PR TITLE
[agent] Add documented user service helpers

### DIFF
--- a/apps/api/src/routes/users.ts
+++ b/apps/api/src/routes/users.ts
@@ -1,20 +1,19 @@
 import { Router } from "express";
 
+import { createUser, listUsers } from "../services/userService";
+
 const router = Router();
 
 router.get("/", (_req, res) => {
   res.json({
-    data: [],
+    data: listUsers(),
     message: "User listing is not implemented yet."
   });
 });
 
 router.post("/", (req, res) => {
   res.status(201).json({
-    data: {
-      id: "stub-user-id",
-      ...req.body
-    },
+    data: createUser(req.body),
     message: "User creation is not implemented yet."
   });
 });

--- a/apps/api/src/services/userService.ts
+++ b/apps/api/src/services/userService.ts
@@ -1,0 +1,32 @@
+import type { Request } from "express";
+
+export type UserPayload = Record<string, unknown>;
+
+export interface StubUser {
+  id: string;
+  [key: string]: unknown;
+}
+
+/**
+ * Returns the current user collection placeholder.
+ *
+ * The API does not persist users yet, so callers receive an empty list while
+ * the route keeps a stable response shape for future storage work.
+ */
+export function listUsers(): StubUser[] {
+  return [];
+}
+
+/**
+ * Builds the current user creation placeholder response.
+ *
+ * The request body is echoed into a deterministic stub user so downstream
+ * clients can develop against the POST /users contract before persistence is
+ * implemented.
+ */
+export function createUser(payload: Request["body"]): StubUser {
+  return {
+    id: "stub-user-id",
+    ...(payload as UserPayload)
+  };
+}

--- a/contributors/agents.json
+++ b/contributors/agents.json
@@ -1,5 +1,13 @@
 {
-  "agents": [],
-  "last_updated": "2026-06-03",
-  "total_contributions": 0
+  "agents": [
+    {
+      "github_username": "szx19970521",
+      "model": "OpenAI Codex",
+      "version": "GPT-5",
+      "pr_number": 0,
+      "issue_number": 1
+    }
+  ],
+  "last_updated": "2026-06-07",
+  "total_contributions": 1
 }

--- a/contributors/agents.json
+++ b/contributors/agents.json
@@ -4,7 +4,7 @@
       "github_username": "szx19970521",
       "model": "OpenAI Codex",
       "version": "GPT-5",
-      "pr_number": 0,
+      "pr_number": 1079,
       "issue_number": 1
     }
   ],


### PR DESCRIPTION
/claim #1

Closes #1

## Summary
- Added a small `userService` module for the existing list/create placeholder behavior.
- Documented the exported user service functions with concise JSDoc.
- Routed `/users` handlers through the service helpers without changing response shapes.
- Added the required AI-agent metadata entry.

## Verification
- Parsed `contributors/agents.json` with Python JSON parser.
- Ran lightweight local file checks for the changed TypeScript files.

Note: local `node.exe` is unavailable in this Windows environment (`Access is denied`) and `npx` is not on PATH, so I could not run the workspace npm scripts locally.