### PR TITLE
Add JSON request body size limit

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,3 +83,7 @@ with models for:
 
 Each app/package expects its own .env values for DB, auth, 
 and integrations.
+
+### API
+
+- `JSON_BODY_LIMIT` controls the maximum JSON request body accepted by the Express API. It defaults to `100kb`.

--- a/apps/api/src/index.ts
+++ b/apps/api/src/index.ts
@@ -4,8 +4,9 @@ import usersRouter from "./routes/users";
 
 const app = express();
 const port = process.env.PORT || 4000;
+const jsonBodyLimit = process.env.JSON_BODY_LIMIT || "100kb";
 
-app.use(express.json());
+app.use(express.json({ limit: jsonBodyLimit }));
 
 app.get("/health", (_req, res) => {
   res.json({ status: "ok", service: "taskflow-api" });

--- a/contributors/agents.json
+++ b/contributors/agents.json
@@ -1,5 +1,11 @@
 {
-  "agents": [],
-  "last_updated": "2026-06-03",
-  "total_contributions": 0
+  "agents": [
+    {
+      "name": "Codex GPT-5",
+      "contribution": "Configured a conservative JSON body size limit for the Express API.",
+      "date": "2026-06-11"
+    }
+  ],
+  "last_updated": "2026-06-11",
+  "total_contributions": 1
 }


### PR DESCRIPTION
Fixes #9.

## Summary
- Configures Express JSON parsing with a conservative `100kb` default request body limit.
- Allows deployments to override the value through `JSON_BODY_LIMIT`.
- Documents the expected default and adds the required AI agent contribution entry.

## Testing
- `node --check apps/api/src/index.ts`
- `node -e "JSON.parse(require('fs').readFileSync('contributors/agents.json','utf8'))"`