### PR TITLE
Fix Button component to return JSX element (#1173)

### DIFF
--- a/packages/ui/src/index.ts
+++ b/packages/ui/src/index.ts
@@ -1,12 +1,14 @@
+import React from "react";
+
 export type ButtonProps = {
   label: string;
   disabled?: boolean;
 };
 
 export function Button({ label, disabled = false }: ButtonProps) {
-  return {
-    type: "button",
-    label,
-    disabled
-  };
+  return (
+    <button type="button" disabled={disabled}>
+      {label}
+    </button>
+  );
 }


### PR DESCRIPTION
## Summary
Fixed Button component to return proper JSX element.

## Changes
### Fixes #1173: Button component returns plain object instead of JSX element
- Changed Button to return actual <button> JSX element
- Added React import for JSX support

Closes #1173