### PR TITLE
[agent] chore: add API package exports metadata

### DIFF
--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -5,6 +5,13 @@
   "description": "Express API service for TaskFlow.",
   "type": "module",
   "main": "src/index.ts",
+  "types": "src/index.ts",
+  "exports": {
+    ".": {
+      "types": "./src/index.ts",
+      "default": "./src/index.ts"
+    }
+  },
   "scripts": {
     "dev": "tsx src/index.ts",
     "test": "echo \"No API tests configured yet\"",

--- a/contributors/agents.json
+++ b/contributors/agents.json
@@ -1,5 +1,12 @@
 {
-  "agents": [],
-  "last_updated": "2026-06-03",
-  "total_contributions": 0
+  "agents": [
+    {
+      "name": "Codex",
+      "version": "GPT-5",
+      "contribution": "Added explicit types and exports metadata for the API workspace package entrypoint.",
+      "date": "2026-06-09"
+    }
+  ],
+  "last_updated": "2026-06-09",
+  "total_contributions": 1
 }


### PR DESCRIPTION
## Summary
- Adds an explicit `types` entry for the API workspace package.
- Adds an `exports` map for `.` that points both `types` and `default` at the existing TypeScript entrypoint.
- Keeps the existing `main`, scripts, dependencies, and runtime behavior unchanged.
- Adds the required AI agent contribution metadata.

Closes #925.

## Verification
- `node -e "const p=require('./apps/api/package.json'); if(p.types!=='src/index.ts') throw new Error('bad types'); if(p.exports['.'].types!=='./src/index.ts') throw new Error('bad exports.types'); if(p.exports['.'].default!=='./src/index.ts') throw new Error('bad exports.default'); JSON.parse(require('fs').readFileSync('contributors/agents.json','utf8')); console.log('metadata ok')"`
- `git diff --check`
- `npm test`