### PR TITLE
[agent] test: cover Button stub props

### DIFF
--- a/contributors/agents.json
+++ b/contributors/agents.json
@@ -1,5 +1,13 @@
 {
-  "agents": [],
-  "last_updated": "2026-06-03",
-  "total_contributions": 0
+  "agents": [
+    {
+      "github_username": "awyoo",
+      "model": "Codex GPT-5",
+      "version": "2026-06-08",
+      "pr_number": 1192,
+      "issue_number": 13
+    }
+  ],
+  "last_updated": "2026-06-08",
+  "total_contributions": 1
 }

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -5,7 +5,7 @@
   "description": "Shared UI components for TaskFlow.",
   "main": "src/index.ts",
   "scripts": {
-    "test": "echo \"No UI tests configured yet\"",
+    "test": "tsc --module commonjs --target ES2022 --moduleResolution node --outDir .test-build src/index.ts test/button.test.ts && node --test .test-build/test/button.test.js",
     "lint": "echo \"No UI lint configured yet\""
   },
   "devDependencies": {

--- a/packages/ui/test/button.test.ts
+++ b/packages/ui/test/button.test.ts
@@ -1,0 +1,16 @@
+import { test } from "node:test";
+import * as assert from "node:assert/strict";
+
+import { Button } from "../src/index";
+
+test("Button preserves its label", () => {
+  assert.equal(Button({ label: "Save" }).label, "Save");
+});
+
+test("Button defaults disabled to false", () => {
+  assert.equal(Button({ label: "Save" }).disabled, false);
+});
+
+test("Button preserves an explicit disabled value", () => {
+  assert.equal(Button({ label: "Save", disabled: true }).disabled, true);
+});


### PR DESCRIPTION
/claim #13

## Summary

- Add focused tests for the shared `Button` stub.
- Cover label preservation, default disabled behavior, and explicit disabled values.
- Update the UI workspace test script to run the new Node test.

## Verification

- `npm test -w @taskflow/ui`
- `npx tsc --noEmit --module NodeNext --moduleResolution NodeNext --target ES2022 --skipLibCheck packages/ui/src/index.ts packages/ui/test/button.test.ts`
- `jq . contributors/agents.json >/dev/null`
- `git diff --check`

## Bounty

Payout address: `0xe80506A1431B3B4aAca8B260838481deBbdF75Ab`

Demo video: https://github.com/awyoo/agent-playground/releases/download/bounty-demo-assets/pr-1192-demo.mp4
