### PR TITLE
Add ESLint config and tsconfig to web workspace

### DIFF
--- a/apps/web/.eslintrc.json
+++ b/apps/web/.eslintrc.json
@@ -1,0 +1,3 @@
+{
+  "extends": "next/core-web-vitals"
+}

--- a/apps/web/next.config.js
+++ b/apps/web/next.config.js
@@ -1,0 +1,4 @@
+/** @type {import('next').NextConfig} */
+const nextConfig = {};
+
+module.exports = nextConfig;

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -17,6 +17,8 @@
     "@types/node": "^20.12.7",
     "@types/react": "^18.3.1",
     "@types/react-dom": "^18.3.0",
+    "eslint": "^8.57.0",
+    "eslint-config-next": "^14.2.3",
     "typescript": "^5.4.5"
   }
 }

--- a/apps/web/tsconfig.json
+++ b/apps/web/tsconfig.json
@@ -1,0 +1,22 @@
+{
+  "compilerOptions": {
+    "target": "es5",
+    "lib": ["dom", "dom.iterable", "esnext"],
+    "allowJs": true,
+    "skipLibCheck": true,
+    "strict": true,
+    "noEmit": true,
+    "esModuleInterop": true,
+    "module": "esnext",
+    "moduleResolution": "bundler",
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "jsx": "preserve",
+    "incremental": true,
+    "paths": {
+      "@/*": ["./src/*"]
+    }
+  },
+  "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx", ".next/types/**/*.ts"],
+  "exclude": ["node_modules"]
+}


### PR DESCRIPTION
## Problem

Closes #655

Running `npm run lint -w apps/web` launches Next.js's interactive ESLint setup wizard because the workspace has a `next lint` script but no committed ESLint config, no ESLint dependencies, and no `tsconfig.json`. In CI or any non-interactive process this exits with a failure instead of producing lint output.

## Solution

Add the files Next.js needs to lint deterministically without prompting:

1. **`.eslintrc.json`** — extends `next/core-web-vitals` (the recommended preset for Next.js projects).
2. **`package.json` devDependencies** — adds `eslint` (^8.57.0) and `eslint-config-next` (^14.2.3) matching the installed Next.js version.
3. **`tsconfig.json`** — standard Next.js TypeScript config with `@/*` path alias pointing to `src/*`. Next.js lint requires this file to exist.
4. **`next.config.js`** — minimal config so Next.js has a project root marker.

After these changes, `next lint` runs non-interactively and either passes or reports concrete findings.

## Verification

- The config files match what `next lint` would generate interactively, so no behavioral surprise.
- ESLint and eslint-config-next versions are pinned to the same major as the Next.js dependency (^14.2.3).
- No application code changes.