### PR TITLE
Use YAML parser in create-labels workflow (#863)

### DIFF
--- a/.github/workflows/create-labels.yml
+++ b/.github/workflows/create-labels.yml
@@ -4,6 +4,7 @@ on:
   workflow_dispatch:
 
 permissions:
+  contents: read
   issues: write
 
 jobs:
@@ -14,55 +15,28 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v4
 
+      - name: Install js-yaml
+        run: npm install js-yaml
+
       - name: Create or update labels
         uses: actions/github-script@v7
         with:
           script: |
             const fs = require("fs");
+            const yaml = require("js-yaml");
 
             const content = fs.readFileSync(".github/labels.yml", "utf8");
-            const labels = [];
-            let current = null;
+            const labels = yaml.load(content);
 
-            for (const rawLine of content.split(/\r?\n/)) {
-              const line = rawLine.trim();
-
-              if (!line) {
-                continue;
-              }
-
-              if (line.startsWith("- name:")) {
-                if (current) {
-                  labels.push(current);
-                }
-
-                current = {
-                  name: line.replace("- name:", "").trim().replace(/^"|"$/g, "")
-                };
-                continue;
-              }
-
-              if (!current) {
-                continue;
-              }
-
-              const separatorIndex = line.indexOf(":");
-
-              if (separatorIndex === -1) {
-                continue;
-              }
-
-              const key = line.slice(0, separatorIndex).trim();
-              const value = line.slice(separatorIndex + 1).trim().replace(/^"|"$/g, "");
-              current[key] = value;
-            }
-
-            if (current) {
-              labels.push(current);
+            if (!Array.isArray(labels)) {
+              throw new Error("labels.yml must contain an array of labels");
             }
 
             for (const label of labels) {
-              const color = label.color.replace(/^#/, "");
+              if (!label.name) {
+                continue;
+              }
+              const color = (label.color || "000000").replace(/^#/, "");
 
               try {
                 await github.rest.issues.createLabel({
@@ -80,6 +54,7 @@ jobs:
                 await github.rest.issues.updateLabel({
                   owner: context.repo.owner,
                   repo: context.repo.repo,
+                  current_name: label.name,
                   name: label.name,
                   color,
                   description: label.description || ""


### PR DESCRIPTION
## Summary
Replaced hand-rolled YAML parser with js-yaml in create-labels workflow.

## Changes
### Fixes #863: create-labels workflow should parse labels.yml with a YAML parser
- Added js-yaml dependency and installation step
- Replaced line-by-line parser with proper yaml.load() call
- Added array validation for parsed labels

### Also includes:
- Fixed updateLabel to use current_name parameter (#845)
- Added contents: read permission for checkout (#910)

Closes #863