### PR TITLE
Add explicit decimal precision to Proposal amount

### DIFF
--- a/packages/db/prisma/schema.prisma
+++ b/packages/db/prisma/schema.prisma
@@ -32,7 +32,7 @@ model Job {
 model Proposal {
   id        String   @id @default(cuid())
   summary   String
-  amount    Decimal?
+  amount    Decimal?  @db.Decimal(12, 2)
   status    String   @default("pending")
   userId    String
   user      User     @relation(fields: [userId], references: [id])


### PR DESCRIPTION
## Problem

Closes #919

packages/db/prisma/schema.prisma models Proposal.amount as a generic optional Decimal without explicit precision and scale. This makes the database column provider-dependent and can allow inconsistent money values.

## Solution

Added @db.Decimal(12, 2) to the amount column. 12 total digits with 2 decimal places is a sensible default for a marketplace proposal amount — supports values up to 9999999999.99 which is more than enough for typical use cases.

## Testing

- Verified the Prisma schema syntax is correct
- The change is backwards compatible (existing null values are unaffected)