### PR TITLE
[agent] feat: normalize health check response shape (#8)

### DIFF
--- a/apps/api/src/index.ts
+++ b/apps/api/src/index.ts
@@ -8,7 +8,12 @@ const port = process.env.PORT || 4000;
 app.use(express.json());
 
 app.get("/health", (_req, res) => {
-  res.json({ status: "ok", service: "taskflow-api" });
+  res.json({
+    status: "ok",
+    service: "taskflow-api",
+    timestamp: new Date().toISOString(),
+    uptime: process.uptime(),
+  });
 });
 
 app.use("/users", usersRouter);


### PR DESCRIPTION
Extends the `/health` endpoint to return `timestamp` and `uptime` alongside `status` and `service` for a consistent response shape.

Closes #8