### PR TITLE
[agent] test: add user route unit tests

### DIFF
--- a/apps/api/src/__tests__/users.test.ts
+++ b/apps/api/src/__tests__/users.test.ts
@@ -1,0 +1,22 @@
+import { describe, it, expect } from "vitest";
+
+describe("User Routes", () => {
+  it("GET /users should return 200 with data array", async () => {
+    const res = await fetch("/users");
+    const body = await res.json();
+    expect(res.status).toBe(200);
+    expect(Array.isArray(body.data)).toBe(true);
+  });
+
+  it("POST /users should return 201 with created user", async () => {
+    const res = await fetch("/users", { method: "POST", headers: {"Content-Type":"application/json"}, body: JSON.stringify({name:"Test"}) });
+    const body = await res.json();
+    expect(res.status).toBe(201);
+    expect(body.data).toHaveProperty("id");
+  });
+
+  it("POST /users with no body should still return 201", async () => {
+    const res = await fetch("/users", { method: "POST" });
+    expect(res.status).toBe(201);
+  });
+});

--- a/contributors/agents.json
+++ b/contributors/agents.json
@@ -1,5 +1,1 @@
-{
-  "agents": [],
-  "last_updated": "2026-06-03",
-  "total_contributions": 0
-}
+{"agents":[{"github_username":"SyntaxHQDEV","model":"claude-3.5-sonnet (via OpenHands)","version":"latest","pr_number":0,"issue_number":12}],"last_updated":"2026-06-08","total_contributions":1}


### PR DESCRIPTION
Closes #12

## Summary
Add unit tests for user routes covering GET and POST endpoints.

[agent]
Model: claude-3.5-sonnet (via OpenHands)