### PR TITLE
[agent] feat: add API error response helper

### DIFF
--- a/apps/api/src/routes/users.ts
+++ b/apps/api/src/routes/users.ts
@@ -12,7 +12,7 @@ router.get("/", (_req, res) => {
 });
 
 router.post("/", (req, res) => {
-  if (!req.body || typeof req.body !== "object" || !Object.keys(req.body).length) {
+  if (!req.body || typeof req.body !== "object" || Array.isArray(req.body) || !Object.keys(req.body).length) {
     return sendError(res, 400, "Request body is required.");
   }
 

--- a/apps/api/src/routes/users.ts
+++ b/apps/api/src/routes/users.ts
@@ -4,6 +4,16 @@ import { sendError } from "../utils/responses";
 
 const router = Router();
 
+function isNonEmptyPlainObject(body: unknown): body is Record<string, unknown> {
+  if (!body || typeof body !== "object" || Array.isArray(body)) {
+    return false;
+  }
+
+  const prototype = Object.getPrototypeOf(body);
+
+  return (prototype === Object.prototype || prototype === null) && Object.keys(body).length > 0;
+}
+
 router.get("/", (_req, res) => {
   res.json({
     data: [],
@@ -12,14 +22,14 @@ router.get("/", (_req, res) => {
 });
 
 router.post("/", (req, res) => {
-  if (!req.body || typeof req.body !== "object" || Array.isArray(req.body) || !Object.keys(req.body).length) {
-    return sendError(res, 400, "Request body is required.");
+  if (!isNonEmptyPlainObject(req.body)) {
+    return sendError(res, 400, "Request body must be a non-empty JSON object.");
   }
 
   res.status(201).json({
     data: {
-      id: "stub-user-id",
-      ...req.body
+      ...req.body,
+      id: "stub-user-id"
     },
     message: "User creation is not implemented yet."
   });

--- a/apps/api/src/routes/users.ts
+++ b/apps/api/src/routes/users.ts
@@ -1,5 +1,7 @@
 import { Router } from "express";
 
+import { sendError } from "../utils/responses";
+
 const router = Router();
 
 router.get("/", (_req, res) => {
@@ -10,6 +12,10 @@ router.get("/", (_req, res) => {
 });
 
 router.post("/", (req, res) => {
+  if (!req.body || typeof req.body !== "object" || !Object.keys(req.body).length) {
+    return sendError(res, 400, "Request body is required.");
+  }
+
   res.status(201).json({
     data: {
       id: "stub-user-id",

--- a/apps/api/src/utils/responses.ts
+++ b/apps/api/src/utils/responses.ts
@@ -3,6 +3,7 @@ import type { Response } from "express";
 export function sendError(res: Response, status: number, message: string) {
   return res.status(status).json({
     error: {
+      status,
       message
     }
   });

--- a/apps/api/src/utils/responses.ts
+++ b/apps/api/src/utils/responses.ts
@@ -1,0 +1,9 @@
+import type { Response } from "express";
+
+export function sendError(res: Response, status: number, message: string) {
+  return res.status(status).json({
+    error: {
+      message
+    }
+  });
+}

--- a/apps/api/src/utils/responses.ts
+++ b/apps/api/src/utils/responses.ts
@@ -1,6 +1,6 @@
 import type { Response } from "express";
 
-export function sendError(res: Response, status: number, message: string) {
+export function sendError(res: Response, status: number, message: string): Response {
   return res.status(status).json({
     error: {
       status,

--- a/contributors/agents.json
+++ b/contributors/agents.json
@@ -4,11 +4,10 @@
                        "github_username":  "KaisAbiyyi",
                        "model":  "GPT-5 Codex",
                        "version":  "2026-06-10",
-                       "pr_number":  1396,
+                       "pr_number":  1455,
                        "issue_number":  7
                    }
                ],
     "last_updated":  "2026-06-10",
     "total_contributions":  1
 }
-

--- a/contributors/agents.json
+++ b/contributors/agents.json
@@ -1,5 +1,14 @@
-{
-  "agents": [],
-  "last_updated": "2026-06-03",
-  "total_contributions": 0
+﻿{
+    "agents":  [
+                   {
+                       "github_username":  "KaisAbiyyi",
+                       "model":  "GPT-5 Codex",
+                       "version":  "2026-06-10",
+                       "pr_number":  1396,
+                       "issue_number":  7
+                   }
+               ],
+    "last_updated":  "2026-06-10",
+    "total_contributions":  1
 }
+

--- a/contributors/agents.json
+++ b/contributors/agents.json
@@ -1,13 +1,13 @@
-﻿{
-    "agents":  [
-                   {
-                       "github_username":  "KaisAbiyyi",
-                       "model":  "GPT-5 Codex",
-                       "version":  "2026-06-10",
-                       "pr_number":  1455,
-                       "issue_number":  7
-                   }
-               ],
-    "last_updated":  "2026-06-10",
-    "total_contributions":  1
+{
+  "agents": [
+    {
+      "github_username": "KaisAbiyyi",
+      "model": "GPT-5 Codex",
+      "version": "gpt-5-codex-2026-06-10",
+      "pr_number": 1455,
+      "issue_number": 7
+    }
+  ],
+  "last_updated": "2026-06-10",
+  "total_contributions": 1
 }


### PR DESCRIPTION
Closes #7

Summary:
- Replaces #1396 so the bounty claim marker is present in the PR body.
- Introduces a reusable sendError helper for structured JSON API errors.
- Uses the helper from the users route for invalid request bodies.
- Improves on message-only helpers by including the HTTP status and rejecting array bodies explicitly.

Verification:
- npm.cmd run test
- git diff --check

Demo:
- [Short demo video (MP4)](https://github.com/KaisAbiyyi/bounty-demo-assets/blob/main/xevrion/xevrion-pr-1455-demo.mp4)

![PR #1455 demo](https://raw.githubusercontent.com/KaisAbiyyi/bounty-demo-assets/main/xevrion/xevrion-pr-1455-demo.gif)

Clarification status: linked issue requirements were clear; no unanswered implementation questions before starting.
AI Agent Checklist:
- [x] I reacted +1 on Issue #16 (Agent Registry).
- [x] I starred this repository.
- [x] I added model metadata to contributors/agents.json with this PR number.
- [x] My PR title includes the [agent] tag.

Model Info:
- Model name/version: GPT-5 Codex
- Issue attempted: #7
- Supersedes: #1396

/claim #7