### PR TITLE
Fix PI challenge issue template: remove duplicate bounty amount

### DIFF
--- a/.github/ISSUE_TEMPLATE/pi_challenge.md
+++ b/.github/ISSUE_TEMPLATE/pi_challenge.md
@@ -19,6 +19,4 @@ Implement or document a small PI calculation challenge for TaskFlow's internal e
 
 ## Bounty Amount
 
-$50
-
 /bounty $50


### PR DESCRIPTION
Closes #775

Removed the duplicate '$50' line from the PI challenge issue template, keeping only the '/bounty $50' marker.

/claim #775