### PR TITLE
Fix #687: Add /bounty marker to bounty_task.md template

### DIFF
--- a/.github/ISSUE_TEMPLATE/bounty_task.md
+++ b/.github/ISSUE_TEMPLATE/bounty_task.md
@@ -18,4 +18,4 @@ Describe the task, expected context, and files likely involved.
 
 ## Bounty Amount
 
-$50
+/bounty $50


### PR DESCRIPTION
## Fix for #687

Updated .github/ISSUE_TEMPLATE/bounty_task.md to use /bounty 50 instead of plain 50.

The bounty program requires the /bounty prefix marker.
Closes #687