### PR TITLE
Add Express security headers and disable X-Powered-By (#1072, #1119)

### DIFF
--- a/apps/api/src/index.ts
+++ b/apps/api/src/index.ts
@@ -5,6 +5,17 @@ import usersRouter from "./routes/users";
 const app = express();
 const port = process.env.PORT || 4000;
 
+// Disable X-Powered-By header
+app.disable("x-powered-by");
+
+// Basic security headers
+app.use((_req, res, next) => {
+  res.setHeader("X-Content-Type-Options", "nosniff");
+  res.setHeader("X-Frame-Options", "DENY");
+  res.setHeader("X-XSS-Protection", "1; mode=block");
+  next();
+});
+
 app.use(express.json());
 
 app.get("/health", (_req, res) => {

--- a/apps/web/next.config.mjs
+++ b/apps/web/next.config.mjs
@@ -1,0 +1,6 @@
+/** @type {import('next').NextConfig} */
+const nextConfig = {
+  poweredByHeader: false,
+};
+
+export default nextConfig;


### PR DESCRIPTION
## Summary
Added Express security headers and disabled X-Powered-By.

## Changes
### Fixes #1072: Disable Express X-Powered-By response header
- Added pp.disable('x-powered-by')

### Fixes #1119: Add baseline web security response headers
- Added X-Content-Type-Options: nosniff
- Added X-Frame-Options: DENY
- Added X-XSS-Protection: 1; mode=block

Closes #1072
Closes #1119