### PR TITLE
fix: validate API PORT before server startup (Fixes #1126)

### DIFF
--- a/apps/api/src/index.ts
+++ b/apps/api/src/index.ts
@@ -3,7 +3,23 @@ import express from "express";
 import usersRouter from "./routes/users";
 
 const app = express();
-const port = process.env.PORT || 4000;
+
+/**
+ * Parse a PORT environment variable value.
+ * Returns the parsed integer port (0-65535) or the defaultPort if unset/invalid.
+ * Exits with a clear error message for configured but invalid values.
+ */
+function parsePort(raw: string | undefined, defaultPort: number): number {
+  if (raw === undefined || raw === "") return defaultPort;
+  const port = Number(raw);
+  if (!Number.isInteger(port) || port < 0 || port > 65535 || raw.trim() !== String(port)) {
+    console.error(`Invalid PORT configured: "${raw}". Must be an integer between 0 and 65535.`);
+    process.exit(1);
+  }
+  return port;
+}
+
+const port = parsePort(process.env.PORT, 4000);
 
 app.use(express.json());
 


### PR DESCRIPTION
## What

Added `parsePort()` helper that validates `process.env.PORT` before `app.listen()`.

- Missing `PORT` → defaults to 4000 (unchanged)
- Invalid values (`-1`, `99999`, `"abc"`) → clear startup error, process exits before listening
- Valid integer 0-65535 → passed through

## Why

Prevents crash with `ERR_SOCKET_BAD_PORT` on invalid PORT values.
Non-numeric strings could previously be interpreted as named pipe/socket paths.

## Testing

- `PORT` unset → defaults to 4000
- `PORT=4000` → uses 4000
- `PORT=-1` → startup error: "Invalid PORT configured: \"-1\". Must be an integer between 0 and 65535."
- `PORT=99999` → startup error
- `PORT=abc` → startup error
- `PORT=4000.5` → startup error (not an integer)