### PR TITLE
Add types and exports fields to API package.json

### DIFF
--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -5,6 +5,13 @@
   "description": "Express API service for TaskFlow.",
   "type": "module",
   "main": "src/index.ts",
+  "types": "src/index.ts",
+  "exports": {
+    ".": {
+      "types": "./src/index.ts",
+      "default": "./src/index.ts"
+    }
+  },
   "scripts": {
     "dev": "tsx src/index.ts",
     "test": "echo \"No API tests configured yet\"",


### PR DESCRIPTION
## Problem

Closes #925

apps/api/package.json declares main but does not declare types or an exports map for the API workspace entrypoint. That leaves package consumers and TypeScript tooling without an explicit package contract.

## Solution

Added types and exports fields pointing to src/index.ts, following the same pattern used in other workspace packages. This gives TypeScript and bundlers a clear entrypoint for type resolution.

## Testing

- Verified package.json is valid JSON
- The exports map correctly points to the existing source file