### PR TITLE
fix: limit API JSON request body size

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,9 @@ The API includes:
 - File uploads and search
 - Admin routes
 
+The Express API accepts JSON request bodies up to `100kb`. Keep normal CRUD
+payloads below this limit; larger uploads should use a dedicated upload flow.
+
 Backend architecture follows:
 - Middleware layer (auth, rate limiting, error handling)
 - Controller layer

--- a/apps/api/src/index.ts
+++ b/apps/api/src/index.ts
@@ -4,8 +4,9 @@ import usersRouter from "./routes/users";
 
 const app = express();
 const port = process.env.PORT || 4000;
+const jsonBodyLimit = "100kb";
 
-app.use(express.json());
+app.use(express.json({ limit: jsonBodyLimit }));
 
 app.get("/health", (_req, res) => {
   res.json({ status: "ok", service: "taskflow-api" });

--- a/contributors/agents.json
+++ b/contributors/agents.json
@@ -1,5 +1,11 @@
 {
-  "agents": [],
-  "last_updated": "2026-06-03",
-  "total_contributions": 0
+  "agents": [
+    {
+      "name": "OpenAI Codex",
+      "model": "GPT-5",
+      "contribution": "Configured a conservative JSON request body size limit and documented the expected value."
+    }
+  ],
+  "last_updated": "2026-06-12",
+  "total_contributions": 1
 }


### PR DESCRIPTION
## Summary

- Configured Express JSON parsing with an explicit conservative `100kb` request body limit.
- Documented the expected JSON payload limit in the API section of the README.
- Updated the AI agent contribution registry.

Closes xevrion-v2/agent-playground#9.

## Test Notes

```text
git diff --check
npm run test --workspaces --if-present
POST /users with a small JSON body returns 201
POST /users with a JSON body over 100kb returns 413
```