### PR TITLE
[agent] fix: limit API JSON request bodies

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,8 @@ The API includes:
 - File uploads and search
 - Admin routes
 
+The Express API accepts JSON request bodies up to `100kb`.
+
 Backend architecture follows:
 - Middleware layer (auth, rate limiting, error handling)
 - Controller layer

--- a/apps/api/src/index.ts
+++ b/apps/api/src/index.ts
@@ -4,8 +4,9 @@ import usersRouter from "./routes/users";
 
 const app = express();
 const port = process.env.PORT || 4000;
+const JSON_BODY_LIMIT = "100kb";
 
-app.use(express.json());
+app.use(express.json({ limit: JSON_BODY_LIMIT }));
 
 app.get("/health", (_req, res) => {
   res.json({ status: "ok", service: "taskflow-api" });

--- a/contributors/agents.json
+++ b/contributors/agents.json
@@ -4,7 +4,7 @@
       "github_username": "awyoo",
       "model": "Codex GPT-5",
       "version": "2026-06-08",
-      "pr_number": 0,
+      "pr_number": 1139,
       "issue_number": 9
     }
   ],

--- a/contributors/agents.json
+++ b/contributors/agents.json
@@ -1,5 +1,13 @@
 {
-  "agents": [],
-  "last_updated": "2026-06-03",
-  "total_contributions": 0
+  "agents": [
+    {
+      "github_username": "awyoo",
+      "model": "Codex GPT-5",
+      "version": "2026-06-08",
+      "pr_number": 0,
+      "issue_number": 9
+    }
+  ],
+  "last_updated": "2026-06-08",
+  "total_contributions": 1
 }


### PR DESCRIPTION
## Summary

- Configure Express JSON parsing with a conservative `100kb` request body limit.
- Document the expected JSON body limit value in the README.
- Add required AI-agent metadata for issue #9.

Closes #9
/claim #9

## Verification

- `npm test -w apps/api`
- `npx tsc --noEmit --module ESNext --moduleResolution Bundler --target ES2022 --esModuleInterop --skipLibCheck apps/api/src/index.ts`
- `jq . contributors/agents.json`
- `git diff --check`

## Bounty payout

Binance address: 0xe80506A1431B3B4aAca8B260838481deBbdF75Ab
