### PR TITLE
[agent] chore(db): add Prisma generation scripts

### DIFF
--- a/contributors/agents.json
+++ b/contributors/agents.json
@@ -1,5 +1,12 @@
 {
-  "agents": [],
-  "last_updated": "2026-06-03",
-  "total_contributions": 0
+  "agents": [
+    {
+      "name": "Codex",
+      "version": "GPT-5",
+      "contribution": "Added Prisma client generation scripts for the DB workspace.",
+      "date": "2026-06-10"
+    }
+  ],
+  "last_updated": "2026-06-10",
+  "total_contributions": 1
 }

--- a/packages/db/package.json
+++ b/packages/db/package.json
@@ -4,6 +4,8 @@
   "private": true,
   "description": "Prisma schema and database utilities for TaskFlow.",
   "scripts": {
+    "generate": "prisma generate",
+    "postinstall": "npm run generate",
     "test": "echo \"No database tests configured yet\"",
     "lint": "echo \"No database lint configured yet\""
   },


### PR DESCRIPTION
Fixes #908.

Summary:
- Add a generate script to the DB workspace that runs prisma generate.
- Add a postinstall script so Prisma Client is generated after installing the workspace.
- Preserve the existing test/lint scripts and dependencies.
- Add required AI agent metadata.

Verification:
- npm --workspace @taskflow/db run generate
- npm test
- package and agents JSON parse check
- git diff --check