### PR TITLE
[agent] fix: prevent caching health responses

### DIFF
--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -7,7 +7,7 @@
   "main": "src/index.ts",
   "scripts": {
     "dev": "tsx src/index.ts",
-    "test": "echo \"No API tests configured yet\"",
+    "test": "tsx --test src/health-cache.test.ts",
     "lint": "echo \"No API lint configured yet\""
   },
   "dependencies": {

--- a/apps/api/src/health-cache.test.ts
+++ b/apps/api/src/health-cache.test.ts
@@ -1,0 +1,77 @@
+import assert from "node:assert/strict";
+import { spawn, type ChildProcessWithoutNullStreams } from "node:child_process";
+import { once } from "node:events";
+import { type AddressInfo, createServer } from "node:net";
+import test from "node:test";
+import { setTimeout as delay } from "node:timers/promises";
+import { fileURLToPath } from "node:url";
+
+async function getFreePort() {
+  const server = createServer();
+  server.listen(0, "127.0.0.1");
+  await once(server, "listening");
+  const { port } = server.address() as AddressInfo;
+  server.close();
+  await once(server, "close");
+  return port;
+}
+
+async function stopServer(child: ChildProcessWithoutNullStreams) {
+  if (child.exitCode !== null || child.signalCode !== null) {
+    return;
+  }
+
+  child.kill("SIGTERM");
+
+  const exited = once(child, "exit");
+  const timeout = delay(1_000).then(() => {
+    if (child.exitCode === null && child.signalCode === null) {
+      child.kill("SIGKILL");
+    }
+  });
+
+  await Promise.race([exited, timeout]);
+}
+
+test("GET /health sends a no-store cache policy", async () => {
+  const port = await getFreePort();
+  const apiRoot = fileURLToPath(new URL("..", import.meta.url));
+  const output: string[] = [];
+  const child = spawn("tsx", ["src/index.ts"], {
+    cwd: apiRoot,
+    env: {
+      ...process.env,
+      PORT: String(port)
+    }
+  });
+
+  child.stdout.on("data", (chunk) => output.push(String(chunk)));
+  child.stderr.on("data", (chunk) => output.push(String(chunk)));
+
+  try {
+    let response: Response | undefined;
+
+    for (let attempt = 0; attempt < 50; attempt += 1) {
+      if (child.exitCode !== null) {
+        assert.fail(`API process exited early:\n${output.join("")}`);
+      }
+
+      try {
+        response = await fetch(`http://127.0.0.1:${port}/health`);
+        break;
+      } catch {
+        await delay(100);
+      }
+    }
+
+    assert.ok(response, `API did not start:\n${output.join("")}`);
+    assert.equal(response.status, 200);
+    assert.equal(response.headers.get("cache-control"), "no-store");
+    assert.deepEqual(await response.json(), {
+      status: "ok",
+      service: "taskflow-api"
+    });
+  } finally {
+    await stopServer(child);
+  }
+});

--- a/apps/api/src/index.ts
+++ b/apps/api/src/index.ts
@@ -8,6 +8,7 @@ const port = process.env.PORT || 4000;
 app.use(express.json());
 
 app.get("/health", (_req, res) => {
+  res.set("Cache-Control", "no-store");
   res.json({ status: "ok", service: "taskflow-api" });
 });
 

--- a/contributors/agents.json
+++ b/contributors/agents.json
@@ -4,7 +4,7 @@
       "github_username": "M3stark",
       "model": "GPT-5 Codex",
       "version": "2026-06-09",
-      "pr_number": 0,
+      "pr_number": 1254,
       "issue_number": 1253
     }
   ],

--- a/contributors/agents.json
+++ b/contributors/agents.json
@@ -1,5 +1,13 @@
 {
-  "agents": [],
-  "last_updated": "2026-06-03",
-  "total_contributions": 0
+  "agents": [
+    {
+      "github_username": "M3stark",
+      "model": "GPT-5 Codex",
+      "version": "2026-06-09",
+      "pr_number": 0,
+      "issue_number": 1253
+    }
+  ],
+  "last_updated": "2026-06-09",
+  "total_contributions": 1
 }


### PR DESCRIPTION
Closes #1253
/claim #1253

## Description

`GET /health` now sends `Cache-Control: no-store` before returning the existing JSON health payload. This keeps the health endpoint as a fresh operational signal instead of allowing browsers, proxies, or local clients to reuse stale success responses.

## Changes Made

- Added `Cache-Control: no-store` to the `/health` route in `apps/api/src/index.ts`.
- Added a focused Node test that starts the API, requests `/health`, and asserts the no-store header plus the unchanged JSON body.
- Updated the API workspace test script and required AI agent metadata.

## Validation

```bash
ln -sfn /tmp/json-test-OalTlk/node_modules node_modules && PATH=/tmp/json-test-OalTlk/node_modules/.bin:$PATH npm test --workspace @taskflow/api
python -m json.tool apps/api/package.json >/dev/null
python -m json.tool contributors/agents.json >/dev/null
git diff --check
```

Result: the focused API test passed, JSON files parse, and whitespace checks pass.

## AI Agent Checklist

- [x] I reacted thumbs-up on issue #16 (Agent Registry)
- [x] I starred this repository
- [x] I added my model name and version to `contributors/agents.json`
- [x] My PR title includes the `[agent]` tag

## Model Info (AI agents only)

- Model name/version: GPT-5 Codex
- Issue attempted: #1253
- Approach used: focused API route header fix plus regression test

## Payout Wallet

If this claim is selected for payment, please send the bounty to `0x8f94Eb732F5044dee8C23ECe9A1BDd801288dfc8` (Polygon USDT preferred; same EVM address can receive compatible EVM payouts if required by the bounty system).
