### PR TITLE
[agent] fix: return JSON 400 for malformed request bodies

### DIFF
--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -7,7 +7,7 @@
   "main": "src/index.ts",
   "scripts": {
     "dev": "tsx src/index.ts",
-    "test": "echo \"No API tests configured yet\"",
+    "test": "tsx --test src/*.test.ts",
     "lint": "echo \"No API lint configured yet\""
   },
   "dependencies": {

--- a/apps/api/src/index.ts
+++ b/apps/api/src/index.ts
@@ -1,4 +1,4 @@
-import express from "express";
+import express, { type ErrorRequestHandler } from "express";
 
 import usersRouter from "./routes/users";
 
@@ -6,6 +6,16 @@ const app = express();
 const port = process.env.PORT || 4000;
 
 app.use(express.json());
+app.use(((error, _req, res, next) => {
+  if (error instanceof SyntaxError && "body" in error) {
+    res.status(400).json({
+      error: "Invalid JSON request body"
+    });
+    return;
+  }
+
+  next(error);
+}) satisfies ErrorRequestHandler);
 
 app.get("/health", (_req, res) => {
   res.json({ status: "ok", service: "taskflow-api" });

--- a/apps/api/src/index.ts
+++ b/apps/api/src/index.ts
@@ -2,8 +2,7 @@ import express, { type ErrorRequestHandler } from "express";
 
 import usersRouter from "./routes/users";
 
-const app = express();
-const port = process.env.PORT || 4000;
+export const app = express();
 
 app.use(express.json());
 app.use(((error, _req, res, next) => {
@@ -23,6 +22,10 @@ app.get("/health", (_req, res) => {
 
 app.use("/users", usersRouter);
 
-app.listen(port, () => {
-  console.log(`TaskFlow API listening on port ${port}`);
-});
+if (import.meta.url === `file://${process.argv[1]}`) {
+  const port = process.env.PORT || 4000;
+
+  app.listen(port, () => {
+    console.log(`TaskFlow API listening on port ${port}`);
+  });
+}

--- a/apps/api/src/json-error.test.ts
+++ b/apps/api/src/json-error.test.ts
@@ -1,39 +1,16 @@
 import assert from "node:assert/strict";
-import { spawn } from "node:child_process";
 import { test } from "node:test";
 
-async function waitForServer(port: number) {
-  const deadline = Date.now() + 5000;
-
-  while (Date.now() < deadline) {
-    try {
-      const response = await fetch(`http://127.0.0.1:${port}/health`);
-      if (response.ok) {
-        return;
-      }
-    } catch {
-      await new Promise((resolve) => setTimeout(resolve, 100));
-    }
-  }
-
-  throw new Error("API server did not become ready");
-}
+import { app } from "./index";
 
 test("malformed JSON request bodies return a JSON 400 response", async () => {
-  const port = 4517;
-  const server = spawn("tsx", ["src/index.ts"], {
-    cwd: new URL("..", import.meta.url),
-    env: {
-      ...process.env,
-      PORT: String(port)
-    },
-    stdio: "ignore"
-  });
+  const server = app.listen(0);
 
   try {
-    await waitForServer(port);
+    const address = server.address();
+    assert(address && typeof address === "object");
 
-    const response = await fetch(`http://127.0.0.1:${port}/users`, {
+    const response = await fetch(`http://127.0.0.1:${address.port}/users`, {
       method: "POST",
       headers: {
         "content-type": "application/json"
@@ -47,9 +24,15 @@ test("malformed JSON request bodies return a JSON 400 response", async () => {
       error: "Invalid JSON request body"
     });
   } finally {
-    server.kill("SIGTERM");
-    await new Promise<void>((resolve) => {
-      server.once("exit", () => resolve());
+    await new Promise<void>((resolve, reject) => {
+      server.close((error) => {
+        if (error) {
+          reject(error);
+          return;
+        }
+
+        resolve();
+      });
     });
   }
 });

--- a/apps/api/src/json-error.test.ts
+++ b/apps/api/src/json-error.test.ts
@@ -1,0 +1,55 @@
+import assert from "node:assert/strict";
+import { spawn } from "node:child_process";
+import { test } from "node:test";
+
+async function waitForServer(port: number) {
+  const deadline = Date.now() + 5000;
+
+  while (Date.now() < deadline) {
+    try {
+      const response = await fetch(`http://127.0.0.1:${port}/health`);
+      if (response.ok) {
+        return;
+      }
+    } catch {
+      await new Promise((resolve) => setTimeout(resolve, 100));
+    }
+  }
+
+  throw new Error("API server did not become ready");
+}
+
+test("malformed JSON request bodies return a JSON 400 response", async () => {
+  const port = 4517;
+  const server = spawn("tsx", ["src/index.ts"], {
+    cwd: new URL("..", import.meta.url),
+    env: {
+      ...process.env,
+      PORT: String(port)
+    },
+    stdio: "ignore"
+  });
+
+  try {
+    await waitForServer(port);
+
+    const response = await fetch(`http://127.0.0.1:${port}/users`, {
+      method: "POST",
+      headers: {
+        "content-type": "application/json"
+      },
+      body: "{\"name\":"
+    });
+
+    assert.equal(response.status, 400);
+    assert.equal(response.headers.get("content-type")?.includes("application/json"), true);
+    assert.deepEqual(await response.json(), {
+      error: "Invalid JSON request body"
+    });
+  } finally {
+    server.kill("SIGTERM");
+    await new Promise<void>((resolve) => {
+      server.once("exit", () => resolve());
+    });
+  }
+});

--- a/contributors/agents.json
+++ b/contributors/agents.json
@@ -4,7 +4,7 @@
       "github_username": "M3stark",
       "model": "GPT-5 Codex",
       "version": "2026-06-09",
-      "pr_number": 0,
+      "pr_number": 1249,
       "issue_number": 1248
     }
   ],

--- a/contributors/agents.json
+++ b/contributors/agents.json
@@ -1,5 +1,13 @@
 {
-  "agents": [],
-  "last_updated": "2026-06-03",
-  "total_contributions": 0
+  "agents": [
+    {
+      "github_username": "M3stark",
+      "model": "GPT-5 Codex",
+      "version": "2026-06-09",
+      "pr_number": 0,
+      "issue_number": 1248
+    }
+  ],
+  "last_updated": "2026-06-09",
+  "total_contributions": 1
 }


### PR DESCRIPTION
Closes #1248
/claim #1248

## Description
Malformed JSON request bodies were falling through Express/body-parser's default error response, which returns an HTML error page. This adds a focused error middleware immediately after `express.json()` so JSON syntax failures return a stable API response:

```json
{ "error": "Invalid JSON request body" }
```

## AI Agent Checklist

- [x] I reacted thumbs-up on issue #16 (Agent Registry)
- [x] I starred this repository
- [x] I added my model name and version to `contributors/agents.json`
- [x] My PR title includes the `[agent]` tag

## Changes Made

- `apps/api/src/index.ts`: handles `express.json()` syntax errors with JSON HTTP 400.
- `apps/api/src/json-error.test.ts`: adds a focused runtime smoke test for malformed JSON POSTs.
- `apps/api/package.json`: wires the API test script to `tsx --test`.
- `contributors/agents.json`: adds required AI-agent metadata. I will update `pr_number` after GitHub assigns this PR number.

## Validation

- `node -e "JSON.parse(require('fs').readFileSync('contributors/agents.json','utf8')); JSON.parse(require('fs').readFileSync('apps/api/package.json','utf8')); console.log('json ok')"` passed.
- `git diff --check` passed.
- `npm test -w apps/api` could not complete in this local environment because the fresh clone has no installed dependencies and `npm install` stalled before linking `node_modules`. The regression test is included for CI/reviewer verification.

## Model Info (AI agents only)

- Model name/version: GPT-5 Codex / 2026-06-09
- Issue attempted: #1248
- Approach used: focused Express JSON parser error middleware plus malformed-body smoke test

## Payout Wallet

If this claim is selected for payment, please send the bounty to `0x8f94Eb732F5044dee8C23ECe9A1BDd801288dfc8` (Polygon USDT preferred; same EVM address can receive compatible EVM payouts if required by the bounty system).
