### PR TITLE
fix: add request body size limit of 100kb (Fixes #9)

### DIFF
--- a/apps/api/src/index.ts
+++ b/apps/api/src/index.ts
@@ -5,7 +5,7 @@ import usersRouter from "./routes/users";
 const app = express();
 const port = process.env.PORT || 4000;
 
-app.use(express.json());
+app.use(express.json({ limit: '100kb' }));
 
 app.get("/health", (_req, res) => {
   res.json({ status: "ok", service: "taskflow-api" });


### PR DESCRIPTION
## What

Configure Express JSON body parser with a 100kb size limit to prevent resource exhaustion from oversized request payloads.

## Why

Without an explicit limit, Express accepts arbitrarily large JSON payloads, making the API vulnerable to memory exhaustion attacks.

## Testing

- Verified `express.json({ limit: '100kb' })` is applied globally
- Requests under 100kb continue to work normally
- `npx tsc --noEmit` passes