### PR TITLE
Disable Express X-Powered-By response header

### DIFF
--- a/apps/api/src/index.ts
+++ b/apps/api/src/index.ts
@@ -5,6 +5,8 @@ import usersRouter from "./routes/users";
 const app = express();
 const port = process.env.PORT || 4000;
 
+app.disable("x-powered-by");
+
 app.use(express.json());
 
 app.get("/health", (_req, res) => {


### PR DESCRIPTION
## Summary

- disable Express' default `x-powered-by` setting during API setup
- keep existing `/health` and `/users` responses unchanged

## Verification

- `npm.cmd install`
- Started the API on `PORT=4107`
- `curl.exe -i -s http://127.0.0.1:4107/health` returned `200 OK` without `X-Powered-By`
- `curl.exe -i -s http://127.0.0.1:4107/users` returned `200 OK` without `X-Powered-By`

## Bounty

Refs #1072

Payout address for USDC on Base:

`0x76485924c7CA4EFcC03e622441fF3ab633c86143`