### PR TITLE
Fix PI template to remove duplicate bounty declaration (#775)

### DIFF
--- a/.github/ISSUE_TEMPLATE/pi_challenge.md
+++ b/.github/ISSUE_TEMPLATE/pi_challenge.md
@@ -19,6 +19,4 @@ Implement or document a small PI calculation challenge for TaskFlow's internal e
 
 ## Bounty Amount
 
-$50
-
 /bounty $50


### PR DESCRIPTION
Fix PI template to remove duplicate bounty declaration

Fixes #775

Removed duplicate  bounty amount, keeping only the /bounty  marker.