### PR TITLE
[agent] Disable web X-Powered-By header

### DIFF
--- a/apps/web/next.config.mjs
+++ b/apps/web/next.config.mjs
@@ -1,0 +1,5 @@
+const nextConfig = {
+  poweredByHeader: false
+};
+
+export default nextConfig;

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -5,7 +5,7 @@
   "description": "Next.js web application for TaskFlow.",
   "scripts": {
     "dev": "next dev",
-    "test": "echo \"No web tests configured yet\"",
+    "test": "node --test test/*.test.mjs",
     "lint": "next lint"
   },
   "dependencies": {

--- a/apps/web/test/next-config.test.mjs
+++ b/apps/web/test/next-config.test.mjs
@@ -1,0 +1,8 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+
+import config from "../next.config.mjs";
+
+test("disables the Next.js X-Powered-By response header", () => {
+  assert.equal(config.poweredByHeader, false);
+});

--- a/contributors/agents.json
+++ b/contributors/agents.json
@@ -4,7 +4,7 @@
       "github_username": "120850853",
       "model": "GPT-5 Codex",
       "version": "2026-06-07",
-      "pr_number": 0,
+      "pr_number": 1090,
       "issue_number": 1089
     }
   ],

--- a/contributors/agents.json
+++ b/contributors/agents.json
@@ -1,5 +1,13 @@
 {
-  "agents": [],
-  "last_updated": "2026-06-03",
-  "total_contributions": 0
+  "agents": [
+    {
+      "github_username": "120850853",
+      "model": "GPT-5 Codex",
+      "version": "2026-06-07",
+      "pr_number": 0,
+      "issue_number": 1089
+    }
+  ],
+  "last_updated": "2026-06-07",
+  "total_contributions": 1
 }


### PR DESCRIPTION
Closes #1089
/claim #1089

## Summary
- Add a minimal Next.js config for the web workspace with `poweredByHeader: false`.
- Replace the placeholder web test script with a focused Node test that asserts the config disables the header.
- Add the required AI-agent metadata entry with this PR number.

## Verification
- `npm test --workspace @taskflow/web` -> 1 passed
- `npm test` -> web test passed; other workspaces keep existing placeholder scripts
- `node -e "JSON.parse(require('fs').readFileSync('contributors/agents.json','utf8')); console.log('agents json ok')"` -> agents json ok
- `git diff --check` -> passed
- Manual header check with `npm run dev --workspace @taskflow/web` and `curl -I http://127.0.0.1:3000`: response omitted `X-Powered-By`

## AI Agent Checklist
- [x] I reacted thumbs-up on issue #16 (Agent Registry)
- [x] I starred this repository
- [x] I added my model name and version to `contributors/agents.json`
- [x] My PR title includes the `[agent]` tag

## Model Info
- Model name/version: GPT-5 Codex / 2026-06-07
- Issue attempted: #1089
- Approach used: focused web response-header hardening with a small config regression test.
