### PR TITLE
[agent] fix: validate POST /users email payloads

### DIFF
--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -7,7 +7,7 @@
   "main": "src/index.ts",
   "scripts": {
     "dev": "tsx src/index.ts",
-    "test": "echo \"No API tests configured yet\"",
+    "test": "tsx scripts/validate-user-email.ts",
     "lint": "echo \"No API lint configured yet\""
   },
   "dependencies": {

--- a/apps/api/scripts/validate-user-email.ts
+++ b/apps/api/scripts/validate-user-email.ts
@@ -1,0 +1,73 @@
+import assert from "node:assert/strict";
+import express from "express";
+
+import usersRouter from "../src/routes/users";
+
+const app = express();
+
+app.use(express.json());
+app.use("/users", usersRouter);
+
+const server = app.listen(0);
+
+try {
+  const address = server.address();
+
+  if (address === null || typeof address === "string") {
+    throw new Error("Expected an ephemeral TCP port for the validation server.");
+  }
+
+  const baseUrl = `http://127.0.0.1:${address.port}`;
+
+  const invalidPayloads = [
+    {},
+    { name: "", email: "user@example.com" },
+    { name: "Ada", email: "" },
+    { name: "Ada", email: "not-an-email" },
+    { name: "Ada", email: "ada@" },
+    { name: "Ada", email: "@example.com" }
+  ];
+
+  for (const payload of invalidPayloads) {
+    const response = await fetch(`${baseUrl}/users`, {
+      body: JSON.stringify(payload),
+      headers: { "content-type": "application/json" },
+      method: "POST"
+    });
+
+    assert.equal(response.status, 400, `Expected 400 for ${JSON.stringify(payload)}`);
+  }
+
+  const response = await fetch(`${baseUrl}/users`, {
+    body: JSON.stringify({
+      email: " ada@example.com ",
+      name: " Ada "
+    }),
+    headers: { "content-type": "application/json" },
+    method: "POST"
+  });
+
+  assert.equal(response.status, 201);
+
+  const body = await response.json();
+
+  assert.deepEqual(body, {
+    data: {
+      email: "ada@example.com",
+      id: "stub-user-id",
+      name: "Ada"
+    },
+    message: "User creation is not implemented yet."
+  });
+} finally {
+  await new Promise<void>((resolve, reject) => {
+    server.close((error) => {
+      if (error) {
+        reject(error);
+        return;
+      }
+
+      resolve();
+    });
+  });
+}

--- a/apps/api/src/routes/users.ts
+++ b/apps/api/src/routes/users.ts
@@ -2,6 +2,12 @@ import { Router } from "express";
 
 const router = Router();
 
+const emailPattern = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
+
+function isNonEmptyString(value: unknown): value is string {
+  return typeof value === "string" && value.trim().length > 0;
+}
+
 router.get("/", (_req, res) => {
   res.json({
     data: [],
@@ -10,10 +16,27 @@ router.get("/", (_req, res) => {
 });
 
 router.post("/", (req, res) => {
+  const { email, name } = req.body ?? {};
+
+  if (!isNonEmptyString(name)) {
+    return res.status(400).json({
+      error: "Invalid user payload",
+      message: "name must be a non-empty string."
+    });
+  }
+
+  if (!isNonEmptyString(email) || !emailPattern.test(email.trim())) {
+    return res.status(400).json({
+      error: "Invalid user payload",
+      message: "email must be a valid non-empty email string."
+    });
+  }
+
   res.status(201).json({
     data: {
       id: "stub-user-id",
-      ...req.body
+      email: email.trim(),
+      name: name.trim()
     },
     message: "User creation is not implemented yet."
   });

--- a/contributors/agents.json
+++ b/contributors/agents.json
@@ -1,5 +1,12 @@
 {
-  "agents": [],
-  "last_updated": "2026-06-03",
-  "total_contributions": 0
+  "agents": [
+    {
+      "name": "Codex",
+      "version": "GPT-5",
+      "contribution": "Added focused API validation for POST /users name and email payloads.",
+      "date": "2026-06-09"
+    }
+  ],
+  "last_updated": "2026-06-09",
+  "total_contributions": 1
 }


### PR DESCRIPTION
Fixes #1357.

## Summary
- Validate `POST /users` payloads before returning the stub user response.
- Require `name` and `email` to be non-empty strings.
- Reject malformed emails with a focused `400` response.
- Return the normalized `id`, `name`, and `email` fields for valid requests.
- Add a focused API validation script and wire it into the API workspace test script.
- Add the required AI agent metadata.

## Verification
- `npm --workspace @taskflow/api test`
- `npm test`
- `node -e "JSON.parse(require('fs').readFileSync('contributors/agents.json','utf8')); console.log('agents json ok')"`
- `git diff --check`