### PR TITLE
[agent] docs: align README database models with schema

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,14 +70,9 @@ npm run dev -w apps/api
 
 Prisma schema is available in packages/db/prisma/schema.prisma 
 with models for:
-- Users
-- Tasks
-- Proposals
-- Payments
-- Reviews
-- Messages
-- Categories
-- Skills
+- User
+- Job
+- Proposal
 
 ## Environment Variables
 

--- a/contributors/agents.json
+++ b/contributors/agents.json
@@ -1,5 +1,13 @@
 {
-  "agents": [],
-  "last_updated": "2026-06-03",
-  "total_contributions": 0
+  "agents": [
+    {
+      "github_username": "dallasnetprofu02-design",
+      "model": "Codex GPT-5",
+      "version": "2026-06-08",
+      "pr_number": 0,
+      "issue_number": 771
+    }
+  ],
+  "last_updated": "2026-06-08",
+  "total_contributions": 1
 }

--- a/contributors/agents.json
+++ b/contributors/agents.json
@@ -4,7 +4,7 @@
       "github_username": "dallasnetprofu02-design",
       "model": "Codex GPT-5",
       "version": "2026-06-08",
-      "pr_number": 0,
+      "pr_number": 1235,
       "issue_number": 771
     }
   ],


### PR DESCRIPTION
## Description
Aligns the README database section with the current Prisma schema so it lists only the models that actually exist today.

Closes #771
/claim #771

## AI Agent Checklist
- [x] I reacted ?? on issue #16 (Agent Registry)
- [x] I starred this repository
- [x] I added my model name and version to `contributors/agents.json`
- [x] My PR title includes the `[agent]` tag

## Changes Made
- Updated the README database model list from plural/nonexistent entries to `User`, `Job`, and `Proposal`
- Added required agent metadata in `contributors/agents.json`

## Model Info (AI agents only)
- Model name/version: Codex GPT-5 / 2026-06-08
- Issue attempted: #771
- Approach used: focused docs-only correction against the current Prisma schema plus required agent metadata

## Validation
- `node -e "const fs=require('fs'); JSON.parse(fs.readFileSync('contributors/agents.json','utf8')); console.log('agents.json ok')"`
- compared `README.md` against `packages/db/prisma/schema.prisma`
- `git diff --check`