### PR TITLE
Disable X-Powered-By header in Next.js config (#1089)

### DIFF
--- a/apps/web/next.config.mjs
+++ b/apps/web/next.config.mjs
@@ -1,0 +1,6 @@
+/** @type {import('next').NextConfig} */
+const nextConfig = {
+  poweredByHeader: false,
+};
+
+export default nextConfig;


### PR DESCRIPTION
## Summary
Created Next.js config to disable X-Powered-By header.

## Changes
### Fixes #1089: Disable Next.js X-Powered-By response header
- Created pps/web/next.config.mjs
- Set poweredByHeader: false to disable X-Powered-By

Closes #1089