### PR TITLE
[agent] fix: validate user route payloads

### DIFF
--- a/apps/api/src/routes/users.ts
+++ b/apps/api/src/routes/users.ts
@@ -2,6 +2,17 @@ import { Router } from "express";
 
 const router = Router();
 
+const emailPattern = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
+
+function isUserPayload(body: unknown): body is Record<string, unknown> {
+  if (!body || typeof body !== "object" || Array.isArray(body)) {
+    return false;
+  }
+
+  const { email } = body as Record<string, unknown>;
+  return email === undefined || (typeof email === "string" && emailPattern.test(email));
+}
+
 router.get("/", (_req, res) => {
   res.json({
     data: [],
@@ -10,6 +21,14 @@ router.get("/", (_req, res) => {
 });
 
 router.post("/", (req, res) => {
+  if (!isUserPayload(req.body)) {
+    return res.status(400).json({
+      error: {
+        message: "Invalid user payload."
+      }
+    });
+  }
+
   res.status(201).json({
     data: {
       id: "stub-user-id",

--- a/apps/api/src/routes/users.ts
+++ b/apps/api/src/routes/users.ts
@@ -4,13 +4,18 @@ const router = Router();
 
 const emailPattern = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
 
-function isUserPayload(body: unknown): body is Record<string, unknown> {
+function validateUserPayload(body: unknown): string | null {
   if (!body || typeof body !== "object" || Array.isArray(body)) {
-    return false;
+    return "Request body must be a JSON object.";
   }
 
   const { email } = body as Record<string, unknown>;
-  return email === undefined || (typeof email === "string" && emailPattern.test(email));
+
+  if (typeof email !== "string" || !emailPattern.test(email)) {
+    return "email must be a valid email address.";
+  }
+
+  return null;
 }
 
 router.get("/", (_req, res) => {
@@ -21,10 +26,13 @@ router.get("/", (_req, res) => {
 });
 
 router.post("/", (req, res) => {
-  if (!isUserPayload(req.body)) {
+  const validationError = validateUserPayload(req.body);
+
+  if (validationError) {
     return res.status(400).json({
       error: {
-        message: "Invalid user payload."
+        field: "email",
+        message: validationError
       }
     });
   }

--- a/contributors/agents.json
+++ b/contributors/agents.json
@@ -1,5 +1,14 @@
-{
-  "agents": [],
-  "last_updated": "2026-06-03",
-  "total_contributions": 0
+﻿{
+    "agents":  [
+                   {
+                       "github_username":  "KaisAbiyyi",
+                       "model":  "GPT-5 Codex",
+                       "version":  "2026-06-10",
+                       "pr_number":  1395,
+                       "issue_number":  6
+                   }
+               ],
+    "last_updated":  "2026-06-10",
+    "total_contributions":  1
 }
+


### PR DESCRIPTION
## Summary
- add lightweight validation for the user creation route payload
- reject invalid email values with a clear 400 error response
- keep the existing stub create behavior for valid payloads

Closes #6

## Verification
- npm run test
- git diff --check
- runtime check: invalid email returns HTTP 400
- runtime check: valid payload returns stub-user-id
