### PR TITLE
Add request body size limit to Express JSON parser

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,3 +83,8 @@ with models for:
 
 Each app/package expects its own .env values for DB, auth, 
 and integrations.
+
+| Variable | Default | Description |
+|----------|---------|-------------|
+| `PORT` | `4000` | API server port |
+| `JSON_BODY_LIMIT` | `100kb` | Max size for incoming JSON request bodies |

--- a/apps/api/src/index.ts
+++ b/apps/api/src/index.ts
@@ -5,7 +5,10 @@ import usersRouter from "./routes/users";
 const app = express();
 const port = process.env.PORT || 4000;
 
-app.use(express.json());
+// Limit incoming JSON bodies to prevent memory abuse.
+// Override via JSON_BODY_LIMIT env var (e.g. "200kb", "1mb").
+const bodyLimit = process.env.JSON_BODY_LIMIT || "100kb";
+app.use(express.json({ limit: bodyLimit }));
 
 app.get("/health", (_req, res) => {
   res.json({ status: "ok", service: "taskflow-api" });


### PR DESCRIPTION
## Summary

Sets a conservative 100kb limit on incoming JSON request bodies to prevent memory exhaustion from oversized payloads.

## Changes

- Added `limit: "100kb"` to `express.json()` middleware
- Made it configurable via `JSON_BODY_LIMIT` env var
- Updated README with the new env var documentation

## Why

Without a body size limit, a malicious client could send a multi-GB JSON payload and eat up server memory. 100kb is a reasonable default for a task management API — most requests will be well under that.

Closes #9