### PR TITLE
fix: normalize health check response to consistent envelope

### DIFF
--- a/apps/api/src/index.ts
+++ b/apps/api/src/index.ts
@@ -8,7 +8,12 @@ const port = process.env.PORT || 4000;
 app.use(express.json());
 
 app.get("/health", (_req, res) => {
-  res.json({ status: "ok", service: "taskflow-api" });
+  res.json({
+    status: "ok",
+    data: {
+      service: "taskflow-api",
+    },
+  });
 });
 
 app.use("/users", usersRouter);


### PR DESCRIPTION
Closes #8

## Summary
Normalize the health check endpoint response to use a consistent envelope with `status` and `data` fields, matching the API response pattern used elsewhere.

## Changes
- `apps/api/src/index.ts`: Changed `/health` response from `{ status, service }` to `{ status, data: { service } }`

## Acceptance Criteria
- ✅ Health check returns envelope with `status` and `data` fields
- ✅ `status: "ok"` maintained
- ✅ Pull request focused on the change
- ✅ Issue #8 linked