### PR TITLE
Ensure labels exist before creating issues in seed workflow (#957)

### DIFF
--- a/.github/workflows/seed-issues.yml
+++ b/.github/workflows/seed-issues.yml
@@ -4,6 +4,7 @@ on:
   workflow_dispatch:
 
 permissions:
+  contents: read
   issues: write
 
 jobs:
@@ -11,6 +12,45 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Ensure labels exist
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const fs = require("fs");
+            const yaml = require("js-yaml");
+
+            const content = fs.readFileSync(".github/labels.yml", "utf8");
+            const labels = yaml.load(content);
+
+            for (const label of labels) {
+              if (!label.name) continue;
+
+              const color = (label.color || "000000").replace(/^#/, "");
+
+              try {
+                await github.rest.issues.createLabel({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  name: label.name,
+                  color,
+                  description: label.description || ""
+                });
+              } catch (error) {
+                if (error.status !== 422) throw error;
+                await github.rest.issues.updateLabel({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  current_name: label.name,
+                  name: label.name,
+                  color,
+                  description: label.description || ""
+                });
+              }
+            }
+
       - name: Create starter issues
         uses: actions/github-script@v7
         with:


### PR DESCRIPTION
Ensure labels exist before creating issues in seed workflow

Fixes #957

- Added checkout step to read labels.yml
- Added label creation step using js-yaml parser (same as create-labels workflow)
- Ensures required labels exist before creating issues