### PR TITLE
[agent] types: tighten Button stub annotations

### DIFF
--- a/contributors/agents.json
+++ b/contributors/agents.json
@@ -4,7 +4,7 @@
       "github_username": "awyoo",
       "model": "Codex GPT-5",
       "version": "2026-06-08",
-      "pr_number": 0,
+      "pr_number": 1137,
       "issue_number": 3
     }
   ],

--- a/contributors/agents.json
+++ b/contributors/agents.json
@@ -1,5 +1,13 @@
 {
-  "agents": [],
-  "last_updated": "2026-06-03",
-  "total_contributions": 0
+  "agents": [
+    {
+      "github_username": "awyoo",
+      "model": "Codex GPT-5",
+      "version": "2026-06-08",
+      "pr_number": 0,
+      "issue_number": 3
+    }
+  ],
+  "last_updated": "2026-06-08",
+  "total_contributions": 1
 }

--- a/packages/ui/src/index.ts
+++ b/packages/ui/src/index.ts
@@ -1,9 +1,17 @@
 export type ButtonProps = {
-  label: string;
-  disabled?: boolean;
+  readonly label: string;
+  readonly disabled?: boolean;
 };
 
-export function Button({ label, disabled = false }: ButtonProps) {
+export type ButtonType = "button";
+
+export type ButtonResult = {
+  readonly type: ButtonType;
+  readonly label: string;
+  readonly disabled: boolean;
+};
+
+export function Button({ label, disabled = false }: ButtonProps): ButtonResult {
   return {
     type: "button",
     label,


### PR DESCRIPTION
## Summary

- Add explicit exported types for the shared Button stub return shape.
- Mark Button props/result fields as readonly at the type boundary.
- Annotate the Button function return type while preserving the existing `{ type, label, disabled }` output.
- Add required AI-agent metadata for issue #3.

Closes #3
/claim #3

## Verification

- `npm test -w packages/ui`
- `npx tsc --noEmit --module NodeNext --moduleResolution NodeNext --target ES2022 --skipLibCheck packages/ui/src/index.ts`
- `jq . contributors/agents.json`
- `git diff --check`

## Bounty payout

Binance address: 0xe80506A1431B3B4aAca8B260838481deBbdF75Ab
