### PR TITLE
[agent] fix: add parent bounty reference to seeded issues

### DIFF
--- a/.github/workflows/seed-issues.yml
+++ b/.github/workflows/seed-issues.yml
@@ -15,7 +15,20 @@ jobs:
         uses: actions/github-script@v7
         with:
           script: |
+            const canonicalBountyTitle = "Bug Bounty Program — How to Participate";
+            const { data: searchResults } = await github.rest.search.issuesAndPullRequests({
+              q: `repo:${context.repo.owner}/${context.repo.repo} is:issue in:title "${canonicalBountyTitle}"`,
+              per_page: 10
+            });
+            const canonicalBountyIssue = searchResults.items.find(
+              (issue) => issue.title === canonicalBountyTitle && !issue.pull_request
+            );
+            const parentBountyLines = canonicalBountyIssue
+              ? [`Parent bounty: #${canonicalBountyIssue.number}`, ""]
+              : [];
+
             const bountyBody = (description) => [
+              ...parentBountyLines,
               description,
               "",
               "## Acceptance Criteria",

--- a/contributors/agents.json
+++ b/contributors/agents.json
@@ -4,7 +4,7 @@
       "github_username": "siwang311",
       "model": "Hermes Agent GPT-5.5",
       "version": "gpt-5.5",
-      "pr_number": 0,
+      "pr_number": 1318,
       "issue_number": 1035
     }
   ],

--- a/contributors/agents.json
+++ b/contributors/agents.json
@@ -1,5 +1,13 @@
 {
-  "agents": [],
-  "last_updated": "2026-06-03",
-  "total_contributions": 0
+  "agents": [
+    {
+      "github_username": "siwang311",
+      "model": "Hermes Agent GPT-5.5",
+      "version": "gpt-5.5",
+      "pr_number": 0,
+      "issue_number": 1035
+    }
+  ],
+  "last_updated": "2026-06-09",
+  "total_contributions": 1
 }


### PR DESCRIPTION
Closes #1035

## Summary
- Search for the canonical `Bug Bounty Program — How to Participate` issue before building seeded starter issue bodies.
- Add `Parent bounty: #<number>` to seeded starter issues when the canonical issue is found.
- Preserve the existing seeded issue descriptions, acceptance criteria, labels, and `/bounty $50` marker.
- Added required AI agent metadata.

## Validation
- `python D:\hero\work\validate_seed_1035.py`
- `node -e "JSON.parse(require('fs').readFileSync('contributors/agents.json','utf8')); console.log('agents json ok')"`
- `git diff --check`
