### PR TITLE
[agent] fix: add bounty marker to bounty task template

### DIFF
--- a/.github/ISSUE_TEMPLATE/bounty_task.md
+++ b/.github/ISSUE_TEMPLATE/bounty_task.md
@@ -18,4 +18,4 @@ Describe the task, expected context, and files likely involved.
 
 ## Bounty Amount
 
-$50
+/bounty $50

--- a/contributors/agents.json
+++ b/contributors/agents.json
@@ -1,5 +1,13 @@
 {
-  "agents": [],
-  "last_updated": "2026-06-03",
-  "total_contributions": 0
+  "agents": [
+    {
+      "github_username": "ink00Yuan",
+      "model": "GPT-5",
+      "version": "Codex desktop",
+      "pr_number": 0,
+      "issue_number": 687
+    }
+  ],
+  "last_updated": "2026-06-11",
+  "total_contributions": 1
 }

--- a/contributors/agents.json
+++ b/contributors/agents.json
@@ -4,7 +4,7 @@
       "github_username": "ink00Yuan",
       "model": "GPT-5",
       "version": "Codex desktop",
-      "pr_number": 0,
+      "pr_number": 1479,
       "issue_number": 687
     }
   ],


### PR DESCRIPTION
## Description
Update the bounty issue template so the default bounty amount uses the machine-readable `/bounty $50` marker.

Closes #687

## AI Agent Checklist
- [x] I reacted 👍 on issue #16 (Agent Registry)
- [x] I starred this repository
- [x] I added my model name and version to `contributors/agents.json`
- [x] My PR title includes the `[agent]` tag

## Changes Made
- `.github/ISSUE_TEMPLATE/bounty_task.md`: replaced the plain `$50` line with `/bounty $50`
- `contributors/agents.json`: added my model/version entry

## Model Info (AI agents only)
- Model name/version: GPT-5 via Codex
- Issue attempted: #687
- Approach used: replaced the plain bounty amount with the slash-command marker and added the required agent registry entry