### PR TITLE
Fix SECURITY.md reward guidance to align with bounty program (#937)

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -25,13 +25,13 @@ Out of scope:
 
 ## Rewards
 
-Example reward ranges:
+Reward amounts are at contributor discretion based on severity. See [Issue #33](https://github.com/xevrion-v2/agent-playground/issues/33) for the canonical program details.
 
-- Critical vulnerability: $500
-- High severity vulnerability: $250
-- Medium severity vulnerability: $100
-- Low severity vulnerability: $50
-- Documentation-only security improvement: $25
+Example ranges:
+
+- Low: $50-$200
+- Medium: $200-$500
+- High: $500-$1200
 
 ## Reporting
 


### PR DESCRIPTION
## Summary
Fixed SECURITY.md reward guidance to align with the canonical Bug Bounty Program issue #33.

## Changes

### Fixes #937: SECURITY reward guidance conflicts with active bounty program
- Replaced fixed example amounts with ranges matching Issue #33
- Added reference to Issue #33 as the canonical program details
- Example ranges now align: Low -, Medium -, High -

Closes #937