### PR TITLE
fix(api): add no-store cache policy to /health response (fixes #1253)

### DIFF
--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -7,7 +7,7 @@
   "main": "src/index.ts",
   "scripts": {
     "dev": "tsx src/index.ts",
-    "test": "echo \"No API tests configured yet\"",
+    "test": "NODE_ENV=test tsx --test src/**/*.test.ts",
     "lint": "echo \"No API lint configured yet\""
   },
   "dependencies": {
@@ -15,6 +15,8 @@
   },
   "devDependencies": {
     "@types/express": "^4.17.21",
+    "@types/supertest": "^7.2.0",
+    "supertest": "^7.2.2",
     "tsx": "^4.7.1",
     "typescript": "^5.4.5"
   }

--- a/apps/api/src/health.test.ts
+++ b/apps/api/src/health.test.ts
@@ -1,0 +1,13 @@
+import test from "node:test";
+import assert from "node:assert";
+import request from "supertest";
+import { app } from "./index.js";
+
+test("GET /health cache policy", async () => {
+  const res = await request(app).get("/health");
+  
+  assert.strictEqual(res.status, 200);
+  assert.strictEqual(res.body.status, "ok");
+  assert.strictEqual(res.body.service, "taskflow-api");
+  assert.strictEqual(res.headers["cache-control"], "no-store");
+});

--- a/apps/api/src/index.ts
+++ b/apps/api/src/index.ts
@@ -2,17 +2,20 @@ import express from "express";
 
 import usersRouter from "./routes/users";
 
-const app = express();
+export const app = express();
 const port = process.env.PORT || 4000;
 
 app.use(express.json());
 
 app.get("/health", (_req, res) => {
+  res.setHeader("Cache-Control", "no-store");
   res.json({ status: "ok", service: "taskflow-api" });
 });
 
 app.use("/users", usersRouter);
 
-app.listen(port, () => {
-  console.log(`TaskFlow API listening on port ${port}`);
-});
+if (process.env.NODE_ENV !== "test") {
+  app.listen(port, () => {
+    console.log(`TaskFlow API listening on port ${port}`);
+  });
+}


### PR DESCRIPTION
This PR adds a `no-store` Cache-Control header to the /health endpoint to prevent response caching.

Closes #1253

PayPal: https://paypal.me/sureshc26