### PR TITLE
docs(prisma): add model comments for TaskFlow domain

### DIFF
--- a/packages/db/prisma/schema.prisma
+++ b/packages/db/prisma/schema.prisma
@@ -7,6 +7,10 @@ datasource db {
   url      = env("DATABASE_URL")
 }
 
+/// User represents a TaskFlow platform account.
+/// Each user can own multiple jobs and submit proposals to jobs.
+/// Authentication and profile data are managed externally; this model
+/// stores only the minimal identity fields required for relations.
 model User {
   id        String     @id @default(cuid())
   email     String     @unique
@@ -17,6 +21,9 @@ model User {
   updatedAt DateTime   @updatedAt
 }
 
+/// Job represents a work item posted by a user (owner).
+/// Jobs have a lifecycle: draft -> open -> in_progress -> completed.
+/// Each job can receive multiple proposals from different users.
 model Job {
   id          String     @id @default(cuid())
   title       String
@@ -29,6 +36,9 @@ model Job {
   updatedAt   DateTime   @updatedAt
 }
 
+/// Proposal represents a user's offer to work on a job.
+/// Contains the proposed summary and optional amount.
+/// Status transitions: pending -> accepted -> rejected -> completed.
 model Proposal {
   id        String   @id @default(cuid())
   summary   String


### PR DESCRIPTION
## Summary

Add descriptive comments to each Prisma model explaining their role in the TaskFlow domain, as requested in issue #5.

## Changes

- **User**: Documents identity model — owns jobs, submits proposals, minimal fields for relations
- **Job**: Documents work item lifecycle (draft → open → in_progress → completed) and proposal reception
- **Proposal**: Documents offer model with status transitions (pending → accepted/rejected → completed)

## Validation

```bash
npx prisma@5.13.0 validate
# Schema is valid 🚀
```

## Bounty Claim

This PR addresses bounty issue #5: "Improve Prisma schema comments" (0).

/claim #5