### PR TITLE
[agent] Return 405 for unsupported /users methods

### DIFF
--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -7,7 +7,7 @@
   "main": "src/index.ts",
   "scripts": {
     "dev": "tsx src/index.ts",
-    "test": "echo \"No API tests configured yet\"",
+    "test": "node --test --import tsx test/*.test.ts",
     "lint": "echo \"No API lint configured yet\""
   },
   "dependencies": {

--- a/apps/api/src/routes/users.ts
+++ b/apps/api/src/routes/users.ts
@@ -19,4 +19,14 @@ router.post("/", (req, res) => {
   });
 });
 
+router.all("/", (req, res) => {
+  res.set("Allow", "GET, POST");
+  res.status(405).json({
+    error: {
+      code: "METHOD_NOT_ALLOWED",
+      message: `Method ${req.method} is not allowed for /users.`
+    }
+  });
+});
+
 export default router;

--- a/apps/api/test/users.test.ts
+++ b/apps/api/test/users.test.ts
@@ -1,0 +1,131 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import type { Server } from "node:http";
+
+import express from "express";
+
+import usersRouter from "../src/routes/users.js";
+
+type TestServer = {
+  baseUrl: string;
+  close: () => Promise<void>;
+};
+
+async function createTestServer(): Promise<TestServer> {
+  const app = express();
+  app.use(express.json());
+  app.use("/users", usersRouter);
+
+  const server = await new Promise<Server>((resolve) => {
+    const listener = app.listen(0, "127.0.0.1", () => resolve(listener));
+  });
+  const address = server.address();
+
+  assert.ok(address && typeof address === "object");
+
+  return {
+    baseUrl: `http://127.0.0.1:${address.port}`,
+    close: () =>
+      new Promise<void>((resolve, reject) => {
+        server.close((error) => {
+          if (error) {
+            reject(error);
+            return;
+          }
+
+          resolve();
+        });
+      })
+  };
+}
+
+test("GET /users returns the list stub response", async () => {
+  const server = await createTestServer();
+
+  try {
+    const response = await fetch(`${server.baseUrl}/users`);
+    const body = await response.json();
+
+    assert.equal(response.status, 200);
+    assert.deepEqual(body, {
+      data: [],
+      message: "User listing is not implemented yet."
+    });
+  } finally {
+    await server.close();
+  }
+});
+
+test("POST /users returns the create stub response", async () => {
+  const server = await createTestServer();
+
+  try {
+    const response = await fetch(`${server.baseUrl}/users`, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json"
+      },
+      body: JSON.stringify({
+        email: "user@example.com",
+        name: "Test User"
+      })
+    });
+    const body = await response.json();
+
+    assert.equal(response.status, 201);
+    assert.deepEqual(body, {
+      data: {
+        id: "stub-user-id",
+        email: "user@example.com",
+        name: "Test User"
+      },
+      message: "User creation is not implemented yet."
+    });
+  } finally {
+    await server.close();
+  }
+});
+
+test("PATCH /users returns 405 with an Allow header", async () => {
+  const server = await createTestServer();
+
+  try {
+    const response = await fetch(`${server.baseUrl}/users`, {
+      method: "PATCH"
+    });
+    const body = await response.json();
+
+    assert.equal(response.status, 405);
+    assert.equal(response.headers.get("allow"), "GET, POST");
+    assert.deepEqual(body, {
+      error: {
+        code: "METHOD_NOT_ALLOWED",
+        message: "Method PATCH is not allowed for /users."
+      }
+    });
+  } finally {
+    await server.close();
+  }
+});
+
+test("DELETE /users returns 405 with an Allow header", async () => {
+  const server = await createTestServer();
+
+  try {
+    const response = await fetch(`${server.baseUrl}/users`, {
+      method: "DELETE"
+    });
+    const body = await response.json();
+
+    assert.equal(response.status, 405);
+    assert.equal(response.headers.get("allow"), "GET, POST");
+    assert.deepEqual(body, {
+      error: {
+        code: "METHOD_NOT_ALLOWED",
+        message: "Method DELETE is not allowed for /users."
+      }
+    });
+  } finally {
+    await server.close();
+  }
+});

--- a/contributors/agents.json
+++ b/contributors/agents.json
@@ -1,5 +1,13 @@
 {
-  "agents": [],
-  "last_updated": "2026-06-03",
-  "total_contributions": 0
+  "agents": [
+    {
+      "github_username": "awyoo",
+      "model": "Codex GPT-5",
+      "version": "2026-06-08",
+      "pr_number": 1205,
+      "issue_number": 1168
+    }
+  ],
+  "last_updated": "2026-06-08",
+  "total_contributions": 1
 }


### PR DESCRIPTION
Closes #1168

/claim #1168

## Summary
- add a route-level fallback so unsupported `/users` collection methods return `405 Method Not Allowed`
- set `Allow: GET, POST` and return a small JSON error payload that identifies the rejected method
- add focused API tests covering preserved `GET`/`POST` behavior plus `PATCH`/`DELETE` 405 responses

## Verification
- `cd /Users/huanwen/agent-playground-1168/apps/api && npm test`
- `cd /Users/huanwen/agent-playground-1168 && npx tsc --noEmit --module NodeNext --moduleResolution NodeNext --target ES2022 --esModuleInterop --skipLibCheck apps/api/src/routes/users.ts apps/api/test/users.test.ts`
- `git -C /Users/huanwen/agent-playground-1168 diff --check`

Payout address: `0xe80506A1431B3B4aAca8B260838481deBbdF75Ab`
