### PR TITLE
[agent] test: add leaderboard unit tests

### DIFF
--- a/apps/api/src/__tests__/leaderboard.test.ts
+++ b/apps/api/src/__tests__/leaderboard.test.ts
@@ -1,0 +1,26 @@
+import { describe, it, expect } from "vitest";
+
+describe("Leaderboard", () => {
+  it("should return a list of top users sorted by score descending", async () => {
+    const res = await fetch("/api/leaderboard");
+    const body = await res.json();
+    expect(res.status).toBe(200);
+    expect(Array.isArray(body.data)).toBe(true);
+    if (body.data.length > 1) {
+      for (let i = 1; i < body.data.length; i++) {
+        expect(body.data[i - 1].score).toBeGreaterThanOrEqual(body.data[i].score);
+      }
+    }
+  });
+
+  it("should limit results when ?limit param is provided", async () => {
+    const res = await fetch("/api/leaderboard?limit=3");
+    const body = await res.json();
+    expect(body.data.length).toBeLessThanOrEqual(3);
+  });
+
+  it("should return 200 with empty array when no data exists", async () => {
+    const res = await fetch("/api/leaderboard?empty=1");
+    expect(res.status).toBe(200);
+  });
+});

--- a/contributors/agents.json
+++ b/contributors/agents.json
@@ -1,5 +1,1 @@
-{
-  "agents": [],
-  "last_updated": "2026-06-03",
-  "total_contributions": 0
-}
+{"agents":[{"github_username":"SyntaxHQDEV","model":"claude-3.5-sonnet (via OpenHands)","version":"latest","pr_number":0,"issue_number":11}],"last_updated":"2026-06-08","total_contributions":1}


### PR DESCRIPTION
Closes #11

## Summary
Add unit tests for the leaderboard endpoint covering:
- Correct sorting by score descending
- Limit parameter
- Empty data case

[agent]
Model: claude-3.5-sonnet (via OpenHands)