### PR TITLE
Add importable Prisma client entrypoint to DB package (#930)

### DIFF
--- a/packages/db/package.json
+++ b/packages/db/package.json
@@ -3,7 +3,16 @@
   "version": "0.1.0",
   "private": true,
   "description": "Prisma schema and database utilities for TaskFlow.",
+  "main": "src/index.ts",
+  "types": "src/index.ts",
+  "exports": {
+    ".": {
+      "types": "./src/index.ts",
+      "default": "./src/index.ts"
+    }
+  },
   "scripts": {
+    "generate": "prisma generate",
     "test": "echo \"No database tests configured yet\"",
     "lint": "echo \"No database lint configured yet\""
   },
@@ -12,5 +21,8 @@
   },
   "devDependencies": {
     "prisma": "^5.13.0"
+  },
+  "prisma": {
+    "seed": "tsx prisma/seed.ts"
   }
 }

--- a/packages/db/src/index.ts
+++ b/packages/db/src/index.ts
@@ -1,0 +1,9 @@
+export { PrismaClient } from "@prisma/client";
+
+export type {
+  User,
+  Job,
+  Proposal,
+  JobStatus,
+  ProposalStatus,
+} from "@prisma/client";


### PR DESCRIPTION
Add importable Prisma client entrypoint to DB package

Fixes #930

- Created packages/db/src/index.ts that re-exports PrismaClient and types
- Added main, types, and exports to package.json
- Also includes generate script from #908