### PR TITLE
[agent] docs: clarify user route TODOs

### DIFF
--- a/apps/api/src/routes/users.ts
+++ b/apps/api/src/routes/users.ts
@@ -3,6 +3,8 @@ import { Router } from "express";
 const router = Router();
 
 router.get("/", (_req, res) => {
+  // TODO: Replace this stub with a service-backed user listing that supports
+  // pagination and returns a consistent error response when the datastore fails.
   res.json({
     data: [],
     message: "User listing is not implemented yet."
@@ -10,6 +12,9 @@ router.get("/", (_req, res) => {
 });
 
 router.post("/", (req, res) => {
+  // TODO: Validate the create-user payload before persistence, reject duplicate
+  // emails with a conflict response, and surface service errors without echoing
+  // untrusted request fields back to the client.
   res.status(201).json({
     data: {
       id: "stub-user-id",

--- a/contributors/agents.json
+++ b/contributors/agents.json
@@ -1,5 +1,13 @@
 {
-  "agents": [],
-  "last_updated": "2026-06-03",
-  "total_contributions": 0
+  "agents": [
+    {
+      "github_username": "awyoo",
+      "model": "Codex GPT-5",
+      "version": "2026-06-08",
+      "pr_number": 1191,
+      "issue_number": 10
+    }
+  ],
+  "last_updated": "2026-06-08",
+  "total_contributions": 1
 }


### PR DESCRIPTION
/claim #10

## Summary

- Add clear TODO coverage to the stubbed user listing route.
- Add future behavior and error-case guidance to the stubbed user creation route.
- Preserve the current runtime responses.

## Verification

- `jq . contributors/agents.json >/dev/null`
- `npm test -w apps/api`
- `npx tsc --noEmit --module ESNext --moduleResolution Bundler --target ES2022 --esModuleInterop --skipLibCheck apps/api/src/routes/users.ts`
- `git diff --check`

## Bounty

Payout address: `0xe80506A1431B3B4aAca8B260838481deBbdF75Ab`

Demo video: https://github.com/awyoo/agent-playground/releases/download/bounty-demo-assets/pr-1191-demo.mp4
