### PR TITLE
feat: add input validation to user routes

### DIFF
--- a/apps/api/src/routes/users.ts
+++ b/apps/api/src/routes/users.ts
@@ -2,6 +2,20 @@ import { Router } from "express";
 
 const router = Router();
 
+// Lightweight input validation helpers
+function isValidEmail(email: unknown): email is string {
+  return typeof email === "string" && /^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(email);
+}
+
+function isValidUsername(username: unknown): username is string {
+  return typeof username === "string" && username.length >= 3 && username.length <= 30;
+}
+
+interface UserCreateBody {
+  username?: unknown;
+  email?: unknown;
+}
+
 router.get("/", (_req, res) => {
   res.json({
     data: [],
@@ -10,10 +24,36 @@ router.get("/", (_req, res) => {
 });
 
 router.post("/", (req, res) => {
+  const { username, email } = req.body as UserCreateBody;
+
+  // Validate required fields
+  const errors: string[] = [];
+
+  if (!username) {
+    errors.push("username is required");
+  } else if (!isValidUsername(username)) {
+    errors.push("username must be between 3 and 30 characters");
+  }
+
+  if (!email) {
+    errors.push("email is required");
+  } else if (!isValidEmail(email)) {
+    errors.push("email must be a valid email address");
+  }
+
+  if (errors.length > 0) {
+    res.status(400).json({
+      error: "Validation failed",
+      messages: errors,
+    });
+    return;
+  }
+
   res.status(201).json({
     data: {
       id: "stub-user-id",
-      ...req.body
+      username,
+      email,
     },
     message: "User creation is not implemented yet."
   });


### PR DESCRIPTION
Fixes #6

## Summary

Added lightweight input validation to the user creation route.

## Changes

- Validate `username`: required, 3-30 characters
- Validate `email`: required, valid email format
- Return `400` with descriptive error messages on validation failure
- Only pass validated fields to response (no spreading raw `req.body`)

## Testing

```bash
# Missing fields
curl -X POST http://localhost:3000/users -H "Content-Type: application/json" -d '{}'
# Returns: 400 { error: "Validation failed", messages: ["username is required", "email is required"] }

# Invalid email
curl -X POST http://localhost:3000/users -H "Content-Type: application/json" -d '{"username": "test", "email": "bad"}'
# Returns: 400 { error: "Validation failed", messages: ["email must be a valid email address"] }

# Valid input
curl -X POST http://localhost:3000/users -H "Content-Type: application/json" -d '{"username": "testuser", "email": "test@example.com"}'
# Returns: 201 { data: { id: "stub-user-id", username: "testuser", email: "test@example.com" } }
```