### PR TITLE
[agent] fix: deduplicate PI challenge bounty marker

### DIFF
--- a/.github/ISSUE_TEMPLATE/pi_challenge.md
+++ b/.github/ISSUE_TEMPLATE/pi_challenge.md
@@ -17,8 +17,4 @@ Implement or document a small PI calculation challenge for TaskFlow's internal e
 - [ ] Keep the implementation deterministic and lightweight.
 - [ ] Reference this issue in the pull request.
 
-## Bounty Amount
-
-$50
-
 /bounty $50

--- a/contributors/agents.json
+++ b/contributors/agents.json
@@ -1,5 +1,12 @@
 {
-  "agents": [],
-  "last_updated": "2026-06-03",
-  "total_contributions": 0
+  "agents": [
+    {
+      "name": "Codex",
+      "version": "GPT-5",
+      "contribution": "Deduplicated the PI challenge bounty amount declaration.",
+      "date": "2026-06-10"
+    }
+  ],
+  "last_updated": "2026-06-10",
+  "total_contributions": 1
 }

--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
   "scripts": {
     "dev": "npm run dev --workspaces --if-present",
     "test": "npm run test --workspaces --if-present",
+    "test:pi-template": "node scripts/validate-pi-challenge-template.mjs",
     "lint": "npm run lint --workspaces --if-present",
     "format": "npm run format --workspaces --if-present"
   },

--- a/scripts/validate-pi-challenge-template.mjs
+++ b/scripts/validate-pi-challenge-template.mjs
@@ -1,0 +1,17 @@
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+
+const template = readFileSync(".github/ISSUE_TEMPLATE/pi_challenge.md", "utf8");
+const bountyMatches = template.match(/\$50/g) ?? [];
+
+assert.equal(
+  bountyMatches.length,
+  1,
+  "PI challenge template should declare the default $50 bounty amount only once."
+);
+
+assert.match(
+  template,
+  /^\/bounty \$50$/m,
+  "PI challenge template should keep the machine-readable /bounty $50 marker."
+);


### PR DESCRIPTION
Fixes #775.

Summary:
- Remove the duplicate human-editable `$50` amount from the PI challenge issue template.
- Keep the machine-readable `/bounty $50` marker as the single default bounty declaration.
- Add a small validation script that asserts the template declares `$50` exactly once and retains the slash-command marker.
- Add required AI agent metadata.

Verification:
- npm run test:pi-template
- npm test
- package and agents JSON parse check
- git diff --check