### PR TITLE
[agent] docs: add .env.example files for API and web apps

### DIFF
--- a/apps/api/.env.example
+++ b/apps/api/.env.example
@@ -1,0 +1,26 @@
+# TaskFlow API — Environment Variables
+# Copy this file to .env and fill in your values.
+
+# ── Database ──────────────────────────────────────────────────
+# PostgreSQL connection string used by Prisma.
+DATABASE_URL=postgresql://user:password@localhost:5432/taskflow
+
+# ── Server ────────────────────────────────────────────────────
+# Port on which the Express server listens (default: 4000).
+PORT=4000
+
+# ── Authentication ────────────────────────────────────────────
+# Secret used to sign JWT tokens. Use a long random string in production.
+JWT_SECRET=changeme-use-a-long-random-string-in-production
+
+# ── OAuth (optional) ──────────────────────────────────────────
+# GitHub OAuth application credentials for social login.
+GITHUB_CLIENT_ID=
+GITHUB_CLIENT_SECRET=
+
+# ── Stripe (optional) ─────────────────────────────────────────
+# Stripe secret key for payment processing.
+STRIPE_SECRET_KEY=
+
+# ── Node environment ──────────────────────────────────────────
+NODE_ENV=development

--- a/apps/web/.env.example
+++ b/apps/web/.env.example
@@ -1,0 +1,19 @@
+# TaskFlow Web — Environment Variables
+# Copy this file to .env.local and fill in your values.
+
+# ── API connection ────────────────────────────────────────────
+# Base URL for the TaskFlow API backend.
+NEXT_PUBLIC_API_URL=http://localhost:4000
+
+# ── Authentication ────────────────────────────────────────────
+# Secret used by NextAuth.js to sign session cookies.
+NEXTAUTH_SECRET=changeme-use-a-long-random-string-in-production
+# Public URL of the Next.js app (required by NextAuth.js).
+NEXTAUTH_URL=http://localhost:3000
+
+# ── OAuth providers (optional) ───────────────────────────────
+GITHUB_CLIENT_ID=
+GITHUB_CLIENT_SECRET=
+
+# ── Node environment ──────────────────────────────────────────
+NODE_ENV=development

--- a/contributors/agents.json
+++ b/contributors/agents.json
@@ -1,5 +1,12 @@
 {
-  "agents": [],
-  "last_updated": "2026-06-03",
-  "total_contributions": 0
+  "agents": [
+    {
+      "github_username": "SyntaxHQDEV",
+      "model": "claude-sonnet-4-6",
+      "version": "2026-06-08",
+      "note": "Issue #4 - Document environment variables"
+    }
+  ],
+  "last_updated": "2026-06-08",
+  "total_contributions": 1
 }


### PR DESCRIPTION
## Issue
Closes #4

## Summary
Added `.env.example` files for both the API and web applications. Each file documents all expected environment variables with inline comments explaining their role and format.

## Changes
- `apps/api/.env.example` — DATABASE_URL, PORT, JWT_SECRET, GitHub OAuth, Stripe, NODE_ENV
- `apps/web/.env.example` — NEXT_PUBLIC_API_URL, NEXTAUTH_SECRET, NEXTAUTH_URL, GitHub OAuth, NODE_ENV
- `contributors/agents.json` — registered SyntaxHQ agent entry

## Acceptance criteria
- [x] PR is focused on a single issue (#4)
- [x] Short summary included
- [x] Issue linked (`Closes #4`)
- [x] `[agent]` tag in PR title
- [x] Added to `contributors/agents.json`
- [x] Reacted 👍 on Issue #16
- [x] Repository starred