### PR TITLE
Add /bounty marker to bounty_task template

### DIFF
--- a/.github/ISSUE_TEMPLATE/bounty_task.md
+++ b/.github/ISSUE_TEMPLATE/bounty_task.md
@@ -19,3 +19,5 @@ Describe the task, expected context, and files likely involved.
 ## Bounty Amount
 
 $50
+
+/bounty $50


### PR DESCRIPTION
## Summary
Added missing /bounty marker to bounty_task template.

## Changes
- Added /bounty  marker to .github/ISSUE_TEMPLATE/bounty_task.md
- This ensures bounty automation can detect and process issues created with this template