### PR TITLE
[agent] docs: document environment variables with .env.example files (Closes #4)

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,5 +81,29 @@ with models for:
 
 ## Environment Variables
 
-Each app/package expects its own .env values for DB, auth, 
-and integrations.
+Each app expects a local `.env` file. Copy the provided examples to get started:
+
+- `apps/api/.env.example` → `apps/api/.env`
+- `apps/web/.env.example` → `apps/web/.env`
+
+### API (`apps/api/.env`)
+
+| Variable | Description |
+|---|---|
+| `DATABASE_URL` | PostgreSQL connection string |
+| `JWT_SECRET` | Secret key for signing access tokens |
+| `JWT_REFRESH_SECRET` | Secret key for signing refresh tokens |
+| `PORT` | API server port (default: `3001`) |
+| `NODE_ENV` | Environment mode (`development` / `production`) |
+| `GOOGLE_CLIENT_ID` | Google OAuth client ID (optional) |
+| `GOOGLE_CLIENT_SECRET` | Google OAuth client secret (optional) |
+| `GITHUB_CLIENT_ID` | GitHub OAuth client ID (optional) |
+| `GITHUB_CLIENT_SECRET` | GitHub OAuth client secret (optional) |
+| `STRIPE_SECRET_KEY` | Stripe secret key (optional) |
+| `STRIPE_WEBHOOK_SECRET` | Stripe webhook secret (optional) |
+
+### Web (`apps/web/.env`)
+
+| Variable | Description |
+|---|---|
+| `NEXT_PUBLIC_API_URL` | Base URL of the API backend |

--- a/apps/api/.env.example
+++ b/apps/api/.env.example
@@ -1,0 +1,20 @@
+# Database
+DATABASE_URL="postgresql://user:password@localhost:5432/taskflow"
+
+# JWT
+JWT_SECRET="your-secret-key"
+JWT_REFRESH_SECRET="your-refresh-secret"
+
+# Server
+PORT=3001
+NODE_ENV=development
+
+# OAuth (optional)
+GOOGLE_CLIENT_ID=""
+GOOGLE_CLIENT_SECRET=""
+GITHUB_CLIENT_ID=""
+GITHUB_CLIENT_SECRET=""
+
+# Stripe (optional)
+STRIPE_SECRET_KEY=""
+STRIPE_WEBHOOK_SECRET=""

--- a/apps/web/.env.example
+++ b/apps/web/.env.example
@@ -1,0 +1,2 @@
+# API Backend URL
+NEXT_PUBLIC_API_URL=http://localhost:3001


### PR DESCRIPTION
## Changes

- Created `apps/api/.env.example` with all expected API environment variables
- Created `apps/web/.env.example` with the web frontend variable
- Updated README with a detailed environment variables table explaining each variable

Closes #4

/bounty $50
Wallet: `0x7F603CD46BC9C2ff735b8B347ed9F19430A0A131`