### PR TITLE
[agent] Add leaderboard update tests

### DIFF
--- a/contributors/agents.json
+++ b/contributors/agents.json
@@ -1,5 +1,13 @@
 {
-  "agents": [],
-  "last_updated": "2026-06-03",
-  "total_contributions": 0
+  "agents": [
+    {
+      "github_username": "awyoo",
+      "model": "Codex GPT-5",
+      "version": "2026-06-08",
+      "pr_number": 1207,
+      "issue_number": 11
+    }
+  ],
+  "last_updated": "2026-06-08",
+  "total_contributions": 1
 }

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
   ],
   "scripts": {
     "dev": "npm run dev --workspaces --if-present",
-    "test": "npm run test --workspaces --if-present",
+    "test": "node --test test/*.test.mjs && npm run test --workspaces --if-present",
     "lint": "npm run lint --workspaces --if-present",
     "format": "npm run format --workspaces --if-present"
   },

--- a/scripts/update-leaderboard.mjs
+++ b/scripts/update-leaderboard.mjs
@@ -1,0 +1,39 @@
+import { readFile, writeFile } from "node:fs/promises";
+
+export function updateLeaderboardEntry(leaderboard, user) {
+  if (typeof user !== "string" || user.trim() === "") {
+    throw new Error("PR_USER must be a non-empty string");
+  }
+
+  return {
+    ...leaderboard,
+    [user]: (leaderboard[user] ?? 0) + 1
+  };
+}
+
+export async function loadLeaderboard(filePath) {
+  try {
+    const raw = await readFile(filePath, "utf8");
+    return JSON.parse(raw);
+  } catch (error) {
+    if (error && typeof error === "object" && "code" in error && error.code === "ENOENT") {
+      return {};
+    }
+
+    throw error;
+  }
+}
+
+export async function saveLeaderboard(filePath, leaderboard) {
+  await writeFile(filePath, `${JSON.stringify(leaderboard, null, 2)}\n`);
+}
+
+if (import.meta.url === `file://${process.argv[1]}`) {
+  const filePath = process.argv[2] ?? "leaderboard.json";
+  const user = process.env.PR_USER;
+
+  const leaderboard = await loadLeaderboard(filePath);
+  const updatedLeaderboard = updateLeaderboardEntry(leaderboard, user);
+
+  await saveLeaderboard(filePath, updatedLeaderboard);
+}

--- a/test/update-leaderboard.test.mjs
+++ b/test/update-leaderboard.test.mjs
@@ -1,0 +1,43 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { mkdtemp, readFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import path from "node:path";
+
+import {
+  loadLeaderboard,
+  saveLeaderboard,
+  updateLeaderboardEntry
+} from "../scripts/update-leaderboard.mjs";
+
+test("updateLeaderboardEntry adds a new contributor with a count of one", () => {
+  const updated = updateLeaderboardEntry({ awyoo: 6 }, "new-contributor");
+
+  assert.deepEqual(updated, {
+    awyoo: 6,
+    "new-contributor": 1
+  });
+});
+
+test("updateLeaderboardEntry increments an existing contributor count", () => {
+  const updated = updateLeaderboardEntry({ awyoo: 6, helper: 2 }, "awyoo");
+
+  assert.deepEqual(updated, {
+    awyoo: 7,
+    helper: 2
+  });
+});
+
+test("saveLeaderboard persists the updated JSON payload", async () => {
+  const tempDir = await mkdtemp(path.join(tmpdir(), "leaderboard-test-"));
+  const leaderboardPath = path.join(tempDir, "leaderboard.json");
+  const updated = updateLeaderboardEntry({}, "awyoo");
+
+  await saveLeaderboard(leaderboardPath, updated);
+
+  const reloaded = await loadLeaderboard(leaderboardPath);
+  const contents = await readFile(leaderboardPath, "utf8");
+
+  assert.deepEqual(reloaded, { awyoo: 1 });
+  assert.match(contents, /"awyoo": 1/);
+});


### PR DESCRIPTION
Closes #11

## Summary
- add a small dependency-free leaderboard update helper script that mirrors the current PR leaderboard increment behavior
- add focused node:test coverage for adding a new contributor and incrementing an existing contributor
- run the new root-level leaderboard tests as part of `npm test`
- add the required AI agent metadata entry for this PR

## Verification
- `npm test`
- `jq . contributors/agents.json >/dev/null`
- `git diff --check`

## Demo
- https://github.com/awyoo/agent-playground/releases/download/bounty-demo-assets/pr-1207-demo.mp4

/claim #11

Payout address: `0xe80506A1431B3B4aAca8B260838481deBbdF75Ab`
