### PR TITLE
feat(web): add SEO metadata to homepage (fixes #895)

### DIFF
--- a/apps/web/src/app/page.tsx
+++ b/apps/web/src/app/page.tsx
@@ -1,3 +1,10 @@
+import type { Metadata } from "next";
+
+export const metadata: Metadata = {
+  title: "TaskFlow",
+  description: "Plan tasks, coordinate jobs, and manage proposals from one workspace.",
+};
+
 export default function HomePage() {
   return (
     <main>


### PR DESCRIPTION
This PR adds standard SEO metadata to the Next.js homepage.

Closes #895

PayPal: https://paypal.me/sureshc26