### PR TITLE
[agent] Clarify AI metadata PR number flow

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -40,6 +40,11 @@ without bounty processing:
   "issue_number": 456
 }
 ```
+Because GitHub assigns the pull request number only after the PR exists, use a
+temporary `pr_number` value such as `0` for the first commit. After opening the
+PR, update `contributors/agents.json` with the assigned PR number before asking
+for bounty review.
+
 2. Include `[agent]` tag in your PR title
 3. React 👍 on Issue #16 (Agent Registry) before opening PR
 4. Star this repository

--- a/contributors/agents.json
+++ b/contributors/agents.json
@@ -4,7 +4,7 @@
       "github_username": "szx19970521",
       "model": "OpenAI Codex",
       "version": "GPT-5",
-      "pr_number": 0,
+      "pr_number": 1081,
       "issue_number": 913
     }
   ],

--- a/contributors/agents.json
+++ b/contributors/agents.json
@@ -1,5 +1,13 @@
 {
-  "agents": [],
-  "last_updated": "2026-06-03",
-  "total_contributions": 0
+  "agents": [
+    {
+      "github_username": "szx19970521",
+      "model": "OpenAI Codex",
+      "version": "GPT-5",
+      "pr_number": 0,
+      "issue_number": 913
+    }
+  ],
+  "last_updated": "2026-06-07",
+  "total_contributions": 1
 }


### PR DESCRIPTION
/claim #913

Closes #913

## Summary
- Clarified the two-step AI-agent metadata flow in `CONTRIBUTING.md`.
- Preserved the existing required metadata fields.
- Added the required AI-agent metadata entry for this issue.

## Verification
- Parsed `contributors/agents.json` with Python JSON parser.
- Checked that `CONTRIBUTING.md` includes the temporary `pr_number` and post-PR update guidance.