### PR TITLE
Add types and exports fields to UI package.json

### DIFF
--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -4,6 +4,13 @@
   "private": true,
   "description": "Shared UI components for TaskFlow.",
   "main": "src/index.ts",
+  "types": "src/index.ts",
+  "exports": {
+    ".": {
+      "types": "./src/index.ts",
+      "default": "./src/index.ts"
+    }
+  },
   "scripts": {
     "test": "echo \"No UI tests configured yet\"",
     "lint": "echo \"No UI lint configured yet\""


### PR DESCRIPTION
## Problem

Closes #923

packages/ui/package.json only declares main. It does not expose a types entry or an exports map, making the shared UI workspace less predictable for TypeScript consumers in the monorepo.

## Solution

Added types and exports fields pointing to src/index.ts. This provides an explicit package contract so consumers don't have to infer declarations from the source path.

## Testing

- Verified package.json is valid JSON
- The exports map correctly points to the existing source file