### PR TITLE
[agent] Add /bounty marker to bounty issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE/bounty_task.md
+++ b/.github/ISSUE_TEMPLATE/bounty_task.md
@@ -18,4 +18,4 @@ Describe the task, expected context, and files likely involved.
 
 ## Bounty Amount
 
-$50
+/bounty $50


### PR DESCRIPTION
Updated .github/ISSUE_TEMPLATE/bounty_task.md to include the required machine-readable /bounty 0 marker as per program instructions in #33.

Closes #687