### PR TITLE
feat: add API error handling helper (closes #7)

### DIFF
--- a/apps/api/src/routes/users.ts
+++ b/apps/api/src/routes/users.ts
@@ -1,22 +1,31 @@
-import { Router } from "express";
+import { Router, Request, Response } from "express";
+import { sendError } from "../utils/errorHandler";
 
 const router = Router();
 
-router.get("/", (_req, res) => {
-  res.json({
-    data: [],
-    message: "User listing is not implemented yet."
-  });
+router.get("/", (_req: Request, res: Response) => {
+  try {
+    res.json({
+      data: [],
+      message: "User listing is not implemented yet."
+    });
+  } catch (err) {
+    return sendError(res, "Failed to list users", 500);
+  }
 });
 
-router.post("/", (req, res) => {
-  res.status(201).json({
-    data: {
-      id: "stub-user-id",
-      ...req.body
-    },
-    message: "User creation is not implemented yet."
-  });
+router.post("/", (req: Request, res: Response) => {
+  try {
+    res.status(201).json({
+      data: {
+        id: "stub-user-id",
+        ...req.body
+      },
+      message: "User creation is not implemented yet."
+    });
+  } catch (err) {
+    return sendError(res, "Failed to create user", 500);
+  }
 });
 
 export default router;

--- a/apps/api/src/utils/errorHandler.ts
+++ b/apps/api/src/utils/errorHandler.ts
@@ -1,0 +1,8 @@
+import { Response } from "express";
+
+export function sendError(res: Response, message: string, statusCode: number = 400) {
+  return res.status(statusCode).json({
+    status: "error",
+    message,
+  });
+}


### PR DESCRIPTION
Introduces a sendError() response helper providing consistent error envelopes.

- Creates utils/errorHandler.ts with sendError utility
- Wraps user routes with try/catch using the helper

Closes #7
/bounty 