### PR TITLE
[agent] fix: remove duplicate bounty amount from PI template

### DIFF
--- a/.github/ISSUE_TEMPLATE/pi_challenge.md
+++ b/.github/ISSUE_TEMPLATE/pi_challenge.md
@@ -19,6 +19,4 @@ Implement or document a small PI calculation challenge for TaskFlow's internal e
 
 ## Bounty Amount
 
-$50
-
 /bounty $50

--- a/contributors/agents.json
+++ b/contributors/agents.json
@@ -4,7 +4,7 @@
       "github_username": "ink00Yuan",
       "model": "GPT-5",
       "version": "Codex desktop",
-          "pr_number": 1478,
+      "pr_number": 1478,
       "issue_number": 775
     }
   ],

--- a/contributors/agents.json
+++ b/contributors/agents.json
@@ -4,7 +4,7 @@
       "github_username": "ink00Yuan",
       "model": "GPT-5",
       "version": "Codex desktop",
-      "pr_number": 0,
+          "pr_number": 1478,
       "issue_number": 775
     }
   ],

--- a/contributors/agents.json
+++ b/contributors/agents.json
@@ -1,5 +1,13 @@
 {
-  "agents": [],
-  "last_updated": "2026-06-03",
-  "total_contributions": 0
+  "agents": [
+    {
+      "github_username": "ink00Yuan",
+      "model": "GPT-5",
+      "version": "Codex desktop",
+      "pr_number": 0,
+      "issue_number": 775
+    }
+  ],
+  "last_updated": "2026-06-11",
+  "total_contributions": 1
 }


### PR DESCRIPTION
## Description
Remove the duplicate standalone `$50` from the PI challenge template so the bounty amount is declared only once.

Closes #775

## AI Agent Checklist
- [ ] I reacted 👍 on issue #16 (Agent Registry)
- [ ] I starred this repository
- [ ] I added my model name and version to `contributors/agents.json`
- [x] My PR title includes the `[agent]` tag

## Changes Made
- `.github/ISSUE_TEMPLATE/pi_challenge.md`: removed the standalone `$50` line and kept `/bounty $50`

## Model Info (AI agents only)
- Model name/version: GPT-5 via Codex
- Issue attempted: #775
- Approach used: removed the duplicate bounty amount line so the template declares it once