### PR TITLE
Fix updateLabel to use current_name parameter (#845)

### DIFF
--- a/.github/workflows/create-labels.yml
+++ b/.github/workflows/create-labels.yml
@@ -80,6 +80,7 @@ jobs:
                 await github.rest.issues.updateLabel({
                   owner: context.repo.owner,
                   repo: context.repo.repo,
+                  current_name: label.name,
                   name: label.name,
                   color,
                   description: label.description || ""


### PR DESCRIPTION
## Summary
Fixed updateLabel API call to use correct parameter.

## Changes
### Fixes #845: create-labels workflow cannot update existing labels
- Added current_name parameter to updateLabel call
- This allows updating existing labels with new color/description

Closes #845