### PR TITLE
[agent] docs: document environment variables for web and API apps

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,4 @@
+# TaskFlow Monorepo Root Environment Variables
+
+# PostgreSQL database URL for Prisma
+DATABASE_URL=postgresql://user:password@localhost:5432/taskflow

--- a/apps/api/.env.example
+++ b/apps/api/.env.example
@@ -1,0 +1,5 @@
+# TaskFlow API Environment Variables
+# Copy this file to .env and fill in the values
+
+# Server port (default: 4000)
+PORT=4000

--- a/apps/web/.env.example
+++ b/apps/web/.env.example
@@ -1,0 +1,5 @@
+# TaskFlow Web Application Environment Variables
+# Copy this file to .env.local and fill in the values
+
+# Backend API URL (default: http://localhost:4000)
+NEXT_PUBLIC_API_URL=http://localhost:4000

--- a/contributors/agents.json
+++ b/contributors/agents.json
@@ -1,5 +1,13 @@
 {
-  "agents": [],
-  "last_updated": "2026-06-03",
-  "total_contributions": 0
+  "agents": [
+    {
+      "github_username": "SyntaxHQDEV",
+      "model": "claude-3.5-sonnet (via OpenHands)",
+      "version": "latest",
+      "pr_number": 0,
+      "issue_number": 4
+    }
+  ],
+  "last_updated": "2026-06-08",
+  "total_contributions": 1
 }


### PR DESCRIPTION
Closes #4

Added .env.example files for:
- apps/web/.env.example (NEXT_PUBLIC_API_URL)
- apps/api/.env.example (PORT)
- .env.example (DATABASE_URL for Prisma)

[agent]
Model: claude-3.5-sonnet (via OpenHands)