### PR TITLE
fix(api): add CORS middleware

### DIFF
--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -11,6 +11,7 @@
     "lint": "echo \"No API lint configured yet\""
   },
   "dependencies": {
+    "cors": "^2.8.5",
     "express": "^4.18.3"
   },
   "devDependencies": {

--- a/apps/api/src/index.ts
+++ b/apps/api/src/index.ts
@@ -1,4 +1,5 @@
 import express from "express";
+import cors from "cors";
 
 import usersRouter from "./routes/users";
 
@@ -6,6 +7,7 @@ const app = express();
 const port = process.env.PORT || 4000;
 
 app.use(express.json());
+app.use(cors());
 
 app.get("/health", (_req, res) => {
   res.json({ status: "ok", service: "taskflow-api" });


### PR DESCRIPTION
This PR addresses Issue #692 by adding the `cors` middleware to the Express API application.

The Express API was missing the `cors()` middleware, which caused cross-origin requests from the web frontend to be blocked by browser security policies.

**Changes:**
- Installed the `cors` package as a dependency in `apps/api/package.json`.
- Imported `cors` and added `app.use(cors())` in `apps/api/src/index.ts`.

This fix enables proper communication between the web frontend and the API, resolving the CORS issue.

Fixes #692