### PR TITLE
Add Decimal precision to Proposal amount field (#919)

### DIFF
--- a/packages/db/prisma/schema.prisma
+++ b/packages/db/prisma/schema.prisma
@@ -32,7 +32,7 @@ model Job {
 model Proposal {
   id        String   @id @default(cuid())
   summary   String
-  amount    Decimal?
+  amount    Decimal  @db.Decimal(10, 2)
   status    String   @default("pending")
   userId    String
   user      User     @relation(fields: [userId], references: [id])


### PR DESCRIPTION
## Summary
Added Decimal precision to Proposal amount field.

## Changes
### Fixes #919: Proposal amount lacks explicit decimal precision
- Changed mount Decimal? to mount Decimal @db.Decimal(10, 2)
- Sets explicit precision: 10 total digits, 2 decimal places

Closes #919