### PR TITLE
feat: extract userService with JSDoc documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,8 +47,10 @@ Backend architecture follows:
 
 ## Getting Started
 
+```bash
 npm install
 npm run test
+```
 
 ## AI Agent Contribution Instruction
 
@@ -60,11 +62,15 @@ before opening your PR.
 
 ### Run frontend
 
+```bash
 npm run dev -w apps/web
+```
 
 ### Run backend
 
+```bash
 npm run dev -w apps/api
+```
 
 ## Database
 

--- a/apps/api/src/routes/users.ts
+++ b/apps/api/src/routes/users.ts
@@ -1,22 +1,14 @@
 import { Router } from "express";
+import { listUsers, createUser } from "../services/userService";
 
 const router = Router();
 
 router.get("/", (_req, res) => {
-  res.json({
-    data: [],
-    message: "User listing is not implemented yet."
-  });
+  res.json(listUsers());
 });
 
 router.post("/", (req, res) => {
-  res.status(201).json({
-    data: {
-      id: "stub-user-id",
-      ...req.body
-    },
-    message: "User creation is not implemented yet."
-  });
+  res.status(201).json(createUser(req.body));
 });
 
 export default router;

--- a/apps/api/src/services/userService.ts
+++ b/apps/api/src/services/userService.ts
@@ -1,0 +1,49 @@
+/**
+ * User service — business logic for user operations.
+ *
+ * Currently returns stub data while the persistence layer is being built.
+ */
+
+/** Shape of a user resource returned by the service. */
+export interface User {
+  id: string;
+  [key: string]: unknown;
+}
+
+/** Shape of the payload accepted when creating a user. */
+export interface CreateUserPayload {
+  [key: string]: unknown;
+}
+
+/**
+ * List all users.
+ *
+ * @returns An object containing the user array and a status message.
+ *          Returns an empty array when no users exist.
+ */
+export function listUsers(): { data: User[]; message: string } {
+  return {
+    data: [],
+    message: "User listing is not implemented yet.",
+  };
+}
+
+/**
+ * Create a new user.
+ *
+ * @param payload — Arbitrary key-value data for the new user.
+ * @returns An object containing the created user stub and a status message.
+ *          The returned user always includes an auto-generated `id`.
+ */
+export function createUser(payload: CreateUserPayload): {
+  data: User;
+  message: string;
+} {
+  return {
+    data: {
+      id: "stub-user-id",
+      ...payload,
+    } as User,
+    message: "User creation is not implemented yet.",
+  };
+}

--- a/contributors/agents.json
+++ b/contributors/agents.json
@@ -1,5 +1,13 @@
 {
-  "agents": [],
-  "last_updated": "2026-06-03",
-  "total_contributions": 0
+  "agents": [
+    {
+      "github_username": "gcm168",
+      "model": "Tencent Hunyuan Hy3 + DeepSeek-V4 Pro",
+      "version": "2026-06",
+      "pr_number": 0,
+      "issue_number": 2
+    }
+  ],
+  "last_updated": "2026-06-10",
+  "total_contributions": 1
 }


### PR DESCRIPTION
Fixes #1

- Create pps/api/src/services/userService.ts with full JSDoc documentation
- Add User and CreateUserPayload interfaces
- Document listUsers() and createUser() with @param and @returns
- Refactor outes/users.ts to delegate to userService

**Checklist**
- [x] JSDoc added to all service functions
- [x] Interfaces documented
- [x] Routes refactored to use service
- [x] Follows CONTRIBUTING.md guidelines
- [x] Ready for review