### PR TITLE
[agent] Fix graceful API shutdown for #906

### DIFF
--- a/apps/api/src/index.ts
+++ b/apps/api/src/index.ts
@@ -4,6 +4,7 @@ import usersRouter from "./routes/users";
 
 const app = express();
 const port = process.env.PORT || 4000;
+const shutdownTimeoutMs = 10_000;
 
 app.use(express.json());
 
@@ -13,6 +14,39 @@ app.get("/health", (_req, res) => {
 
 app.use("/users", usersRouter);
 
-app.listen(port, () => {
+const server = app.listen(port, () => {
   console.log(`TaskFlow API listening on port ${port}`);
 });
+
+let isShuttingDown = false;
+
+function shutdown(signal: NodeJS.Signals) {
+  if (isShuttingDown) {
+    return;
+  }
+
+  isShuttingDown = true;
+  console.log(`${signal} received, shutting down gracefully`);
+
+  const forceShutdownTimer = setTimeout(() => {
+    console.error(`Shutdown timed out after ${shutdownTimeoutMs}ms, forcing exit`);
+    process.exit(1);
+  }, shutdownTimeoutMs);
+
+  forceShutdownTimer.unref();
+
+  server.close((error) => {
+    clearTimeout(forceShutdownTimer);
+
+    if (error) {
+      console.error("Failed to shut down server cleanly", error);
+      process.exit(1);
+      return;
+    }
+
+    process.exit(0);
+  });
+}
+
+process.once("SIGINT", shutdown);
+process.once("SIGTERM", shutdown);

--- a/contributors/agents.json
+++ b/contributors/agents.json
@@ -1,5 +1,13 @@
 {
-  "agents": [],
-  "last_updated": "2026-06-03",
-  "total_contributions": 0
+  "agents": [
+    {
+      "github_username": "Votienduong2208",
+      "model": "gpt-5",
+      "version": "Codex GPT-5",
+      "pr_number": 0,
+      "issue_number": 906
+    }
+  ],
+  "last_updated": "2026-06-12",
+  "total_contributions": 1
 }

--- a/contributors/agents.json
+++ b/contributors/agents.json
@@ -4,7 +4,7 @@
       "github_username": "Votienduong2208",
       "model": "gpt-5",
       "version": "Codex GPT-5",
-      "pr_number": 0,
+      "pr_number": 1529,
       "issue_number": 906
     }
   ],


### PR DESCRIPTION
/claim #906

Closes #906.

## Summary
- keep the `http.Server` returned by `app.listen()`
- handle `SIGINT`/`SIGTERM` exactly once with a bounded graceful shutdown path
- add the required AI agent registry entry for this issue

## Verification
- `npm.cmd install`
- `PORT=4102; node --import tsx -e "import('./apps/api/src/index.ts').then(() => setTimeout(() => process.emit('SIGTERM', 'SIGTERM'), 100))"`
  - observed `TaskFlow API listening on port 4102`
  - observed `SIGTERM received, shutting down gracefully`
- `git diff --check`