### PR TITLE
[agent] Fix JSON body size limit

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,7 @@ Backend architecture follows:
 - Route layer
 - Validation schemas (Zod)
 - Utility helpers
+- The API accepts JSON request bodies up to `100kb`.
 
 ## Getting Started
 

--- a/apps/api/src/index.ts
+++ b/apps/api/src/index.ts
@@ -4,8 +4,9 @@ import usersRouter from "./routes/users";
 
 const app = express();
 const port = process.env.PORT || 4000;
+const jsonBodyLimit = "100kb";
 
-app.use(express.json());
+app.use(express.json({ limit: jsonBodyLimit }));
 
 app.get("/health", (_req, res) => {
   res.json({ status: "ok", service: "taskflow-api" });

--- a/contributors/agents.json
+++ b/contributors/agents.json
@@ -1,5 +1,13 @@
 {
-  "agents": [],
-  "last_updated": "2026-06-03",
-  "total_contributions": 0
+  "agents": [
+    {
+      "github_username": "SSD1222-1",
+      "model": "OpenAI Codex",
+      "version": "GPT-5",
+      "pr_number": 1506,
+      "issue_number": 9
+    }
+  ],
+  "last_updated": "2026-06-12",
+  "total_contributions": 1
 }


### PR DESCRIPTION
Closes #9

## Summary
- Configures Express JSON parsing with a conservative `100kb` request body limit.
- Documents the API JSON request body limit in the README.

## Verification
- npm.cmd test
- npm.cmd run lint -w apps/api
- Manually verified oversized JSON POST returns HTTP 413.