### PR TITLE
feat(api): add API error handling helper and use it in user routes

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,8 +47,10 @@ Backend architecture follows:
 
 ## Getting Started
 
+```bash
 npm install
 npm run test
+```
 
 ## AI Agent Contribution Instruction
 
@@ -60,11 +62,15 @@ before opening your PR.
 
 ### Run frontend
 
+```bash
 npm run dev -w apps/web
+```
 
 ### Run backend
 
+```bash
 npm run dev -w apps/api
+```
 
 ## Database
 

--- a/apps/api/src/index.ts
+++ b/apps/api/src/index.ts
@@ -1,6 +1,7 @@
 import express from "express";
 
 import usersRouter from "./routes/users";
+import { errorHandler } from "./utils/errorHandler";
 
 const app = express();
 const port = process.env.PORT || 4000;
@@ -12,6 +13,8 @@ app.get("/health", (_req, res) => {
 });
 
 app.use("/users", usersRouter);
+
+app.use(errorHandler);
 
 app.listen(port, () => {
   console.log(`TaskFlow API listening on port ${port}`);

--- a/apps/api/src/routes/users.ts
+++ b/apps/api/src/routes/users.ts
@@ -1,5 +1,7 @@
 import { Router } from "express";
 
+import { ApiError } from "../utils/errorHandler";
+
 const router = Router();
 
 router.get("/", (_req, res) => {
@@ -9,14 +11,24 @@ router.get("/", (_req, res) => {
   });
 });
 
-router.post("/", (req, res) => {
-  res.status(201).json({
-    data: {
-      id: "stub-user-id",
-      ...req.body
-    },
-    message: "User creation is not implemented yet."
-  });
+router.post("/", (req, res, next) => {
+  try {
+    const { body } = req;
+
+    if (!body || typeof body !== "object" || Array.isArray(body)) {
+      throw new ApiError(400, "Request body must be a JSON object.");
+    }
+
+    res.status(201).json({
+      data: {
+        id: "stub-user-id",
+        ...body
+      },
+      message: "User creation is not implemented yet."
+    });
+  } catch (err) {
+    next(err);
+  }
 });
 
 export default router;

--- a/apps/api/src/utils/errorHandler.ts
+++ b/apps/api/src/utils/errorHandler.ts
@@ -1,0 +1,36 @@
+export class ApiError extends Error {
+  statusCode: number;
+
+  constructor(statusCode: number, message: string) {
+    super(message);
+    this.statusCode = statusCode;
+    this.name = "ApiError";
+  }
+}
+
+import { Request, Response, NextFunction } from "express";
+
+export function errorHandler(
+  err: Error,
+  _req: Request,
+  res: Response,
+  _next: NextFunction
+): void {
+  if (err instanceof ApiError) {
+    res.status(err.statusCode).json({
+      error: {
+        message: err.message,
+        statusCode: err.statusCode,
+      },
+    });
+    return;
+  }
+
+  console.error("Unhandled error:", err);
+  res.status(500).json({
+    error: {
+      message: "Internal server error",
+      statusCode: 500,
+    },
+  });
+}

--- a/contributors/agents.json
+++ b/contributors/agents.json
@@ -1,5 +1,13 @@
 {
-  "agents": [],
-  "last_updated": "2026-06-03",
-  "total_contributions": 0
+  "agents": [
+    {
+      "github_username": "gcm168",
+      "model": "Tencent Hunyuan Hy3 + DeepSeek-V4 Pro",
+      "version": "2026-06",
+      "pr_number": 0,
+      "issue_number": 2
+    }
+  ],
+  "last_updated": "2026-06-10",
+  "total_contributions": 1
 }


### PR DESCRIPTION
## Summary

Add API error handling helper for the Express app:
- Create `ApiError` class with statusCode and message
- Create `errorHandler` middleware to catch and respond to ApiError instances
- Integrate errorHandler into the Express app
- Add request body validation to POST /users route using ApiError

Closes #7

## Changes

- `apps/api/src/utils/errorHandler.ts` — New file: ApiError class + errorHandler middleware
- `apps/api/src/index.ts` — Register errorHandler middleware
- `apps/api/src/routes/users.ts` — Add body validation with ApiError

/bounty $50