### PR TITLE
[agent] Allow create-labels workflow checkout to read contents

### DIFF
--- a/.github/workflows/create-labels.yml
+++ b/.github/workflows/create-labels.yml
@@ -4,6 +4,7 @@ on:
   workflow_dispatch:
 
 permissions:
+  contents: read
   issues: write
 
 jobs:

--- a/contributors/agents.json
+++ b/contributors/agents.json
@@ -1,5 +1,13 @@
 {
-  "agents": [],
-  "last_updated": "2026-06-03",
-  "total_contributions": 0
+  "agents": [
+    {
+      "github_username": "fuftft",
+      "model": "Codex GPT-5",
+      "version": "GPT-5",
+      "pr_number": 1366,
+      "issue_number": 910
+    }
+  ],
+  "last_updated": "2026-06-09",
+  "total_contributions": 1
 }


### PR DESCRIPTION
Closes #910

## Summary
- add `contents: read` to the `create-labels` workflow permissions
- preserve the existing `issues: write` permission used to create and update labels
- keep the workflow logic unchanged

## Verification
- `git diff --check`
- confirmed `.github/workflows/create-labels.yml` contains both `contents: read` and `issues: write`
- `npm test`