### PR TITLE
fix: issue template label + seed workflow dedupe/label guards

### DIFF
--- a/.github/ISSUE_TEMPLATE/task.md
+++ b/.github/ISSUE_TEMPLATE/task.md
@@ -2,7 +2,7 @@
 name: Small task
 about: Small maintenance task for first-time contributors
 title: ""
-labels: good-first-issue
+labels: good first issue
 assignees: ""
 ---
 

--- a/.github/workflows/seed-issues.yml
+++ b/.github/workflows/seed-issues.yml
@@ -11,10 +11,14 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
       - name: Create starter issues
         uses: actions/github-script@v7
         with:
           script: |
+            const fs = require("fs");
             const bountyBody = (description) => [
               description,
               "",
@@ -26,6 +30,66 @@ jobs:
               "",
               "/bounty $50"
             ].join("\n");
+
+            const parseLabels = (content) => {
+              const labels = [];
+              let current = null;
+
+              for (const rawLine of content.split(/\r?\n/)) {
+                const line = rawLine.trim();
+                if (!line) continue;
+
+                if (line.startsWith("- name:")) {
+                  if (current) labels.push(current);
+                  current = {
+                    name: line.replace("- name:", "").trim().replace(/^"|"$/g, "")
+                  };
+                  continue;
+                }
+
+                if (!current) continue;
+
+                const separatorIndex = line.indexOf(":");
+                if (separatorIndex === -1) continue;
+
+                const key = line.slice(0, separatorIndex).trim();
+                const value = line.slice(separatorIndex + 1).trim().replace(/^"|"$/g, "");
+                current[key] = value;
+              }
+
+              if (current) labels.push(current);
+              return labels;
+            };
+
+            const requiredLabelNames = new Set(["good first issue", "bounty", "AI agent friendly"]);
+            const allLabels = parseLabels(fs.readFileSync(".github/labels.yml", "utf8"));
+            const requiredLabels = allLabels.filter((label) => requiredLabelNames.has(label.name));
+
+            for (const label of requiredLabels) {
+              const color = (label.color || "").replace(/^#/, "");
+
+              try {
+                await github.rest.issues.createLabel({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  name: label.name,
+                  color,
+                  description: label.description || ""
+                });
+                core.info(`Created label: ${label.name}`);
+              } catch (error) {
+                if (error.status !== 422) throw error;
+
+                await github.rest.issues.updateLabel({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  name: label.name,
+                  color,
+                  description: label.description || ""
+                });
+                core.info(`Updated label: ${label.name}`);
+              }
+            }
 
             const issues = [
               {
@@ -90,7 +154,26 @@ jobs:
               }
             ];
 
+            const existingTitles = new Set();
+            for await (const page of github.paginate.iterator(github.rest.issues.listForRepo, {
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              state: "all",
+              per_page: 100
+            })) {
+              for (const existingIssue of page.data) {
+                if (!existingIssue.pull_request) {
+                  existingTitles.add(existingIssue.title);
+                }
+              }
+            }
+
             for (const issue of issues) {
+              if (existingTitles.has(issue.title)) {
+                core.info(`Skipping existing starter issue: ${issue.title}`);
+                continue;
+              }
+
               await github.rest.issues.create({
                 owner: context.repo.owner,
                 repo: context.repo.repo,
@@ -98,4 +181,7 @@ jobs:
                 body: issue.body,
                 labels: ["good first issue", "bounty", "AI agent friendly"]
               });
+
+              existingTitles.add(issue.title);
+              core.info(`Created starter issue: ${issue.title}`);
             }

--- a/.github/workflows/seed-meta-issue.yml
+++ b/.github/workflows/seed-meta-issue.yml
@@ -11,10 +11,75 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
       - name: Create and pin bug bounty program issue
         uses: actions/github-script@v7
         with:
           script: |
+            const fs = require("fs");
+
+            const parseLabels = (content) => {
+              const labels = [];
+              let current = null;
+
+              for (const rawLine of content.split(/\r?\n/)) {
+                const line = rawLine.trim();
+                if (!line) continue;
+
+                if (line.startsWith("- name:")) {
+                  if (current) labels.push(current);
+                  current = {
+                    name: line.replace("- name:", "").trim().replace(/^"|"$/g, "")
+                  };
+                  continue;
+                }
+
+                if (!current) continue;
+
+                const separatorIndex = line.indexOf(":");
+                if (separatorIndex === -1) continue;
+
+                const key = line.slice(0, separatorIndex).trim();
+                const value = line.slice(separatorIndex + 1).trim().replace(/^"|"$/g, "");
+                current[key] = value;
+              }
+
+              if (current) labels.push(current);
+              return labels;
+            };
+
+            const requiredLabelNames = new Set(["good first issue", "bounty", "AI agent friendly"]);
+            const allLabels = parseLabels(fs.readFileSync(".github/labels.yml", "utf8"));
+            const requiredLabels = allLabels.filter((label) => requiredLabelNames.has(label.name));
+
+            for (const label of requiredLabels) {
+              const color = (label.color || "").replace(/^#/, "");
+
+              try {
+                await github.rest.issues.createLabel({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  name: label.name,
+                  color,
+                  description: label.description || ""
+                });
+                core.info(`Created label: ${label.name}`);
+              } catch (error) {
+                if (error.status !== 422) throw error;
+
+                await github.rest.issues.updateLabel({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  name: label.name,
+                  color,
+                  description: label.description || ""
+                });
+                core.info(`Updated label: ${label.name}`);
+              }
+            }
+
             const bodyForIssue = (issueNumber) => [
               "This repository runs an open bug bounty program.",
               "",


### PR DESCRIPTION
## Summary
- use canonical `good first issue` label in `.github/ISSUE_TEMPLATE/task.md`
- make `seed-issues.yml` idempotent by skipping issue creation when the same title already exists
- ensure required labels from `.github/labels.yml` exist before both seed workflows run

## Fixes
- #769
- #875
- #957