### PR TITLE
[agent] docs: describe Prisma model roles

### DIFF
--- a/contributors/agents.json
+++ b/contributors/agents.json
@@ -4,11 +4,10 @@
                        "github_username":  "KaisAbiyyi",
                        "model":  "GPT-5 Codex",
                        "version":  "2026-06-10",
-                       "pr_number":  1400,
+                       "pr_number":  1457,
                        "issue_number":  5
                    }
                ],
     "last_updated":  "2026-06-10",
     "total_contributions":  1
 }
-

--- a/contributors/agents.json
+++ b/contributors/agents.json
@@ -1,13 +1,13 @@
-﻿{
-    "agents":  [
-                   {
-                       "github_username":  "KaisAbiyyi",
-                       "model":  "GPT-5 Codex",
-                       "version":  "2026-06-10",
-                       "pr_number":  1457,
-                       "issue_number":  5
-                   }
-               ],
-    "last_updated":  "2026-06-10",
-    "total_contributions":  1
+{
+  "agents": [
+    {
+      "github_username": "KaisAbiyyi",
+      "model": "GPT-5 Codex",
+      "version": "gpt-5-codex-2026-06-10",
+      "pr_number": 1457,
+      "issue_number": 5
+    }
+  ],
+  "last_updated": "2026-06-10",
+  "total_contributions": 1
 }

--- a/contributors/agents.json
+++ b/contributors/agents.json
@@ -1,5 +1,14 @@
-{
-  "agents": [],
-  "last_updated": "2026-06-03",
-  "total_contributions": 0
+﻿{
+    "agents":  [
+                   {
+                       "github_username":  "KaisAbiyyi",
+                       "model":  "GPT-5 Codex",
+                       "version":  "2026-06-10",
+                       "pr_number":  1400,
+                       "issue_number":  5
+                   }
+               ],
+    "last_updated":  "2026-06-10",
+    "total_contributions":  1
 }
+

--- a/packages/db/prisma/schema.prisma
+++ b/packages/db/prisma/schema.prisma
@@ -7,6 +7,7 @@ datasource db {
   url      = env("DATABASE_URL")
 }
 
+/// Represents a TaskFlow account that can own jobs and submit proposals.
 model User {
   id        String     @id @default(cuid())
   email     String     @unique
@@ -17,6 +18,7 @@ model User {
   updatedAt DateTime   @updatedAt
 }
 
+/// Represents work posted by a user for freelancers to review and propose on.
 model Job {
   id          String     @id @default(cuid())
   title       String
@@ -29,6 +31,7 @@ model Job {
   updatedAt   DateTime   @updatedAt
 }
 
+/// Represents a freelancer's offer to complete a specific job.
 model Proposal {
   id        String   @id @default(cuid())
   summary   String

--- a/packages/db/prisma/schema.prisma
+++ b/packages/db/prisma/schema.prisma
@@ -7,7 +7,7 @@ datasource db {
   url      = env("DATABASE_URL")
 }
 
-/// Represents a TaskFlow account that can own jobs and submit proposals.
+/// Represents an account that can own jobs and submit proposals.
 model User {
   id        String     @id @default(cuid())
   email     String     @unique

--- a/packages/db/prisma/schema.prisma
+++ b/packages/db/prisma/schema.prisma
@@ -18,7 +18,7 @@ model User {
   updatedAt DateTime   @updatedAt
 }
 
-/// Represents work posted by a user for freelancers to review and propose on.
+/// Represents work posted by a user for freelancers to review and submit proposals for.
 model Job {
   id          String     @id @default(cuid())
   title       String


### PR DESCRIPTION
Closes #5

Summary:
- Replaces #1400 so the bounty claim marker is present in the PR body.
- Adds concise Prisma comments for User, Job, and Proposal models.
- Keeps schema behavior unchanged while explaining each model role.
- Uses product-agnostic wording after review so comments do not overstate domain behavior.

Verification:
- npm.cmd run test
- git diff --check

Demo:
- [Short demo video (MP4)](https://github.com/KaisAbiyyi/bounty-demo-assets/blob/main/xevrion/xevrion-pr-1457-demo.mp4)

![PR #1457 demo](https://raw.githubusercontent.com/KaisAbiyyi/bounty-demo-assets/main/xevrion/xevrion-pr-1457-demo.gif)

Clarification status: linked issue requirements were clear; no unanswered implementation questions before starting.
AI Agent Checklist:
- [x] I reacted +1 on Issue #16 (Agent Registry).
- [x] I starred this repository.
- [x] I added model metadata to contributors/agents.json with this PR number.
- [x] My PR title includes the [agent] tag.

Model Info:
- Model name/version: GPT-5 Codex
- Issue attempted: #5
- Supersedes: #1400

/claim #5