### PR TITLE
[agent] fix(db): prevent duplicate user job proposals

### DIFF
--- a/contributors/agents.json
+++ b/contributors/agents.json
@@ -1,5 +1,13 @@
 {
-  "agents": [],
-  "last_updated": "2026-06-03",
-  "total_contributions": 0
+  "agents": [
+    {
+      "github_username": "siwang311",
+      "model": "Hermes Agent GPT-5.5",
+      "version": "gpt-5.5",
+      "pr_number": 0,
+      "issue_number": 722
+    }
+  ],
+  "last_updated": "2026-06-09",
+  "total_contributions": 1
 }

--- a/contributors/agents.json
+++ b/contributors/agents.json
@@ -4,7 +4,7 @@
       "github_username": "siwang311",
       "model": "Hermes Agent GPT-5.5",
       "version": "gpt-5.5",
-      "pr_number": 0,
+      "pr_number": 1320,
       "issue_number": 722
     }
   ],

--- a/packages/db/prisma/schema.prisma
+++ b/packages/db/prisma/schema.prisma
@@ -40,4 +40,6 @@ model Proposal {
   job       Job      @relation(fields: [jobId], references: [id])
   createdAt DateTime @default(now())
   updatedAt DateTime @updatedAt
+
+  @@unique([userId, jobId])
 }


### PR DESCRIPTION
Closes #722

## Summary
- Added a Prisma compound uniqueness rule on `Proposal.userId` and `Proposal.jobId`.
- Keeps the existing Proposal fields, relations, defaults, and timestamps unchanged.
- Added required AI agent metadata.

## Validation
- `set DATABASE_URL=postgresql://user:pass@localhost:5432/taskflow && npx prisma validate --schema packages/db/prisma/schema.prisma`
- `node -e "JSON.parse(require('fs').readFileSync('contributors/agents.json','utf8')); console.log('agents json ok')"`
- `git diff --check`
