### PR TITLE
Add 405 Method Not Allowed for unsupported /users methods (#1168)

### DIFF
--- a/apps/api/src/routes/users.ts
+++ b/apps/api/src/routes/users.ts
@@ -10,13 +10,27 @@ router.get("/", (_req, res) => {
 });
 
 router.post("/", (req, res) => {
+  const { email, name } = req.body;
+
+  if (!email || typeof email !== "string") {
+    res.status(400).json({ error: "email is required and must be a string" });
+    return;
+  }
+
   res.status(201).json({
     data: {
       id: "stub-user-id",
-      ...req.body
+      email,
+      name: name || null
     },
     message: "User creation is not implemented yet."
   });
+});
+
+// 405 for unsupported methods on /users collection
+router.all("/", (_req, res) => {
+  res.setHeader("Allow", "GET, POST");
+  res.status(405).json({ error: "Method not allowed" });
 });
 
 export default router;


### PR DESCRIPTION
Add 405 Method Not Allowed for unsupported /users methods

Fixes #1168

- Added router.all() fallback for /users collection
- Returns 405 with Allow header listing GET, POST
- Returns JSON error response
- Also includes POST /users validation fix (#694)