### PR TITLE
fix: add explicit decimal precision to Proposal.amount (Fixes #919)

### DIFF
--- a/packages/db/prisma/schema.prisma
+++ b/packages/db/prisma/schema.prisma
@@ -32,7 +32,7 @@ model Job {
 model Proposal {
   id        String   @id @default(cuid())
   summary   String
-  amount    Decimal?
+  amount    Decimal? @db.Decimal(18, 8)
   status    String   @default("pending")
   userId    String
   user      User     @relation(fields: [userId], references: [id])


### PR DESCRIPTION
## What
Added @db.Decimal(18,8) to Proposal.amount
## Why
Consistent precision across DB backends
## Testing
npx prisma validate passes