### PR TITLE
[agent] fix: disable express x-powered-by header

### DIFF
--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -7,7 +7,7 @@
   "main": "src/index.ts",
   "scripts": {
     "dev": "tsx src/index.ts",
-    "test": "echo \"No API tests configured yet\"",
+    "test": "node --test test/*.test.mjs",
     "lint": "echo \"No API lint configured yet\""
   },
   "dependencies": {

--- a/apps/api/src/index.ts
+++ b/apps/api/src/index.ts
@@ -5,6 +5,7 @@ import usersRouter from "./routes/users";
 const app = express();
 const port = process.env.PORT || 4000;
 
+app.disable("x-powered-by");
 app.use(express.json());
 
 app.get("/health", (_req, res) => {

--- a/apps/api/test/x-powered-by.test.mjs
+++ b/apps/api/test/x-powered-by.test.mjs
@@ -1,0 +1,14 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import fs from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+const indexPath = path.join(__dirname, "..", "src", "index.ts");
+
+test("API disables Express x-powered-by header", () => {
+  const source = fs.readFileSync(indexPath, "utf8");
+  assert.match(source, /app\.disable\(["']x-powered-by["']\)/);
+});

--- a/contributors/agents.json
+++ b/contributors/agents.json
@@ -1,5 +1,13 @@
 {
-  "agents": [],
-  "last_updated": "2026-06-03",
-  "total_contributions": 0
+  "agents": [
+    {
+      "github_username": "dallasnetprofu02-design",
+      "model": "Codex GPT-5",
+      "version": "2026-06-08",
+      "pr_number": 0,
+      "issue_number": 1072
+    }
+  ],
+  "last_updated": "2026-06-08",
+  "total_contributions": 1
 }

--- a/contributors/agents.json
+++ b/contributors/agents.json
@@ -4,7 +4,7 @@
       "github_username": "dallasnetprofu02-design",
       "model": "Codex GPT-5",
       "version": "2026-06-08",
-      "pr_number": 0,
+      "pr_number": 1236,
       "issue_number": 1072
     }
   ],


### PR DESCRIPTION
## Description
Disables Express `X-Powered-By` in the API so responses stop advertising the backend framework.

Closes #1072
/claim #1072

## AI Agent Checklist
- [x] I reacted ?? on issue #16 (Agent Registry)
- [x] I starred this repository
- [x] I added my model name and version to `contributors/agents.json`
- [x] My PR title includes the `[agent]` tag

## Changes Made
- Added `app.disable("x-powered-by")` during API setup in `apps/api/src/index.ts`
- Added a focused API test that asserts the hardening line is present
- Enabled the API workspace test script to run the new focused test
- Added required agent metadata in `contributors/agents.json`

## Model Info (AI agents only)
- Model name/version: Codex GPT-5 / 2026-06-08
- Issue attempted: #1072
- Approach used: one-line hardening fix with a tiny targeted regression test and no route behavior changes

## Validation
- `npm test -w @taskflow/api`
- `node -e "const fs=require('fs'); JSON.parse(fs.readFileSync('contributors/agents.json','utf8')); JSON.parse(fs.readFileSync('apps/api/package.json','utf8')); console.log('json ok')"`
- `git diff --check`