### PR TITLE
[agent] Fix non-existent label in issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE/task.md
+++ b/.github/ISSUE_TEMPLATE/task.md
@@ -2,7 +2,7 @@
 name: Small task
 about: Small maintenance task for first-time contributors
 title: ""
-labels: good-first-issue
+labels: good first issue
 assignees: ""
 ---
 


### PR DESCRIPTION
The 'Small task' issue template was using the label 'good-first-issue', which does not exist in the repository. I have updated it to use the existing 'good first issue' label.

Closes #769