### PR TITLE
Add importable Prisma client entrypoint to DB package (#930)

### DIFF
--- a/packages/db/package.json
+++ b/packages/db/package.json
@@ -3,7 +3,16 @@
   "version": "0.1.0",
   "private": true,
   "description": "Prisma schema and database utilities for TaskFlow.",
+  "main": "src/index.js",
+  "exports": {
+    ".": {
+      "import": "./src/index.js",
+      "types": "./src/index.ts"
+    }
+  },
   "scripts": {
+    "generate": "prisma generate",
+    "postinstall": "prisma generate",
     "test": "echo \"No database tests configured yet\"",
     "lint": "echo \"No database lint configured yet\""
   },

--- a/packages/db/src/index.ts
+++ b/packages/db/src/index.ts
@@ -1,0 +1,5 @@
+import { PrismaClient } from "@prisma/client";
+
+export const prisma = new PrismaClient();
+
+export * from "@prisma/client";


### PR DESCRIPTION
## Summary
Added importable Prisma client entrypoint to DB package.

## Changes
### Fixes #930: DB package lacks importable Prisma client entrypoint
- Created packages/db/src/index.ts exporting PrismaClient
- Updated package.json with main and exports fields
- Added generate and postinstall scripts for Prisma client generation

Closes #930