### PR TITLE
fix(api): reject unsupported methods on /users with 405 (fixes #1168)

### DIFF
--- a/apps/api/src/routes/users.ts
+++ b/apps/api/src/routes/users.ts
@@ -19,4 +19,11 @@ router.post("/", (req, res) => {
   });
 });
 
+router.all("/", (req, res) => {
+  res.set("Allow", "GET, POST");
+  res.status(405).json({
+    error: `Method ${req.method} is not supported for this endpoint.`
+  });
+});
+
 export default router;


### PR DESCRIPTION
This PR returns a 405 Method Not Allowed with an Allow header for unsupported HTTP methods on /users.

Closes #1168

PayPal: https://paypal.me/sureshc26