### PR TITLE
Add root layout for Next.js App Router (#447)

### DIFF
--- a/apps/web/src/app/layout.tsx
+++ b/apps/web/src/app/layout.tsx
@@ -1,0 +1,18 @@
+import type { Metadata } from "next";
+
+export const metadata: Metadata = {
+  title: "TaskFlow",
+  description: "Task management system powered by AI agents",
+};
+
+export default function RootLayout({
+  children,
+}: {
+  children: React.ReactNode;
+}) {
+  return (
+    <html lang="en">
+      <body>{children}</body>
+    </html>
+  );
+}

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -8,7 +8,11 @@
     "test": "echo \"No UI tests configured yet\"",
     "lint": "echo \"No UI lint configured yet\""
   },
+  "dependencies": {
+    "react": "^18.3.1"
+  },
   "devDependencies": {
+    "@types/react": "^18.3.1",
     "typescript": "^5.4.5"
   }
 }


### PR DESCRIPTION
## Summary
Added root layout for Next.js App Router.

## Changes
### Fixes #447: Web app build fails because App Router root layout is missing
- Created pps/web/src/app/layout.tsx with standard Next.js root layout
- Added metadata export with title and description
- Includes proper HTML structure with html and ody tags

Closes #447