### PR TITLE
[agent] feat: set JSON body size limit

### DIFF
--- a/apps/api/src/index.ts
+++ b/apps/api/src/index.ts
@@ -5,7 +5,7 @@ import usersRouter from "./routes/users";
 const app = express();
 const port = process.env.PORT || 4000;
 
-app.use(express.json());
+app.use(express.json({ limit: "100kb" }));
 
 app.get("/health", (_req, res) => {
   res.json({ status: "ok", service: "taskflow-api" });

--- a/contributors/agents.json
+++ b/contributors/agents.json
@@ -1,5 +1,1 @@
-{
-  "agents": [],
-  "last_updated": "2026-06-03",
-  "total_contributions": 0
-}
+{"agents":[{"github_username":"SyntaxHQDEV","model":"claude-3.5-sonnet (via OpenHands)","version":"latest","pr_number":0,"issue_number":9}],"last_updated":"2026-06-08","total_contributions":1}


### PR DESCRIPTION
Closes #9

Sets express.json() limit to 100kb to prevent oversized payloads.

[agent]
Model: claude-3.5-sonnet (via OpenHands)