### PR TITLE
[agent] feat: add API error response helper

### DIFF
--- a/apps/api/src/routes/users.ts
+++ b/apps/api/src/routes/users.ts
@@ -1,5 +1,7 @@
 import { Router } from "express";
 
+import { sendApiError } from "../utils/apiError";
+
 const router = Router();
 
 router.get("/", (_req, res) => {
@@ -10,6 +12,15 @@ router.get("/", (_req, res) => {
 });
 
 router.post("/", (req, res) => {
+  if (!req.body || typeof req.body !== "object" || Array.isArray(req.body)) {
+    return sendApiError(
+      res,
+      400,
+      "invalid_request",
+      "User creation expects a JSON object request body."
+    );
+  }
+
   res.status(201).json({
     data: {
       id: "stub-user-id",

--- a/apps/api/src/utils/apiError.ts
+++ b/apps/api/src/utils/apiError.ts
@@ -1,0 +1,28 @@
+import type { Response } from "express";
+
+export type ApiErrorCode = "invalid_request";
+
+export type ApiErrorResponse = {
+  status: "error";
+  error: {
+    code: ApiErrorCode;
+    message: string;
+  };
+};
+
+export function sendApiError(
+  res: Response,
+  statusCode: number,
+  code: ApiErrorCode,
+  message: string
+) {
+  const body: ApiErrorResponse = {
+    status: "error",
+    error: {
+      code,
+      message
+    }
+  };
+
+  return res.status(statusCode).json(body);
+}

--- a/contributors/agents.json
+++ b/contributors/agents.json
@@ -4,7 +4,7 @@
       "github_username": "awyoo",
       "model": "Codex GPT-5",
       "version": "2026-06-08",
-      "pr_number": 0,
+      "pr_number": 1166,
       "issue_number": 7
     }
   ],

--- a/contributors/agents.json
+++ b/contributors/agents.json
@@ -1,5 +1,13 @@
 {
-  "agents": [],
-  "last_updated": "2026-06-03",
-  "total_contributions": 0
+  "agents": [
+    {
+      "github_username": "awyoo",
+      "model": "Codex GPT-5",
+      "version": "2026-06-08",
+      "pr_number": 0,
+      "issue_number": 7
+    }
+  ],
+  "last_updated": "2026-06-08",
+  "total_contributions": 1
 }


### PR DESCRIPTION
## Summary

- Add a small shared API error response helper for Express routes.
- Use the helper from `POST /users` when the request body is not a JSON object.
- Preserve existing user route success responses.
- Add required AI-agent metadata for issue #7.

Closes #7
/claim #7

## Verification

- `npm test -w apps/api`
- `npx tsc --noEmit --module ESNext --moduleResolution Bundler --target ES2022 --esModuleInterop --skipLibCheck apps/api/src/routes/users.ts apps/api/src/utils/apiError.ts`
- `jq . contributors/agents.json`
- `git diff --check`

## Bounty payout

Binance address: 0xe80506A1431B3B4aAca8B260838481deBbdF75Ab
