### PR TITLE
Add SEO metadata export to homepage

### DIFF
--- a/apps/web/src/app/page.tsx
+++ b/apps/web/src/app/page.tsx
@@ -1,3 +1,11 @@
+import type { Metadata } from "next";
+
+export const metadata: Metadata = {
+  title: "TaskFlow — Plan, Coordinate, and Manage Tasks",
+  description:
+    "Plan tasks, coordinate jobs, and manage proposals from one workspace. TaskFlow keeps your team organized and productive.",
+};
+
 export default function HomePage() {
   return (
     <main>


### PR DESCRIPTION
## Problem

Closes #837

The homepage at apps/web/src/app/page.tsx exports no metadata object. Next.js App Router uses exported metadata for <title> and <meta> tags. Without it, the page has no title or description — bad for SEO and accessibility.

## Solution

Added an exported metadata const with a descriptive title and description following the Next.js App Router convention. This is a minimal change — just the metadata export, no other changes to the page component.

## Testing

- Verified the metadata object conforms to the Next.js Metadata type
- Title and description accurately reflect the app purpose