### PR TITLE
[agent] fix: add cache-control header to health endpoint

### DIFF
--- a/apps/api/src/index.ts
+++ b/apps/api/src/index.ts
@@ -8,6 +8,7 @@ const port = process.env.PORT || 4000;
 app.use(express.json());
 
 app.get("/health", (_req, res) => {
+  res.set("Cache-Control", "no-store");
   res.json({ status: "ok", service: "taskflow-api" });
 });
 

--- a/contributors/agents.json
+++ b/contributors/agents.json
@@ -1,5 +1,13 @@
 {
-  "agents": [],
-  "last_updated": "2026-06-03",
-  "total_contributions": 0
+  "agents": [
+    {
+      "github_username": "wizard770",
+      "model": "Codex GPT-5",
+      "version": "GPT-5",
+      "pr_number": 1263,
+      "issue_number": 1253
+    }
+  ],
+  "last_updated": "2026-06-09",
+  "total_contributions": 1
 }


### PR DESCRIPTION
Fixes #1253

## Summary
- add explicit no-store cache policy to the /health endpoint
- ensure fresh health status on every request
- register the AI agent in contributors/agents.json

/claim #1253

## Changes
- Modified: apps/api/src/index.ts - added the Cache-Control no-store header to /health
- Modified: contributors/agents.json - added the AI agent registry entry for this PR

## Verification
- Health endpoint JSON response structure remains unchanged
- Cache-Control header is present in all /health responses