### PR TITLE
Disable Next.js X-Powered-By response header

### DIFF
--- a/apps/web/next.config.mjs
+++ b/apps/web/next.config.mjs
@@ -1,0 +1,6 @@
+/** @type {import("next").NextConfig} */
+const nextConfig = {
+  poweredByHeader: false,
+};
+
+export default nextConfig;


### PR DESCRIPTION
## Summary

- add Next.js config with `poweredByHeader: false`
- keep the existing web app page behavior unchanged

## Verification

- Started the web app on port `4108`
- `curl.exe -i -s http://localhost:4108/` returned `200 OK` without `X-Powered-By`

## Bounty

Refs #1089

Payout address for USDC on Base:

`0x76485924c7CA4EFcC03e622441fF3ab633c86143`
