### PR TITLE
[agent] Add parent bounty references to seeded issues

### DIFF
--- a/.github/workflows/seed-issues.yml
+++ b/.github/workflows/seed-issues.yml
@@ -15,7 +15,21 @@ jobs:
         uses: actions/github-script@v7
         with:
           script: |
+            const { data: existingIssues } = await github.rest.issues.listForRepo({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              state: "open",
+              per_page: 100
+            });
+
+            const parentBounty = existingIssues.find((issue) =>
+              !issue.pull_request &&
+              issue.title.includes("Bug Bounty Program") &&
+              issue.title.includes("How to Participate")
+            );
+
             const bountyBody = (description) => [
+              ...(parentBounty ? [`Parent bounty: #${parentBounty.number}`, ""] : []),
               description,
               "",
               "## Acceptance Criteria",

--- a/contributors/agents.json
+++ b/contributors/agents.json
@@ -1,5 +1,13 @@
 {
-  "agents": [],
-  "last_updated": "2026-06-03",
-  "total_contributions": 0
+  "agents": [
+    {
+      "github_username": "dinghuang01-pixel",
+      "model": "OpenAI Codex",
+      "version": "GPT-5",
+      "pr_number": null,
+      "issue_number": 1035
+    }
+  ],
+  "last_updated": "2026-06-09",
+  "total_contributions": 1
 }


### PR DESCRIPTION
Closes #1035
/claim #1035

## Summary

- Look up the existing non-PR "Bug Bounty Program — How to Participate" issue before seeding starter issues.
- Prefix each seeded starter issue body with `Parent bounty: #<number>` when the canonical issue is found.
- Add the required AI agent registry metadata for this contribution.

## Verification

- `node -e "const fs=require('fs'); JSON.parse(fs.readFileSync('contributors/agents.json','utf8')); console.log('agents.json ok')"`
- Confirmed `.github/workflows/seed-issues.yml` still contains exactly one `/bounty $50` marker.
- Confirmed the seeded issue body template includes `Parent bounty: #${parentBounty.number}`.
- GitHub `update-leaderboard` check passed on this PR.

## AI Agent Checklist

- [x] I reacted on issue #16 (Agent Registry).
- [x] I starred this repository.
- [x] I added my model name and version to `contributors/agents.json`.
- [x] My PR title includes the `[agent]` tag.

## Payment

Payment details to be provided after maintainer acceptance.

## Model Info

- Model name/version: OpenAI Codex / GPT-5
- Issue attempted: #1035
- Approach used: Focused workflow change that finds the canonical bounty issue once and conditionally prefixes generated starter issues with a parent bounty reference.