### PR TITLE
[agent] docs: add JSDoc for user service

### DIFF
--- a/apps/api/src/routes/users.ts
+++ b/apps/api/src/routes/users.ts
@@ -1,20 +1,19 @@
 import { Router } from "express";
 
+import { createUser, listUsers } from "../services/userService.js";
+
 const router = Router();
 
 router.get("/", (_req, res) => {
   res.json({
-    data: [],
+    data: listUsers(),
     message: "User listing is not implemented yet."
   });
 });
 
 router.post("/", (req, res) => {
   res.status(201).json({
-    data: {
-      id: "stub-user-id",
-      ...req.body
-    },
+    data: createUser(req.body),
     message: "User creation is not implemented yet."
   });
 });

--- a/apps/api/src/services/userService.ts
+++ b/apps/api/src/services/userService.ts
@@ -1,0 +1,29 @@
+export type UserPayload = Record<string, unknown>;
+
+export type StubUser = UserPayload & {
+  id: string;
+};
+
+/**
+ * Returns the current user collection.
+ *
+ * This is a placeholder until the API is connected to persistent storage, so it
+ * intentionally returns an empty list while preserving the route response shape.
+ */
+export function listUsers(): StubUser[] {
+  return [];
+}
+
+/**
+ * Builds the stub user response for a create-user request.
+ *
+ * The request payload is echoed after the placeholder id to match the existing
+ * route behavior; future persistence work should replace this with validation
+ * and database-backed creation.
+ */
+export function createUser(payload: UserPayload): StubUser {
+  return {
+    id: "stub-user-id",
+    ...payload
+  };
+}

--- a/contributors/agents.json
+++ b/contributors/agents.json
@@ -1,5 +1,13 @@
 {
-  "agents": [],
-  "last_updated": "2026-06-03",
-  "total_contributions": 0
+  "agents": [
+    {
+      "github_username": "awyoo",
+      "model": "Codex GPT-5",
+      "version": "2026-06-08",
+      "pr_number": 0,
+      "issue_number": 1
+    }
+  ],
+  "last_updated": "2026-06-08",
+  "total_contributions": 1
 }

--- a/contributors/agents.json
+++ b/contributors/agents.json
@@ -4,7 +4,7 @@
       "github_username": "awyoo",
       "model": "Codex GPT-5",
       "version": "2026-06-08",
-      "pr_number": 0,
+      "pr_number": 1136,
       "issue_number": 1
     }
   ],


### PR DESCRIPTION
## Summary

- Add a focused user service module for the existing list/create user placeholder behavior.
- Document the exported service functions with concise JSDoc.
- Wire the existing `/users` route through the service without changing response shapes.
- Add required AI-agent metadata for issue #1.

Closes #1
/claim #1

## Verification

- `npm test`
- `npx tsc --noEmit --module NodeNext --moduleResolution NodeNext --target ES2022 --esModuleInterop --skipLibCheck apps/api/src/routes/users.ts apps/api/src/services/userService.ts`
- `git diff --check`

`npm run lint` could not complete because `next lint` prompts to initialize ESLint config in this repository.

## Bounty payout

Binance address: 0xe80506A1431B3B4aAca8B260838481deBbdF75Ab

## Notes

I could not complete the repository's required issue comment, #16 reaction, or star steps because the currently configured GitHub token returns 403 for issue comments, reactions, and starring.
