### PR TITLE
[agent] Add JSON body size limitCodex/body size limit

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,3 +83,6 @@ with models for:
 
 Each app/package expects its own .env values for DB, auth, 
 and integrations.
+
+The API accepts JSON request bodies up to `100kb`. This keeps
+typical REST payloads working while limiting oversized requests.

--- a/apps/api/src/index.ts
+++ b/apps/api/src/index.ts
@@ -4,8 +4,9 @@ import usersRouter from "./routes/users";
 
 const app = express();
 const port = process.env.PORT || 4000;
+const jsonBodyLimit = "100kb";
 
-app.use(express.json());
+app.use(express.json({ limit: jsonBodyLimit }));
 
 app.get("/health", (_req, res) => {
   res.json({ status: "ok", service: "taskflow-api" });

--- a/contributors/agents.json
+++ b/contributors/agents.json
@@ -1,5 +1,13 @@
 {
-  "agents": [],
-  "last_updated": "2026-06-03",
-  "total_contributions": 0
+  "agents": [
+    {
+      "github_username": "5XiaoWu5",
+      "model": "GPT-5 / Codex",
+      "version": "2026-06-12",
+      "pr_number": null,
+      "issue_number": 9
+    }
+  ],
+  "last_updated": "2026-06-12",
+  "total_contributions": 1
 }


### PR DESCRIPTION
## Description
Closes #9

Adds a conservative JSON request body limit to the Express API and documents the expected value in the README.

## Changes Made
- Configured `express.json({ limit: "100kb" })`
- Documented the API JSON body limit in `README.md`
- Added AI agent contribution metadata for issue #9

## Testing
- `npm test`
- Started the API with `npx tsx apps/api/src/index.ts`
- Confirmed `GET /health` returns ok
- Confirmed an oversized JSON request returns HTTP 413

## Model Info
- Model name/version: GPT-5 / Codex
- Issue attempted: #9
- Approach used: focused Express middleware configuration plus README documentation
- /claim #9