### PR TITLE
[agent] feat: add type annotations and JSDoc to Button props (Closes #3)

### DIFF
--- a/packages/ui/src/index.ts
+++ b/packages/ui/src/index.ts
@@ -1,9 +1,18 @@
+/** Props for the shared Button component. */
 export type ButtonProps = {
+  /** The text label displayed on the button. */
   label: string;
+  /** Whether the button is disabled. Defaults to false. */
   disabled?: boolean;
 };
 
-export function Button({ label, disabled = false }: ButtonProps) {
+/**
+ * Creates a Button configuration object.
+ * @param label - The text label displayed on the button.
+ * @param disabled - Whether the button is disabled.
+ * @returns A ButtonProps-compatible object with a type discriminator.
+ */
+export function Button({ label, disabled = false }: ButtonProps): ButtonProps & { type: string } {
   return {
     type: "button",
     label,


### PR DESCRIPTION
## Changes

- Added JSDoc comments to ButtonProps type and its properties
- Added explicit return type annotation to Button function
- Added @param JSDoc tags for function parameters
- No changes to runtime behavior or public API shape

Closes #3

/bounty $50
Wallet: `0x7F603CD46BC9C2ff735b8B347ed9F19430A0A131`