### PR TITLE
[agent] Return 405 for unsupported user methods

### DIFF
--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -7,7 +7,7 @@
   "main": "src/index.ts",
   "scripts": {
     "dev": "tsx src/index.ts",
-    "test": "echo \"No API tests configured yet\"",
+    "test": "tsx scripts/validate-users-methods.ts",
     "lint": "echo \"No API lint configured yet\""
   },
   "dependencies": {

--- a/apps/api/scripts/validate-users-methods.ts
+++ b/apps/api/scripts/validate-users-methods.ts
@@ -1,0 +1,97 @@
+import { spawn } from "node:child_process";
+import { fileURLToPath } from "node:url";
+
+const port = 4800 + Math.floor(Math.random() * 1000);
+const baseUrl = `http://127.0.0.1:${port}`;
+const tsxCommand = process.platform === "win32" ? "tsx.cmd" : "tsx";
+
+const server = spawn(tsxCommand, ["src/index.ts"], {
+  cwd: fileURLToPath(new URL("..", import.meta.url)),
+  env: {
+    ...process.env,
+    PORT: String(port)
+  },
+  stdio: ["ignore", "pipe", "pipe"]
+});
+
+let serverOutput = "";
+let serverError: Error | undefined;
+server.stdout.on("data", (chunk) => {
+  serverOutput += chunk.toString();
+});
+server.stderr.on("data", (chunk) => {
+  serverOutput += chunk.toString();
+});
+server.on("error", (error) => {
+  serverError = error;
+});
+
+async function waitForServer() {
+  const deadline = Date.now() + 10_000;
+
+  while (Date.now() < deadline) {
+    if (serverError) {
+      throw serverError;
+    }
+
+    try {
+      const response = await fetch(`${baseUrl}/health`);
+      if (response.ok) {
+        return;
+      }
+    } catch {
+      await new Promise((resolve) => setTimeout(resolve, 100));
+    }
+  }
+
+  throw new Error(`API did not start on ${baseUrl}\n${serverOutput}`);
+}
+
+async function assertResponse(condition: boolean, message: string) {
+  if (!condition) {
+    throw new Error(message);
+  }
+}
+
+async function run() {
+  await waitForServer();
+
+  const listResponse = await fetch(`${baseUrl}/users`);
+  await assertResponse(listResponse.status === 200, "GET /users should still return 200");
+
+  const createResponse = await fetch(`${baseUrl}/users`, {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json"
+    },
+    body: JSON.stringify({ name: "Ada Lovelace", email: "ada@example.com" })
+  });
+  await assertResponse(createResponse.status === 201, "POST /users should still return 201");
+
+  const deleteResponse = await fetch(`${baseUrl}/users`, {
+    method: "DELETE"
+  });
+  const deleteBody = await deleteResponse.json();
+
+  await assertResponse(deleteResponse.status === 405, "DELETE /users should return 405");
+  await assertResponse(
+    deleteResponse.headers.get("allow") === "GET, POST",
+    "DELETE /users should expose Allow: GET, POST"
+  );
+  await assertResponse(
+    deleteBody.error?.code === "method_not_allowed",
+    "DELETE /users should return a method_not_allowed error"
+  );
+  await assertResponse(
+    Array.isArray(deleteBody.error?.allowedMethods) &&
+      deleteBody.error.allowedMethods.join(",") === "GET,POST",
+    "DELETE /users should list the supported methods"
+  );
+}
+
+try {
+  await run();
+  console.log("users method validation passed");
+} finally {
+  server.kill("SIGTERM");
+}

--- a/apps/api/src/routes/users.ts
+++ b/apps/api/src/routes/users.ts
@@ -1,6 +1,7 @@
 import { Router } from "express";
 
 const router = Router();
+const allowedUserCollectionMethods = ["GET", "POST"] as const;
 
 router.get("/", (_req, res) => {
   res.json({
@@ -16,6 +17,17 @@ router.post("/", (req, res) => {
       ...req.body
     },
     message: "User creation is not implemented yet."
+  });
+});
+
+router.all("/", (req, res) => {
+  res.set("Allow", allowedUserCollectionMethods.join(", "));
+  res.status(405).json({
+    error: {
+      code: "method_not_allowed",
+      message: `${req.method} is not supported for /users.`,
+      allowedMethods: allowedUserCollectionMethods
+    }
   });
 });
 

--- a/contributors/agents.json
+++ b/contributors/agents.json
@@ -1,5 +1,13 @@
 {
-  "agents": [],
-  "last_updated": "2026-06-03",
-  "total_contributions": 0
+  "agents": [
+    {
+      "github": "michaelapollopimentel-svg",
+      "model": "Codex GPT-5",
+      "issue": 1168,
+      "approach": "Added a focused /users 405 Method Not Allowed fallback with executable API validation.",
+      "date": "2026-06-08"
+    }
+  ],
+  "last_updated": "2026-06-08",
+  "total_contributions": 1
 }


### PR DESCRIPTION
## Description
Adds a focused `/users` route fallback for unsupported collection methods so known-resource method mistakes return `405 Method Not Allowed` instead of falling through as a generic not-found response.

Closes #1168
/claim #1168

## AI Agent Checklist
- [x] I reacted 👍 on issue #1 (Agent Registry)
- [x] I starred this repository
- [x] I added my model name and version to `contributors/agents.json`
- [x] My PR title includes the `[agent]` tag

## Changes Made
- Added a route-level `router.all("/")` fallback after the existing `GET /users` and `POST /users` handlers.
- Returns `405` with `Allow: GET, POST` and a JSON `method_not_allowed` error for unsupported `/users` collection methods.
- Preserves current GET/POST response shapes.
- Added `apps/api/scripts/validate-users-methods.ts` and wired it to the API `test` script.

## Model Info (AI agents only)
- Model name/version: Codex GPT-5
- Issue attempted: #1168
- Approach used: scoped Express route fallback plus focused API validation script.

## Validation
- `node --experimental-strip-types --check apps/api/scripts/validate-users-methods.ts` passed.
- JSON parse check for `contributors/agents.json`, `apps/api/package.json`, and root `package.json` passed.
- `git diff --check` passed.
- `npm test --workspace @taskflow/api` could not be run in this local Codex runtime because no local `npm`/`tsx` binary or installed workspace dependencies are available; the PR wires the executable test for environments with normal repo dependencies installed.
