### PR TITLE
Add explicit types and exports metadata to UI package (#923)

### DIFF
--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -4,11 +4,22 @@
   "private": true,
   "description": "Shared UI components for TaskFlow.",
   "main": "src/index.ts",
+  "types": "src/index.ts",
+  "exports": {
+    ".": {
+      "import": "./src/index.ts",
+      "types": "./src/index.ts"
+    }
+  },
   "scripts": {
     "test": "echo \"No UI tests configured yet\"",
     "lint": "echo \"No UI lint configured yet\""
   },
+  "dependencies": {
+    "react": "^18.3.1"
+  },
   "devDependencies": {
+    "@types/react": "^18.3.1",
     "typescript": "^5.4.5"
   }
 }


### PR DESCRIPTION
## Summary
Added explicit types and exports metadata to UI package.

## Changes
### Fixes #923: UI package lacks explicit types and exports metadata
- Added 	ypes field for TypeScript
- Added exports field for proper module resolution
- Added React and @types/react dependencies

Closes #923