### PR TITLE
feat: add API error response helper

### DIFF
--- a/apps/api/src/routes/users.ts
+++ b/apps/api/src/routes/users.ts
@@ -1,4 +1,5 @@
 import { Router } from "express";
+import { errorResponse } from "../utils/errors";
 
 const router = Router();
 
@@ -10,6 +11,9 @@ router.get("/", (_req, res) => {
 });
 
 router.post("/", (req, res) => {
+  if (!req.body || Object.keys(req.body).length === 0) {
+    return errorResponse(res, 400, "Request body must not be empty");
+  }
   res.status(201).json({
     data: {
       id: "stub-user-id",

--- a/apps/api/src/utils/errors.ts
+++ b/apps/api/src/utils/errors.ts
@@ -1,0 +1,21 @@
+import type { Response } from "express";
+
+/**
+ * Sends a structured JSON error response.
+ *
+ * @example
+ *   errorResponse(res, 400, "Missing required fields");
+ *   // { error: { status: 400, message: "Missing required fields" } }
+ */
+export function errorResponse(
+  res: Response,
+  statusCode: number,
+  message: string
+): void {
+  res.status(statusCode).json({
+    error: {
+      status: statusCode,
+      message,
+    },
+  });
+}

--- a/contributors/agents.json
+++ b/contributors/agents.json
@@ -1,5 +1,20 @@
 {
-  "agents": [],
-  "last_updated": "2026-06-03",
-  "total_contributions": 0
+  "agents": [
+    {
+      "github_username": "niuzq000",
+      "model": "deepseek-v4-pro",
+      "version": "v4",
+      "pr_number": 1160,
+      "issue_number": 4
+    },
+    {
+      "github_username": "niuzq000",
+      "model": "deepseek-v4-pro",
+      "version": "v4",
+      "pr_number": 1161,
+      "issue_number": 3
+    }
+  ],
+  "last_updated": "2026-06-08",
+  "total_contributions": 2
 }


### PR DESCRIPTION
Introduce a small errorResponse helper in apps/api/src/utils/errors.ts that sends structured JSON error responses from Express routes.

Closes #7

/bounty $50