### PR TITLE
fix: disable Next.js X-Powered-By response header (Fixes #1089)

### DIFF
--- a/apps/web/next.config.mjs
+++ b/apps/web/next.config.mjs
@@ -1,0 +1,8 @@
+// @ts-check
+
+/** @type {import('next').NextConfig} */
+const nextConfig = {
+  poweredByHeader: false,
+};
+
+export default nextConfig;


### PR DESCRIPTION
## What

Added `next.config.mjs` with `poweredByHeader: false` to remove the `X-Powered-By: Next.js` header from all HTTP responses.

## Why

Security hardening - prevents information disclosure about the web framework in use.

## Testing

1. `curl -sI http://localhost:3000 | grep X-Powered-By` returns nothing
2. Build succeeds with `next build`