### PR TITLE
feat: add readonly modifiers and improve type annotations for ButtonProp

### DIFF
--- a/packages/ui/src/index.ts
+++ b/packages/ui/src/index.ts
@@ -1,6 +1,6 @@
 export type ButtonProps = {
-  label: string;
-  disabled?: boolean;
+  readonly label: string;
+  readonly disabled?: boolean;
 };
 
 export function Button({ label, disabled = false }: ButtonProps) {


### PR DESCRIPTION
为 packages/ui 中的 ButtonProps 类型添加 readonly 修饰符，增强类型安全性，同时保持公共接口不变。