### PR TITLE
[agent] fix(web): disable Next X-Powered-By header

### DIFF
--- a/apps/web/next.config.mjs
+++ b/apps/web/next.config.mjs
@@ -1,0 +1,6 @@
+/** @type {import('next').NextConfig} */
+const nextConfig = {
+  poweredByHeader: false
+};
+
+export default nextConfig;

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -5,7 +5,7 @@
   "description": "Next.js web application for TaskFlow.",
   "scripts": {
     "dev": "next dev",
-    "test": "echo \"No web tests configured yet\"",
+    "test": "node scripts/validate-powered-by-header.mjs",
     "lint": "next lint"
   },
   "dependencies": {

--- a/apps/web/scripts/validate-powered-by-header.mjs
+++ b/apps/web/scripts/validate-powered-by-header.mjs
@@ -1,0 +1,9 @@
+import assert from "node:assert/strict";
+
+import nextConfig from "../next.config.mjs";
+
+assert.equal(
+  nextConfig.poweredByHeader,
+  false,
+  "Next.js poweredByHeader should be disabled for web responses."
+);

--- a/contributors/agents.json
+++ b/contributors/agents.json
@@ -1,5 +1,12 @@
 {
-  "agents": [],
-  "last_updated": "2026-06-03",
-  "total_contributions": 0
+  "agents": [
+    {
+      "name": "Codex",
+      "version": "GPT-5",
+      "contribution": "Disabled the Next.js X-Powered-By response header for the web app.",
+      "date": "2026-06-10"
+    }
+  ],
+  "last_updated": "2026-06-10",
+  "total_contributions": 1
 }


### PR DESCRIPTION
Fixes #1089.

Summary:
- Add a focused Next.js config for the web workspace with poweredByHeader disabled.
- Add a small web validation script that asserts the config disables the header.
- Wire the script into the web workspace test command.
- Add required AI agent metadata.

Verification:
- npm --workspace @taskflow/web test
- npm test
- web package and agents JSON parse check
- git diff --check
- Started Next dev locally and verified the home response returned HTTP 200 with zero X-Powered-By header lines.