### PR TITLE
Add lookup indexes for foreign key columns in Prisma schema

### DIFF
--- a/packages/db/prisma/schema.prisma
+++ b/packages/db/prisma/schema.prisma
@@ -27,6 +27,8 @@ model Job {
   proposals   Proposal[]
   createdAt   DateTime   @default(now())
   updatedAt   DateTime   @updatedAt
+
+  @@index([ownerId])
 }
 
 model Proposal {
@@ -40,4 +42,7 @@ model Proposal {
   job       Job      @relation(fields: [jobId], references: [id])
   createdAt DateTime @default(now())
   updatedAt DateTime @updatedAt
+
+  @@index([userId])
+  @@index([jobId])
 }


### PR DESCRIPTION
## Problem

Closes #659

The Prisma schema defines relations queried by foreign key, but the relation scalar fields (`Job.ownerId`, `Proposal.userId`, `Proposal.jobId`) have no explicit indexes. PostgreSQL does not automatically create indexes on referencing columns of foreign keys, so common marketplace queries — owner dashboards, a user's proposals, a job's proposal review queue — can degrade into sequential scans as tables grow.

## Solution

Add `@@index` declarations to the three relation lookup fields:

```prisma
model Job {
  // ... existing fields ...
  @@index([ownerId])
}

model Proposal {
  // ... existing fields ...
  @@index([userId])
  @@index([jobId])
}
```

No existing ids, relations, defaults, or optional fields are changed. The indexes are narrow single-column indexes targeting the exact FK lookups used by the core workflow.

## Verification

- `prisma validate` passes against the updated schema (Prisma 5.13.0).
- No migrations needed beyond the existing schema — the indexes are additive and will be created on the next `prisma migrate` or `prisma db push`.
- The change is scoped entirely to `packages/db/prisma/schema.prisma`.