### PR TITLE
fix: disable Next.js X-Powered-By response header

### DIFF
--- a/apps/web/next.config.mjs
+++ b/apps/web/next.config.mjs
@@ -1,0 +1,6 @@
+/** @type {import('next').NextConfig} */
+const nextConfig = {
+  poweredByHeader: false,
+};
+
+export default nextConfig;

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -5,7 +5,7 @@
   "description": "Next.js web application for TaskFlow.",
   "scripts": {
     "dev": "next dev",
-    "test": "echo \"No web tests configured yet\"",
+    "test": "node test-config.mjs",
     "lint": "next lint"
   },
   "dependencies": {

--- a/apps/web/test-config.mjs
+++ b/apps/web/test-config.mjs
@@ -1,0 +1,6 @@
+import nextConfig from "./next.config.mjs";
+
+if (nextConfig.poweredByHeader !== false) {
+  throw new Error("poweredByHeader should be false");
+}
+console.log("✓ poweredByHeader is false");


### PR DESCRIPTION
## Summary

Disables the `X-Powered-By: Next.js` response header by adding a `next.config.mjs` with `poweredByHeader: false`.

Closes #1089

## Changes

- **`apps/web/next.config.mjs`** — new Next.js config setting `poweredByHeader: false`
- **`apps/web/test-config.mjs`** — verification test confirming the config value
- **`apps/web/package.json`** — updated test script to run the config verification

## Acceptance Criteria

- [x] Add a focused Next.js config that sets `poweredByHeader: false`
- [x] Add a small web test proving the config disables the header
- [x] The change stays focused on web response header hardening
- [x] Does not change existing route behavior

/bounty $50