### PR TITLE
[agent] Disable Express X-Powered-By response header

### DIFF
--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -7,7 +7,7 @@
   "main": "src/index.ts",
   "scripts": {
     "dev": "tsx src/index.ts",
-    "test": "echo \"No API tests configured yet\"",
+    "test": "node --import tsx --test tests/*.test.ts",
     "lint": "echo \"No API lint configured yet\""
   },
   "dependencies": {

--- a/apps/api/src/app.ts
+++ b/apps/api/src/app.ts
@@ -1,0 +1,17 @@
+import express from "express";
+
+import usersRouter from "./routes/users";
+
+const app = express();
+
+app.disable("x-powered-by");
+
+app.use(express.json());
+
+app.get("/health", (_req, res) => {
+  res.json({ status: "ok", service: "taskflow-api" });
+});
+
+app.use("/users", usersRouter);
+
+export default app;

--- a/apps/api/src/index.ts
+++ b/apps/api/src/index.ts
@@ -1,17 +1,6 @@
-import express from "express";
+import app from "./app";
 
-import usersRouter from "./routes/users";
-
-const app = express();
 const port = process.env.PORT || 4000;
-
-app.use(express.json());
-
-app.get("/health", (_req, res) => {
-  res.json({ status: "ok", service: "taskflow-api" });
-});
-
-app.use("/users", usersRouter);
 
 app.listen(port, () => {
   console.log(`TaskFlow API listening on port ${port}`);

--- a/apps/api/tests/powered-by-header.test.ts
+++ b/apps/api/tests/powered-by-header.test.ts
@@ -1,0 +1,22 @@
+import assert from "node:assert/strict";
+import { AddressInfo } from "node:net";
+import test from "node:test";
+
+import app from "../src/app";
+
+test("does not expose the Express X-Powered-By response header", async (t) => {
+  const server = app.listen(0);
+
+  await new Promise<void>((resolve) => {
+    server.once("listening", resolve);
+  });
+
+  t.after(() => {
+    server.close();
+  });
+
+  const address = server.address() as AddressInfo;
+  const response = await fetch(`http://127.0.0.1:${address.port}/health`);
+
+  assert.equal(response.headers.has("x-powered-by"), false);
+});

--- a/contributors/agents.json
+++ b/contributors/agents.json
@@ -1,5 +1,13 @@
 {
-  "agents": [],
-  "last_updated": "2026-06-03",
-  "total_contributions": 0
+  "agents": [
+    {
+      "github_username": "chenshangyi1",
+      "model": "GPT-5 Codex",
+      "version": "2026-06-07",
+      "pr_number": 0,
+      "issue_number": 1072
+    }
+  ],
+  "last_updated": "2026-06-07",
+  "total_contributions": 1
 }


### PR DESCRIPTION
## Summary
- Disable Express' default X-Powered-By header by moving app setup into a reusable module.
- Add a focused regression test that starts the API app and asserts `/health` does not include `x-powered-by`.
- Register the agent metadata for issue #1072.

## Tests
- `npm test`

Closes #1072
