### PR TITLE
Make seed-issues workflow idempotent (#875)

### DIFF
--- a/.github/workflows/seed-issues.yml
+++ b/.github/workflows/seed-issues.yml
@@ -4,6 +4,7 @@ on:
   workflow_dispatch:
 
 permissions:
+  contents: read
   issues: write
 
 jobs:
@@ -11,7 +12,46 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - name: Create starter issues
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Ensure labels exist
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const fs = require("fs");
+            const yaml = require("js-yaml");
+
+            const content = fs.readFileSync(".github/labels.yml", "utf8");
+            const labels = yaml.load(content);
+
+            for (const label of labels) {
+              if (!label.name) continue;
+
+              const color = (label.color || "000000").replace(/^#/, "");
+
+              try {
+                await github.rest.issues.createLabel({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  name: label.name,
+                  color,
+                  description: label.description || ""
+                });
+              } catch (error) {
+                if (error.status !== 422) throw error;
+                await github.rest.issues.updateLabel({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  current_name: label.name,
+                  name: label.name,
+                  color,
+                  description: label.description || ""
+                });
+              }
+            }
+
+      - name: Create starter issues (idempotent)
         uses: actions/github-script@v7
         with:
           script: |
@@ -90,12 +130,39 @@ jobs:
               }
             ];
 
+            const LABELS = ["good first issue", "bounty", "AI agent friendly"];
+
+            // Get existing open issues to check for duplicates
+            const existingIssues = await github.rest.issues.listForRepo({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              state: "open",
+              per_page: 100
+            });
+
+            const existingTitles = new Set(
+              existingIssues.data.map((issue) => issue.title)
+            );
+
+            let created = 0;
+            let skipped = 0;
+
             for (const issue of issues) {
+              if (existingTitles.has(issue.title)) {
+                console.log(`Skipping existing issue: ${issue.title}`);
+                skipped++;
+                continue;
+              }
+
               await github.rest.issues.create({
                 owner: context.repo.owner,
                 repo: context.repo.repo,
                 title: issue.title,
                 body: issue.body,
-                labels: ["good first issue", "bounty", "AI agent friendly"]
+                labels: LABELS
               });
+              console.log(`Created issue: ${issue.title}`);
+              created++;
             }
+
+            console.log(`\nSummary: Created ${created}, skipped ${skipped}`);


### PR DESCRIPTION
Make seed-issues workflow idempotent

Fixes #875

- Check existing open issues before creating new ones
- Skip issues that already exist
- Only create missing starter issues
- Also includes labels check from #957