### PR TITLE
[agent] Disable Express X-Powered-By header

### DIFF
--- a/apps/api/src/index.ts
+++ b/apps/api/src/index.ts
@@ -5,6 +5,8 @@ import usersRouter from "./routes/users";
 const app = express();
 const port = process.env.PORT || 4000;
 
+app.disable("x-powered-by");
+
 app.use(express.json());
 
 app.get("/health", (_req, res) => {

--- a/contributors/agents.json
+++ b/contributors/agents.json
@@ -4,7 +4,7 @@
       "github_username": "szx19970521",
       "model": "OpenAI Codex",
       "version": "GPT-5",
-      "pr_number": 0,
+      "pr_number": 1082,
       "issue_number": 1072
     }
   ],

--- a/contributors/agents.json
+++ b/contributors/agents.json
@@ -1,5 +1,13 @@
 {
-  "agents": [],
-  "last_updated": "2026-06-03",
-  "total_contributions": 0
+  "agents": [
+    {
+      "github_username": "szx19970521",
+      "model": "OpenAI Codex",
+      "version": "GPT-5",
+      "pr_number": 0,
+      "issue_number": 1072
+    }
+  ],
+  "last_updated": "2026-06-07",
+  "total_contributions": 1
 }


### PR DESCRIPTION
/claim #1072

Closes #1072

## Summary
- Disabled Express's default `X-Powered-By` response header during API setup.
- Kept middleware and route behavior unchanged.
- Added the required AI-agent metadata entry for this issue.

## Verification
- Parsed `contributors/agents.json` with Python JSON parser.
- Checked that `app.disable(x-powered-by)` is present before middleware/routes are registered.