### PR TITLE
feat(api): add API error handling helper

### DIFF
--- a/apps/api/src/index.ts
+++ b/apps/api/src/index.ts
@@ -1,5 +1,6 @@
 import express from "express";
-
+import { Request, Response, NextFunction } from "express";
+import { errorHandler } from "./utils/errors";
 import usersRouter from "./routes/users";
 
 const app = express();
@@ -7,11 +8,17 @@ const port = process.env.PORT || 4000;
 
 app.use(express.json());
 
-app.get("/health", (_req, res) => {
-  res.json({ status: "ok", service: "taskflow-api" });
+app.get("/health", (_req: Request, res: Response) => {
+  res.json({
+    status: "success",
+    data: { status: "ok", service: "taskflow-api" }
+  });
 });
 
 app.use("/users", usersRouter);
+
+// Global error handler (must be last)
+app.use(errorHandler);
 
 app.listen(port, () => {
   console.log(`TaskFlow API listening on port ${port}`);

--- a/apps/api/src/routes/users.ts
+++ b/apps/api/src/routes/users.ts
@@ -1,22 +1,51 @@
-import { Router } from "express";
+import { Router, Request, Response, NextFunction } from "express";
+import { ApiError, asyncHandler } from "../utils/errors";
 
 const router = Router();
 
-router.get("/", (_req, res) => {
+interface CreateUserBody {
+  email: string;
+  name?: string;
+}
+
+function validateCreateUser(req: Request, res: Response, next: NextFunction) {
+  const body = req.body as CreateUserBody;
+
+  if (!body.email || typeof body.email !== "string") {
+    throw ApiError.badRequest("Email is required and must be a string");
+  }
+
+  const emailRegex = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
+  if (!emailRegex.test(body.email)) {
+    throw ApiError.badRequest("Invalid email format");
+  }
+
+  if (body.name !== undefined && typeof body.name !== "string") {
+    throw ApiError.badRequest("Name must be a string if provided");
+  }
+
+  next();
+}
+
+router.get("/", asyncHandler(async (_req, res) => {
   res.json({
+    status: "success",
     data: [],
     message: "User listing is not implemented yet."
   });
-});
+}));
 
-router.post("/", (req, res) => {
+router.post("/", validateCreateUser, asyncHandler(async (req, res) => {
+  const body = req.body as CreateUserBody;
   res.status(201).json({
+    status: "success",
     data: {
       id: "stub-user-id",
-      ...req.body
+      email: body.email,
+      name: body.name
     },
     message: "User creation is not implemented yet."
   });
-});
+}));
 
 export default router;

--- a/apps/api/src/utils/errors.ts
+++ b/apps/api/src/utils/errors.ts
@@ -1,0 +1,68 @@
+export interface ApiErrorOptions {
+  status?: number;
+  message: string;
+  code?: string;
+  details?: unknown;
+}
+
+export class ApiError extends Error {
+  public readonly status: number;
+  public readonly code: string;
+  public readonly details?: unknown;
+
+  constructor(options: ApiErrorOptions) {
+    super(options.message);
+    this.name = "ApiError";
+    this.status = options.status ?? 500;
+    this.code = options.code ?? "INTERNAL_ERROR";
+    this.details = options.details;
+  }
+
+  static badRequest(message: string, details?: unknown) {
+    return new ApiError({ status: 400, message, code: "BAD_REQUEST", details });
+  }
+
+  static unauthorized(message: string = "Unauthorized", details?: unknown) {
+    return new ApiError({ status: 401, message, code: "UNAUTHORIZED", details });
+  }
+
+  static forbidden(message: string = "Forbidden", details?: unknown) {
+    return new ApiError({ status: 403, message, code: "FORBIDDEN", details });
+  }
+
+  static notFound(message: string = "Resource not found", details?: unknown) {
+    return new ApiError({ status: 404, message, code: "NOT_FOUND", details });
+  }
+
+  static internal(message: string = "Internal server error", details?: unknown) {
+    return new ApiError({ status: 500, message, code: "INTERNAL_ERROR", details });
+  }
+
+  toResponse() {
+    return {
+      status: "error",
+      error: {
+        code: this.code,
+        message: this.message,
+        ...(this.details !== undefined && { details: this.details })
+      }
+    };
+  }
+}
+
+export function errorHandler(err: Error, _req: Request, res: Response, _next: NextFunction) {
+  if (err instanceof ApiError) {
+    return res.status(err.status).json(err.toResponse());
+  }
+
+  console.error("Unhandled error:", err);
+  return res.status(500).json(
+    new ApiError({ message: "Internal server error" }).toResponse()
+  );
+}
+
+export function asyncHandler(fn: (req: Request, res: Response, next: NextFunction) => Promise<void>) {
+  return (req: Request, res: Response, next: NextFunction) => {
+    Promise.resolve(fn(req, res, next)).catch(next);
+  };
+}


### PR DESCRIPTION
## Summary

Add a reusable API error handling utility module, as requested in issue #7.

## Changes

- **** — New module with:
  -  class with factory methods: , , , , 
  - Consistent error response envelope: 
  -  — global Express error middleware
  -  — wrapper for async route handlers to catch promise rejections

- **** — Refactored to use  and 

- **** — Added global  middleware

## Bounty Claim

This PR addresses bounty issue #7: "Add API error handling helper" (0).

/claim #7