### PR TITLE
Add Prisma enums for Job and Proposal status (#657)

### DIFF
--- a/packages/db/prisma/schema.prisma
+++ b/packages/db/prisma/schema.prisma
@@ -7,6 +7,21 @@ datasource db {
   url      = env("DATABASE_URL")
 }
 
+enum JobStatus {
+  draft
+  open
+  in_progress
+  completed
+  cancelled
+}
+
+enum ProposalStatus {
+  pending
+  accepted
+  rejected
+  withdrawn
+}
+
 model User {
   id        String     @id @default(cuid())
   email     String     @unique
@@ -21,7 +36,7 @@ model Job {
   id          String     @id @default(cuid())
   title       String
   description String?
-  status      String     @default("draft")
+  status      JobStatus  @default(draft)
   ownerId     String
   owner       User       @relation(fields: [ownerId], references: [id])
   proposals   Proposal[]
@@ -30,14 +45,14 @@ model Job {
 }
 
 model Proposal {
-  id        String   @id @default(cuid())
+  id        String         @id @default(cuid())
   summary   String
   amount    Decimal?
-  status    String   @default("pending")
+  status    ProposalStatus @default(pending)
   userId    String
-  user      User     @relation(fields: [userId], references: [id])
+  user      User          @relation(fields: [userId], references: [id])
   jobId     String
-  job       Job      @relation(fields: [jobId], references: [id])
-  createdAt DateTime @default(now())
-  updatedAt DateTime @updatedAt
+  job       Job           @relation(fields: [jobId], references: [id])
+  createdAt DateTime      @default(now())
+  updatedAt DateTime      @updatedAt
 }


### PR DESCRIPTION
Add Prisma enums for Job and Proposal status

Fixes #657

- Added JobStatus enum with values: draft, open, in_progress, completed, cancelled
- Added ProposalStatus enum with values: pending, accepted, rejected, withdrawn
- Updated Job.status to use JobStatus enum with draft default
- Updated Proposal.status to use ProposalStatus enum with pending default