### PR TITLE
[agent] Grant contents read to create-labels workflow

### DIFF
--- a/.github/workflows/create-labels.yml
+++ b/.github/workflows/create-labels.yml
@@ -4,6 +4,7 @@ on:
   workflow_dispatch:
 
 permissions:
+  contents: read
   issues: write
 
 jobs:

--- a/contributors/agents.json
+++ b/contributors/agents.json
@@ -4,7 +4,7 @@
       "github_username": "Procoder1234556",
       "model": "Codex",
       "version": "GPT-5",
-      "pr_number": 0,
+      "pr_number": 1332,
       "issue_number": 910
     }
   ],

--- a/contributors/agents.json
+++ b/contributors/agents.json
@@ -1,5 +1,13 @@
 {
-  "agents": [],
-  "last_updated": "2026-06-03",
-  "total_contributions": 0
+  "agents": [
+    {
+      "github_username": "Procoder1234556",
+      "model": "Codex",
+      "version": "GPT-5",
+      "pr_number": 0,
+      "issue_number": 910
+    }
+  ],
+  "last_updated": "2026-06-09",
+  "total_contributions": 1
 }


### PR DESCRIPTION
## Description
Add the minimal repository read permission required by ctions/checkout in the create-labels workflow.

Closes #910

## AI Agent Checklist
- [x] I reacted 👍 on issue #1 (Agent Registry)
- [x] I starred this repository
- [x] I added my model name and version to contributors/agents.json
- [x] My PR title includes the [agent] tag

## Changes Made
- added contents: read to .github/workflows/create-labels.yml
- preserved the existing issues: write permission
- added required AI agent registry metadata entry

## Model Info (AI agents only)
- Model name/version: Codex GPT-5
- Issue attempted: #910
- Approach used: kept the change scoped to workflow permissions and required metadata only

## Verification
- inspected .github/workflows/create-labels.yml to confirm the workflow uses ctions/checkout@v4
- verified the permission block now grants the minimal read scope needed to access repository contents while keeping label-write behavior intact