### PR TITLE
[agent] Add baseline web security headers

### DIFF
--- a/apps/web/next.config.mjs
+++ b/apps/web/next.config.mjs
@@ -1,0 +1,31 @@
+export const securityHeaders = [
+  {
+    key: 'X-Frame-Options',
+    value: 'DENY'
+  },
+  {
+    key: 'X-Content-Type-Options',
+    value: 'nosniff'
+  },
+  {
+    key: 'Referrer-Policy',
+    value: 'strict-origin-when-cross-origin'
+  },
+  {
+    key: 'Permissions-Policy',
+    value: 'camera=(), microphone=(), geolocation=()'
+  }
+];
+
+const nextConfig = {
+  async headers() {
+    return [
+      {
+        source: '/:path*',
+        headers: securityHeaders
+      }
+    ];
+  }
+};
+
+export default nextConfig;

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -5,7 +5,7 @@
   "description": "Next.js web application for TaskFlow.",
   "scripts": {
     "dev": "next dev",
-    "test": "echo \"No web tests configured yet\"",
+    "test": "node scripts/validate-security-headers.mjs",
     "lint": "next lint"
   },
   "dependencies": {

--- a/apps/web/scripts/validate-security-headers.mjs
+++ b/apps/web/scripts/validate-security-headers.mjs
@@ -1,0 +1,29 @@
+import assert from 'node:assert/strict';
+import nextConfig, { securityHeaders } from '../next.config.mjs';
+
+const requiredHeaders = new Map([
+  ['X-Frame-Options', 'DENY'],
+  ['X-Content-Type-Options', 'nosniff'],
+  ['Referrer-Policy', 'strict-origin-when-cross-origin'],
+  ['Permissions-Policy', 'camera=(), microphone=(), geolocation=()']
+]);
+
+assert.equal(typeof nextConfig.headers, 'function', 'nextConfig.headers must be defined');
+
+const routes = await nextConfig.headers();
+assert.equal(routes.length, 1, 'security headers should use one catch-all route');
+assert.equal(routes[0].source, '/:path*', 'security headers should apply to all routes');
+
+const configuredHeaders = new Map(routes[0].headers.map(({ key, value }) => [key, value]));
+
+for (const [key, value] of requiredHeaders) {
+  assert.equal(configuredHeaders.get(key), value, `${key} should be configured`);
+}
+
+assert.deepEqual(
+  securityHeaders.map(({ key }) => key).sort(),
+  [...requiredHeaders.keys()].sort(),
+  'exported securityHeaders should match the validated set'
+);
+
+console.log('baseline security headers configured');

--- a/contributors/agents.json
+++ b/contributors/agents.json
@@ -1,5 +1,12 @@
 {
-  "agents": [],
-  "last_updated": "2026-06-03",
-  "total_contributions": 0
+  "agents": [
+    {
+      "model": "OpenAI Codex GPT-5",
+      "contribution": "Issue #1119 baseline web security response headers",
+      "package": "@taskflow/web",
+      "date": "2026-06-08"
+    }
+  ],
+  "last_updated": "2026-06-08",
+  "total_contributions": 1
 }


### PR DESCRIPTION
/claim #1119

## Summary
- Add a focused `apps/web/next.config.mjs` with baseline security response headers for all routes.
- Configure `X-Frame-Options`, `X-Content-Type-Options`, `Referrer-Policy`, and a conservative `Permissions-Policy`.
- Add `apps/web/scripts/validate-security-headers.mjs` and wire the web workspace test script to validate the header config.
- Update `contributors/agents.json` with the required AI-agent metadata.

## Verification
- `npm test -w @taskflow/web`
- `npm test --workspaces --if-present`
- `jq . contributors/agents.json`
- `git diff --check`

## Notes
- Focused on issue #1119 web response-header hardening.
- No secrets, private keys, wallets, platform initialization text, or private credentials are included.

Refs #1119.