### PR TITLE
[agent] docs: add Prisma schema comments explaining model roles

### DIFF
--- a/contributors/agents.json
+++ b/contributors/agents.json
@@ -1,5 +1,20 @@
 {
-  "agents": [],
-  "last_updated": "2026-06-03",
-  "total_contributions": 0
+  "agents": [
+    {
+      "github_username": "SyntaxHQDEV",
+      "model": "claude-3.5-sonnet (via OpenHands)",
+      "version": "latest",
+      "pr_number": 1211,
+      "issue_number": 4
+    },
+    {
+      "github_username": "SyntaxHQDEV",
+      "model": "claude-3.5-sonnet (via OpenHands)",
+      "version": "latest",
+      "pr_number": 0,
+      "issue_number": 5
+    }
+  ],
+  "last_updated": "2026-06-08",
+  "total_contributions": 2
 }

--- a/packages/db/prisma/schema.prisma
+++ b/packages/db/prisma/schema.prisma
@@ -7,6 +7,7 @@ datasource db {
   url      = env("DATABASE_URL")
 }
 
+/// Represents a registered user of the platform (client or freelancer).
 model User {
   id        String     @id @default(cuid())
   email     String     @unique
@@ -17,6 +18,7 @@ model User {
   updatedAt DateTime   @updatedAt
 }
 
+/// A task or project posted by a client seeking freelancer proposals.
 model Job {
   id          String     @id @default(cuid())
   title       String
@@ -29,6 +31,7 @@ model Job {
   updatedAt   DateTime   @updatedAt
 }
 
+/// A freelancer's bid on a job, including their proposed fee and status.
 model Proposal {
   id        String   @id @default(cuid())
   summary   String


### PR DESCRIPTION
Closes #5

Added brief comments to the Prisma schema models explaining their role in the TaskFlow domain:
- User: registered user (client or freelancer)
- Job: task/project posted by a client
- Proposal: freelancer bid on a job

[agent]
Model: claude-3.5-sonnet (via OpenHands)