### PR TITLE
fix: add request body size limit (closes #9)

### DIFF
--- a/apps/api/src/index.ts
+++ b/apps/api/src/index.ts
@@ -5,7 +5,8 @@ import usersRouter from "./routes/users";
 const app = express();
 const port = process.env.PORT || 4000;
 
-app.use(express.json());
+// Body size limit: 100KB (conservative default)
+app.use(express.json({ limit: "100kb" }));
 
 app.get("/health", (_req, res) => {
   res.json({ status: "ok", service: "taskflow-api" });


### PR DESCRIPTION
Configures a conservative JSON body size limit of 100KB on the Express app.

Closes #9
/bounty 