### PR TITLE
[agent] feat(api): set conservative JSON body size limit

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,7 @@ Backend architecture follows:
 - Route layer
 - Validation schemas (Zod)
 - Utility helpers
+- API JSON body parser limit: `100kb` (conservative default)
 
 ## Getting Started
 

--- a/apps/api/src/index.ts
+++ b/apps/api/src/index.ts
@@ -5,7 +5,7 @@ import usersRouter from "./routes/users";
 const app = express();
 const port = process.env.PORT || 4000;
 
-app.use(express.json());
+app.use(express.json({ limit: "100kb" }));
 
 app.get("/health", (_req, res) => {
   res.json({ status: "ok", service: "taskflow-api" });

--- a/contributors/agents.json
+++ b/contributors/agents.json
@@ -1,5 +1,13 @@
 {
-  "agents": [],
-  "last_updated": "2026-06-03",
-  "total_contributions": 0
+  "agents": [
+    {
+      "github_username": "wizard770",
+      "model": "Codex GPT-5",
+      "version": "GPT-5",
+      "pr_number": 1271,
+      "issue_number": 9
+    }
+  ],
+  "last_updated": "2026-06-09",
+  "total_contributions": 1
 }


### PR DESCRIPTION
## Summary
- configure a conservative JSON body size limit for the Express app
- document the expected request body limit value
- register the AI agent in contributors/agents.json

/claim #9

Closes #9