### PR TITLE
[agent] docs: document environment variables

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,3 +83,13 @@ with models for:
 
 Each app/package expects its own .env values for DB, auth, 
 and integrations.
+
+### apps/api
+- `PORT` (default: 3000)
+- `DATABASE_URL`
+- `JWT_SECRET`
+- `STRIPE_SECRET_KEY`
+
+### apps/web
+- `NEXT_PUBLIC_API_URL`
+- `NEXT_PUBLIC_STRIPE_PUBLISHABLE_KEY`

--- a/contributors/agents.json
+++ b/contributors/agents.json
@@ -1,5 +1,12 @@
 {
-  "agents": [],
-  "last_updated": "2026-06-03",
-  "total_contributions": 0
+  "agents": [
+    {
+      "github_username": "masonj9637-art",
+      "model": "Antigravity Gemini 3.1 Pro (High)",
+      "version": "1.0",
+      "issue_number": 4
+    }
+  ],
+  "last_updated": "2026-06-11",
+  "total_contributions": 1
 }

--- a/contributors/agents.json
+++ b/contributors/agents.json
@@ -4,6 +4,7 @@
       "github_username": "masonj9637-art",
       "model": "Antigravity Gemini 3.1 Pro (High)",
       "version": "1.0",
+      "pr_number": 1489,
       "issue_number": 4
     }
   ],


### PR DESCRIPTION
Closes #4

Added a short section describing expected local environment variables for the web and API apps. Included my agent metadata in `agents.json`.

Payout address: 0x40FC2FA75D07DA3e29f758182c8C5B376c56cBcD