### PR TITLE
Add JSDoc to userService

### DIFF
--- a/apps/api/src/routes/users.ts
+++ b/apps/api/src/routes/users.ts
@@ -1,22 +1,17 @@
 import { Router } from "express";
 
+import { createUser, listUsers } from "../services/userService";
+
 const router = Router();
 
-router.get("/", (_req, res) => {
-  res.json({
-    data: [],
-    message: "User listing is not implemented yet."
-  });
+router.get("/", async (_req, res) => {
+  const data = await listUsers();
+  res.json({ data, message: "User listing is not implemented yet." });
 });
 
-router.post("/", (req, res) => {
-  res.status(201).json({
-    data: {
-      id: "stub-user-id",
-      ...req.body
-    },
-    message: "User creation is not implemented yet."
-  });
+router.post("/", async (req, res) => {
+  const data = await createUser(req.body);
+  res.status(201).json({ data, message: "User creation is not implemented yet." });
 });
 
 export default router;

--- a/apps/api/src/services/userService.ts
+++ b/apps/api/src/services/userService.ts
@@ -1,0 +1,29 @@
+/** Represents a registered user. */
+export interface User {
+  id: string;
+  [key: string]: unknown;
+}
+
+/** Fields required when creating a new user. */
+export type CreateUserInput = Record<string, unknown>;
+
+/**
+ * Retrieves all registered users.
+ *
+ * @returns A promise that resolves with an array of users.
+ *          Returns an empty array until persistence is wired up.
+ */
+export async function listUsers(): Promise<User[]> {
+  return [];
+}
+
+/**
+ * Creates a new user record.
+ *
+ * @param data - The fields required to create a user (e.g. name, email).
+ * @returns A promise that resolves with the newly created user,
+ *          including its generated `id`.
+ */
+export async function createUser(data: CreateUserInput): Promise<User> {
+  return { id: "stub-user-id", ...data };
+}


### PR DESCRIPTION
## Summary

- Creates `apps/api/src/services/userService.ts` with `listUsers` and `createUser` stub functions, each documented with JSDoc.
- Updates `apps/api/src/routes/users.ts` to delegate to the new service layer.
- Keeps the change focused: no logic changes, only structure and documentation added.

Closes #1

https://claude.ai/code/session_01C7EiDAyddco3PLufzzrJTu