### PR TITLE
fix: add /bounty marker to template (Fixes #687)

### DIFF
--- a/.github/ISSUE_TEMPLATE/bounty_task.md
+++ b/.github/ISSUE_TEMPLATE/bounty_task.md
@@ -16,6 +16,8 @@ Describe the task, expected context, and files likely involved.
 - [ ] Documentation or tests are updated when relevant.
 - [ ] The pull request links this issue.
 
+/bounty $50
+
 ## Bounty Amount
 
 $50


### PR DESCRIPTION
Fixes #687