### PR TITLE
test(api): add unit tests for user routes

### DIFF
--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -7,7 +7,7 @@
   "main": "src/index.ts",
   "scripts": {
     "dev": "tsx src/index.ts",
-    "test": "echo \"No API tests configured yet\"",
+    "test": "vitest run",
     "lint": "echo \"No API lint configured yet\""
   },
   "dependencies": {
@@ -15,7 +15,10 @@
   },
   "devDependencies": {
     "@types/express": "^4.17.21",
+    "@types/supertest": "^7.2.0",
+    "supertest": "^7.2.2",
     "tsx": "^4.7.1",
-    "typescript": "^5.4.5"
+    "typescript": "^5.4.5",
+    "vitest": "^4.1.8"
   }
 }

--- a/apps/api/src/__tests__/users.test.ts
+++ b/apps/api/src/__tests__/users.test.ts
@@ -1,0 +1,72 @@
+import { describe, it, expect } from 'vitest'
+import request from 'supertest'
+import express from 'express'
+import usersRouter from '../routes/users'
+
+function createApp() {
+  const app = express()
+  app.use(express.json())
+  app.use('/users', usersRouter)
+  return app
+}
+
+describe('GET /users', () => {
+  it('should return status 200', async () => {
+    const app = createApp()
+    const res = await request(app).get('/users')
+    expect(res.status).toBe(200)
+  })
+
+  it('should return JSON content type', async () => {
+    const app = createApp()
+    const res = await request(app).get('/users')
+    expect(res.headers['content-type']).toMatch(/json/)
+  })
+
+  it('should return empty data array', async () => {
+    const app = createApp()
+    const res = await request(app).get('/users')
+    expect(res.body.data).toEqual([])
+  })
+
+  it('should include a message about not being implemented', async () => {
+    const app = createApp()
+    const res = await request(app).get('/users')
+    expect(res.body.message).toContain('not implemented')
+  })
+})
+
+describe('POST /users', () => {
+  it('should return status 201', async () => {
+    const app = createApp()
+    const res = await request(app)
+      .post('/users')
+      .send({ name: 'test' })
+    expect(res.status).toBe(201)
+  })
+
+  it('should return a stub user id', async () => {
+    const app = createApp()
+    const res = await request(app)
+      .post('/users')
+      .send({ name: 'test' })
+    expect(res.body.data.id).toBe('stub-user-id')
+  })
+
+  it('should include request body in response', async () => {
+    const app = createApp()
+    const res = await request(app)
+      .post('/users')
+      .send({ name: 'Alice', role: 'admin' })
+    expect(res.body.data.name).toBe('Alice')
+    expect(res.body.data.role).toBe('admin')
+  })
+
+  it('should include a message about not being implemented', async () => {
+    const app = createApp()
+    const res = await request(app)
+      .post('/users')
+      .send({})
+    expect(res.body.message).toContain('not implemented')
+  })
+})

--- a/apps/api/vitest.config.ts
+++ b/apps/api/vitest.config.ts
@@ -1,0 +1,7 @@
+import { defineConfig } from 'vitest/config'
+
+export default defineConfig({
+  test: {
+    environment: 'node',
+  },
+})


### PR DESCRIPTION
## Summary
Add supertest + vitest based unit tests for the Express user route stubs.

## Test Results (8 tests, all passing)
**GET /users**
- Returns 200 status
- Returns JSON content type
- Returns empty data array
- Includes not-implemented message

**POST /users**
- Returns 201 status
- Returns stub user id
- Includes request body in response
- Includes not-implemented message

Closes #12