### PR TITLE
[agent] Add API graceful shutdown handling

### DIFF
--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -7,7 +7,7 @@
   "main": "src/index.ts",
   "scripts": {
     "dev": "tsx src/index.ts",
-    "test": "echo \"No API tests configured yet\"",
+    "test": "node scripts/validate-graceful-shutdown.mjs",
     "lint": "echo \"No API lint configured yet\""
   },
   "dependencies": {

--- a/apps/api/scripts/validate-graceful-shutdown.mjs
+++ b/apps/api/scripts/validate-graceful-shutdown.mjs
@@ -1,0 +1,16 @@
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { dirname, join } from "node:path";
+
+const scriptDir = dirname(fileURLToPath(import.meta.url));
+const source = readFileSync(join(scriptDir, "../src/index.ts"), "utf8");
+
+assert.match(source, /const\s+server\s*=\s*app\.listen\(/, "server instance must be retained");
+assert.match(source, /function\s+shutdown\s*\(\s*signal:\s*NodeJS\.Signals\s*\)/, "shutdown handler must accept the signal");
+assert.match(source, /server\.close\(/, "shutdown handler must close the HTTP server");
+assert.match(source, /setTimeout\(/, "shutdown handler must include a forced-exit timeout");
+assert.match(source, /process\.once\(\s*["']SIGTERM["']\s*,\s*\(\)\s*=>\s*shutdown\(["']SIGTERM["']\)\s*\)/, "SIGTERM must be handled once");
+assert.match(source, /process\.once\(\s*["']SIGINT["']\s*,\s*\(\)\s*=>\s*shutdown\(["']SIGINT["']\)\s*\)/, "SIGINT must be handled once");
+
+console.log("Graceful shutdown validation passed.");

--- a/apps/api/src/index.ts
+++ b/apps/api/src/index.ts
@@ -4,6 +4,7 @@ import usersRouter from "./routes/users";
 
 const app = express();
 const port = process.env.PORT || 4000;
+const shutdownTimeoutMs = 10_000;
 
 app.use(express.json());
 
@@ -13,6 +14,38 @@ app.get("/health", (_req, res) => {
 
 app.use("/users", usersRouter);
 
-app.listen(port, () => {
+const server = app.listen(port, () => {
   console.log(`TaskFlow API listening on port ${port}`);
 });
+
+let shutdownStarted = false;
+
+function shutdown(signal: NodeJS.Signals) {
+  if (shutdownStarted) {
+    return;
+  }
+
+  shutdownStarted = true;
+  console.log(`${signal} received. Closing TaskFlow API server...`);
+
+  const forceExitTimer = setTimeout(() => {
+    console.error("Graceful shutdown timed out. Forcing process exit.");
+    process.exit(1);
+  }, shutdownTimeoutMs);
+  forceExitTimer.unref();
+
+  server.close((error?: Error) => {
+    clearTimeout(forceExitTimer);
+
+    if (error) {
+      console.error("Error while closing TaskFlow API server:", error);
+      process.exit(1);
+    }
+
+    console.log("TaskFlow API server closed gracefully.");
+    process.exit(0);
+  });
+}
+
+process.once("SIGTERM", () => shutdown("SIGTERM"));
+process.once("SIGINT", () => shutdown("SIGINT"));

--- a/contributors/agents.json
+++ b/contributors/agents.json
@@ -1,5 +1,13 @@
 {
-  "agents": [],
-  "last_updated": "2026-06-03",
-  "total_contributions": 0
+  "agents": [
+    {
+      "github_username": "phucnguyen1707",
+      "model": "gpt-5-codex",
+      "version": "2026-06-10",
+      "pr_number": 0,
+      "issue_number": 1437
+    }
+  ],
+  "last_updated": "2026-06-10",
+  "total_contributions": 1
 }

--- a/contributors/agents.json
+++ b/contributors/agents.json
@@ -4,7 +4,7 @@
       "github_username": "phucnguyen1707",
       "model": "gpt-5-codex",
       "version": "2026-06-10",
-      "pr_number": 0,
+      "pr_number": 1438,
       "issue_number": 1437
     }
   ],


### PR DESCRIPTION
Closes #1437

/claim #1437

## Summary

- keep the API server instance returned by `app.listen()`
- add a guarded SIGTERM/SIGINT shutdown path that calls `server.close()`
- add a forced shutdown timeout so the process cannot hang forever
- wire a dependency-free validation script into the API test command

## Validation

- `npm test`
- `git diff --check`
- `node -e "JSON.parse(require('fs').readFileSync('contributors/agents.json','utf8')); console.log('agents json ok')"`

## Payment

USDC on Base: `0x162005ecd17d0Adc6c2eb207bf6BaD076C79e6b0`
