### PR TITLE
[agent] fix(api): add graceful shutdown handling

### DIFF
--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -7,7 +7,7 @@
   "main": "src/index.ts",
   "scripts": {
     "dev": "tsx src/index.ts",
-    "test": "echo \"No API tests configured yet\"",
+    "test": "tsx --test src/graceful-shutdown.test.ts",
     "lint": "echo \"No API lint configured yet\""
   },
   "dependencies": {

--- a/apps/api/src/graceful-shutdown.test.ts
+++ b/apps/api/src/graceful-shutdown.test.ts
@@ -72,3 +72,42 @@ test("graceful shutdown ignores duplicate signals while closing", async () => {
 
   assert.equal(closeCalls, 1);
 });
+
+test("graceful shutdown exits with failure when the server cannot close", async () => {
+  const events: string[] = [];
+  let exitCode: number | undefined;
+
+  const shutdown = installGracefulShutdown(
+    {
+      close(callback: (error?: Error) => void) {
+        queueMicrotask(() => callback(new Error("close failed")));
+        return this as never;
+      },
+    },
+    {
+      signals: [],
+      timeoutMs: 100,
+      exit(code) {
+        exitCode = code;
+        return undefined as never;
+      },
+      logger: {
+        log(message: string) {
+          events.push(message);
+        },
+        error(message: string) {
+          events.push(message);
+        },
+      },
+    },
+  );
+
+  shutdown("SIGTERM");
+  await new Promise((resolve) => setImmediate(resolve));
+
+  assert.equal(exitCode, 1);
+  assert.deepEqual(events, [
+    "Received SIGTERM; closing TaskFlow API gracefully",
+    "TaskFlow API shutdown failed",
+  ]);
+});

--- a/apps/api/src/graceful-shutdown.test.ts
+++ b/apps/api/src/graceful-shutdown.test.ts
@@ -1,0 +1,74 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+
+import { installGracefulShutdown } from "./index";
+
+test("graceful shutdown closes the server and exits cleanly", async () => {
+  const events: string[] = [];
+  let closeCalled = false;
+  let exitCode: number | undefined;
+
+  const shutdown = installGracefulShutdown(
+    {
+      close(callback: (error?: Error) => void) {
+        closeCalled = true;
+        queueMicrotask(callback);
+        return this as never;
+      },
+    },
+    {
+      signals: [],
+      timeoutMs: 100,
+      exit(code) {
+        exitCode = code;
+        return undefined as never;
+      },
+      logger: {
+        log(message: string) {
+          events.push(message);
+        },
+        error(message: string) {
+          events.push(message);
+        },
+      },
+    },
+  );
+
+  shutdown("SIGTERM");
+  await new Promise((resolve) => setImmediate(resolve));
+
+  assert.equal(closeCalled, true);
+  assert.equal(exitCode, 0);
+  assert.deepEqual(events, [
+    "Received SIGTERM; closing TaskFlow API gracefully",
+    "TaskFlow API closed cleanly",
+  ]);
+});
+
+test("graceful shutdown ignores duplicate signals while closing", async () => {
+  let closeCalls = 0;
+
+  const shutdown = installGracefulShutdown(
+    {
+      close() {
+        closeCalls += 1;
+        return this as never;
+      },
+    },
+    {
+      signals: [],
+      exit(code) {
+        return undefined as never;
+      },
+      logger: {
+        log() {},
+        error() {},
+      },
+    },
+  );
+
+  shutdown("SIGTERM");
+  shutdown("SIGINT");
+
+  assert.equal(closeCalls, 1);
+});

--- a/apps/api/src/index.ts
+++ b/apps/api/src/index.ts
@@ -1,9 +1,11 @@
 import express from "express";
+import type { Server } from "node:http";
 
 import usersRouter from "./routes/users";
 
 const app = express();
 const port = process.env.PORT || 4000;
+const shutdownTimeoutMs = 10_000;
 
 app.use(express.json());
 
@@ -13,6 +15,62 @@ app.get("/health", (_req, res) => {
 
 app.use("/users", usersRouter);
 
-app.listen(port, () => {
-  console.log(`TaskFlow API listening on port ${port}`);
-});
+export function installGracefulShutdown(
+  server: Pick<Server, "close">,
+  options: {
+    signals?: NodeJS.Signals[];
+    timeoutMs?: number;
+    exit?: (code: number) => never;
+    logger?: Pick<typeof console, "log" | "error">;
+  } = {},
+) {
+  const signals = options.signals ?? ["SIGTERM", "SIGINT"];
+  const timeoutMs = options.timeoutMs ?? shutdownTimeoutMs;
+  const exit = options.exit ?? process.exit;
+  const logger = options.logger ?? console;
+  let shuttingDown = false;
+
+  const shutdown = (signal: NodeJS.Signals) => {
+    if (shuttingDown) {
+      return;
+    }
+
+    shuttingDown = true;
+    logger.log(`Received ${signal}; closing TaskFlow API gracefully`);
+
+    const forcedExit = setTimeout(() => {
+      logger.error(`Forced shutdown after ${timeoutMs}ms`);
+      exit(1);
+    }, timeoutMs);
+    forcedExit.unref?.();
+
+    server.close((error?: Error) => {
+      clearTimeout(forcedExit);
+      if (error) {
+        logger.error("TaskFlow API shutdown failed", error);
+        exit(1);
+      }
+
+      logger.log("TaskFlow API closed cleanly");
+      exit(0);
+    });
+  };
+
+  for (const signal of signals) {
+    process.once(signal, shutdown);
+  }
+
+  return shutdown;
+}
+
+export function startServer() {
+  const server = app.listen(port, () => {
+    console.log(`TaskFlow API listening on port ${port}`);
+  });
+  installGracefulShutdown(server);
+  return server;
+}
+
+if (import.meta.url === `file://${process.argv[1]}`) {
+  startServer();
+}

--- a/apps/api/src/index.ts
+++ b/apps/api/src/index.ts
@@ -48,7 +48,7 @@ export function installGracefulShutdown(
       clearTimeout(forcedExit);
       if (error) {
         logger.error("TaskFlow API shutdown failed", error);
-        exit(1);
+        return exit(1);
       }
 
       logger.log("TaskFlow API closed cleanly");

--- a/contributors/agents.json
+++ b/contributors/agents.json
@@ -1,5 +1,13 @@
 {
-  "agents": [],
-  "last_updated": "2026-06-03",
-  "total_contributions": 0
+  "agents": [
+    {
+      "github_username": "aviu16",
+      "model": "Codex GPT-5",
+      "version": "GPT-5",
+      "pr_number": 0,
+      "issue_number": 1165
+    }
+  ],
+  "last_updated": "2026-06-08",
+  "total_contributions": 1
 }

--- a/contributors/agents.json
+++ b/contributors/agents.json
@@ -4,7 +4,7 @@
       "github_username": "aviu16",
       "model": "Codex GPT-5",
       "version": "GPT-5",
-      "pr_number": 0,
+      "pr_number": 1167,
       "issue_number": 1165
     }
   ],


### PR DESCRIPTION
/claim #1165

Closes #1165

## Summary
- Wrap API startup in a reusable `startServer()` helper.
- Add graceful `SIGTERM` and `SIGINT` handling around the HTTP server.
- Stop accepting new connections with `server.close()`, allow in-flight requests to finish, and use a bounded forced-shutdown timeout.
- Add focused `node:test` coverage for clean shutdown and duplicate signal handling.
- Add required AI-agent metadata in `contributors/agents.json` with PR #1167 and issue #1165.

## Verification
- `npm test -w @taskflow/api`
- `npm test --workspaces --if-present`
- `node -e "JSON.parse(require('fs').readFileSync('contributors/agents.json','utf8')); console.log('agents json ok')"`
- `git diff --check`

Payment details can be provided privately after maintainer acceptance.