### PR TITLE
[agent] fix(api): validate user creation payload

### DIFF
--- a/apps/api/src/routes/users.ts
+++ b/apps/api/src/routes/users.ts
@@ -10,10 +10,29 @@ router.get("/", (_req, res) => {
 });
 
 router.post("/", (req, res) => {
+  const body = req.body;
+  const allowedFields = ["name", "email"];
+
+  if (
+    body === null ||
+    typeof body !== "object" ||
+    Array.isArray(body) ||
+    Object.keys(body).some((field) => !allowedFields.includes(field)) ||
+    typeof body.name !== "string" ||
+    typeof body.email !== "string"
+  ) {
+    res.status(400).json({
+      error: "Invalid request body",
+      message: "Request body must include only string name and email fields."
+    });
+    return;
+  }
+
   res.status(201).json({
     data: {
       id: "stub-user-id",
-      ...req.body
+      name: body.name,
+      email: body.email
     },
     message: "User creation is not implemented yet."
   });

--- a/contributors/agents.json
+++ b/contributors/agents.json
@@ -4,7 +4,7 @@
       "github_username": "siwang311",
       "model": "Hermes Agent GPT-5.5",
       "version": "gpt-5.5",
-      "pr_number": 0,
+      "pr_number": 1336,
       "issue_number": 223
     }
   ],

--- a/contributors/agents.json
+++ b/contributors/agents.json
@@ -1,5 +1,13 @@
 {
-  "agents": [],
-  "last_updated": "2026-06-03",
-  "total_contributions": 0
+  "agents": [
+    {
+      "github_username": "siwang311",
+      "model": "Hermes Agent GPT-5.5",
+      "version": "gpt-5.5",
+      "pr_number": 0,
+      "issue_number": 223
+    }
+  ],
+  "last_updated": "2026-06-09",
+  "total_contributions": 1
 }


### PR DESCRIPTION
Closes #223

## Summary
- Added focused validation for `POST /users` request bodies.
- Accepts only `name` and `email`, both required as strings.
- Rejects non-object payloads, arrays, missing fields, wrong types, and extra fields with a clear JSON 400 response.
- Builds the success response from whitelisted fields only, so arbitrary fields like `role`, `isAdmin`, `__proto__`, or client-supplied `id` are not mass-assigned.
- Preserves the existing GET `/users` behavior, POST `201` status, success message, and server-controlled `stub-user-id`.
- Added required AI agent metadata.

## Validation
- `npm test -w @taskflow/api`
- `node -e "JSON.parse(require('fs').readFileSync('contributors/agents.json','utf8')); console.log('agents json ok')"`
- `git diff --check`

Implemented via Codex CLI, with Hermes review/adjustment before PR.
