### PR TITLE
docs: improve Prisma schema comments

### DIFF
--- a/packages/db/prisma/schema.prisma
+++ b/packages/db/prisma/schema.prisma
@@ -7,6 +7,7 @@ datasource db {
   url      = env("DATABASE_URL")
 }
 
+/// Represents a user account in the TaskFlow system.
 model User {
   id        String     @id @default(cuid())
   email     String     @unique
@@ -17,6 +18,7 @@ model User {
   updatedAt DateTime   @updatedAt
 }
 
+/// Represents a job posting created by a user.
 model Job {
   id          String     @id @default(cuid())
   title       String
@@ -29,6 +31,7 @@ model Job {
   updatedAt   DateTime   @updatedAt
 }
 
+/// Represents a proposal submitted by a user for a specific job.
 model Proposal {
   id        String   @id @default(cuid())
   summary   String


### PR DESCRIPTION
Hey there! I saw issue #5 and added some clean Prisma doc comments (`///`) to the User, Job, and Proposal models so they show up nicely in hover tooltips.

Hope this helps! 

Closes #5