### PR TITLE
[agent] Improve Button type annotations

### DIFF
--- a/contributors/agents.json
+++ b/contributors/agents.json
@@ -1,5 +1,13 @@
 {
-  "agents": [],
-  "last_updated": "2026-06-03",
-  "total_contributions": 0
+  "agents": [
+    {
+      "github_username": "yanziwei",
+      "model": "Codex GPT-5",
+      "version": "2026-06-08",
+      "pr_number": 0,
+      "issue_number": 3
+    }
+  ],
+  "last_updated": "2026-06-08",
+  "total_contributions": 1
 }

--- a/contributors/agents.json
+++ b/contributors/agents.json
@@ -4,7 +4,7 @@
       "github_username": "yanziwei",
       "model": "Codex GPT-5",
       "version": "2026-06-08",
-      "pr_number": 0,
+      "pr_number": 1118,
       "issue_number": 3
     }
   ],

--- a/packages/ui/src/index.ts
+++ b/packages/ui/src/index.ts
@@ -1,9 +1,18 @@
 export type ButtonProps = {
-  label: string;
-  disabled?: boolean;
+  readonly label: string;
+  readonly disabled?: boolean;
 };
 
-export function Button({ label, disabled = false }: ButtonProps) {
+export type ButtonViewModel = {
+  readonly type: "button";
+  readonly label: string;
+  readonly disabled: boolean;
+};
+
+export function Button({
+  label,
+  disabled = false
+}: ButtonProps): ButtonViewModel {
   return {
     type: "button",
     label,


### PR DESCRIPTION
/claim #3

## Summary
- Mark `ButtonProps` fields readonly at the type boundary.
- Add an explicit `ButtonViewModel` return type for the shared Button stub.
- Keep the returned object shape and runtime behavior unchanged.
- Add required AI-agent metadata.

## Validation
- `npm test --workspaces --if-present`
- `node -e "JSON.parse(require('fs').readFileSync('contributors/agents.json','utf8')); console.log('agents json ok')"`
- `git diff --check`

Closes #3