### PR TITLE
test: add unit tests for Button component stub covering label and disabl

### DIFF
--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -5,10 +5,11 @@
   "description": "Shared UI components for TaskFlow.",
   "main": "src/index.ts",
   "scripts": {
-    "test": "echo \"No UI tests configured yet\"",
+    "test": "vitest run",
     "lint": "echo \"No UI lint configured yet\""
   },
   "devDependencies": {
-    "typescript": "^5.4.5"
+    "typescript": "^5.4.5",
+    "vitest": "^1.6.0"
   }
 }

--- a/packages/ui/src/__tests__/Button.test.ts
+++ b/packages/ui/src/__tests__/Button.test.ts
@@ -1,0 +1,31 @@
+import { describe, it, expect } from 'vitest';
+import { Button } from '../index';
+
+describe('Button', () => {
+  it('should return a button object with default disabled as false', () => {
+    const result = Button({ label: 'Click me' });
+    expect(result).toEqual({
+      type: 'button',
+      label: 'Click me',
+      disabled: false,
+    });
+  });
+
+  it('should return a button object with disabled true', () => {
+    const result = Button({ label: 'Submit', disabled: true });
+    expect(result).toEqual({
+      type: 'button',
+      label: 'Submit',
+      disabled: true,
+    });
+  });
+
+  it('should override disabled when explicitly set to false', () => {
+    const result = Button({ label: 'Save', disabled: false });
+    expect(result).toEqual({
+      type: 'button',
+      label: 'Save',
+      disabled: false,
+    });
+  });
+});


### PR DESCRIPTION
为 packages/ui 中的 Button 组件添加单元测试，验证 label 和 disabled 属性。更新 package.json 添加 vitest 依赖和测试脚本。