### PR TITLE
[agent] fix: validate user creation payloads

### DIFF
--- a/apps/api/src/routes/users.ts
+++ b/apps/api/src/routes/users.ts
@@ -2,6 +2,26 @@ import { Router } from "express";
 
 const router = Router();
 
+type CreateUserPayload = {
+  name: string;
+  email: string;
+};
+
+function isCreateUserPayload(body: unknown): body is CreateUserPayload {
+  if (!body || typeof body !== "object" || Array.isArray(body)) {
+    return false;
+  }
+
+  const payload = body as Partial<Record<keyof CreateUserPayload, unknown>>;
+
+  return (
+    typeof payload.name === "string" &&
+    payload.name.trim().length > 0 &&
+    typeof payload.email === "string" &&
+    payload.email.trim().length > 0
+  );
+}
+
 router.get("/", (_req, res) => {
   res.json({
     data: [],
@@ -10,10 +30,21 @@ router.get("/", (_req, res) => {
 });
 
 router.post("/", (req, res) => {
+  if (!isCreateUserPayload(req.body)) {
+    return res.status(400).json({
+      error: {
+        code: "invalid_user_payload",
+        message: "User creation requires non-empty name and email fields."
+      }
+    });
+  }
+
   res.status(201).json({
     data: {
       id: "stub-user-id",
-      ...req.body
+      ...req.body,
+      name: req.body.name.trim(),
+      email: req.body.email.trim()
     },
     message: "User creation is not implemented yet."
   });

--- a/contributors/agents.json
+++ b/contributors/agents.json
@@ -4,7 +4,7 @@
       "github_username": "awyoo",
       "model": "Codex GPT-5",
       "version": "2026-06-08",
-      "pr_number": 0,
+      "pr_number": 1169,
       "issue_number": 6
     }
   ],

--- a/contributors/agents.json
+++ b/contributors/agents.json
@@ -1,5 +1,13 @@
 {
-  "agents": [],
-  "last_updated": "2026-06-03",
-  "total_contributions": 0
+  "agents": [
+    {
+      "github_username": "awyoo",
+      "model": "Codex GPT-5",
+      "version": "2026-06-08",
+      "pr_number": 0,
+      "issue_number": 6
+    }
+  ],
+  "last_updated": "2026-06-08",
+  "total_contributions": 1
 }


### PR DESCRIPTION
## Summary

- Add lightweight validation for the `POST /users` stub payload.
- Require a JSON object with non-empty `name` and `email` string fields.
- Return a clear `400` error response for invalid request shapes.
- Preserve the existing successful stub response shape while trimming accepted values.
- Add required AI-agent metadata for issue #6.

Closes #6
/claim #6

## Verification

- `npm test -w apps/api`
- `npx tsc --noEmit --module ESNext --moduleResolution Bundler --target ES2022 --esModuleInterop --skipLibCheck apps/api/src/routes/users.ts`
- `jq . contributors/agents.json`
- `git diff --check`

## Bounty payout

Binance address: 0xe80506A1431B3B4aAca8B260838481deBbdF75Ab
