### PR TITLE
fix: normalize health check response envelope (closes #8)

### DIFF
--- a/apps/api/src/index.ts
+++ b/apps/api/src/index.ts
@@ -8,7 +8,7 @@ const port = process.env.PORT || 4000;
 app.use(express.json());
 
 app.get("/health", (_req, res) => {
-  res.json({ status: "ok", service: "taskflow-api" });
+  res.json({ status: "ok", data: { service: "taskflow-api" } });
 });
 
 app.use("/users", usersRouter);


### PR DESCRIPTION
Normalizes health check response to use a consistent status + data envelope.

- Changes from { status, service } to { status: ok, data: { service } }

Closes #8
/bounty 