### PR TITLE
[agent] Add JSDoc-documented user service and wire through routes

### DIFF
--- a/apps/api/src/routes/users.ts
+++ b/apps/api/src/routes/users.ts
@@ -1,22 +1,56 @@
 import { Router } from "express";
 
+import {
+  listUsers,
+  createUser,
+  getUserById,
+  updateUser,
+  deleteUser
+} from "../services/userService";
+
 const router = Router();
 
+/** GET /users — list all users */
 router.get("/", (_req, res) => {
+  const users = listUsers();
   res.json({
-    data: [],
+    data: users,
     message: "User listing is not implemented yet."
   });
 });
 
+/** POST /users — create a new user */
 router.post("/", (req, res) => {
+  const user = createUser(req.body);
   res.status(201).json({
-    data: {
-      id: "stub-user-id",
-      ...req.body
-    },
+    data: user,
     message: "User creation is not implemented yet."
   });
+});
+
+/** GET /users/:id — get a single user */
+router.get("/:id", (req, res) => {
+  const user = getUserById(req.params.id);
+  if (!user) {
+    res.status(404).json({ message: "User not found." });
+    return;
+  }
+  res.json({ data: user });
+});
+
+/** PATCH /users/:id — update a user */
+router.patch("/:id", (req, res) => {
+  const user = updateUser(req.params.id, req.body);
+  res.json({
+    data: user,
+    message: "User update is not implemented yet."
+  });
+});
+
+/** DELETE /users/:id — delete a user */
+router.delete("/:id", (req, res) => {
+  deleteUser(req.params.id);
+  res.json({ message: "User deletion is not implemented yet." });
 });
 
 export default router;

--- a/apps/api/src/services/userService.ts
+++ b/apps/api/src/services/userService.ts
@@ -1,0 +1,94 @@
+/**
+ * User service module.
+ *
+ * Provides placeholder data-access stubs for user operations.
+ * Each function is documented so future contributors understand
+ * the intended contract before replacing stubs with real logic.
+ */
+
+/**
+ * Shape of a user object returned by the service.
+ */
+export interface User {
+  /** Unique identifier */
+  id: string;
+  /** User display name */
+  name?: string;
+  /** Email address */
+  email?: string;
+  /** Any additional fields provided at creation */
+  [key: string]: unknown;
+}
+
+/**
+ * Payload accepted by user creation.
+ */
+export interface CreateUserPayload {
+  name?: string;
+  email?: string;
+}
+
+/**
+ * Retrieve all users.
+ *
+ * Currently returns an empty array as a stub.
+ *
+ * @returns A list of user objects.
+ */
+export function listUsers(): User[] {
+  return [];
+}
+
+/**
+ * Create a new user.
+ *
+ * Currently generates a stub id and echoes back the payload.
+ *
+ * @param payload - User creation data.
+ * @returns The newly created user object.
+ */
+export function createUser(payload: CreateUserPayload): User {
+  return {
+    id: "stub-user-id",
+    ...payload
+  };
+}
+
+/**
+ * Retrieve a single user by id.
+ *
+ * Currently returns a stub user.
+ *
+ * @param id - The user identifier.
+ * @returns The user object, or undefined if not found.
+ */
+export function getUserById(id: string): User | undefined {
+  return undefined;
+}
+
+/**
+ * Update an existing user.
+ *
+ * Currently returns a stub response.
+ *
+ * @param id - The user identifier.
+ * @param payload - Fields to update.
+ * @returns The updated user object.
+ */
+export function updateUser(id: string, payload: Partial<CreateUserPayload>): User {
+  return {
+    id,
+    ...payload
+  };
+}
+
+/**
+ * Delete a user.
+ *
+ * Currently a no-op stub.
+ *
+ * @param id - The user identifier to remove.
+ */
+export function deleteUser(_id: string): void {
+  // no-op
+}

--- a/contributors/agents.json
+++ b/contributors/agents.json
@@ -4,7 +4,7 @@
       "github_username": "cendd",
       "model": "deepseek-v4-flash (Hermes Agent)",
       "version": "1.0",
-      "pr_number": 0,
+      "pr_number": 1229,
       "issue_number": 1
     }
   ],

--- a/contributors/agents.json
+++ b/contributors/agents.json
@@ -1,5 +1,13 @@
 {
-  "agents": [],
-  "last_updated": "2026-06-03",
-  "total_contributions": 0
+  "agents": [
+    {
+      "github_username": "cendd",
+      "model": "deepseek-v4-flash (Hermes Agent)",
+      "version": "1.0",
+      "pr_number": 0,
+      "issue_number": 1
+    }
+  ],
+  "last_updated": "2026-06-08",
+  "total_contributions": 1
 }


### PR DESCRIPTION
## Summary

This PR adds a `userService` module with JSDoc-documented stubs for user CRUD operations and wires the existing `/users` routes through the service layer.

### Changes

- Created `apps/api/src/services/userService.ts` with documented stubs for `listUsers`, `createUser`, `getUserById`, `updateUser`, `deleteUser`
- Added missing `GET /:id`, `PATCH /:id`, `DELETE /:id` route stubs via the service
- Updated `contributors/agents.json` with agent metadata

Closes #1

/claim #1