### PR TITLE
test: add unit tests for Button stub (Closes #13)

### DIFF
--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -5,10 +5,11 @@
   "description": "Shared UI components for TaskFlow.",
   "main": "src/index.ts",
   "scripts": {
-    "test": "echo \"No UI tests configured yet\"",
-    "lint": "echo \"No UI lint configured yet\""
+    "test": "tsx --test src/index.test.ts",
+    "lint": "echo "No UI lint configured yet""
   },
   "devDependencies": {
+    "tsx": "^4.19.0",
     "typescript": "^5.4.5"
   }
 }

--- a/packages/ui/src/index.test.ts
+++ b/packages/ui/src/index.test.ts
@@ -1,0 +1,30 @@
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import { Button } from './index.js';
+
+describe('Button', () => {
+  it('should return an object with the provided label', () => {
+    const result = Button({ label: 'Click me' });
+    assert.strictEqual(result.label, 'Click me');
+  });
+
+  it('should default disabled to false when not provided', () => {
+    const result = Button({ label: 'Test' });
+    assert.strictEqual(result.disabled, false);
+  });
+
+  it('should allow explicit disabled=true', () => {
+    const result = Button({ label: 'Test', disabled: true });
+    assert.strictEqual(result.disabled, true);
+  });
+
+  it('should allow explicit disabled=false', () => {
+    const result = Button({ label: 'Test', disabled: false });
+    assert.strictEqual(result.disabled, false);
+  });
+
+  it('should return type "button"', () => {
+    const result = Button({ label: 'Test' });
+    assert.strictEqual(result.type, 'button');
+  });
+});


### PR DESCRIPTION
## Summary

Add focused unit tests for the shared Button stub covering label and disabled values.

### Changes

- **New file**: `packages/ui/src/index.test.ts` — 5 test cases using `node:test` + `node:assert/strict`
  - Label preservation
  - Default `disabled=false` when not provided
  - Explicit `disabled=true`
  - Explicit `disabled=false`
  - Return type is `"button"`
- **Modified**: `packages/ui/package.json` — add `tsx` devDependency and update test script to `tsx --test src/index.test.ts`

### Acceptance Criteria

- ✅ Keep the pull request focused
- ✅ Include a short summary of the change
- ✅ Link this issue in the pull request description

Closes #13