### PR TITLE
Add SEO metadata to homepage (#895)

### DIFF
--- a/apps/web/src/app/page.tsx
+++ b/apps/web/src/app/page.tsx
@@ -1,3 +1,10 @@
+import type { Metadata } from "next";
+
+export const metadata: Metadata = {
+  title: "TaskFlow - Task Management Platform",
+  description: "Plan tasks, coordinate jobs, and manage proposals from one workspace. TaskFlow is a full-stack task management SaaS for freelancers and clients.",
+};
+
 export default function HomePage() {
   return (
     <main>


### PR DESCRIPTION
Add SEO metadata to homepage

Fixes #895

- Added export const metadata with title and description
- Next.js App Router will use this for title and meta description tags