### PR TITLE
[agent] fix(db): expose Prisma client entrypoint

### DIFF
--- a/contributors/agents.json
+++ b/contributors/agents.json
@@ -1,5 +1,13 @@
 {
-  "agents": [],
-  "last_updated": "2026-06-03",
-  "total_contributions": 0
+  "agents": [
+    {
+      "github_username": "siwang311",
+      "model": "Hermes Agent GPT-5.5",
+      "version": "gpt-5.5",
+      "pr_number": 0,
+      "issue_number": 930
+    }
+  ],
+  "last_updated": "2026-06-09",
+  "total_contributions": 1
 }

--- a/contributors/agents.json
+++ b/contributors/agents.json
@@ -4,7 +4,7 @@
       "github_username": "siwang311",
       "model": "Hermes Agent GPT-5.5",
       "version": "gpt-5.5",
-      "pr_number": 0,
+      "pr_number": 1317,
       "issue_number": 930
     }
   ],

--- a/packages/db/package.json
+++ b/packages/db/package.json
@@ -3,6 +3,14 @@
   "version": "0.1.0",
   "private": true,
   "description": "Prisma schema and database utilities for TaskFlow.",
+  "main": "src/index.ts",
+  "types": "src/index.ts",
+  "exports": {
+    ".": {
+      "types": "./src/index.ts",
+      "default": "./src/index.ts"
+    }
+  },
   "scripts": {
     "test": "echo \"No database tests configured yet\"",
     "lint": "echo \"No database lint configured yet\""

--- a/packages/db/src/index.ts
+++ b/packages/db/src/index.ts
@@ -1,0 +1,2 @@
+export { PrismaClient } from "@prisma/client";
+export type { Prisma } from "@prisma/client";


### PR DESCRIPTION
Closes #930

## Summary
- Added a stable `@taskflow/db` entrypoint at `packages/db/src/index.ts`.
- Re-exported `PrismaClient` and Prisma types from `@prisma/client`.
- Added `main`, `types`, and `exports` metadata for the DB package.
- Added required AI agent metadata.

## Validation
- `npx prisma generate --schema packages/db/prisma/schema.prisma`
- `npx tsc --noEmit --module NodeNext --moduleResolution NodeNext --target ES2022 --skipLibCheck packages/db/src/index.ts`
- `npm test -w @taskflow/db`
- `git diff --check`
