### PR TITLE
[agent] Add API graceful shutdown handling

### DIFF
--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -7,7 +7,7 @@
   "main": "src/index.ts",
   "scripts": {
     "dev": "tsx src/index.ts",
-    "test": "echo \"No API tests configured yet\"",
+    "test": "tsx --test \"src/**/*.test.ts\"",
     "lint": "echo \"No API lint configured yet\""
   },
   "dependencies": {

--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -6,8 +6,8 @@
   "type": "module",
   "main": "src/index.ts",
   "scripts": {
-    "dev": "tsx src/index.ts",
-    "test": "tsx --test \"src/**/*.test.ts\"",
+    "dev": "tsx src/server.ts",
+    "test": "tsx --test src/index.test.ts",
     "lint": "echo \"No API lint configured yet\""
   },
   "dependencies": {

--- a/apps/api/src/index.test.ts
+++ b/apps/api/src/index.test.ts
@@ -1,0 +1,62 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { createGracefulShutdown, startServer } from "./index";
+
+test("startServer drains the HTTP server when SIGTERM is handled", async () => {
+  const messages: string[] = [];
+  let exitCode: number | undefined;
+
+  const { disposeSignalHandlers, server } = startServer({
+    port: 0,
+    timeoutMs: 1_000,
+    logger: {
+      error: (...args) => messages.push(args.join(" ")),
+      log: (...args) => messages.push(args.join(" "))
+    },
+    exit: (code = 0) => {
+      exitCode = code;
+    }
+  });
+
+  await new Promise<void>((resolve) => server.once("listening", resolve));
+
+  const closed = new Promise<void>((resolve) => server.once("close", resolve));
+  process.emit("SIGTERM", "SIGTERM");
+  await closed;
+  disposeSignalHandlers();
+
+  assert.equal(exitCode, 0);
+  assert.ok(messages.includes("Received SIGTERM; draining TaskFlow API server"));
+  assert.ok(messages.includes("TaskFlow API server closed cleanly"));
+});
+
+test("graceful shutdown is idempotent for repeated signals", async () => {
+  let closeCalls = 0;
+  let exitCode: number | undefined;
+
+  const server = {
+    close(callback: (error?: Error) => void) {
+      closeCalls += 1;
+      callback();
+      return this;
+    }
+  };
+
+  const shutdown = createGracefulShutdown(server as never, {
+    exit: (code = 0) => {
+      exitCode = code;
+    },
+    logger: {
+      error: () => undefined,
+      log: () => undefined
+    },
+    timeoutMs: 1_000
+  });
+
+  shutdown("SIGINT");
+  shutdown("SIGTERM");
+
+  assert.equal(closeCalls, 1);
+  assert.equal(exitCode, 0);
+});

--- a/apps/api/src/index.test.ts
+++ b/apps/api/src/index.test.ts
@@ -5,35 +5,35 @@ import { createGracefulShutdown, startServer } from "./index";
 
 test("startServer drains the HTTP server when SIGTERM is handled", async () => {
   const messages: string[] = [];
-  let exitCode: number | undefined;
+  let cleanExitCode: number | undefined;
 
-  const { disposeSignalHandlers, server } = startServer({
+  const { disposeSignalHandlers, ready, server } = startServer({
     port: 0,
     timeoutMs: 1_000,
     logger: {
       error: (...args) => messages.push(args.join(" ")),
       log: (...args) => messages.push(args.join(" "))
     },
-    exit: (code = 0) => {
-      exitCode = code;
+    setExitCode: (code) => {
+      cleanExitCode = code;
     }
   });
 
-  await new Promise<void>((resolve) => server.once("listening", resolve));
+  await ready;
 
   const closed = new Promise<void>((resolve) => server.once("close", resolve));
   process.emit("SIGTERM", "SIGTERM");
   await closed;
   disposeSignalHandlers();
 
-  assert.equal(exitCode, 0);
+  assert.equal(cleanExitCode, 0);
   assert.ok(messages.includes("Received SIGTERM; draining TaskFlow API server"));
   assert.ok(messages.includes("TaskFlow API server closed cleanly"));
 });
 
 test("graceful shutdown is idempotent for repeated signals", async () => {
   let closeCalls = 0;
-  let exitCode: number | undefined;
+  let cleanExitCode: number | undefined;
 
   const server = {
     close(callback: (error?: Error) => void) {
@@ -44,8 +44,8 @@ test("graceful shutdown is idempotent for repeated signals", async () => {
   };
 
   const shutdown = createGracefulShutdown(server as never, {
-    exit: (code = 0) => {
-      exitCode = code;
+    setExitCode: (code) => {
+      cleanExitCode = code;
     },
     logger: {
       error: () => undefined,
@@ -58,5 +58,60 @@ test("graceful shutdown is idempotent for repeated signals", async () => {
   shutdown("SIGTERM");
 
   assert.equal(closeCalls, 1);
-  assert.equal(exitCode, 0);
+  assert.equal(cleanExitCode, 0);
+});
+
+test("graceful shutdown exits with code 1 when server close fails", () => {
+  const closeError = new Error("close failed");
+  const messages: string[] = [];
+  let exitCode: number | undefined;
+
+  const server = {
+    close(callback: (error?: Error) => void) {
+      callback(closeError);
+      return this;
+    }
+  };
+
+  const shutdown = createGracefulShutdown(server as never, {
+    exit: (code = 0) => {
+      exitCode = code;
+    },
+    logger: {
+      error: (...args) => messages.push(args.join(" ")),
+      log: () => undefined
+    },
+    timeoutMs: 1_000
+  });
+
+  shutdown("SIGTERM");
+
+  assert.equal(exitCode, 1);
+  assert.ok(messages.some((message) => message.includes("Error while closing TaskFlow API server")));
+});
+
+test("graceful shutdown forces exit when server close hangs", async () => {
+  let exitCode: number | undefined;
+
+  const server = {
+    close() {
+      return this;
+    }
+  };
+
+  const shutdown = createGracefulShutdown(server as never, {
+    exit: (code = 0) => {
+      exitCode = code;
+    },
+    logger: {
+      error: () => undefined,
+      log: () => undefined
+    },
+    timeoutMs: 1
+  });
+
+  shutdown("SIGTERM");
+  await new Promise((resolve) => setTimeout(resolve, 10));
+
+  assert.equal(exitCode, 1);
 });

--- a/apps/api/src/index.ts
+++ b/apps/api/src/index.ts
@@ -1,9 +1,12 @@
 import express from "express";
+import type { Server } from "node:http";
+import { pathToFileURL } from "node:url";
 
 import usersRouter from "./routes/users";
 
 const app = express();
 const port = process.env.PORT || 4000;
+const shutdownTimeoutMs = 10_000;
 
 app.use(express.json());
 
@@ -13,6 +16,79 @@ app.get("/health", (_req, res) => {
 
 app.use("/users", usersRouter);
 
-app.listen(port, () => {
-  console.log(`TaskFlow API listening on port ${port}`);
-});
+type Exit = (code?: number) => never | void;
+type Logger = Pick<Console, "error" | "log">;
+type Signal = "SIGINT" | "SIGTERM";
+
+interface ShutdownOptions {
+  exit?: Exit;
+  logger?: Logger;
+  timeoutMs?: number;
+}
+
+interface StartOptions extends ShutdownOptions {
+  port?: number | string;
+}
+
+export function createGracefulShutdown(
+  server: Server,
+  { exit = process.exit, logger = console, timeoutMs = shutdownTimeoutMs }: ShutdownOptions = {}
+) {
+  let shuttingDown = false;
+
+  return (signal: Signal) => {
+    if (shuttingDown) {
+      return;
+    }
+
+    shuttingDown = true;
+    logger.log(`Received ${signal}; draining TaskFlow API server`);
+
+    const forceExitTimer = setTimeout(() => {
+      logger.error("Graceful shutdown timed out; forcing exit");
+      exit(1);
+    }, timeoutMs);
+    forceExitTimer.unref();
+
+    server.close((error?: Error) => {
+      clearTimeout(forceExitTimer);
+
+      if (error) {
+        logger.error("Error while closing TaskFlow API server", error);
+        exit(1);
+        return;
+      }
+
+      logger.log("TaskFlow API server closed cleanly");
+      exit(0);
+    });
+  };
+}
+
+export function startServer({ port: listenPort = port, ...shutdownOptions }: StartOptions = {}) {
+  const server = app.listen(listenPort, () => {
+    console.log(`TaskFlow API listening on port ${listenPort}`);
+  });
+
+  const shutdown = createGracefulShutdown(server, shutdownOptions);
+  const onSigterm = () => shutdown("SIGTERM");
+  const onSigint = () => shutdown("SIGINT");
+
+  process.once("SIGTERM", onSigterm);
+  process.once("SIGINT", onSigint);
+
+  const disposeSignalHandlers = () => {
+    process.off("SIGTERM", onSigterm);
+    process.off("SIGINT", onSigint);
+  };
+
+  return { disposeSignalHandlers, server, shutdown };
+}
+
+const isEntrypoint = process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href;
+
+if (isEntrypoint) {
+  startServer();
+}
+
+export { app };

--- a/apps/api/src/index.ts
+++ b/apps/api/src/index.ts
@@ -1,11 +1,9 @@
 import express from "express";
 import type { Server } from "node:http";
-import { pathToFileURL } from "node:url";
 
 import usersRouter from "./routes/users";
 
 const app = express();
-const port = process.env.PORT || 4000;
 const shutdownTimeoutMs = 10_000;
 
 app.use(express.json());
@@ -19,10 +17,12 @@ app.use("/users", usersRouter);
 type Exit = (code?: number) => never | void;
 type Logger = Pick<Console, "error" | "log">;
 type Signal = "SIGINT" | "SIGTERM";
+type SetExitCode = (code: number) => void;
 
 interface ShutdownOptions {
   exit?: Exit;
   logger?: Logger;
+  setExitCode?: SetExitCode;
   timeoutMs?: number;
 }
 
@@ -32,7 +32,14 @@ interface StartOptions extends ShutdownOptions {
 
 export function createGracefulShutdown(
   server: Server,
-  { exit = process.exit, logger = console, timeoutMs = shutdownTimeoutMs }: ShutdownOptions = {}
+  {
+    exit = process.exit,
+    logger = console,
+    setExitCode = (code) => {
+      process.exitCode = code;
+    },
+    timeoutMs = shutdownTimeoutMs
+  }: ShutdownOptions = {}
 ) {
   let shuttingDown = false;
 
@@ -60,15 +67,21 @@ export function createGracefulShutdown(
       }
 
       logger.log("TaskFlow API server closed cleanly");
-      exit(0);
+      setExitCode(0);
     });
   };
 }
 
-export function startServer({ port: listenPort = port, ...shutdownOptions }: StartOptions = {}) {
+export function startServer({ port: listenPort = process.env.PORT || 4000, ...shutdownOptions }: StartOptions = {}) {
   const server = app.listen(listenPort, () => {
     console.log(`TaskFlow API listening on port ${listenPort}`);
   });
+
+  const ready = server.listening
+    ? Promise.resolve()
+    : new Promise<void>((resolve) => {
+        server.once("listening", resolve);
+      });
 
   const shutdown = createGracefulShutdown(server, shutdownOptions);
   const onSigterm = () => shutdown("SIGTERM");
@@ -82,13 +95,7 @@ export function startServer({ port: listenPort = port, ...shutdownOptions }: Sta
     process.off("SIGINT", onSigint);
   };
 
-  return { disposeSignalHandlers, server, shutdown };
-}
-
-const isEntrypoint = process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href;
-
-if (isEntrypoint) {
-  startServer();
+  return { disposeSignalHandlers, ready, server, shutdown };
 }
 
 export { app };

--- a/apps/api/src/server.ts
+++ b/apps/api/src/server.ts
@@ -1,0 +1,3 @@
+import { startServer } from "./index";
+
+startServer();

--- a/contributors/agents.json
+++ b/contributors/agents.json
@@ -4,7 +4,7 @@
       "github_username": "KaisAbiyyi",
       "model": "GPT-5 Codex",
       "version": "2026-06-12",
-      "pr_number": null,
+      "pr_number": 1509,
       "issue_number": 1437
     }
   ],

--- a/contributors/agents.json
+++ b/contributors/agents.json
@@ -1,5 +1,13 @@
 {
-  "agents": [],
-  "last_updated": "2026-06-03",
-  "total_contributions": 0
+  "agents": [
+    {
+      "github_username": "KaisAbiyyi",
+      "model": "GPT-5 Codex",
+      "version": "2026-06-12",
+      "pr_number": null,
+      "issue_number": 1437
+    }
+  ],
+  "last_updated": "2026-06-12",
+  "total_contributions": 1
 }


### PR DESCRIPTION
## Description
Closes #1437
/claim #1437

Adds a graceful shutdown path for the API server so SIGTERM and SIGINT stop accepting new connections, drain the HTTP server with server.close(), and force exit if shutdown hangs.

## Changes Made
- Keeps the Express app import-safe and exports app/start helpers for real tests.
- Retains the HTTP server instance and installs one-shot SIGTERM/SIGINT handlers.
- Adds an idempotent shutdown guard, forced timeout, and signal-handler disposal for tests.
- Replaces the placeholder API test script with node:test coverage for real shutdown behavior.
- Adds my AI agent metadata for issue #1437.

## Tests
- npm.cmd run test -w apps/api
- npm.cmd run test
- npx.cmd tsc --noEmit --module ESNext --moduleResolution Bundler --target ES2022 --esModuleInterop --types node --skipLibCheck apps/api/src/index.ts apps/api/src/index.test.ts
- git diff --check

## AI Agent Checklist
- [x] I commented on issue #16 (Agent Registry) with model, issue, and approach.
- [x] I starred this repository.
- [x] I added my model name and version to contributors/agents.json.
- [x] My PR title includes the [agent] tag.

Note: the issue body reaction control on #16 currently says reactions are unavailable in GitHub UI, so I posted the registry comment instead.