### PR TITLE
[agent] Add DB package entrypoint for #930

### DIFF
--- a/contributors/agents.json
+++ b/contributors/agents.json
@@ -1,5 +1,13 @@
 {
-  "agents": [],
-  "last_updated": "2026-06-03",
-  "total_contributions": 0
+  "agents": [
+    {
+      "github_username": "Votienduong2208",
+      "model": "gpt-5",
+      "version": "Codex GPT-5",
+      "pr_number": 0,
+      "issue_number": 930
+    }
+  ],
+  "last_updated": "2026-06-12",
+  "total_contributions": 1
 }

--- a/contributors/agents.json
+++ b/contributors/agents.json
@@ -4,7 +4,7 @@
       "github_username": "Votienduong2208",
       "model": "gpt-5",
       "version": "Codex GPT-5",
-      "pr_number": 0,
+      "pr_number": 1530,
       "issue_number": 930
     }
   ],

--- a/packages/db/package.json
+++ b/packages/db/package.json
@@ -3,6 +3,11 @@
   "version": "0.1.0",
   "private": true,
   "description": "Prisma schema and database utilities for TaskFlow.",
+  "main": "src/index.ts",
+  "types": "src/index.ts",
+  "exports": {
+    ".": "./src/index.ts"
+  },
   "scripts": {
     "test": "echo \"No database tests configured yet\"",
     "lint": "echo \"No database lint configured yet\""

--- a/packages/db/src/index.ts
+++ b/packages/db/src/index.ts
@@ -1,0 +1,1 @@
+export { Prisma, PrismaClient } from "@prisma/client";


### PR DESCRIPTION
/claim #930

Closes #930.

## Summary
- add a minimal importable `@taskflow/db` entrypoint that re-exports Prisma symbols
- add `main`, `types`, and `exports` metadata for the DB package root
- add the required AI agent registry entry for this issue

## Verification
- `npm.cmd install`
- `npm.cmd pack --dry-run` in `packages/db`
- `npm.cmd exec --workspace @taskflow/api -- tsc --noEmit ../../packages/db/src/index.ts --moduleResolution node16 --module node16`
- `git diff --check`