### PR TITLE
[agent] test: add unit tests for UI Button stub

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,8 +47,10 @@ Backend architecture follows:
 
 ## Getting Started
 
+```bash
 npm install
 npm run test
+```
 
 ## AI Agent Contribution Instruction
 
@@ -60,11 +62,15 @@ before opening your PR.
 
 ### Run frontend
 
+```bash
 npm run dev -w apps/web
+```
 
 ### Run backend
 
+```bash
 npm run dev -w apps/api
+```
 
 ## Database
 

--- a/contributors/agents.json
+++ b/contributors/agents.json
@@ -1,5 +1,13 @@
 {
-  "agents": [],
-  "last_updated": "2026-06-03",
-  "total_contributions": 0
+  "agents": [
+    {
+      "github_username": "gcm168",
+      "model": "Tencent Hunyuan Hy3 + DeepSeek-V4 Pro",
+      "version": "2026-06",
+      "pr_number": 0,
+      "issue_number": 2
+    }
+  ],
+  "last_updated": "2026-06-10",
+  "total_contributions": 1
 }

--- a/contributors/agents.json
+++ b/contributors/agents.json
@@ -6,8 +6,15 @@
       "version": "2026-06",
       "pr_number": 0,
       "issue_number": 2
+    },
+    {
+      "github_username": "gcm168",
+      "model": "Tencent Hunyuan Hy3 + DeepSeek-V4 Pro",
+      "version": "2026-06",
+      "pr_number": 0,
+      "issue_number": 13
     }
   ],
   "last_updated": "2026-06-10",
-  "total_contributions": 1
+  "total_contributions": 2
 }

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -5,10 +5,11 @@
   "description": "Shared UI components for TaskFlow.",
   "main": "src/index.ts",
   "scripts": {
-    "test": "echo \"No UI tests configured yet\"",
+    "test": "vitest run",
     "lint": "echo \"No UI lint configured yet\""
   },
   "devDependencies": {
-    "typescript": "^5.4.5"
+    "typescript": "^5.4.5",
+    "vitest": "^1.6.0"
   }
 }

--- a/packages/ui/src/__tests__/Button.test.ts
+++ b/packages/ui/src/__tests__/Button.test.ts
@@ -1,0 +1,31 @@
+import { describe, it, expect } from "vitest";
+import { Button } from "../index";
+
+describe("Button", () => {
+  it("should return an object with type set to 'button'", () => {
+    const result = Button({ label: "Submit" });
+    expect(result.type).toBe("button");
+  });
+
+  it("should set the label from props", () => {
+    const result = Button({ label: "Submit" });
+    expect(result.label).toBe("Submit");
+  });
+
+  it("should set disabled to false by default", () => {
+    const result = Button({ label: "Click me" });
+    expect(result.disabled).toBe(false);
+  });
+
+  it("should set disabled to true when passed", () => {
+    const result = Button({ label: "Click me", disabled: true });
+    expect(result.disabled).toBe(true);
+  });
+
+  it("should handle an empty label", () => {
+    const result = Button({ label: "" });
+    expect(result.type).toBe("button");
+    expect(result.label).toBe("");
+    expect(result.disabled).toBe(false);
+  });
+});


### PR DESCRIPTION
Closes #13

## Changes
- Added 5 unit tests for the Button component covering:
  - type property set to 'button'
  - label from props
  - disabled defaults to false
  - disabled set to true when passed
  - empty label edge case
- Installed vitest as test runner
- Updated package.json test script

All tests pass (5/5).