### PR TITLE
docs: document expected environment variables for API and Web (closes #4)

### DIFF
--- a/apps/api/.env.example
+++ b/apps/api/.env.example
@@ -1,0 +1,5 @@
+# TaskFlow API environment variables
+# Copy this file to .env and fill in your values
+PORT=4000          # API server port (default: 4000)
+DATABASE_URL=postgresql://user:password@localhost:5432/taskflow
+NODE_ENV=development

--- a/apps/web/.env.example
+++ b/apps/web/.env.example
@@ -1,0 +1,3 @@
+# TaskFlow Web environment variables
+# Copy this file to .env.local and fill in your values
+NEXT_PUBLIC_API_URL=http://localhost:4000  # API base URL for client-side requests


### PR DESCRIPTION
Adds .env.example files documenting expected local environment variables.

- apps/api/.env.example: PORT, DATABASE_URL, NODE_ENV
- apps/web/.env.example: NEXT_PUBLIC_API_URL

Closes #4
/bounty 