### PR TITLE
[agent] fix(api): validate port before startup

### DIFF
--- a/apps/api/src/index.ts
+++ b/apps/api/src/index.ts
@@ -3,7 +3,31 @@ import express from "express";
 import usersRouter from "./routes/users";
 
 const app = express();
-const port = process.env.PORT || 4000;
+
+function getPort(rawPort: string | undefined): number {
+  if (rawPort === undefined) {
+    return 4000;
+  }
+
+  if (!/^[0-9]+$/.test(rawPort)) {
+    console.error(
+      `Invalid PORT value "${rawPort}". PORT must be an integer between 1 and 65535.`
+    );
+    process.exit(1);
+  }
+
+  const port = Number(rawPort);
+  if (port < 1 || port > 65535) {
+    console.error(
+      `Invalid PORT value "${rawPort}". PORT must be an integer between 1 and 65535.`
+    );
+    process.exit(1);
+  }
+
+  return port;
+}
+
+const port = getPort(process.env.PORT);
 
 app.use(express.json());
 

--- a/contributors/agents.json
+++ b/contributors/agents.json
@@ -1,5 +1,13 @@
 {
-  "agents": [],
-  "last_updated": "2026-06-03",
-  "total_contributions": 0
+  "agents": [
+    {
+      "github_username": "siwang311",
+      "model": "Hermes Agent GPT-5.5",
+      "version": "gpt-5.5",
+      "pr_number": 0,
+      "issue_number": 1126
+    }
+  ],
+  "last_updated": "2026-06-09",
+  "total_contributions": 1
 }

--- a/contributors/agents.json
+++ b/contributors/agents.json
@@ -4,7 +4,7 @@
       "github_username": "siwang311",
       "model": "Hermes Agent GPT-5.5",
       "version": "gpt-5.5",
-      "pr_number": 0,
+      "pr_number": 1339,
       "issue_number": 1126
     }
   ],


### PR DESCRIPTION
Closes #1126

## Summary
- Added focused `PORT` validation before API server startup.
- Keeps the existing default of `4000` when `PORT` is unset.
- Rejects non-integers, negative values, zero, values above `65535`, decimals, and blank/whitespace values with a clear startup error and non-zero exit.
- Leaves existing `/health` and `/users` behavior unchanged.
- Added required AI agent metadata.

## Validation
- `npm test -w @taskflow/api`
- `node -e "JSON.parse(require('fs').readFileSync('contributors/agents.json','utf8')); console.log('agents json ok')"`
- `git diff --check`
- Manual invalid `PORT` checks: `-1`, `99999`, `abc`, `1.5`, whitespace string all exited non-zero with the expected error.

Implemented via Codex CLI, with Hermes orchestration and verification.
