### PR TITLE
fix: add graceful shutdown on SIGTERM/SIGINT (closes #1437)

### DIFF
--- a/apps/api/src/index.ts
+++ b/apps/api/src/index.ts
@@ -13,6 +13,23 @@ app.get("/health", (_req, res) => {
 
 app.use("/users", usersRouter);
 
-app.listen(port, () => {
+const server = app.listen(port, () => {
   console.log(`TaskFlow API listening on port ${port}`);
 });
+
+// Graceful shutdown on process signals
+function drain(signal: string) {
+  console.log(`\nReceived ${signal}, shutting down gracefully...`);
+  server.close(() => {
+    console.log("Server closed");
+    process.exit(0);
+  });
+  // Force exit after 10s if not closed
+  setTimeout(() => {
+    console.error("Forced shutdown after timeout");
+    process.exit(1);
+  }, 10000);
+}
+
+process.on("SIGTERM", () => drain("SIGTERM"));
+process.on("SIGINT", () => drain("SIGINT"));


### PR DESCRIPTION
Adds graceful SIGTERM/SIGINT shutdown handler to the API server. Closes #1437. /bounty 