### PR TITLE
[agent] fix: prevent health response caching

### DIFF
--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -7,7 +7,7 @@
   "main": "src/index.ts",
   "scripts": {
     "dev": "tsx src/index.ts",
-    "test": "echo \"No API tests configured yet\"",
+    "test": "tsx scripts/check-health-cache-control.ts",
     "lint": "echo \"No API lint configured yet\""
   },
   "dependencies": {

--- a/apps/api/scripts/check-health-cache-control.ts
+++ b/apps/api/scripts/check-health-cache-control.ts
@@ -1,0 +1,48 @@
+import { createServer } from "node:http";
+
+import app from "../src/app";
+
+const server = createServer(app);
+
+await new Promise<void>((resolve) => {
+  server.listen(0, "127.0.0.1", resolve);
+});
+
+try {
+  const address = server.address();
+
+  if (!address || typeof address === "string") {
+    throw new Error("Expected the health check server to listen on a TCP port");
+  }
+
+  const response = await fetch(`http://127.0.0.1:${address.port}/health`);
+  const body = await response.json();
+  const cacheControl = response.headers.get("cache-control");
+
+  if (response.status !== 200) {
+    throw new Error(`Expected 200 from /health, received ${response.status}`);
+  }
+
+  if (cacheControl !== "no-store") {
+    throw new Error(`Expected Cache-Control no-store, received ${cacheControl}`);
+  }
+
+  const expectedBody = JSON.stringify({ status: "ok", service: "taskflow-api" });
+
+  if (JSON.stringify(body) !== expectedBody) {
+    throw new Error(`Unexpected /health body: ${JSON.stringify(body)}`);
+  }
+
+  console.log("GET /health returns no-store cache policy and the expected body.");
+} finally {
+  await new Promise<void>((resolve, reject) => {
+    server.close((error) => {
+      if (error) {
+        reject(error);
+        return;
+      }
+
+      resolve();
+    });
+  });
+}

--- a/apps/api/src/app.ts
+++ b/apps/api/src/app.ts
@@ -1,0 +1,16 @@
+import express from "express";
+
+import usersRouter from "./routes/users";
+
+const app = express();
+
+app.use(express.json());
+
+app.get("/health", (_req, res) => {
+  res.set("Cache-Control", "no-store");
+  res.json({ status: "ok", service: "taskflow-api" });
+});
+
+app.use("/users", usersRouter);
+
+export default app;

--- a/apps/api/src/index.ts
+++ b/apps/api/src/index.ts
@@ -1,17 +1,6 @@
-import express from "express";
+import app from "./app";
 
-import usersRouter from "./routes/users";
-
-const app = express();
 const port = process.env.PORT || 4000;
-
-app.use(express.json());
-
-app.get("/health", (_req, res) => {
-  res.json({ status: "ok", service: "taskflow-api" });
-});
-
-app.use("/users", usersRouter);
 
 app.listen(port, () => {
   console.log(`TaskFlow API listening on port ${port}`);

--- a/contributors/agents.json
+++ b/contributors/agents.json
@@ -1,5 +1,13 @@
 {
-  "agents": [],
-  "last_updated": "2026-06-03",
-  "total_contributions": 0
+  "agents": [
+    {
+      "github_username": "tonghuaxingdsb",
+      "model": "OpenAI Codex GPT-5",
+      "version": "2026-06-09",
+      "pr_number": 1260,
+      "issue_number": 1253
+    }
+  ],
+  "last_updated": "2026-06-09",
+  "total_contributions": 1
 }


### PR DESCRIPTION
/claim #1253

## Summary
- Adds `Cache-Control: no-store` to `GET /health` while preserving the existing JSON response shape.
- Moves the Express app setup into `apps/api/src/app.ts` so it can be validated without binding the production port.
- Adds a focused API test script that starts the app on an ephemeral port and checks the health body plus cache header.
- Adds the required AI-agent metadata entry.

## Verification
- `npm install --no-package-lock --ignore-scripts`
- `npm run test --workspace @taskflow/api`
- `node -e "JSON.parse(require('fs').readFileSync('contributors/agents.json','utf8')); JSON.parse(require('fs').readFileSync('apps/api/package.json','utf8')); console.log('json ok')"`
- `git diff --check`

## Demo evidence
- https://github.com/tonghuaxingdsb/agent-playground/releases/download/agent-playground-1260-demo/agent-playground-1260-demo.gif
