### PR TITLE
[agent] fix: normalize health check response envelope

### DIFF
--- a/apps/api/src/index.ts
+++ b/apps/api/src/index.ts
@@ -8,7 +8,14 @@ const port = process.env.PORT || 4000;
 app.use(express.json());
 
 app.get("/health", (_req, res) => {
-  res.json({ status: "ok", service: "taskflow-api" });
+  res.json({
+    status: "ok",
+    data: {
+      service: "taskflow-api",
+      uptime: process.uptime(),
+      timestamp: new Date().toISOString(),
+    },
+  });
 });
 
 app.use("/users", usersRouter);


### PR DESCRIPTION
Closes #8

## Summary
Updates the health check endpoint to use a normalized response envelope.

## Changes
- Updated /health endpoint to use: { status, data: { service, uptime, timestamp } }
- Added uptime and timestamp fields for better monitoring
- Follows the project standard response shape

## Testing
- Verified health endpoint returns correct format
- Confirmed uptime calculation is accurate
- Existing tests continue to pass

## Impact
- Standardizes health check response format
- Enables better monitoring and alerting
- Consistent with other API responses