### PR TITLE
[agent] fix(api): validate user email payloads

### DIFF
--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -7,7 +7,7 @@
   "main": "src/index.ts",
   "scripts": {
     "dev": "tsx src/index.ts",
-    "test": "echo \"No API tests configured yet\"",
+    "test": "tsx --test src/tests/*.test.ts",
     "lint": "echo \"No API lint configured yet\""
   },
   "dependencies": {

--- a/apps/api/src/routes/users.ts
+++ b/apps/api/src/routes/users.ts
@@ -2,6 +2,12 @@ import { Router } from "express";
 
 const router = Router();
 
+const EMAIL_PATTERN = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
+
+function isNonEmptyString(value: unknown): value is string {
+  return typeof value === "string" && value.trim().length > 0;
+}
+
 router.get("/", (_req, res) => {
   res.json({
     data: [],
@@ -10,6 +16,20 @@ router.get("/", (_req, res) => {
 });
 
 router.post("/", (req, res) => {
+  const { name, email } = req.body ?? {};
+
+  if (!isNonEmptyString(name)) {
+    return res.status(400).json({
+      error: "Name must be a non-empty string."
+    });
+  }
+
+  if (!isNonEmptyString(email) || !EMAIL_PATTERN.test(email)) {
+    return res.status(400).json({
+      error: "Email must be a valid non-empty email address."
+    });
+  }
+
   res.status(201).json({
     data: {
       id: "stub-user-id",

--- a/apps/api/src/tests/usersValidation.test.ts
+++ b/apps/api/src/tests/usersValidation.test.ts
@@ -1,0 +1,103 @@
+import { spawn, type ChildProcessWithoutNullStreams } from "node:child_process";
+import assert from "node:assert/strict";
+import { fileURLToPath } from "node:url";
+import { after, before, describe, it } from "node:test";
+
+const port = 45157;
+const baseUrl = `http://127.0.0.1:${port}`;
+const apiRoot = fileURLToPath(new URL("../../../", import.meta.url));
+let server: ChildProcessWithoutNullStreams;
+
+function waitForServerReady(process: ChildProcessWithoutNullStreams): Promise<void> {
+  return new Promise((resolve, reject) => {
+    const timeout = setTimeout(() => {
+      reject(new Error("Timed out waiting for API server to start."));
+    }, 10_000);
+
+    process.stdout.on("data", (chunk: Buffer) => {
+      if (chunk.toString().includes("TaskFlow API listening")) {
+        clearTimeout(timeout);
+        resolve();
+      }
+    });
+
+    process.stderr.on("data", (chunk: Buffer) => {
+      const text = chunk.toString();
+      if (text.includes("EADDRINUSE")) {
+        clearTimeout(timeout);
+        reject(new Error(text));
+      }
+    });
+
+    process.on("exit", (code) => {
+      clearTimeout(timeout);
+      reject(new Error(`API server exited before readiness with code ${code}.`));
+    });
+  });
+}
+
+async function postUser(payload: unknown): Promise<Response> {
+  return fetch(`${baseUrl}/users`, {
+    method: "POST",
+    headers: {
+      "content-type": "application/json"
+    },
+    body: JSON.stringify(payload)
+  });
+}
+
+describe("POST /users validation", () => {
+  before(async () => {
+    server = spawn(process.execPath, ["--import", "tsx", "src/index.ts"], {
+      cwd: apiRoot,
+      env: {
+        ...process.env,
+        PORT: String(port)
+      }
+    });
+
+    await waitForServerReady(server);
+  });
+
+  after(() => {
+    server.kill();
+  });
+
+  it("rejects missing or blank names", async () => {
+    const missingName = await postUser({ email: "person@example.com" });
+    assert.equal(missingName.status, 400);
+    assert.deepEqual(await missingName.json(), {
+      error: "Name must be a non-empty string."
+    });
+
+    const blankName = await postUser({ name: "   ", email: "person@example.com" });
+    assert.equal(blankName.status, 400);
+  });
+
+  it("rejects missing, blank, and malformed email values", async () => {
+    for (const email of [undefined, "", "   ", "not-an-email", "person@", "@example.com"]) {
+      const response = await postUser({ name: "Ada", email });
+      assert.equal(response.status, 400);
+      assert.deepEqual(await response.json(), {
+        error: "Email must be a valid non-empty email address."
+      });
+    }
+  });
+
+  it("accepts a valid name and email", async () => {
+    const response = await postUser({
+      name: "Ada Lovelace",
+      email: "ada@example.com"
+    });
+
+    assert.equal(response.status, 201);
+    assert.deepEqual(await response.json(), {
+      data: {
+        id: "stub-user-id",
+        name: "Ada Lovelace",
+        email: "ada@example.com"
+      },
+      message: "User creation is not implemented yet."
+    });
+  });
+});

--- a/contributors/agents.json
+++ b/contributors/agents.json
@@ -4,7 +4,7 @@
       "github_username": "russjont-cloud",
       "model": "gpt-5-codex",
       "version": "2026-06-11",
-      "pr_number": null,
+      "pr_number": 1494,
       "issue_number": 1357
     }
   ],

--- a/contributors/agents.json
+++ b/contributors/agents.json
@@ -1,5 +1,13 @@
 {
-  "agents": [],
-  "last_updated": "2026-06-03",
-  "total_contributions": 0
+  "agents": [
+    {
+      "github_username": "russjont-cloud",
+      "model": "gpt-5-codex",
+      "version": "2026-06-11",
+      "pr_number": null,
+      "issue_number": 1357
+    }
+  ],
+  "last_updated": "2026-06-11",
+  "total_contributions": 1
 }


### PR DESCRIPTION
Closes #1357.

/claim #1357

## Summary
- Reject missing or blank names in POST /users.
- Reject missing, blank, and malformed email values.
- Add focused node:test coverage for invalid and valid POST /users payloads.
- Register the AI agent contribution as required by CONTRIBUTING.md.

## Testing
- Not run locally: npm is unavailable in this Codex PowerShell environment.
- Intended repo command: npm --workspace @taskflow/api test.