### PR TITLE
test(ui): add unit tests for Button stub

### DIFF
--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -5,10 +5,11 @@
   "description": "Shared UI components for TaskFlow.",
   "main": "src/index.ts",
   "scripts": {
-    "test": "echo \"No UI tests configured yet\"",
+    "test": "vitest run",
     "lint": "echo \"No UI lint configured yet\""
   },
   "devDependencies": {
-    "typescript": "^5.4.5"
+    "typescript": "^5.4.5",
+    "vitest": "^4.1.8"
   }
 }

--- a/packages/ui/src/__tests__/button.test.ts
+++ b/packages/ui/src/__tests__/button.test.ts
@@ -1,0 +1,34 @@
+import { describe, it, expect } from 'vitest'
+import { Button } from '../index'
+
+describe('Button', () => {
+  it('should return an object with type "button"', () => {
+    const result = Button({ label: 'Click me' })
+    expect(result.type).toBe('button')
+  })
+
+  it('should use the provided label', () => {
+    const result = Button({ label: 'Submit' })
+    expect(result.label).toBe('Submit')
+  })
+
+  it('should default disabled to false', () => {
+    const result = Button({ label: 'Click me' })
+    expect(result.disabled).toBe(false)
+  })
+
+  it('should accept disabled as true', () => {
+    const result = Button({ label: 'Click me', disabled: true })
+    expect(result.disabled).toBe(true)
+  })
+
+  it('should handle empty label', () => {
+    const result = Button({ label: '' })
+    expect(result.label).toBe('')
+  })
+
+  it('should handle special characters in label', () => {
+    const result = Button({ label: '🚀 Launch' })
+    expect(result.label).toBe('🚀 Launch')
+  })
+})

--- a/packages/ui/vitest.config.ts
+++ b/packages/ui/vitest.config.ts
@@ -1,0 +1,7 @@
+import { defineConfig } from 'vitest/config'
+
+export default defineConfig({
+  test: {
+    environment: 'node',
+  },
+})


### PR DESCRIPTION
## Summary
Add Vitest test framework and 6 unit tests for the Button component.

## Changes
- **packages/ui/package.json**: Replace placeholder test script with vitest run
- **packages/ui/vitest.config.ts**: Minimal Vitest config  
- **packages/ui/src/__tests__/button.test.ts**: 6 test cases

## Test Results
All 6 tests pass (97ms):
1. Returns object with type button
2. Uses provided label
3. Defaults disabled to false
4. Accepts disabled=true
5. Handles empty label
6. Handles special characters (emoji)

Closes #13