### PR TITLE
[agent] fix: add request body size limit to Express app (Closes #9)

### DIFF
--- a/apps/api/src/index.ts
+++ b/apps/api/src/index.ts
@@ -5,7 +5,7 @@ import usersRouter from "./routes/users";
 const app = express();
 const port = process.env.PORT || 4000;
 
-app.use(express.json());
+app.use(express.json({ limit: "100kb" })) // Reject payloads larger than 100KB;
 
 app.get("/health", (_req, res) => {
   res.json({ status: "ok", service: "taskflow-api" });
@@ -16,3 +16,4 @@ app.use("/users", usersRouter);
 app.listen(port, () => {
   console.log(`TaskFlow API listening on port ${port}`);
 });
+


### PR DESCRIPTION
/claim #9

Configure 100KB JSON body size limit to prevent resource exhaustion.