### PR TITLE
fix: remove duplicate bounty amount in PI template (Fixes #775)

### DIFF
--- a/.github/ISSUE_TEMPLATE/pi_challenge.md
+++ b/.github/ISSUE_TEMPLATE/pi_challenge.md
@@ -17,8 +17,4 @@ Implement or document a small PI calculation challenge for TaskFlow's internal e
 - [ ] Keep the implementation deterministic and lightweight.
 - [ ] Reference this issue in the pull request.
 
-## Bounty Amount
-
-$50
-
 /bounty $50


### PR DESCRIPTION
Fixes #775. Removes redundant '## Bounty Amount $50' section, keeping only the /bounty $50 marker.