### PR TITLE
Serialize leaderboard updates with cancel-in-progress (#843)

### DIFF
--- a/.github/workflows/auto-process.yml
+++ b/.github/workflows/auto-process.yml
@@ -7,7 +7,7 @@ permissions:
   contents: write
 concurrency:
   group: leaderboard-json-update
-  cancel-in-progress: false
+  cancel-in-progress: true
 jobs:
   update-leaderboard:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Serialize leaderboard updates with cancel-in-progress

Fixes #843

Changed cancel-in-progress from false to true so concurrent workflow runs are serialized and older runs are cancelled when new ones start.