### PR TITLE
fix: validate POST /users input by destructuring expected fields (Fixes #694)

### DIFF
--- a/apps/api/src/routes/users.ts
+++ b/apps/api/src/routes/users.ts
@@ -10,10 +10,12 @@ router.get("/", (_req, res) => {
 });
 
 router.post("/", (req, res) => {
+  const { name, email } = req.body;
   res.status(201).json({
     data: {
       id: "stub-user-id",
-      ...req.body
+      name,
+      email
     },
     message: "User creation is not implemented yet."
   });


### PR DESCRIPTION
Fixes #694. Destructure only expected fields from req.body instead of spreading all fields.