### PR TITLE
Fix bounty template to use /bounty marker (#687)

### DIFF
--- a/.github/ISSUE_TEMPLATE/bounty_task.md
+++ b/.github/ISSUE_TEMPLATE/bounty_task.md
@@ -18,4 +18,4 @@ Describe the task, expected context, and files likely involved.
 
 ## Bounty Amount
 
-$50
+/bounty $50


### PR DESCRIPTION
Fix bounty template to use /bounty marker

Fixes #687

Updated bounty amount to use /bounty  marker instead of plain  text.