### PR TITLE
fix: normalize health check response shape

### DIFF
--- a/apps/api/src/index.ts
+++ b/apps/api/src/index.ts
@@ -8,7 +8,13 @@ const port = process.env.PORT || 4000;
 app.use(express.json());
 
 app.get("/health", (_req, res) => {
-  res.json({ status: "ok", service: "taskflow-api" });
+  res.json({
+    status: "ok",
+    data: {
+      service: "taskflow-api",
+      uptime: process.uptime(),
+    },
+  });
 });
 
 app.use("/users", usersRouter);


### PR DESCRIPTION
## Summary

Normalizes the `/health` endpoint response to use a consistent envelope with `status` and `data` fields.

### Before
```json
{ "status": "ok", "service": "taskflow-api" }
```

### After
```json
{
  "status": "ok",
  "data": {
    "service": "taskflow-api",
    "uptime": 123.456
  }
}
```

### Changes
- Restructured health check response to `{ status, data: { service, uptime } }` format
- Added `process.uptime()` to provide server uptime information
- Maintains backward compatibility with `status: "ok"` at top level

Closes #8
