### PR TITLE
[agent] fix(api): export app without starting server

### DIFF
--- a/apps/api/src/app.ts
+++ b/apps/api/src/app.ts
@@ -1,0 +1,15 @@
+import express from "express";
+
+import usersRouter from "./routes/users";
+
+export const app = express();
+
+app.use(express.json());
+
+app.get("/health", (_req, res) => {
+  res.json({ status: "ok", service: "taskflow-api" });
+});
+
+app.use("/users", usersRouter);
+
+export default app;

--- a/apps/api/src/index.ts
+++ b/apps/api/src/index.ts
@@ -1,17 +1,6 @@
-import express from "express";
+import app from "./app";
 
-import usersRouter from "./routes/users";
-
-const app = express();
 const port = process.env.PORT || 4000;
-
-app.use(express.json());
-
-app.get("/health", (_req, res) => {
-  res.json({ status: "ok", service: "taskflow-api" });
-});
-
-app.use("/users", usersRouter);
 
 app.listen(port, () => {
   console.log(`TaskFlow API listening on port ${port}`);

--- a/contributors/agents.json
+++ b/contributors/agents.json
@@ -1,5 +1,13 @@
 {
-  "agents": [],
-  "last_updated": "2026-06-03",
-  "total_contributions": 0
+  "agents": [
+    {
+      "github_username": "siwang311",
+      "model": "Hermes Agent GPT-5.5",
+      "version": "gpt-5.5",
+      "pr_number": 0,
+      "issue_number": 720
+    }
+  ],
+  "last_updated": "2026-06-09",
+  "total_contributions": 1
 }

--- a/contributors/agents.json
+++ b/contributors/agents.json
@@ -4,7 +4,7 @@
       "github_username": "siwang311",
       "model": "Hermes Agent GPT-5.5",
       "version": "gpt-5.5",
-      "pr_number": 0,
+      "pr_number": 1331,
       "issue_number": 720
     }
   ],


### PR DESCRIPTION
Closes #720

## Summary
- Added `apps/api/src/app.ts` to create and export the Express app without starting a listener.
- Kept the existing `express.json()` middleware, `/health` route, and `/users` router behavior unchanged.
- Updated `apps/api/src/index.ts` so runtime/dev startup imports the app and calls `app.listen()` with the existing `PORT || 4000` behavior.
- Added required AI agent metadata.

## Validation
- `npm test -w @taskflow/api`
- `node -e "JSON.parse(require('fs').readFileSync('contributors/agents.json','utf8')); console.log('agents json ok')"`
- `git diff --check`
- `node --import tsx -e "const m = await import('./apps/api/src/app.ts'); console.log(typeof (m.default || m.app).listen)"`

Implemented via Codex CLI using the local auth wrapper.
