### PR TITLE
fix: add CORS middleware to Express API (Fixes #692)

### DIFF
--- a/apps/api/src/index.ts
+++ b/apps/api/src/index.ts
@@ -3,6 +3,7 @@ import express from "express";
 import usersRouter from "./routes/users";
 
 const app = express();
+app.use(cors());
 const port = process.env.PORT || 4000;
 
 app.use(express.json());


### PR DESCRIPTION
Fixes #692. Adds `cors()` middleware to allow cross-origin requests.