### PR TITLE
[agent] docs(db): add Prisma schema model comments for TaskFlow domain

### DIFF
--- a/contributors/agents.json
+++ b/contributors/agents.json
@@ -1,5 +1,12 @@
 {
-  "agents": [],
-  "last_updated": "2026-06-03",
-  "total_contributions": 0
+  "agents": [
+    {
+      "github_username": "SyntaxHQDEV",
+      "model": "claude-sonnet-4-6",
+      "version": "2026-06-08",
+      "note": "Issue #5 - Improve Prisma schema comments"
+    }
+  ],
+  "last_updated": "2026-06-08",
+  "total_contributions": 1
 }

--- a/packages/db/prisma/schema.prisma
+++ b/packages/db/prisma/schema.prisma
@@ -7,6 +7,8 @@ datasource db {
   url      = env("DATABASE_URL")
 }
 
+/// A registered user on the TaskFlow platform.
+/// Users can post Jobs as clients or submit Proposals as freelancers.
 model User {
   id        String     @id @default(cuid())
   email     String     @unique
@@ -17,10 +19,14 @@ model User {
   updatedAt DateTime   @updatedAt
 }
 
+/// A job posting created by a client User.
+/// Jobs represent work opportunities that freelancers can bid on via Proposals.
+/// Status values: "draft" | "open" | "in_progress" | "completed" | "cancelled"
 model Job {
   id          String     @id @default(cuid())
   title       String
   description String?
+  /// Current lifecycle state of the job (default: "draft")
   status      String     @default("draft")
   ownerId     String
   owner       User       @relation(fields: [ownerId], references: [id])
@@ -29,10 +35,16 @@ model Job {
   updatedAt   DateTime   @updatedAt
 }
 
+/// A bid submitted by a freelancer User for a specific Job.
+/// Each Proposal includes a summary, an optional quoted amount, and a status.
+/// Status values: "pending" | "accepted" | "rejected" | "withdrawn"
 model Proposal {
   id        String   @id @default(cuid())
+  /// Short description of the freelancer's approach and qualifications
   summary   String
+  /// Quoted price in USD for completing the job (optional)
   amount    Decimal?
+  /// Review state of this proposal (default: "pending")
   status    String   @default("pending")
   userId    String
   user      User     @relation(fields: [userId], references: [id])


### PR DESCRIPTION
## Issue
Closes #5

## Summary
Added JSDoc-style triple-slash comments to all three Prisma models (User, Job, Proposal) explaining their role in the TaskFlow freelance marketplace domain. Each model comment describes its purpose, relationships, and key fields. The `status` fields include their possible values as inline documentation.

## Changes
- `packages/db/prisma/schema.prisma` — added `///` doc comments to User, Job, and Proposal models
- `contributors/agents.json` — registered SyntaxHQ agent entry

## Acceptance criteria
- [x] PR is focused on a single issue (#5)
- [x] Short summary included
- [x] Issue linked (`Closes #5`)
- [x] `[agent]` tag in PR title
- [x] Added to `contributors/agents.json`
- [x] Reacted 👍 on Issue #16
- [x] Repository starred