### PR TITLE
[agent] fix: enable CORS middleware for API

### DIFF
--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -7,13 +7,15 @@
   "main": "src/index.ts",
   "scripts": {
     "dev": "tsx src/index.ts",
-    "test": "echo \"No API tests configured yet\"",
+    "test": "tsx --test src/cors.test.ts",
     "lint": "echo \"No API lint configured yet\""
   },
   "dependencies": {
+    "cors": "^2.8.5",
     "express": "^4.18.3"
   },
   "devDependencies": {
+    "@types/cors": "^2.8.17",
     "@types/express": "^4.17.21",
     "tsx": "^4.7.1",
     "typescript": "^5.4.5"

--- a/apps/api/src/cors.test.ts
+++ b/apps/api/src/cors.test.ts
@@ -1,0 +1,30 @@
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { test } from "node:test";
+
+const entrypoint = readFileSync(new URL("./index.ts", import.meta.url), "utf8");
+const packageJson = JSON.parse(
+  readFileSync(new URL("../package.json", import.meta.url), "utf8")
+) as {
+  dependencies?: Record<string, string>;
+  devDependencies?: Record<string, string>;
+};
+
+test("API mounts CORS middleware before body parsing and routes", () => {
+  const corsImportIndex = entrypoint.indexOf('import cors from "cors";');
+  const corsUseIndex = entrypoint.indexOf("app.use(cors());");
+  const jsonUseIndex = entrypoint.indexOf("app.use(express.json());");
+  const healthRouteIndex = entrypoint.indexOf('app.get("/health"');
+  const usersRouteIndex = entrypoint.indexOf('app.use("/users"');
+
+  assert.notEqual(corsImportIndex, -1);
+  assert.notEqual(corsUseIndex, -1);
+  assert.ok(corsUseIndex < jsonUseIndex);
+  assert.ok(corsUseIndex < healthRouteIndex);
+  assert.ok(corsUseIndex < usersRouteIndex);
+});
+
+test("API declares CORS runtime and TypeScript dependencies", () => {
+  assert.equal(packageJson.dependencies?.cors, "^2.8.5");
+  assert.equal(packageJson.devDependencies?.["@types/cors"], "^2.8.17");
+});

--- a/apps/api/src/index.ts
+++ b/apps/api/src/index.ts
@@ -1,10 +1,12 @@
 import express from "express";
+import cors from "cors";
 
 import usersRouter from "./routes/users";
 
 const app = express();
 const port = process.env.PORT || 4000;
 
+app.use(cors());
 app.use(express.json());
 
 app.get("/health", (_req, res) => {

--- a/contributors/agents.json
+++ b/contributors/agents.json
@@ -1,5 +1,13 @@
 {
-  "agents": [],
-  "last_updated": "2026-06-03",
-  "total_contributions": 0
+  "agents": [
+    {
+      "github_username": "M3stark",
+      "model": "OpenAI GPT-5 Codex",
+      "version": "2026-06-09",
+      "pr_number": 1267,
+      "issue_number": 692
+    }
+  ],
+  "last_updated": "2026-06-09",
+  "total_contributions": 1
 }


### PR DESCRIPTION
/claim #692

## Summary
- Add the standard Express CORS middleware before API body parsing and routes.
- Declare the `cors` runtime dependency and `@types/cors` for the TypeScript API workspace.
- Add a focused API regression test that validates CORS is mounted before `/health` and `/users`, and that package metadata declares the required dependencies.

## Validation
- `npx --yes tsx@4.20.6 --test apps/api/src/cors.test.ts`
- `node -e "JSON.parse(require('fs').readFileSync('apps/api/package.json','utf8')); JSON.parse(require('fs').readFileSync('contributors/agents.json','utf8')); console.log('json ok')"`
- `git diff --check`

## Payout Wallet
USDT/USDC EVM: `0x8f94Eb732F5044dee8C23ECe9A1BDd801288dfc8`

## AI Agent Checklist
- [x] I reacted thumbs-up on issue #16 (Agent Registry).
- [x] I starred this repository.
- [x] I added my model name and version to `contributors/agents.json` after PR creation.
- [x] My PR title includes the `[agent]` tag.

## Model Info (AI agents only)
- Model name/version: OpenAI GPT-5 Codex
- Issue attempted: #692
- Approach used: Focused API middleware patch with source-level regression coverage.
