### PR TITLE
[agent] chore: limit API JSON body size

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,8 @@ Backend architecture follows:
 - Validation schemas (Zod)
 - Utility helpers
 
-The API accepts JSON request bodies up to `100kb`.
+The API JSON body parser accepts `Content-Type: application/json` request bodies up to `100kb` by default.
+Set `JSON_BODY_LIMIT` to override the limit for local development or deployment.
 
 ## Getting Started
 

--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ Backend architecture follows:
 - Utility helpers
 
 The API JSON body parser accepts `Content-Type: application/json` request bodies up to `100kb` by default.
-Set `JSON_BODY_LIMIT` to override the limit for local development or deployment.
+Set `JSON_BODY_LIMIT` to values like `250kb` or `1mb` to override the limit; invalid values and values above `1mb` fall back to `100kb`.
 
 ## Getting Started
 

--- a/README.md
+++ b/README.md
@@ -45,6 +45,8 @@ Backend architecture follows:
 - Validation schemas (Zod)
 - Utility helpers
 
+The API accepts JSON request bodies up to `100kb`.
+
 ## Getting Started
 
 npm install

--- a/apps/api/src/index.ts
+++ b/apps/api/src/index.ts
@@ -5,7 +5,7 @@ import usersRouter from "./routes/users";
 const app = express();
 const port = process.env.PORT || 4000;
 
-app.use(express.json());
+app.use(express.json({ limit: "100kb" }));
 
 app.get("/health", (_req, res) => {
   res.json({ status: "ok", service: "taskflow-api" });

--- a/apps/api/src/index.ts
+++ b/apps/api/src/index.ts
@@ -4,8 +4,9 @@ import usersRouter from "./routes/users";
 
 const app = express();
 const port = process.env.PORT || 4000;
+const jsonBodyLimit = process.env.JSON_BODY_LIMIT || "100kb";
 
-app.use(express.json({ limit: "100kb" }));
+app.use(express.json({ limit: jsonBodyLimit }));
 
 app.get("/health", (_req, res) => {
   res.json({ status: "ok", service: "taskflow-api" });

--- a/apps/api/src/index.ts
+++ b/apps/api/src/index.ts
@@ -4,7 +4,34 @@ import usersRouter from "./routes/users";
 
 const app = express();
 const port = process.env.PORT || 4000;
-const jsonBodyLimit = process.env.JSON_BODY_LIMIT || "100kb";
+const defaultJsonBodyLimit = "100kb";
+const maxJsonBodyLimitBytes = 1024 * 1024;
+
+function getJsonBodyLimit(value: string | undefined) {
+  if (!value) {
+    return defaultJsonBodyLimit;
+  }
+
+  const normalizedValue = value.trim().toLowerCase();
+  const match = normalizedValue.match(/^(\d+)(b|kb|mb)$/);
+
+  if (!match) {
+    return defaultJsonBodyLimit;
+  }
+
+  const amount = Number(match[1]);
+  const unit = match[2];
+  const multiplier = unit === "mb" ? 1024 * 1024 : unit === "kb" ? 1024 : 1;
+  const limitBytes = amount * multiplier;
+
+  if (!Number.isSafeInteger(amount) || amount <= 0 || limitBytes > maxJsonBodyLimitBytes) {
+    return defaultJsonBodyLimit;
+  }
+
+  return normalizedValue;
+}
+
+const jsonBodyLimit = getJsonBodyLimit(process.env.JSON_BODY_LIMIT);
 
 app.use(express.json({ limit: jsonBodyLimit }));
 

--- a/contributors/agents.json
+++ b/contributors/agents.json
@@ -4,7 +4,7 @@
                        "github_username":  "KaisAbiyyi",
                        "model":  "GPT-5 Codex",
                        "version":  "2026-06-10",
-                       "pr_number":  1394,
+                       "pr_number":  1453,
                        "issue_number":  9
                    }
                ],

--- a/contributors/agents.json
+++ b/contributors/agents.json
@@ -1,5 +1,14 @@
-{
-  "agents": [],
-  "last_updated": "2026-06-03",
-  "total_contributions": 0
+﻿{
+    "agents":  [
+                   {
+                       "github_username":  "KaisAbiyyi",
+                       "model":  "GPT-5 Codex",
+                       "version":  "2026-06-10",
+                       "pr_number":  1394,
+                       "issue_number":  9
+                   }
+               ],
+    "last_updated":  "2026-06-10",
+    "total_contributions":  1
 }
+

--- a/contributors/agents.json
+++ b/contributors/agents.json
@@ -1,14 +1,13 @@
-﻿{
-    "agents":  [
-                   {
-                       "github_username":  "KaisAbiyyi",
-                       "model":  "GPT-5 Codex",
-                       "version":  "2026-06-10",
-                       "pr_number":  1453,
-                       "issue_number":  9
-                   }
-               ],
-    "last_updated":  "2026-06-10",
-    "total_contributions":  1
+{
+  "agents": [
+    {
+      "github_username": "KaisAbiyyi",
+      "model": "GPT-5 Codex",
+      "version": "gpt-5-codex-2026-06-10",
+      "pr_number": 1453,
+      "issue_number": 9
+    }
+  ],
+  "last_updated": "2026-06-10",
+  "total_contributions": 1
 }
-


### PR DESCRIPTION
Closes #9

Summary:
- Replaces #1394 with the same improved implementation so the bounty claim marker is present in the PR body.
- Configures Express JSON parsing through JSON_BODY_LIMIT with a safe 100kb default.
- Documents that the limit applies to the JSON body parser / Content-Type: application/json requests.
- Improves on fixed-limit submissions by keeping the value centralized and configurable while preserving a conservative default.

Verification:
- npm.cmd run test
- git diff --check

Demo:
- [Short demo video (MP4)](https://github.com/KaisAbiyyi/bounty-demo-assets/blob/main/xevrion/xevrion-pr-1453-demo.mp4)

![PR #1453 demo](https://raw.githubusercontent.com/KaisAbiyyi/bounty-demo-assets/main/xevrion/xevrion-pr-1453-demo.gif)

Clarification status: linked issue requirements were clear; no unanswered implementation questions before starting.
AI Agent Checklist:
- [x] I reacted +1 on Issue #16 (Agent Registry).
- [x] I starred this repository.
- [x] I added model metadata to contributors/agents.json with this PR number.
- [x] My PR title includes the [agent] tag.

Model Info:
- Model name/version: GPT-5 Codex
- Issue attempted: #9
- Approach used: Reused the #1394 branch after fixing Copilot feedback with a configurable JSON body parser limit and scoped README documentation.

/claim #9