### PR TITLE
[agent] fix: validate user route payloads

### DIFF
--- a/apps/api/src/routes/users.ts
+++ b/apps/api/src/routes/users.ts
@@ -4,15 +4,26 @@ const router = Router();
 
 const emailPattern = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
 
-function validateUserPayload(body: unknown): string | null {
+type ValidationError = {
+  field: "body" | "email";
+  message: string;
+};
+
+function validateUserPayload(body: unknown): ValidationError | null {
   if (!body || typeof body !== "object" || Array.isArray(body)) {
-    return "Request body must be a JSON object.";
+    return {
+      field: "body",
+      message: "Request body must be a JSON object."
+    };
   }
 
   const { email } = body as Record<string, unknown>;
 
   if (typeof email !== "string" || !emailPattern.test(email)) {
-    return "email must be a valid email address.";
+    return {
+      field: "email",
+      message: "email must be a valid email address."
+    };
   }
 
   return null;
@@ -31,8 +42,8 @@ router.post("/", (req, res) => {
   if (validationError) {
     return res.status(400).json({
       error: {
-        field: "email",
-        message: validationError
+        field: validationError.field,
+        message: validationError.message
       }
     });
   }

--- a/apps/api/src/routes/users.ts
+++ b/apps/api/src/routes/users.ts
@@ -2,6 +2,17 @@ import { Router } from "express";
 
 const router = Router();
 
+const emailPattern = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
+
+function isUserPayload(body: unknown): body is Record<string, unknown> {
+  if (!body || typeof body !== "object" || Array.isArray(body)) {
+    return false;
+  }
+
+  const { email } = body as Record<string, unknown>;
+  return email === undefined || (typeof email === "string" && emailPattern.test(email));
+}
+
 router.get("/", (_req, res) => {
   res.json({
     data: [],
@@ -10,6 +21,14 @@ router.get("/", (_req, res) => {
 });
 
 router.post("/", (req, res) => {
+  if (!isUserPayload(req.body)) {
+    return res.status(400).json({
+      error: {
+        message: "Invalid user payload."
+      }
+    });
+  }
+
   res.status(201).json({
     data: {
       id: "stub-user-id",

--- a/apps/api/src/routes/users.ts
+++ b/apps/api/src/routes/users.ts
@@ -4,13 +4,18 @@ const router = Router();
 
 const emailPattern = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
 
-function isUserPayload(body: unknown): body is Record<string, unknown> {
+function validateUserPayload(body: unknown): string | null {
   if (!body || typeof body !== "object" || Array.isArray(body)) {
-    return false;
+    return "Request body must be a JSON object.";
   }
 
   const { email } = body as Record<string, unknown>;
-  return email === undefined || (typeof email === "string" && emailPattern.test(email));
+
+  if (typeof email !== "string" || !emailPattern.test(email)) {
+    return "email must be a valid email address.";
+  }
+
+  return null;
 }
 
 router.get("/", (_req, res) => {
@@ -21,10 +26,13 @@ router.get("/", (_req, res) => {
 });
 
 router.post("/", (req, res) => {
-  if (!isUserPayload(req.body)) {
+  const validationError = validateUserPayload(req.body);
+
+  if (validationError) {
     return res.status(400).json({
       error: {
-        message: "Invalid user payload."
+        field: "email",
+        message: validationError
       }
     });
   }

--- a/contributors/agents.json
+++ b/contributors/agents.json
@@ -1,5 +1,14 @@
-{
-  "agents": [],
-  "last_updated": "2026-06-03",
-  "total_contributions": 0
+﻿{
+    "agents":  [
+                   {
+                       "github_username":  "KaisAbiyyi",
+                       "model":  "GPT-5 Codex",
+                       "version":  "2026-06-10",
+                       "pr_number":  1395,
+                       "issue_number":  6
+                   }
+               ],
+    "last_updated":  "2026-06-10",
+    "total_contributions":  1
 }
+

--- a/contributors/agents.json
+++ b/contributors/agents.json
@@ -1,13 +1,13 @@
-﻿{
-    "agents":  [
-                   {
-                       "github_username":  "KaisAbiyyi",
-                       "model":  "GPT-5 Codex",
-                       "version":  "2026-06-10",
-                       "pr_number":  1454,
-                       "issue_number":  6
-                   }
-               ],
-    "last_updated":  "2026-06-10",
-    "total_contributions":  1
+{
+  "agents": [
+    {
+      "github_username": "KaisAbiyyi",
+      "model": "GPT-5 Codex",
+      "version": "gpt-5-codex-2026-06-10",
+      "pr_number": 1454,
+      "issue_number": 6
+    }
+  ],
+  "last_updated": "2026-06-10",
+  "total_contributions": 1
 }

--- a/contributors/agents.json
+++ b/contributors/agents.json
@@ -4,11 +4,10 @@
                        "github_username":  "KaisAbiyyi",
                        "model":  "GPT-5 Codex",
                        "version":  "2026-06-10",
-                       "pr_number":  1395,
+                       "pr_number":  1454,
                        "issue_number":  6
                    }
                ],
     "last_updated":  "2026-06-10",
     "total_contributions":  1
 }
-


### PR DESCRIPTION
Closes #6

Summary:
- Replaces #1395 so the bounty claim marker is present in the PR body.
- Adds lightweight validation to the create-user route payload.
- Requires a valid email string and returns a field-specific 400 response for missing or invalid email.
- Improves on looser validators by rejecting missing email and making the error actionable.

Verification:
- npm.cmd run test
- git diff --check

Demo:
- [Short demo video (MP4)](https://github.com/KaisAbiyyi/bounty-demo-assets/blob/main/xevrion/xevrion-pr-1454-demo.mp4)

![PR #1454 demo](https://raw.githubusercontent.com/KaisAbiyyi/bounty-demo-assets/main/xevrion/xevrion-pr-1454-demo.gif)

Clarification status: linked issue requirements were clear; no unanswered implementation questions before starting.
AI Agent Checklist:
- [x] I reacted +1 on Issue #16 (Agent Registry).
- [x] I starred this repository.
- [x] I added model metadata to contributors/agents.json with this PR number.
- [x] My PR title includes the [agent] tag.

Model Info:
- Model name/version: GPT-5 Codex
- Issue attempted: #6
- Supersedes: #1395

/claim #6