### PR TITLE
feat: add request body size limit

### DIFF
--- a/apps/api/src/index.ts
+++ b/apps/api/src/index.ts
@@ -1,14 +1,17 @@
 import express from "express";
-
 import usersRouter from "./routes/users";
 
 const app = express();
 const port = process.env.PORT || 4000;
+const bodySizeLimit = process.env.BODY_SIZE_LIMIT || "1mb";
 
-app.use(express.json());
+app.use(express.json({ limit: bodySizeLimit }));
 
 app.get("/health", (_req, res) => {
-  res.json({ status: "ok", service: "taskflow-api" });
+  res.json({
+    status: "ok",
+    service: "taskflow-api"
+  });
 });
 
 app.use("/users", usersRouter);


### PR DESCRIPTION
Fixes #9

This PR adds request body size limit:
- Configured body-parser with max size limit
- Returns 413 Payload Too Large for oversized requests
- Default limit set to 1MB