### PR TITLE
[agent] Add API JSON body size limit

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,9 @@ Backend architecture follows:
 - Validation schemas (Zod)
 - Utility helpers
 
+The Express API currently applies a conservative default JSON body
+limit of `100kb` to reduce oversized request payloads.
+
 ## Getting Started
 
 npm install

--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -7,7 +7,7 @@
   "main": "src/index.ts",
   "scripts": {
     "dev": "tsx src/index.ts",
-    "test": "echo \"No API tests configured yet\"",
+    "test": "node --test --import tsx test/*.test.ts",
     "lint": "echo \"No API lint configured yet\""
   },
   "dependencies": {

--- a/apps/api/src/app.ts
+++ b/apps/api/src/app.ts
@@ -1,0 +1,17 @@
+import express from "express";
+
+import usersRouter from "./routes/users.js";
+
+export const JSON_BODY_LIMIT = "100kb";
+
+const app = express();
+
+app.use(express.json({ limit: JSON_BODY_LIMIT }));
+
+app.get("/health", (_req, res) => {
+  res.json({ status: "ok", service: "taskflow-api" });
+});
+
+app.use("/users", usersRouter);
+
+export default app;

--- a/apps/api/src/index.ts
+++ b/apps/api/src/index.ts
@@ -1,17 +1,6 @@
-import express from "express";
+import app from "./app.js";
 
-import usersRouter from "./routes/users";
-
-const app = express();
 const port = process.env.PORT || 4000;
-
-app.use(express.json());
-
-app.get("/health", (_req, res) => {
-  res.json({ status: "ok", service: "taskflow-api" });
-});
-
-app.use("/users", usersRouter);
 
 app.listen(port, () => {
   console.log(`TaskFlow API listening on port ${port}`);

--- a/apps/api/test/app.test.ts
+++ b/apps/api/test/app.test.ts
@@ -1,0 +1,74 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import type { Server } from "node:http";
+
+import app, { JSON_BODY_LIMIT } from "../src/app.js";
+
+type TestServer = {
+  baseUrl: string;
+  close: () => Promise<void>;
+};
+
+async function createTestServer(): Promise<TestServer> {
+  const server = await new Promise<Server>((resolve) => {
+    const listener = app.listen(0, () => resolve(listener));
+  });
+  const address = server.address();
+
+  assert.ok(address && typeof address === "object");
+
+  return {
+    baseUrl: `http://127.0.0.1:${address.port}`,
+    close: () =>
+      new Promise<void>((resolve, reject) => {
+        server.close((error) => {
+          if (error) {
+            reject(error);
+            return;
+          }
+
+          resolve();
+        });
+      })
+  };
+}
+
+test("GET /health returns the API health payload", async () => {
+  const server = await createTestServer();
+
+  try {
+    const response = await fetch(`${server.baseUrl}/health`);
+    const body = await response.json();
+
+    assert.equal(response.status, 200);
+    assert.deepEqual(body, {
+      status: "ok",
+      service: "taskflow-api"
+    });
+  } finally {
+    await server.close();
+  }
+});
+
+test("POST /users rejects JSON payloads above the configured body limit", async () => {
+  const server = await createTestServer();
+  const oversizedName = "x".repeat(110 * 1024);
+
+  try {
+    const response = await fetch(`${server.baseUrl}/users`, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json"
+      },
+      body: JSON.stringify({
+        email: "too-large@example.com",
+        name: oversizedName
+      })
+    });
+
+    assert.equal(JSON_BODY_LIMIT, "100kb");
+    assert.equal(response.status, 413);
+  } finally {
+    await server.close();
+  }
+});

--- a/contributors/agents.json
+++ b/contributors/agents.json
@@ -1,5 +1,13 @@
 {
-  "agents": [],
-  "last_updated": "2026-06-03",
-  "total_contributions": 0
+  "agents": [
+    {
+      "github_username": "awyoo",
+      "model": "Codex GPT-5",
+      "version": "2026-06-08",
+      "pr_number": 1206,
+      "issue_number": 9
+    }
+  ],
+  "last_updated": "2026-06-08",
+  "total_contributions": 1
 }


### PR DESCRIPTION
Closes #9

## Summary
- configure the Express API to enforce a conservative default JSON body size limit of `100kb`
- extract the API app into a reusable module and add focused tests for the health route and oversized payload rejection
- document the expected body size limit in the README
- add the required AI agent metadata entry for this PR

## Verification
- `npm test -w @taskflow/api`
- `npx tsc --noEmit --module NodeNext --moduleResolution NodeNext --target ES2022 --esModuleInterop --skipLibCheck apps/api/src/app.ts apps/api/src/index.ts apps/api/src/routes/users.ts apps/api/test/app.test.ts`
- `git diff --check`

## Demo
- https://github.com/awyoo/agent-playground/releases/download/bounty-demo-assets/pr-1206-demo.mp4

/claim #9

Payout address: `0xe80506A1431B3B4aAca8B260838481deBbdF75Ab`
