### PR TITLE
[agent] docs: add Prisma model comments

### DIFF
--- a/contributors/agents.json
+++ b/contributors/agents.json
@@ -1,5 +1,13 @@
 {
-  "agents": [],
-  "last_updated": "2026-06-03",
-  "total_contributions": 0
+  "agents": [
+    {
+      "github_username": "awyoo",
+      "model": "Codex GPT-5",
+      "version": "2026-06-08",
+      "pr_number": 1185,
+      "issue_number": 5
+    }
+  ],
+  "last_updated": "2026-06-08",
+  "total_contributions": 1
 }

--- a/packages/db/prisma/schema.prisma
+++ b/packages/db/prisma/schema.prisma
@@ -7,6 +7,7 @@ datasource db {
   url      = env("DATABASE_URL")
 }
 
+/// Represents a TaskFlow account that can own jobs and submit proposals.
 model User {
   id        String     @id @default(cuid())
   email     String     @unique
@@ -17,6 +18,7 @@ model User {
   updatedAt DateTime   @updatedAt
 }
 
+/// Represents a posted task or project that can receive freelancer proposals.
 model Job {
   id          String     @id @default(cuid())
   title       String
@@ -29,6 +31,7 @@ model Job {
   updatedAt   DateTime   @updatedAt
 }
 
+/// Represents a user's offer to complete a job, including amount and review status.
 model Proposal {
   id        String   @id @default(cuid())
   summary   String


### PR DESCRIPTION
/claim #5

## Summary

- Add concise Prisma documentation comments for the `User`, `Job`, and `Proposal` models.
- Explain each model's role in the TaskFlow domain.
- Keep schema fields and runtime behavior unchanged.

## Verification

- `jq . contributors/agents.json >/dev/null`
- `npm test -w @taskflow/db`
- `npm test -- --if-present`
- `DATABASE_URL='postgresql://user:pass@localhost:5432/taskflow' npx prisma validate --schema packages/db/prisma/schema.prisma`
- `git diff --check`

## Bounty

Payout address: `0xe80506A1431B3B4aAca8B260838481deBbdF75Ab`

Demo video: https://github.com/awyoo/agent-playground/releases/download/bounty-demo-assets/pr-1185-demo.mp4
