### PR TITLE
[Bug] Add API graceful shutdown handling

### DIFF
--- a/apps/api/src/index.ts
+++ b/apps/api/src/index.ts
@@ -4,6 +4,7 @@ import usersRouter from "./routes/users";
 
 const app = express();
 const port = process.env.PORT || 4000;
+const shutdownTimeoutMs = 10_000;
 
 app.use(express.json());
 
@@ -13,6 +14,38 @@ app.get("/health", (_req, res) => {
 
 app.use("/users", usersRouter);
 
-app.listen(port, () => {
+const server = app.listen(port, () => {
   console.log(`TaskFlow API listening on port ${port}`);
 });
+
+let isShuttingDown = false;
+
+function shutdown(signal: string) {
+  if (isShuttingDown) {
+    return;
+  }
+
+  isShuttingDown = true;
+  console.log(`Received ${signal}. Closing TaskFlow API server...`);
+
+  const timeout = setTimeout(() => {
+    console.error("Graceful shutdown timed out. Forcing exit.");
+    process.exit(1);
+  }, shutdownTimeoutMs);
+  timeout.unref();
+
+  server.close((error) => {
+    clearTimeout(timeout);
+
+    if (error) {
+      console.error("TaskFlow API server failed to close cleanly.", error);
+      process.exit(1);
+    }
+
+    console.log("TaskFlow API server closed cleanly.");
+    process.exit(0);
+  });
+}
+
+process.on("SIGTERM", () => shutdown("SIGTERM"));
+process.on("SIGINT", () => shutdown("SIGINT"));


### PR DESCRIPTION
## Summary
- add SIGTERM/SIGINT shutdown handling around the API server
- stop accepting new connections and close the HTTP server before exiting
- add a 10 second timeout fallback so shutdown cannot hang indefinitely

## Validation
- npm.cmd test --workspace @taskflow/api
- npm.cmd run lint --workspace @taskflow/api
- node --import tsx health smoke for /health
- semantic shutdown checks for server.close, signal handlers, timeout fallback, and clean exit
- git diff --check

Closes #1130
/claim #1130