### PR TITLE
[agent] Add conservative JSON body size limit

### DIFF
--- a/apps/api/src/index.ts
+++ b/apps/api/src/index.ts
@@ -5,7 +5,15 @@ import usersRouter from "./routes/users";
 const app = express();
 const port = process.env.PORT || 4000;
 
-app.use(express.json());
+// Configure a conservative JSON body size limit (100kb).
+// This prevents denial-of-service attacks via oversized payloads while
+// allowing legitimate requests (typical JSON bodies are <10kb).
+// The 100kb limit aligns with Express's recommended security practices
+// and is sufficient for the TaskFlow API's user and task payloads.
+// Override via the JSON_BODY_LIMIT environment variable if needed.
+const BODY_LIMIT = process.env.JSON_BODY_LIMIT || "100kb";
+
+app.use(express.json({ limit: BODY_LIMIT }));
 
 app.get("/health", (_req, res) => {
   res.json({ status: "ok", service: "taskflow-api" });

--- a/contributors/agents.json
+++ b/contributors/agents.json
@@ -1,5 +1,13 @@
 {
-  "agents": [],
-  "last_updated": "2026-06-03",
-  "total_contributions": 0
+  "agents": [
+    {
+      "github_username": "starz0275",
+      "model": "anthropic/claude-sonnet-4",
+      "version": "20250514",
+      "pr_number": 0,
+      "issue_number": 9
+    }
+  ],
+  "last_updated": "2026-06-12",
+  "total_contributions": 1
 }


### PR DESCRIPTION
## Summary
Configures a conservative JSON body size limit (100kb) for the Express app to prevent denial-of-service attacks via oversized payloads.

## Changes
- Added `limit` option to `express.json()` middleware with a default of 100kb
- Made the limit configurable via `JSON_BODY_LIMIT` environment variable
- Added inline documentation explaining the chosen value
- Updated `contributors/agents.json` per CONTRIBUTING.md requirements

## Why 100kb?
- Default Express limit is 100kb, which is the recommended security practice
- Typical JSON API payloads are well under 10kb
- 100kb provides generous headroom while blocking oversized attack payloads
- Environment variable override allows deployment-specific tuning

Closes #9