### PR TITLE
Ensure labels exist before seeding issues (#957)

### DIFF
--- a/.github/workflows/seed-issues.yml
+++ b/.github/workflows/seed-issues.yml
@@ -11,6 +11,44 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
+      - name: Ensure labels exist
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const labels = [
+              { name: "good first issue", color: "7057ff", description: "Good for newcomers" },
+              { name: "bounty", color: "00FF00", description: "Has a bounty" },
+              { name: "AI agent friendly", color: "FF6B6B", description: "AI agents can work on this" }
+            ];
+
+            for (const label of labels) {
+              try {
+                await github.rest.issues.createLabel({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  name: label.name,
+                  color: label.color,
+                  description: label.description
+                });
+                core.info(`Created label: ${label.name}`);
+              } catch (error) {
+                if (error.status === 422) {
+                  // Label already exists, update it
+                  await github.rest.issues.updateLabel({
+                    owner: context.repo.owner,
+                    repo: context.repo.repo,
+                    current_name: label.name,
+                    name: label.name,
+                    color: label.color,
+                    description: label.description
+                  });
+                  core.info(`Updated label: ${label.name}`);
+                } else {
+                  throw error;
+                }
+              }
+            }
+
       - name: Create starter issues
         uses: actions/github-script@v7
         with:


### PR DESCRIPTION
## Summary
Ensured labels exist before seeding issues in seed-issues workflow.

## Changes
### Fixes #957: Seed workflows fail when bounty labels are missing
- Added step to create/update labels before seeding issues
- Ensures labels exist even in fresh repositories

Closes #957