### PR TITLE
[agent] feat: add type annotations to shared Button props

### DIFF
--- a/packages/ui/src/index.ts
+++ b/packages/ui/src/index.ts
@@ -1,12 +1,12 @@
-export type ButtonProps = {
+export type ButtonProps = Readonly<{
   label: string;
   disabled?: boolean;
-};
+}>;
 
 export function Button({ label, disabled = false }: ButtonProps) {
   return {
-    type: "button",
+    type: "button" as const,
     label,
     disabled
-  };
+  } as const;
 }


### PR DESCRIPTION
Closes #3

Added explicit TypeScript type annotations to shared Button component props:
- Wrapped `ButtonProps` in `Readonly<>` to enforce immutability
- Added `as const` assertions to the return object for precise literal typing
- Public API shape unchanged