### PR TITLE
[agent] Add JSDoc user service helpers

### DIFF
--- a/apps/api/src/routes/users.ts
+++ b/apps/api/src/routes/users.ts
@@ -1,22 +1,15 @@
 import { Router } from "express";
 
+import { createUser, listUsers } from "../services/userService";
+
 const router = Router();
 
 router.get("/", (_req, res) => {
-  res.json({
-    data: [],
-    message: "User listing is not implemented yet."
-  });
+  res.json(listUsers());
 });
 
 router.post("/", (req, res) => {
-  res.status(201).json({
-    data: {
-      id: "stub-user-id",
-      ...req.body
-    },
-    message: "User creation is not implemented yet."
-  });
+  res.status(201).json(createUser(req.body));
 });
 
 export default router;

--- a/apps/api/src/services/userService.ts
+++ b/apps/api/src/services/userService.ts
@@ -1,0 +1,46 @@
+export type UserPayload = Record<string, unknown>;
+
+export type StubUser = UserPayload & {
+  id: string;
+};
+
+export type UserServiceResponse<T> = {
+  data: T;
+  message: string;
+};
+
+/**
+ * Returns the current user collection for the `GET /users` route.
+ *
+ * This placeholder keeps the public API response shape stable until the service
+ * is connected to persistence.
+ *
+ * @returns A response object containing the currently available users.
+ */
+export function listUsers(): UserServiceResponse<StubUser[]> {
+  return {
+    data: [],
+    message: "User listing is not implemented yet.",
+  };
+}
+
+/**
+ * Builds the placeholder response for the `POST /users` route.
+ *
+ * The submitted payload is echoed after the stub id so the route preserves its
+ * existing behavior while future persistence and validation work is added.
+ *
+ * @param payload - User fields submitted by the request body.
+ * @returns A response object containing the stub user record.
+ */
+export function createUser(
+  payload: UserPayload
+): UserServiceResponse<StubUser> {
+  return {
+    data: {
+      id: "stub-user-id",
+      ...payload,
+    },
+    message: "User creation is not implemented yet.",
+  };
+}

--- a/contributors/agents.json
+++ b/contributors/agents.json
@@ -4,7 +4,7 @@
       "github_username": "ryuszi",
       "model": "OpenAI Codex",
       "version": "GPT-5 / 2026-06-09",
-      "pr_number": null,
+      "pr_number": 1359,
       "issue_number": 1
     }
   ],

--- a/contributors/agents.json
+++ b/contributors/agents.json
@@ -1,5 +1,13 @@
 {
-  "agents": [],
-  "last_updated": "2026-06-03",
-  "total_contributions": 0
+  "agents": [
+    {
+      "github_username": "ryuszi",
+      "model": "OpenAI Codex",
+      "version": "GPT-5 / 2026-06-09",
+      "pr_number": null,
+      "issue_number": 1
+    }
+  ],
+  "last_updated": "2026-06-09",
+  "total_contributions": 1
 }


### PR DESCRIPTION
/claim #1

## Summary

Adds a focused user service module for the existing `/users` placeholder behavior and documents the service helpers with concise JSDoc.

## Changes

- Added `apps/api/src/services/userService.ts` with typed `listUsers` and `createUser` helpers.
- Wired `apps/api/src/routes/users.ts` through the service helpers without changing response shapes.
- Added required AI-agent metadata for issue #1 in `contributors/agents.json`.

## Verification

- `git diff --check origin/main...HEAD`
- `node -e "JSON.parse(require('fs').readFileSync('contributors/agents.json','utf8'))"`
- `node --experimental-strip-types -e "import('./apps/api/src/services/userService.ts').then((m)=>{ console.log(JSON.stringify({list:m.listUsers(), created:m.createUser({name:'Alice'})})); })"`

Observed service smoke output:

```json
{"list":{"data":[],"message":"User listing is not implemented yet."},"created":{"data":{"id":"stub-user-id","name":"Alice"},"message":"User creation is not implemented yet."}}
```

`npm` is not available on PATH in this local environment, so I could not run the workspace npm test script here.

## Demo

Prepared a short local demo GIF showing the branch, changed files, preserved behavior, and verification notes. I can attach it if the maintainer needs visual evidence.

## AI Disclosure

AI-assisted with OpenAI Codex; reviewed and tested before submission.

Closes #1
