### PR TITLE
Add production build scripts to monorepo (#915)

### DIFF
--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -4,6 +4,7 @@
   "private": true,
   "description": "Next.js web application for TaskFlow.",
   "scripts": {
+    "build": "next build",
     "dev": "next dev",
     "test": "echo \"No web tests configured yet\"",
     "lint": "next lint"

--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
     "packages/*"
   ],
   "scripts": {
+    "build": "npm run build --workspaces --if-present",
     "dev": "npm run dev --workspaces --if-present",
     "test": "npm run test --workspaces --if-present",
     "lint": "npm run lint --workspaces --if-present",


### PR DESCRIPTION
## Summary
Added production build scripts to monorepo.

## Changes
### Fixes #915: Monorepo lacks production build scripts
- Added uild script to root package.json
- Added uild script to web package.json running 
ext build

Closes #915