### PR TITLE
[agent] Add type annotations to shared Button props

### DIFF
--- a/packages/ui/src/index.ts
+++ b/packages/ui/src/index.ts
@@ -1,11 +1,17 @@
+/** Props for the shared Button component. */
 export type ButtonProps = {
+  /** Visible text rendered inside the button. */
   label: string;
+  /** When true, the button is non-interactive. @default false */
   disabled?: boolean;
 };
 
-export function Button({ label, disabled = false }: ButtonProps) {
+/** Renders a button descriptor object. */
+export function Button(
+  { label, disabled = false }: Readonly<ButtonProps>
+): Readonly<{ type: "button"; label: string; disabled: boolean }> {
   return {
-    type: "button",
+    type: "button" as const,
     label,
     disabled
   };


### PR DESCRIPTION
Closes #3 - JSDoc comments on ButtonProps/Button, Readonly wrapper, explicit return type, as const for literal narrowing