### PR TITLE
[agent] fix(api): add graceful shutdown handling

### DIFF
--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -7,7 +7,7 @@
   "main": "src/index.ts",
   "scripts": {
     "dev": "tsx src/index.ts",
-    "test": "echo \"No API tests configured yet\"",
+    "test": "tsx scripts/validate-graceful-shutdown.ts",
     "lint": "echo \"No API lint configured yet\""
   },
   "dependencies": {

--- a/apps/api/scripts/validate-graceful-shutdown.ts
+++ b/apps/api/scripts/validate-graceful-shutdown.ts
@@ -1,0 +1,42 @@
+import assert from "node:assert/strict";
+import type { Server } from "node:http";
+
+import { createShutdownHandler } from "../src/shutdown";
+
+const logs: string[] = [];
+const exits: number[] = [];
+let closeCalls = 0;
+
+const server = {
+  close(callback?: (error?: Error) => void) {
+    closeCalls += 1;
+    callback?.();
+    return server as Server;
+  }
+} as Server;
+
+const shutdown = createShutdownHandler({
+  exit(code) {
+    exits.push(code);
+  },
+  logger: {
+    error(...args: unknown[]) {
+      logs.push(args.join(" "));
+    },
+    log(...args: unknown[]) {
+      logs.push(args.join(" "));
+    }
+  },
+  server,
+  timeoutMs: 2000
+});
+
+shutdown("SIGTERM");
+shutdown("SIGINT");
+
+assert.equal(closeCalls, 1, "Expected only the first shutdown signal to close the server.");
+assert.deepEqual(exits, [0], "Expected graceful shutdown to exit successfully.");
+assert.deepEqual(logs, [
+  "Received SIGTERM; closing TaskFlow API server.",
+  "TaskFlow API server closed."
+]);

--- a/apps/api/src/index.ts
+++ b/apps/api/src/index.ts
@@ -1,9 +1,11 @@
 import express from "express";
 
 import usersRouter from "./routes/users";
+import { createShutdownHandler } from "./shutdown";
 
 const app = express();
 const port = process.env.PORT || 4000;
+const shutdownTimeoutMs = Number.parseInt(process.env.SHUTDOWN_TIMEOUT_MS ?? "10000", 10);
 
 app.use(express.json());
 
@@ -13,6 +15,14 @@ app.get("/health", (_req, res) => {
 
 app.use("/users", usersRouter);
 
-app.listen(port, () => {
+const server = app.listen(port, () => {
   console.log(`TaskFlow API listening on port ${port}`);
 });
+
+const shutdown = createShutdownHandler({
+  server,
+  timeoutMs: shutdownTimeoutMs
+});
+
+process.on("SIGTERM", shutdown);
+process.on("SIGINT", shutdown);

--- a/apps/api/src/shutdown.ts
+++ b/apps/api/src/shutdown.ts
@@ -1,0 +1,47 @@
+import type { Server } from "node:http";
+
+type ExitFunction = (code: number) => never | void;
+type Logger = Pick<Console, "error" | "log">;
+
+export function createShutdownHandler({
+  exit = process.exit,
+  logger = console,
+  server,
+  timeoutMs
+}: {
+  exit?: ExitFunction;
+  logger?: Logger;
+  server: Server;
+  timeoutMs: number;
+}) {
+  let isShuttingDown = false;
+
+  return (signal: NodeJS.Signals) => {
+    if (isShuttingDown) {
+      return;
+    }
+
+    isShuttingDown = true;
+    logger.log(`Received ${signal}; closing TaskFlow API server.`);
+
+    const forceExit = setTimeout(() => {
+      logger.error(`Forced shutdown after ${timeoutMs}ms.`);
+      exit(1);
+    }, timeoutMs);
+
+    forceExit.unref();
+
+    server.close((error) => {
+      clearTimeout(forceExit);
+
+      if (error) {
+        logger.error("TaskFlow API shutdown failed.", error);
+        exit(1);
+        return;
+      }
+
+      logger.log("TaskFlow API server closed.");
+      exit(0);
+    });
+  };
+}

--- a/contributors/agents.json
+++ b/contributors/agents.json
@@ -1,5 +1,12 @@
 {
-  "agents": [],
-  "last_updated": "2026-06-03",
-  "total_contributions": 0
+  "agents": [
+    {
+      "name": "Codex",
+      "version": "GPT-5",
+      "contribution": "Added graceful API shutdown handling for SIGTERM and SIGINT.",
+      "date": "2026-06-09"
+    }
+  ],
+  "last_updated": "2026-06-09",
+  "total_contributions": 1
 }


### PR DESCRIPTION
Fixes #1165.

## Summary
- Keep the HTTP server returned by app.listen().
- Register SIGTERM and SIGINT graceful shutdown handlers.
- Stop accepting new connections with server.close().
- Add a forced shutdown timeout so termination cannot hang forever.
- Add focused validation coverage for successful shutdown and duplicate signal handling.
- Add required AI agent metadata.

## Verification
- npm --workspace @taskflow/api test
- npm test
- agents JSON parse check
- git diff --check