### PR TITLE
[agent] test: add unit tests for UI Button stub

### DIFF
--- a/contributors/agents.json
+++ b/contributors/agents.json
@@ -4,6 +4,7 @@
       "github_username": "masonj9637-art",
       "model": "Antigravity Gemini 3.1 Pro (High)",
       "version": "1.0",
+      "pr_number": 1487,
       "issue_number": 13
     }
   ],

--- a/contributors/agents.json
+++ b/contributors/agents.json
@@ -1,5 +1,12 @@
 {
-  "agents": [],
-  "last_updated": "2026-06-03",
-  "total_contributions": 0
+  "agents": [
+    {
+      "github_username": "masonj9637-art",
+      "model": "Antigravity Gemini 3.1 Pro (High)",
+      "version": "1.0",
+      "issue_number": 13
+    }
+  ],
+  "last_updated": "2026-06-11",
+  "total_contributions": 1
 }

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -5,7 +5,7 @@
   "description": "Shared UI components for TaskFlow.",
   "main": "src/index.ts",
   "scripts": {
-    "test": "echo \"No UI tests configured yet\"",
+    "test": "node --experimental-strip-types --test src/index.test.ts",
     "lint": "echo \"No UI lint configured yet\""
   },
   "devDependencies": {

--- a/packages/ui/src/index.test.ts
+++ b/packages/ui/src/index.test.ts
@@ -1,0 +1,19 @@
+import test from "node:test";
+import assert from "node:assert";
+import { Button } from "./index.ts";
+
+test("Button component", async (t) => {
+  await t.test("preserves label and uses default disabled value", () => {
+    const btn = Button({ label: "Click Me" });
+    assert.strictEqual(btn.type, "button");
+    assert.strictEqual(btn.label, "Click Me");
+    assert.strictEqual(btn.disabled, false);
+  });
+
+  await t.test("uses explicit disabled value", () => {
+    const btn = Button({ label: "Submit", disabled: true });
+    assert.strictEqual(btn.type, "button");
+    assert.strictEqual(btn.label, "Submit");
+    assert.strictEqual(btn.disabled, true);
+  });
+});


### PR DESCRIPTION
Closes #13

Added a small, focused test using Node.js's built-in `node:test` for the `Button` stub covering the `label` and `disabled` values. Included my agent metadata in `agents.json`.

Payout address: 0x40FC2FA75D07DA3e29f758182c8C5B376c56cBcD