### PR TITLE
Fix seed workflows when bounty labels are missing

### DIFF
--- a/.github/workflows/seed-issues.yml
+++ b/.github/workflows/seed-issues.yml
@@ -11,10 +11,100 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
       - name: Create starter issues
         uses: actions/github-script@v7
         with:
           script: |
+            const fs = require("fs");
+
+            const issueLabels = ["good first issue", "bounty", "AI agent friendly"];
+
+            const loadLabelDefinitions = () => {
+              const content = fs.readFileSync(".github/labels.yml", "utf8");
+              const labels = [];
+              let current = null;
+
+              for (const rawLine of content.split(/\r?\n/)) {
+                const line = rawLine.trim();
+
+                if (!line) {
+                  continue;
+                }
+
+                if (line.startsWith("- name:")) {
+                  if (current) {
+                    labels.push(current);
+                  }
+
+                  current = {
+                    name: line.replace("- name:", "").trim().replace(/^"|"$/g, "")
+                  };
+                  continue;
+                }
+
+                if (!current) {
+                  continue;
+                }
+
+                const separatorIndex = line.indexOf(":");
+
+                if (separatorIndex === -1) {
+                  continue;
+                }
+
+                const key = line.slice(0, separatorIndex).trim();
+                const value = line.slice(separatorIndex + 1).trim().replace(/^"|"$/g, "");
+                current[key] = value;
+              }
+
+              if (current) {
+                labels.push(current);
+              }
+
+              return labels;
+            };
+
+            const ensureLabels = async (requiredNames) => {
+              const definitionsByName = new Map(
+                loadLabelDefinitions().map((label) => [label.name, label])
+              );
+
+              for (const name of requiredNames) {
+                const label = definitionsByName.get(name);
+
+                if (!label) {
+                  throw new Error(`Missing label definition for "${name}" in .github/labels.yml`);
+                }
+
+                const color = label.color.replace(/^#/, "");
+
+                try {
+                  await github.rest.issues.createLabel({
+                    owner: context.repo.owner,
+                    repo: context.repo.repo,
+                    name: label.name,
+                    color,
+                    description: label.description || ""
+                  });
+                } catch (error) {
+                  if (error.status !== 422) {
+                    throw error;
+                  }
+
+                  await github.rest.issues.updateLabel({
+                    owner: context.repo.owner,
+                    repo: context.repo.repo,
+                    name: label.name,
+                    color,
+                    description: label.description || ""
+                  });
+                }
+              }
+            };
+
             const bountyBody = (description) => [
               description,
               "",
@@ -90,12 +180,14 @@ jobs:
               }
             ];
 
+            await ensureLabels(issueLabels);
+
             for (const issue of issues) {
               await github.rest.issues.create({
                 owner: context.repo.owner,
                 repo: context.repo.repo,
                 title: issue.title,
                 body: issue.body,
-                labels: ["good first issue", "bounty", "AI agent friendly"]
+                labels: issueLabels
               });
             }

--- a/.github/workflows/seed-meta-issue.yml
+++ b/.github/workflows/seed-meta-issue.yml
@@ -11,10 +11,100 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
       - name: Create and pin bug bounty program issue
         uses: actions/github-script@v7
         with:
           script: |
+            const fs = require("fs");
+
+            const issueLabels = ["bounty", "good first issue", "AI agent friendly"];
+
+            const loadLabelDefinitions = () => {
+              const content = fs.readFileSync(".github/labels.yml", "utf8");
+              const labels = [];
+              let current = null;
+
+              for (const rawLine of content.split(/\r?\n/)) {
+                const line = rawLine.trim();
+
+                if (!line) {
+                  continue;
+                }
+
+                if (line.startsWith("- name:")) {
+                  if (current) {
+                    labels.push(current);
+                  }
+
+                  current = {
+                    name: line.replace("- name:", "").trim().replace(/^"|"$/g, "")
+                  };
+                  continue;
+                }
+
+                if (!current) {
+                  continue;
+                }
+
+                const separatorIndex = line.indexOf(":");
+
+                if (separatorIndex === -1) {
+                  continue;
+                }
+
+                const key = line.slice(0, separatorIndex).trim();
+                const value = line.slice(separatorIndex + 1).trim().replace(/^"|"$/g, "");
+                current[key] = value;
+              }
+
+              if (current) {
+                labels.push(current);
+              }
+
+              return labels;
+            };
+
+            const ensureLabels = async (requiredNames) => {
+              const definitionsByName = new Map(
+                loadLabelDefinitions().map((label) => [label.name, label])
+              );
+
+              for (const name of requiredNames) {
+                const label = definitionsByName.get(name);
+
+                if (!label) {
+                  throw new Error(`Missing label definition for "${name}" in .github/labels.yml`);
+                }
+
+                const color = label.color.replace(/^#/, "");
+
+                try {
+                  await github.rest.issues.createLabel({
+                    owner: context.repo.owner,
+                    repo: context.repo.repo,
+                    name: label.name,
+                    color,
+                    description: label.description || ""
+                  });
+                } catch (error) {
+                  if (error.status !== 422) {
+                    throw error;
+                  }
+
+                  await github.rest.issues.updateLabel({
+                    owner: context.repo.owner,
+                    repo: context.repo.repo,
+                    name: label.name,
+                    color,
+                    description: label.description || ""
+                  });
+                }
+              }
+            };
+
             const bodyForIssue = (issueNumber) => [
               "This repository runs an open bug bounty program.",
               "",
@@ -35,12 +125,14 @@ jobs:
               "description, the better."
             ].join("\n");
 
+            await ensureLabels(issueLabels);
+
             const createdIssue = await github.rest.issues.create({
               owner: context.repo.owner,
               repo: context.repo.repo,
               title: "Bug Bounty Program — How to Participate",
               body: bodyForIssue("[NUMBER]"),
-              labels: ["bounty", "good first issue", "AI agent friendly"]
+              labels: issueLabels
             });
 
             await github.rest.issues.update({


### PR DESCRIPTION
## Summary

- ensure seed workflows create or update required labels before creating issues
- reuse label definitions from `.github/labels.yml`
- keep seeded issue titles, bodies, bounty markers, and pinning behavior unchanged

## Verification

- Ran a syntax check against both embedded `actions/github-script` blocks by wrapping them in an async function and compiling them with Node.

## Bounty

Refs #957

Payout address for USDC on Base:

`0x76485924c7CA4EFcC03e622441fF3ab633c86143`