### PR TITLE
Add contents read permission to create-labels workflow (#910)

### DIFF
--- a/.github/workflows/create-labels.yml
+++ b/.github/workflows/create-labels.yml
@@ -4,6 +4,7 @@ on:
   workflow_dispatch:
 
 permissions:
+  contents: read
   issues: write
 
 jobs:


### PR DESCRIPTION
## Summary
Added contents read permission to create-labels workflow.

## Changes
### Fixes #910: create-labels workflow checkout lacks contents read permission
- Added contents: read permission for actions/checkout@v4

Closes #910