### PR TITLE
[agent] feat: add input validation to user routes (Closes #6)

### DIFF
--- a/apps/api/src/routes/users.ts
+++ b/apps/api/src/routes/users.ts
@@ -1,7 +1,40 @@
-import { Router } from "express";
+import { Router, Request, Response, NextFunction } from "express";
 
+/**
+ * Validates that the request body contains a valid user payload.
+ * Returns 400 for invalid input.
+ */
+function validateUserBody(req: Request, res: Response, next: NextFunction): void {
+  const { email, name } = req.body;
+
+  if (req.body === undefined || req.body === null || typeof req.body !== "object") {
+    res.status(400).json({ error: "Request body must be a JSON object." });
+    return;
+  }
+
+  if (email !== undefined && typeof email !== "string") {
+    res.status(400).json({ error: "email must be a string." });
+    return;
+  }
+
+  if (name !== undefined && typeof name !== "string") {
+    res.status(400).json({ error: "name must be a string." });
+    return;
+  }
+
+  next();
+}
+
+/**
+ * Express router for user-related endpoints.
+ * Provides stub implementations for user listing and creation.
+ */
 const router = Router();
 
+/**
+ * GET /users
+ * Returns a list of users. Currently returns a stub response.
+ */
 router.get("/", (_req, res) => {
   res.json({
     data: [],
@@ -9,7 +42,12 @@ router.get("/", (_req, res) => {
   });
 });
 
-router.post("/", (req, res) => {
+/**
+ * POST /users
+ * Creates a new user with the provided body. Currently returns a stub response.
+ * Validates that the request body is a valid JSON object.
+ */
+router.post("/", validateUserBody, (req, res) => {
   res.status(201).json({
     data: {
       id: "stub-user-id",


### PR DESCRIPTION
## Changes

- Added a `validateUserBody` middleware that validates incoming POST request bodies
- Returns 400 with a descriptive error message for invalid input shapes
- Validates that the body is a JSON object and optional fields have correct types
- Clean minimal implementation without adding new dependencies

Closes #6

/bounty $50
Wallet: `0x7F603CD46BC9C2ff735b8B347ed9F19430A0A131`