### PR TITLE
docs: document environment variables

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,17 @@ Backend architecture follows:
 - Validation schemas (Zod)
 - Utility helpers
 
+## Environment Variables
+
+For local development, the following environment variables are expected:
+
+**API (`apps/api`)**
+- `PORT`: The port for the API server (defaults to 4000)
+- `DATABASE_URL`: The Prisma database connection string
+
+**Web (`apps/web`)**
+No specific environment variables are required at this time (standard Next.js behavior applies).
+
 ## Getting Started
 
 npm install


### PR DESCRIPTION
Hey! Saw issue #4 so I added a quick section to the README detailing the `PORT` and `DATABASE_URL` env variables for the API. 

Let me know if you need any other ones listed. 

Closes #4