### PR TITLE
Make API entrypoint import-safe for route tests

### DIFF
--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -7,7 +7,7 @@
   "main": "src/index.ts",
   "scripts": {
     "dev": "tsx src/index.ts",
-    "test": "echo \"No API tests configured yet\"",
+    "test": "node --test --import tsx test/*.test.ts",
     "lint": "echo \"No API lint configured yet\""
   },
   "dependencies": {

--- a/apps/api/src/app.ts
+++ b/apps/api/src/app.ts
@@ -1,0 +1,21 @@
+import express from "express";
+
+import usersRouter from "./routes/users.js";
+
+export function createApp() {
+  const app = express();
+
+  app.use(express.json());
+
+  app.get("/health", (_req, res) => {
+    res.json({ status: "ok", service: "taskflow-api" });
+  });
+
+  app.use("/users", usersRouter);
+
+  return app;
+}
+
+const app = createApp();
+
+export default app;

--- a/apps/api/src/index.ts
+++ b/apps/api/src/index.ts
@@ -1,18 +1,17 @@
-import express from "express";
+import { pathToFileURL } from "node:url";
 
-import usersRouter from "./routes/users";
+import app from "./app.js";
 
-const app = express();
 const port = process.env.PORT || 4000;
 
-app.use(express.json());
+function isEntrypoint() {
+  return Boolean(process.argv[1]) && import.meta.url === pathToFileURL(process.argv[1]).href;
+}
 
-app.get("/health", (_req, res) => {
-  res.json({ status: "ok", service: "taskflow-api" });
-});
+if (isEntrypoint()) {
+  app.listen(port, () => {
+    console.log(`TaskFlow API listening on port ${port}`);
+  });
+}
 
-app.use("/users", usersRouter);
-
-app.listen(port, () => {
-  console.log(`TaskFlow API listening on port ${port}`);
-});
+export default app;

--- a/apps/api/test/app.test.ts
+++ b/apps/api/test/app.test.ts
@@ -1,0 +1,46 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import app, { createApp } from "../src/app.js";
+
+type Layer = {
+  route?: {
+    path?: string;
+  };
+  name?: string;
+  handle?: {
+    stack?: Array<{
+      route?: {
+        path?: string;
+      };
+    }>;
+  };
+};
+
+function getRoutes(target: unknown): Layer[] {
+  return ((target as { _router?: { stack?: Layer[] } })._router?.stack ?? []).filter(Boolean);
+}
+
+test("app export registers the health endpoint", () => {
+  const routes = getRoutes(app);
+  const healthRoute = routes.find((layer) => layer.route?.path === "/health");
+
+  assert.ok(healthRoute);
+});
+
+test("createApp mounts the users router", () => {
+  const routes = getRoutes(createApp());
+  const usersRouter = routes.find(
+    (layer) =>
+      layer.name === "router" &&
+      layer.handle?.stack?.some((nestedLayer) => nestedLayer.route?.path === "/")
+  );
+
+  assert.ok(usersRouter);
+});
+
+test("index import stays side-effect free for smoke tests", async () => {
+  const imported = await import("../src/index.js");
+
+  assert.equal(imported.default, app);
+});

--- a/contributors/agents.json
+++ b/contributors/agents.json
@@ -1,5 +1,13 @@
 {
-  "agents": [],
-  "last_updated": "2026-06-03",
-  "total_contributions": 0
+  "agents": [
+    {
+      "github_username": "awyoo",
+      "model": "Codex GPT-5",
+      "version": "2026-06-08",
+      "pr_number": 1204,
+      "issue_number": 235
+    }
+  ],
+  "last_updated": "2026-06-08",
+  "total_contributions": 1
 }


### PR DESCRIPTION
/claim #235

## Summary

- Move Express app construction into `apps/api/src/app.ts` so route tests can import the app without starting a listener.
- Keep `apps/api/src/index.ts` as the runtime entrypoint that calls `listen` only when executed directly.
- Add smoke tests covering app export, user router mounting, and side-effect-free index imports.

## Verification

- `npm test -w @taskflow/api`
- `npx tsc --noEmit --module NodeNext --moduleResolution NodeNext --target ES2022 --esModuleInterop --skipLibCheck apps/api/src/app.ts apps/api/src/index.ts apps/api/test/app.test.ts`
- `git diff --check HEAD~1..HEAD`

## Bounty

Payout address: `0xe80506A1431B3B4aAca8B260838481deBbdF75Ab`

Demo video: https://github.com/awyoo/agent-playground/releases/download/bounty-demo-assets/pr-1204-demo.mp4
