### PR TITLE
feat: add API error handling helper

### DIFF
--- a/apps/api/src/helpers/errors.ts
+++ b/apps/api/src/helpers/errors.ts
@@ -1,0 +1,44 @@
+import { Response } from "express";
+
+// Standard API error response shape
+export interface ApiErrorResponse {
+  error: string;
+  messages?: string[];
+  statusCode: number;
+}
+
+// Helper to send consistent error responses
+export function sendError(
+  res: Response,
+  statusCode: number,
+  message: string,
+  messages?: string[]
+): void {
+  const response: ApiErrorResponse = {
+    error: message,
+    statusCode,
+    ...(messages && { messages }),
+  };
+  res.status(statusCode).json(response);
+}
+
+// Common error helpers
+export function sendBadRequest(res: Response, messages: string[]): void {
+  sendError(res, 400, "Validation failed", messages);
+}
+
+export function sendNotFound(res: Response, resource: string = "Resource"): void {
+  sendError(res, 404, `${resource} not found`);
+}
+
+export function sendUnauthorized(res: Response): void {
+  sendError(res, 401, "Unauthorized");
+}
+
+export function sendForbidden(res: Response): void {
+  sendError(res, 403, "Forbidden");
+}
+
+export function sendInternalError(res: Response): void {
+  sendError(res, 500, "Internal server error");
+}

--- a/apps/api/src/routes/users.ts
+++ b/apps/api/src/routes/users.ts
@@ -2,6 +2,20 @@ import { Router } from "express";
 
 const router = Router();
 
+// Lightweight input validation helpers
+function isValidEmail(email: unknown): email is string {
+  return typeof email === "string" && /^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(email);
+}
+
+function isValidUsername(username: unknown): username is string {
+  return typeof username === "string" && username.length >= 3 && username.length <= 30;
+}
+
+interface UserCreateBody {
+  username?: unknown;
+  email?: unknown;
+}
+
 router.get("/", (_req, res) => {
   res.json({
     data: [],
@@ -10,10 +24,36 @@ router.get("/", (_req, res) => {
 });
 
 router.post("/", (req, res) => {
+  const { username, email } = req.body as UserCreateBody;
+
+  // Validate required fields
+  const errors: string[] = [];
+
+  if (!username) {
+    errors.push("username is required");
+  } else if (!isValidUsername(username)) {
+    errors.push("username must be between 3 and 30 characters");
+  }
+
+  if (!email) {
+    errors.push("email is required");
+  } else if (!isValidEmail(email)) {
+    errors.push("email must be a valid email address");
+  }
+
+  if (errors.length > 0) {
+    res.status(400).json({
+      error: "Validation failed",
+      messages: errors,
+    });
+    return;
+  }
+
   res.status(201).json({
     data: {
       id: "stub-user-id",
-      ...req.body
+      username,
+      email,
     },
     message: "User creation is not implemented yet."
   });

--- a/apps/api/src/routes/users.ts
+++ b/apps/api/src/routes/users.ts
@@ -1,4 +1,5 @@
 import { Router } from "express";
+import { sendBadRequest } from "../helpers/errors";
 
 const router = Router();
 
@@ -42,10 +43,7 @@ router.post("/", (req, res) => {
   }
 
   if (errors.length > 0) {
-    res.status(400).json({
-      error: "Validation failed",
-      messages: errors,
-    });
+    sendBadRequest(res, errors);
     return;
   }
 


### PR DESCRIPTION
Fixes #7

## Summary

Added a reusable API error handling helper for consistent error responses.

## Changes

- Created `apps/api/src/helpers/errors.ts` with:
  - `sendError()` - base error response helper
  - `sendBadRequest()` - 400 validation errors
  - `sendNotFound()` - 404 not found
  - `sendUnauthorized()` - 401 unauthorized
  - `sendForbidden()` - 403 forbidden
  - `sendInternalError()` - 500 server errors
- Updated `users.ts` to use `sendBadRequest()` for validation errors

## Standard Error Response Format

```json
{
  "error": "Validation failed",
  "messages": ["username is required", "email is required"],
  "statusCode": 400
}
```