### PR TITLE
fix(api): return JSON 400 for malformed request bodies (#1248)

### DIFF
--- a/apps/api/src/index.ts
+++ b/apps/api/src/index.ts
@@ -1,4 +1,4 @@
-import express from "express";
+import express, { type ErrorRequestHandler } from "express";
 
 import usersRouter from "./routes/users";
 
@@ -12,6 +12,21 @@ app.get("/health", (_req, res) => {
 });
 
 app.use("/users", usersRouter);
+
+// Focused error middleware for express.json() parse failures.
+// Returns a JSON 400 instead of Express's default HTML error page so API
+// clients can parse the response and route smoke tests can assert shape.
+// Non-SyntaxError errors fall through to any later error handler.
+const jsonParseErrorHandler: ErrorRequestHandler = (err, _req, res, next) => {
+  if (err instanceof SyntaxError && "body" in err) {
+    res.status(400).json({ error: "Invalid JSON request body" });
+    return;
+  }
+
+  next(err);
+};
+
+app.use(jsonParseErrorHandler);
 
 app.listen(port, () => {
   console.log(`TaskFlow API listening on port ${port}`);

--- a/scripts/smoke-json-parse.sh
+++ b/scripts/smoke-json-parse.sh
@@ -1,0 +1,91 @@
+#!/usr/bin/env bash
+# Smoke test for the malformed-JSON body handler (issue #1248).
+# Spins up the API, hits POST /users with a malformed JSON body, and asserts
+# the response is HTTP 400 with the spec's JSON error shape.
+#
+# Usage:  bash scripts/smoke-json-parse.sh
+# Exits 0 on success, non-zero on any assertion failure.
+
+set -euo pipefail
+
+PORT="${PORT:-4321}"
+BASE="http://127.0.0.1:${PORT}"
+LOG_DIR="$(mktemp -d)"
+LOG_FILE="${LOG_DIR}/api.log"
+
+cleanup() {
+  if [[ -n "${API_PID:-}" ]] && kill -0 "${API_PID}" 2>/dev/null; then
+    kill "${API_PID}" 2>/dev/null || true
+    wait "${API_PID}" 2>/dev/null || true
+  fi
+  rm -rf "${LOG_DIR}"
+}
+trap cleanup EXIT
+
+echo "[smoke] starting API on port ${PORT}..."
+PORT="${PORT}" npx --prefix apps/api tsx apps/api/src/index.ts >"${LOG_FILE}" 2>&1 &
+API_PID=$!
+
+# Wait for the server to be ready (max ~10s).
+for _ in $(seq 1 50); do
+  if curl -fsS "${BASE}/health" >/dev/null 2>&1; then
+    break
+  fi
+  sleep 0.2
+done
+
+if ! curl -fsS "${BASE}/health" >/dev/null 2>&1; then
+  echo "[smoke] API failed to start. Log tail:" >&2
+  tail -n 50 "${LOG_FILE}" >&2 || true
+  exit 1
+fi
+
+echo "[smoke] API up. Running assertions..."
+
+# 1. Valid /health still returns 200 JSON (regression guard).
+HEALTH_BODY="$(curl -fsS "${BASE}/health")"
+echo "${HEALTH_BODY}" | grep -q '"status":"ok"' \
+  || { echo "[smoke] FAIL: /health body regressed: ${HEALTH_BODY}"; exit 1; }
+
+# 2. Malformed JSON body returns 400 + the spec's error shape, not HTML.
+TMP_HEADERS="$(mktemp)"
+TMP_BODY="$(mktemp)"
+HTTP_STATUS="$(curl -sS -o "${TMP_BODY}" -D "${TMP_HEADERS}" -w "%{http_code}" \
+  -X POST "${BASE}/users" \
+  -H "Content-Type: application/json" \
+  --data-binary '{ this is not json')"
+
+CONTENT_TYPE="$(grep -i '^content-type:' "${TMP_HEADERS}" | tr -d '\r' | head -n1 | awk '{print tolower($2)}')"
+BODY="$(cat "${TMP_BODY}")"
+
+echo "[smoke] malformed POST /users -> ${HTTP_STATUS} (${CONTENT_TYPE})"
+echo "[smoke] body: ${BODY}"
+
+[[ "${HTTP_STATUS}" == "400" ]] \
+  || { echo "[smoke] FAIL: expected 400, got ${HTTP_STATUS}"; exit 1; }
+
+[[ "${CONTENT_TYPE}" == application/json* ]] \
+  || { echo "[smoke] FAIL: expected JSON content-type, got '${CONTENT_TYPE}'"; exit 1; }
+
+# Body must match the spec's shape; do not require exact key order.
+echo "${BODY}" | grep -q '"error"' \
+  || { echo "[smoke] FAIL: response missing 'error' key: ${BODY}"; exit 1; }
+
+echo "${BODY}" | grep -q '"Invalid JSON request body"' \
+  || { echo "[smoke] FAIL: response missing spec error string: ${BODY}"; exit 1; }
+
+# Body must NOT be HTML.
+echo "${BODY}" | grep -qiE '<html|<body|<!doctype' \
+  && { echo "[smoke] FAIL: response looks like HTML: ${BODY}"; exit 1; }
+
+# 3. Valid JSON still works on /users (regression guard for happy path).
+VALID_STATUS="$(curl -sS -o /dev/null -w "%{http_code}" \
+  -X POST "${BASE}/users" \
+  -H "Content-Type: application/json" \
+  --data '{"name":"larry"}')"
+[[ "${VALID_STATUS}" == "201" ]] \
+  || { echo "[smoke] FAIL: valid JSON POST /users expected 201, got ${VALID_STATUS}"; exit 1; }
+
+rm -f "${TMP_HEADERS}" "${TMP_BODY}"
+
+echo "[smoke] OK — malformed JSON returns JSON 400 with the spec error string."


### PR DESCRIPTION
Fixes #1248.

## What
Adds a focused error-handling middleware after the routes that catches the `SyntaxError` thrown by `express.json()` on parse failure and returns:

```http
HTTP/1.1 400 Bad Request
Content-Type: application/json

{"error":"Invalid JSON request body"}
```

instead of Express's default HTML error page.

## Why
- API clients that always parse JSON were getting HTML for malformed bodies.
- The /users response shape was inconsistent with the rest of the API.
- The default HTML page is hard to assert in route smoke tests and automated clients.

## Scope
- Only handles the JSON-parse-failure path described in #1248.
- Does **not** touch the broader global error-handler work in #225.
- Non-SyntaxError errors fall through to the next error handler (`next(err)`).

## Diff vs #1252
- Uses the spec's **exact** error string: `"Invalid JSON request body"` (no trailing period).
- Adds `scripts/smoke-json-parse.sh` — a self-contained regression smoke test (boots the API, posts malformed + valid JSON to `/users`, asserts 400/JSON shape and 201 happy path). `apps/api/package.json` has no test framework configured, so bash + curl is the lightest-weight option that still satisfies the issue's acceptance criterion.

## Verification
Ran `bash scripts/smoke-json-parse.sh` locally on the change — all assertions pass:
```
[smoke] starting API on port 4321...
[smoke] API up. Running assertions...
[smoke] malformed POST /users -> 400 (application/json;)
[smoke] body: {"error":"Invalid JSON request body"}
[smoke] OK — malformed JSON returns JSON 400 with the spec error string.
```