### PR TITLE
fix: add strict type annotations to Button

### DIFF
--- a/packages/ui/src/index.ts
+++ b/packages/ui/src/index.ts
@@ -1,9 +1,15 @@
 export type ButtonProps = {
-  label: string;
-  disabled?: boolean;
+  readonly label: string;
+  readonly disabled?: boolean;
 };
 
-export function Button({ label, disabled = false }: ButtonProps) {
+export type ButtonResult = {
+  readonly type: "button";
+  readonly label: string;
+  readonly disabled: boolean;
+};
+
+export function Button({ label, disabled = false }: ButtonProps): ButtonResult {
   return {
     type: "button",
     label,


### PR DESCRIPTION
Hey, saw issue #3. I added a clear return type `ButtonResult` and made the properties `readonly` just to be safe. 

Let me know if this covers what you need!

Closes #3