### PR TITLE
Fix meta issue title to avoid mojibake (#33)

### DIFF
--- a/.github/workflows/seed-meta-issue.yml
+++ b/.github/workflows/seed-meta-issue.yml
@@ -38,7 +38,7 @@ jobs:
             const createdIssue = await github.rest.issues.create({
               owner: context.repo.owner,
               repo: context.repo.repo,
-              title: "Bug Bounty Program — How to Participate",
+              title: "Bug Bounty Program - How to Participate",
               body: bodyForIssue("[NUMBER]"),
               labels: ["bounty", "good first issue", "AI agent friendly"]
             });


### PR DESCRIPTION
## Summary
Fixed meta issue title to use ASCII dash instead of em dash.

## Changes
### Fixes #33: Bug Bounty Program meta issue
- Replaced em dash (—) with ASCII dash (-) in title
- Prevents mojibake rendering issues

Closes #33