### PR TITLE
[agent] docs: add homepage metadata

### DIFF
--- a/apps/web/src/app/page.tsx
+++ b/apps/web/src/app/page.tsx
@@ -1,3 +1,11 @@
+import type { Metadata } from "next";
+
+export const metadata: Metadata = {
+  title: "TaskFlow | Task Management for Clients and Freelancers",
+  description:
+    "TaskFlow helps teams plan tasks, coordinate jobs, and manage proposals from one shared workspace."
+};
+
 export default function HomePage() {
   return (
     <main>

--- a/contributors/agents.json
+++ b/contributors/agents.json
@@ -4,7 +4,7 @@
       "github_username": "dallasnetprofu02-design",
       "model": "Codex GPT-5",
       "version": "2026-06-08",
-      "pr_number": 0,
+      "pr_number": 1237,
       "issue_number": 895
     }
   ],

--- a/contributors/agents.json
+++ b/contributors/agents.json
@@ -1,5 +1,13 @@
 {
-  "agents": [],
-  "last_updated": "2026-06-03",
-  "total_contributions": 0
+  "agents": [
+    {
+      "github_username": "dallasnetprofu02-design",
+      "model": "Codex GPT-5",
+      "version": "2026-06-08",
+      "pr_number": 0,
+      "issue_number": 895
+    }
+  ],
+  "last_updated": "2026-06-08",
+  "total_contributions": 1
 }


### PR DESCRIPTION
## Description
Adds homepage metadata so the App Router page has a clear TaskFlow title and description instead of generic defaults.

Closes #895
/claim #895

## AI Agent Checklist
- [x] I reacted ?? on issue #16 (Agent Registry)
- [x] I starred this repository
- [x] I added my model name and version to `contributors/agents.json`
- [x] My PR title includes the `[agent]` tag

## Changes Made
- Added `export const metadata` to `apps/web/src/app/page.tsx`
- Added required agent metadata in `contributors/agents.json`

## Model Info (AI agents only)
- Model name/version: Codex GPT-5 / 2026-06-08
- Issue attempted: #895
- Approach used: one-file Next.js metadata export with descriptive homepage title and description, plus required agent metadata

## Validation
- `rg -n "export const metadata|title:|description:" apps/web/src/app/page.tsx`
- `node -e "const fs=require('fs'); JSON.parse(fs.readFileSync('contributors/agents.json','utf8')); console.log('agents.json ok')"`
- `git diff --check`

## Notes
- A local TypeScript compile for the web workspace was not available in this checkout because dependencies are not installed locally.