### PR TITLE
fix(api): reject invalid email values in POST /users (fixes #1357)

### DIFF
--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -7,7 +7,7 @@
   "main": "src/index.ts",
   "scripts": {
     "dev": "tsx src/index.ts",
-    "test": "echo \"No API tests configured yet\"",
+    "test": "NODE_ENV=test tsx --test src/**/*.test.ts",
     "lint": "echo \"No API lint configured yet\""
   },
   "dependencies": {
@@ -15,6 +15,8 @@
   },
   "devDependencies": {
     "@types/express": "^4.17.21",
+    "@types/supertest": "^7.2.0",
+    "supertest": "^7.2.2",
     "tsx": "^4.7.1",
     "typescript": "^5.4.5"
   }

--- a/apps/api/src/index.ts
+++ b/apps/api/src/index.ts
@@ -2,7 +2,7 @@ import express from "express";
 
 import usersRouter from "./routes/users";
 
-const app = express();
+export const app = express();
 const port = process.env.PORT || 4000;
 
 app.use(express.json());
@@ -13,6 +13,8 @@ app.get("/health", (_req, res) => {
 
 app.use("/users", usersRouter);
 
-app.listen(port, () => {
-  console.log(`TaskFlow API listening on port ${port}`);
-});
+if (process.env.NODE_ENV !== "test") {
+  app.listen(port, () => {
+    console.log(`TaskFlow API listening on port ${port}`);
+  });
+}

--- a/apps/api/src/routes/users.test.ts
+++ b/apps/api/src/routes/users.test.ts
@@ -1,0 +1,52 @@
+import test from "node:test";
+import assert from "node:assert";
+import request from "supertest";
+import { app } from "../index.js";
+
+test("POST /users payload validation", async (t) => {
+  await t.test("accepts valid name and email", async () => {
+    const res = await request(app)
+      .post("/users")
+      .send({ name: "Alice", email: "alice@example.com" });
+    
+    assert.strictEqual(res.status, 201);
+    assert.strictEqual(res.body.data.name, "Alice");
+    assert.strictEqual(res.body.data.email, "alice@example.com");
+  });
+
+  await t.test("rejects missing name", async () => {
+    const res = await request(app)
+      .post("/users")
+      .send({ email: "alice@example.com" });
+    
+    assert.strictEqual(res.status, 400);
+    assert.strictEqual(res.body.error, "Invalid or missing 'name'");
+  });
+
+  await t.test("rejects missing email", async () => {
+    const res = await request(app)
+      .post("/users")
+      .send({ name: "Alice" });
+    
+    assert.strictEqual(res.status, 400);
+    assert.strictEqual(res.body.error, "Invalid or missing 'email'");
+  });
+
+  await t.test("rejects invalid email format", async () => {
+    const invalidEmails = ["not-an-email", "alice@", "@example.com", "alice@example", ""];
+    
+    for (const email of invalidEmails) {
+      const res = await request(app)
+        .post("/users")
+        .send({ name: "Alice", email });
+      
+      assert.strictEqual(res.status, 400, `Expected 400 for email: ${email}`);
+      // for empty string it fails the missing email check
+      if (email === "") {
+        assert.strictEqual(res.body.error, "Invalid or missing 'email'");
+      } else {
+        assert.strictEqual(res.body.error, "Invalid email format");
+      }
+    }
+  });
+});

--- a/apps/api/src/routes/users.ts
+++ b/apps/api/src/routes/users.ts
@@ -10,6 +10,22 @@ router.get("/", (_req, res) => {
 });
 
 router.post("/", (req, res) => {
+  const { name, email } = req.body;
+
+  if (typeof name !== "string" || name.trim() === "") {
+    return res.status(400).json({ error: "Invalid or missing 'name'" });
+  }
+
+  if (typeof email !== "string" || email.trim() === "") {
+    return res.status(400).json({ error: "Invalid or missing 'email'" });
+  }
+
+  // Simple conservative email validation pattern
+  const emailRegex = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
+  if (!emailRegex.test(email)) {
+    return res.status(400).json({ error: "Invalid email format" });
+  }
+
   res.status(201).json({
     data: {
       id: "stub-user-id",


### PR DESCRIPTION
This PR implements strict email validation for POST /users to reject invalid or empty email/name values.

Closes #1357

PayPal: https://paypal.me/sureshc26