### PR TITLE
Replace free-form status strings with Prisma enums

### DIFF
--- a/packages/db/prisma/schema.prisma
+++ b/packages/db/prisma/schema.prisma
@@ -21,7 +21,7 @@ model Job {
   id          String     @id @default(cuid())
   title       String
   description String?
-  status      String     @default("draft")
+  status      JobStatus  @default(draft)
   ownerId     String
   owner       User       @relation(fields: [ownerId], references: [id])
   proposals   Proposal[]
@@ -30,14 +30,29 @@ model Job {
 }
 
 model Proposal {
-  id        String   @id @default(cuid())
+  id        String         @id @default(cuid())
   summary   String
   amount    Decimal?
-  status    String   @default("pending")
+  status    ProposalStatus @default(pending)
   userId    String
-  user      User     @relation(fields: [userId], references: [id])
+  user      User           @relation(fields: [userId], references: [id])
   jobId     String
-  job       Job      @relation(fields: [jobId], references: [id])
-  createdAt DateTime @default(now())
-  updatedAt DateTime @updatedAt
+  job       Job            @relation(fields: [jobId], references: [id])
+  createdAt DateTime       @default(now())
+  updatedAt DateTime       @updatedAt
+}
+
+enum JobStatus {
+  draft
+  published
+  in_progress
+  completed
+  cancelled
+}
+
+enum ProposalStatus {
+  pending
+  accepted
+  rejected
+  withdrawn
 }


### PR DESCRIPTION
## Problem

Closes #657

`Job.status` and `Proposal.status` are stored as free-form `String` fields with `@default` values, but nothing prevents invalid status values like `draftt`, `published-but-misspelled`, or `pendng` from being persisted. Once those exist, API filters, dashboards, and review logic can silently miss records.

## Solution

Replace both `String` status fields with narrow Prisma enums:

```prisma
enum JobStatus {
  draft
  published
  in_progress
  completed
  cancelled
}

enum ProposalStatus {
  pending
  accepted
  rejected
  withdrawn
}
```

- `Job.status` is now `JobStatus @default(draft)` — same default, type-safe.
- `Proposal.status` is now `ProposalStatus @default(pending)` — same default, type-safe.
- Relations, ids, timestamps, and optional fields are unchanged.

## Verification

- `prisma validate` passes against the updated schema (Prisma 5.13.0).
- Existing default values are preserved.
- Change is scoped to `packages/db/prisma/schema.prisma`.