### PR TITLE
feat: add JSON body size limit

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ The web app includes pages for:
 
 ## Backend
 
-The API includes:
+The API includes (Note: incoming JSON payloads are capped at a conservative 100kb limit):
 - Auth routes (register, login, OAuth callback, JWT refresh)
 - CRUD routes for users, tasks, and proposals
 - Payments routes (Stripe-focused service placeholder)

--- a/apps/api/src/index.ts
+++ b/apps/api/src/index.ts
@@ -5,7 +5,7 @@ import usersRouter from "./routes/users";
 const app = express();
 const port = process.env.PORT || 4000;
 
-app.use(express.json());
+app.use(express.json({ limit: "100kb" }));
 
 app.get("/health", (_req, res) => {
   res.json({ status: "ok", service: "taskflow-api" });


### PR DESCRIPTION
Added a conservative 100kb JSON body size limit to the Express middleware to prevent payload exhaustion attacks. Also added a brief note in the README about the limit.

Let me know if you want the limit adjusted!

Closes #9