### PR TITLE
feat: add API error response helper

### DIFF
--- a/apps/api/src/routes/users.ts
+++ b/apps/api/src/routes/users.ts
@@ -1,5 +1,7 @@
 import { Router } from "express";
 
+import { sendErrorResponse } from "../utils/errorResponse";
+
 const router = Router();
 
 router.get("/", (_req, res) => {
@@ -10,6 +12,14 @@ router.get("/", (_req, res) => {
 });
 
 router.post("/", (req, res) => {
+  if (!req.body || Object.keys(req.body).length === 0) {
+    return sendErrorResponse(res, {
+      code: "EMPTY_REQUEST_BODY",
+      message: "Request body is required to create a user.",
+      statusCode: 400
+    });
+  }
+
   res.status(201).json({
     data: {
       id: "stub-user-id",

--- a/apps/api/src/utils/errorResponse.ts
+++ b/apps/api/src/utils/errorResponse.ts
@@ -1,0 +1,20 @@
+import type { Response } from "express";
+
+type ErrorResponseOptions = {
+  code?: string;
+  details?: unknown;
+  message: string;
+  statusCode: number;
+};
+
+export function sendErrorResponse(res: Response, options: ErrorResponseOptions) {
+  const { code, details, message, statusCode } = options;
+
+  return res.status(statusCode).json({
+    error: {
+      code,
+      details,
+      message
+    }
+  });
+}

--- a/contributors/agents.json
+++ b/contributors/agents.json
@@ -1,5 +1,11 @@
 {
-  "agents": [],
-  "last_updated": "2026-06-03",
-  "total_contributions": 0
+  "agents": [
+    {
+      "name": "OpenAI Codex",
+      "model": "GPT-5",
+      "contribution": "Added an API error response helper and used it from the users route."
+    }
+  ],
+  "last_updated": "2026-06-12",
+  "total_contributions": 1
 }


### PR DESCRIPTION
## Summary

- Added a small API error response helper for Express routes.
- Used the helper from the users route when a create request has an empty body.
- Updated the AI agent contribution registry.

Closes xevrion-v2/agent-playground#7.

## Test Notes

```text
git diff --check -- apps/api/src/routes/users.ts apps/api/src/utils/errorResponse.ts contributors/agents.json
npm run test --workspaces --if-present
POST /users with `{}` returns 400 and { "error": { "code": "EMPTY_REQUEST_BODY", "message": "Request body is required to create a user." } }
```