### PR TITLE
Add input validation to POST /users (#694)

### DIFF
--- a/apps/api/src/routes/users.ts
+++ b/apps/api/src/routes/users.ts
@@ -10,10 +10,18 @@ router.get("/", (_req, res) => {
 });
 
 router.post("/", (req, res) => {
+  const { email, name } = req.body;
+
+  if (!email || typeof email !== "string") {
+    res.status(400).json({ error: "email is required and must be a string" });
+    return;
+  }
+
   res.status(201).json({
     data: {
       id: "stub-user-id",
-      ...req.body
+      email,
+      name: name || null
     },
     message: "User creation is not implemented yet."
   });


### PR DESCRIPTION
Add input validation to POST /users

Fixes #694

- Destructure only expected fields (email, name)
- Validate email is required and must be a string
- Return 400 error for invalid input