### PR TITLE
[agent] feat: add missing API route stubs (#10)

### DIFF
--- a/apps/api/src/routes/users.ts
+++ b/apps/api/src/routes/users.ts
@@ -19,4 +19,19 @@ router.post("/", (req, res) => {
   });
 });
 
+/** GET /users/:id - Returns a single user by ID (stub). */
+router.get("/:id", (_req, res) => {
+  res.status(501).json({ data: null, message: "User detail is not implemented yet." });
+});
+
+/** PUT /users/:id - Updates a user by ID (stub). */
+router.put("/:id", (_req, res) => {
+  res.status(501).json({ data: null, message: "User update is not implemented yet." });
+});
+
+/** DELETE /users/:id - Deletes a user by ID (stub). */
+router.delete("/:id", (_req, res) => {
+  res.status(501).json({ data: null, message: "User deletion is not implemented yet." });
+});
+
 export default router;


### PR DESCRIPTION
Adds stub implementations for `GET /users/:id`, `PUT /users/:id`, and `DELETE /users/:id` returning 501 with descriptive messages. Improves API route TODO coverage.

Closes #10