### PR TITLE
Fix task template to use correct label name (#769)

### DIFF
--- a/.github/ISSUE_TEMPLATE/task.md
+++ b/.github/ISSUE_TEMPLATE/task.md
@@ -2,7 +2,7 @@
 name: Small task
 about: Small maintenance task for first-time contributors
 title: ""
-labels: good-first-issue
+labels: good first issue
 assignees: ""
 ---
 


### PR DESCRIPTION
## Summary
Fixed the task template to use the correct label name.

## Changes
### Fixes #769: Small task issue template uses non-existent good-first-issue label
- Changed label from good-first-issue to good first issue
- Verified no other good-first-issue references exist in issue templates

Closes #769