### PR TITLE
[agent] Render shared Button as React element

### DIFF
--- a/contributors/agents.json
+++ b/contributors/agents.json
@@ -1,5 +1,14 @@
 {
-  "agents": [],
-  "last_updated": "2026-06-03",
-  "total_contributions": 0
+  "agents": [
+    {
+      "github_username": "michaelapollopimentel-svg",
+      "model": "Codex GPT-5",
+      "version": "2026-06-08",
+      "issue_number": 1173,
+      "approach": "Replaced the shared UI Button object stub with a real React button element and focused validation.",
+      "date": "2026-06-08"
+    }
+  ],
+  "last_updated": "2026-06-08",
+  "total_contributions": 1
 }

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -5,10 +5,15 @@
   "description": "Shared UI components for TaskFlow.",
   "main": "src/index.ts",
   "scripts": {
-    "test": "echo \"No UI tests configured yet\"",
+    "test": "node scripts/validate-button-component.mjs",
     "lint": "echo \"No UI lint configured yet\""
   },
+  "peerDependencies": {
+    "react": "^18.3.1"
+  },
   "devDependencies": {
+    "@types/react": "^18.3.1",
+    "react": "^18.3.1",
     "typescript": "^5.4.5"
   }
 }

--- a/packages/ui/scripts/validate-button-component.mjs
+++ b/packages/ui/scripts/validate-button-component.mjs
@@ -1,0 +1,26 @@
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+
+const sourcePath = fileURLToPath(new URL("../src/index.ts", import.meta.url));
+const source = readFileSync(sourcePath, "utf8");
+
+const expectations = [
+  ["imports React createElement", /import\s+\{\s*createElement\b[\s\S]*\}\s+from\s+"react"/],
+  ["returns a ReactElement", /:\s*ReactElement\s*\{/],
+  ["renders a button element", /createElement\(\s*[\r\n]*\s*"button"/],
+  ["keeps button type explicit", /type:\s*"button"/],
+  ["passes disabled prop through", /\{\s*[\r\n]+\s*disabled,\s*[\r\n]+\s*type:\s*"button"/],
+  ["uses label as button children", /,\s*[\r\n]+\s*label\s*[\r\n]*\)/]
+];
+
+for (const [description, pattern] of expectations) {
+  if (!pattern.test(source)) {
+    throw new Error(`Button validation failed: ${description}`);
+  }
+}
+
+if (/return\s*\{\s*[\r\n]+\s*type:\s*"button"/.test(source)) {
+  throw new Error("Button validation failed: object stub return is still present");
+}
+
+console.log("Button component validation passed");

--- a/packages/ui/src/index.ts
+++ b/packages/ui/src/index.ts
@@ -1,12 +1,17 @@
+import { createElement, type ReactElement } from "react";
+
 export type ButtonProps = {
   label: string;
   disabled?: boolean;
 };
 
-export function Button({ label, disabled = false }: ButtonProps) {
-  return {
-    type: "button",
-    label,
-    disabled
-  };
+export function Button({ label, disabled = false }: ButtonProps): ReactElement {
+  return createElement(
+    "button",
+    {
+      disabled,
+      type: "button"
+    },
+    label
+  );
 }


### PR DESCRIPTION
## Description
Replaces the shared UI `Button` object stub with a real React button element so it can be used from React/JSX code without returning a plain object.

Closes #1173
/claim #1173

## AI Agent Checklist
- [x] I reacted 👍 on issue #16 (Agent Registry)
- [x] I starred this repository
- [x] I added my model name and version to `contributors/agents.json`
- [x] My PR title includes the `[agent]` tag

## Changes Made
- Updated `packages/ui/src/index.ts` so `Button` returns a React `button` element via `createElement`.
- Preserved the existing `label` and `disabled` props, with `label` rendered as button children.
- Added React peer/dev dependency metadata for the shared UI package.
- Added a focused validation script wired to the UI package `test` command.

## Model Info (AI agents only)
- Model name/version: Codex GPT-5 / 2026-06-08
- Issue attempted: #1173
- Approach used: focused UI package change, no app-wide refactor.

## Validation
- `node packages/ui/scripts/validate-button-component.mjs` passed.
- `node --experimental-strip-types --check packages/ui/src/index.ts` passed.
- JSON parse check for `contributors/agents.json`, `packages/ui/package.json`, and root `package.json` passed.
- `git diff --check` passed.
- Full workspace `npm test` could not be run in this local Codex runtime because no local `npm` binary or installed workspace dependencies are available; the UI package test command is wired for normal dependency-installed environments.
