### PR TITLE
[agent] chore: limit API JSON body size

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,8 @@ Backend architecture follows:
 - Validation schemas (Zod)
 - Utility helpers
 
-The API accepts JSON request bodies up to `100kb`.
+The API JSON body parser accepts `Content-Type: application/json` request bodies up to `100kb` by default.
+Set `JSON_BODY_LIMIT` to override the limit for local development or deployment.
 
 ## Getting Started
 

--- a/README.md
+++ b/README.md
@@ -45,6 +45,8 @@ Backend architecture follows:
 - Validation schemas (Zod)
 - Utility helpers
 
+The API accepts JSON request bodies up to `100kb`.
+
 ## Getting Started
 
 npm install

--- a/apps/api/src/index.ts
+++ b/apps/api/src/index.ts
@@ -5,7 +5,7 @@ import usersRouter from "./routes/users";
 const app = express();
 const port = process.env.PORT || 4000;
 
-app.use(express.json());
+app.use(express.json({ limit: "100kb" }));
 
 app.get("/health", (_req, res) => {
   res.json({ status: "ok", service: "taskflow-api" });

--- a/apps/api/src/index.ts
+++ b/apps/api/src/index.ts
@@ -4,8 +4,9 @@ import usersRouter from "./routes/users";
 
 const app = express();
 const port = process.env.PORT || 4000;
+const jsonBodyLimit = process.env.JSON_BODY_LIMIT || "100kb";
 
-app.use(express.json({ limit: "100kb" }));
+app.use(express.json({ limit: jsonBodyLimit }));
 
 app.get("/health", (_req, res) => {
   res.json({ status: "ok", service: "taskflow-api" });

--- a/contributors/agents.json
+++ b/contributors/agents.json
@@ -1,5 +1,14 @@
-{
-  "agents": [],
-  "last_updated": "2026-06-03",
-  "total_contributions": 0
+﻿{
+    "agents":  [
+                   {
+                       "github_username":  "KaisAbiyyi",
+                       "model":  "GPT-5 Codex",
+                       "version":  "2026-06-10",
+                       "pr_number":  1394,
+                       "issue_number":  9
+                   }
+               ],
+    "last_updated":  "2026-06-10",
+    "total_contributions":  1
 }
+


### PR DESCRIPTION
## Summary
- configure Express JSON parsing with a conservative 100kb body limit
- document the expected JSON request body limit in the README

Closes #9

## Verification
- npm run test
- git diff --check
- runtime check: oversized JSON POST returns HTTP 413
