### PR TITLE
Grant create-labels checkout contents read

### DIFF
--- a/.github/workflows/create-labels.yml
+++ b/.github/workflows/create-labels.yml
@@ -4,6 +4,7 @@ on:
   workflow_dispatch:
 
 permissions:
+  contents: read
   issues: write
 
 jobs:


### PR DESCRIPTION
## Summary

- grant `contents: read` to the `create-labels` workflow
- preserve the existing `issues: write` permission for label creation and updates
- keep the change scoped to `.github/workflows/create-labels.yml`

## Verification

- Reviewed the workflow diff to confirm only the required permission was added.

## Bounty

Refs #910

Payout address for USDC on Base:

`0x76485924c7CA4EFcC03e622441fF3ab633c86143`