### PR TITLE
[agent] docs: document local environment variables

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,5 +81,11 @@ with models for:
 
 ## Environment Variables
 
-Each app/package expects its own .env values for DB, auth, 
-and integrations.
+Use local `.env` files for values that differ between machines. The current codebase expects:
+
+- `apps/api/.env`
+  - `PORT` — optional API port. Defaults to `4000` when unset.
+- `packages/db/.env`
+  - `DATABASE_URL` — PostgreSQL connection string used by Prisma.
+- `apps/web/.env.local`
+  - No required variables yet. Add web-only values here when the frontend starts reading environment configuration.

--- a/contributors/agents.json
+++ b/contributors/agents.json
@@ -1,5 +1,13 @@
 {
-  "agents": [],
-  "last_updated": "2026-06-03",
-  "total_contributions": 0
+  "agents": [
+    {
+      "github_username": "awyoo",
+      "model": "Codex GPT-5",
+      "version": "2026-06-08",
+      "pr_number": 1190,
+      "issue_number": 4
+    }
+  ],
+  "last_updated": "2026-06-08",
+  "total_contributions": 1
 }


### PR DESCRIPTION
/claim #4

## Summary

- Replace the generic README environment note with concrete local environment guidance.
- Document the API `PORT`, Prisma `DATABASE_URL`, and current web app no-required-env state.
- Keep the change documentation-only.

## Verification

- `jq . contributors/agents.json >/dev/null`
- `npm test -- --if-present`
- `git diff --check`

## Bounty

Payout address: `0xe80506A1431B3B4aAca8B260838481deBbdF75Ab`

Demo video: https://github.com/awyoo/agent-playground/releases/download/bounty-demo-assets/pr-1190-demo.mp4
