### PR TITLE
feat: add request body size limit (100kb default)

### DIFF
--- a/apps/api/src/index.ts
+++ b/apps/api/src/index.ts
@@ -5,7 +5,9 @@ import usersRouter from "./routes/users";
 const app = express();
 const port = process.env.PORT || 4000;
 
-app.use(express.json());
+// Configure JSON body size limit to prevent large payload attacks (Issue #9)
+const bodyLimit = process.env.JSON_BODY_LIMIT || "100kb";
+app.use(express.json({ limit: bodyLimit }));
 
 app.get("/health", (_req, res) => {
   res.json({ status: "ok", service: "taskflow-api" });


### PR DESCRIPTION
## Summary

Configures `express.json()` with a conservative 100kb body size limit to prevent oversized payload attacks.

### Changes
- Default limit: `100kb` (configurable via `JSON_BODY_LIMIT` env var)
- Returns HTTP 413 for payloads exceeding the limit

### Testing
- Payloads under 100kb: accepted normally
- Payloads over 100kb: rejected with 413 status
- Custom limit via env var: works correctly

Closes #9