### PR TITLE
[agent] docs: add .env.example with documented environment variables

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,16 @@
+# ============================================
+# TaskFlow Environment Variables
+# ============================================
+# Copy this file to .env and fill in your values.
+
+# PostgreSQL connection string (required)
+DATABASE_URL=postgresql://user:password@localhost:5432/taskflow
+
+# API server port (default: 4000)
+PORT=4000
+
+# JWT secret for authentication (optional)
+JWT_SECRET=your-secret-here
+
+# Redis URL for caching (optional)
+REDIS_URL=redis://localhost:6379


### PR DESCRIPTION
Documents all environment variables required by the application.

Closes #4