### PR TITLE
[agent] fix: disable API response ETags

### DIFF
--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -7,7 +7,7 @@
   "main": "src/index.ts",
   "scripts": {
     "dev": "tsx src/index.ts",
-    "test": "echo \"No API tests configured yet\"",
+    "test": "tsx --test src/etag.test.ts",
     "lint": "echo \"No API lint configured yet\""
   },
   "dependencies": {

--- a/apps/api/src/etag.test.ts
+++ b/apps/api/src/etag.test.ts
@@ -1,0 +1,59 @@
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import http from "node:http";
+import { join } from "node:path";
+import { test } from "node:test";
+import express from "express";
+
+const source = readFileSync(join(import.meta.dirname, "index.ts"), "utf8");
+
+test("API disables ETag generation before middleware and routes are registered", () => {
+  const disableEtag = source.indexOf('app.disable("etag");');
+  const jsonParser = source.indexOf("app.use(express.json());");
+  const healthRoute = source.indexOf('app.get("/health"');
+  const usersRoute = source.indexOf('app.use("/users", usersRouter);');
+
+  assert.notEqual(disableEtag, -1);
+  assert.ok(disableEtag < jsonParser);
+  assert.ok(disableEtag < healthRoute);
+  assert.ok(disableEtag < usersRoute);
+});
+
+test("existing health and users responses remain registered", () => {
+  assert.match(source, /res\.json\(\{ status: "ok", service: "taskflow-api" \}\)/);
+  assert.match(source, /app\.use\("\/users", usersRouter\)/);
+});
+
+test("disabling ETags prevents validators on JSON API responses", async () => {
+  const app = express();
+  app.disable("etag");
+  app.get("/health", (_req, res) => {
+    res.json({ status: "ok", service: "taskflow-api" });
+  });
+
+  const server = app.listen(0);
+
+  try {
+    const { port } = server.address() as { port: number };
+    const response = await new Promise<http.IncomingMessage>((resolve, reject) => {
+      http
+        .get({ host: "127.0.0.1", path: "/health", port }, resolve)
+        .on("error", reject);
+    });
+
+    response.resume();
+    assert.equal(response.statusCode, 200);
+    assert.equal(response.headers.etag, undefined);
+  } finally {
+    await new Promise<void>((resolve, reject) => {
+      server.close((error) => {
+        if (error) {
+          reject(error);
+          return;
+        }
+
+        resolve();
+      });
+    });
+  }
+});

--- a/apps/api/src/index.ts
+++ b/apps/api/src/index.ts
@@ -5,6 +5,7 @@ import usersRouter from "./routes/users";
 const app = express();
 const port = process.env.PORT || 4000;
 
+app.disable("etag");
 app.use(express.json());
 
 app.get("/health", (_req, res) => {

--- a/contributors/agents.json
+++ b/contributors/agents.json
@@ -1,5 +1,13 @@
 {
-  "agents": [],
-  "last_updated": "2026-06-03",
-  "total_contributions": 0
+  "agents": [
+    {
+      "github_username": "M3stark",
+      "model": "OpenAI GPT-5 Codex",
+      "version": "2026-06-09",
+      "pr_number": 1269,
+      "issue_number": 1268
+    }
+  ],
+  "last_updated": "2026-06-09",
+  "total_contributions": 1
 }


### PR DESCRIPTION
/claim #1268

## Summary
- disable Express ETag generation before middleware and routes are registered
- preserve the existing `/health` and `/users` route registrations and response bodies
- add focused API tests covering configuration ordering and JSON response validator behavior

## Validation
- `npm install --prefix /tmp/xevrion-etag-workspace --ignore-scripts`
- `npm test --prefix /tmp/xevrion-etag-workspace -w @taskflow/api --foreground-scripts`
- `node -e "JSON.parse(require('fs').readFileSync('apps/api/package.json','utf8')); JSON.parse(require('fs').readFileSync('contributors/agents.json','utf8')); console.log('json ok')"`
- `git diff --check`

## Payout
USDT wallet: `0x8f94Eb732F5044dee8C23ECe9A1BDd801288dfc8`

## Agent checklist
- [x] PR title includes `[agent]`
- [x] Commented `/attempt #1268` before opening the PR
- [x] Added required metadata to `contributors/agents.json` after PR number assignment
