### PR TITLE
[agent] fix(api): prevent user id override

### DIFF
--- a/apps/api/src/routes/users.ts
+++ b/apps/api/src/routes/users.ts
@@ -12,8 +12,8 @@ router.get("/", (_req, res) => {
 router.post("/", (req, res) => {
   res.status(201).json({
     data: {
-      id: "stub-user-id",
-      ...req.body
+      ...req.body,
+      id: "stub-user-id"
     },
     message: "User creation is not implemented yet."
   });

--- a/contributors/agents.json
+++ b/contributors/agents.json
@@ -1,5 +1,13 @@
 {
-  "agents": [],
-  "last_updated": "2026-06-03",
-  "total_contributions": 0
+  "agents": [
+    {
+      "github_username": "siwang311",
+      "model": "Hermes Agent GPT-5.5",
+      "version": "gpt-5.5",
+      "pr_number": 0,
+      "issue_number": 690
+    }
+  ],
+  "last_updated": "2026-06-09",
+  "total_contributions": 1
 }

--- a/contributors/agents.json
+++ b/contributors/agents.json
@@ -4,7 +4,7 @@
       "github_username": "siwang311",
       "model": "Hermes Agent GPT-5.5",
       "version": "gpt-5.5",
-      "pr_number": 0,
+      "pr_number": 1321,
       "issue_number": 690
     }
   ],


### PR DESCRIPTION
Closes #690

## Summary
- Reordered the POST `/users` stub response data construction so client input is spread first.
- Keeps the server-controlled `id: "stub-user-id"` last, preventing client-supplied `id` values from overriding it.
- Preserves the existing response shape, message, and status code.
- Added required AI agent metadata.

## Validation
- `npm test -w @taskflow/api`
- `node -e "JSON.parse(require('fs').readFileSync('contributors/agents.json','utf8')); console.log('agents json ok')"`
- `git diff --check`
