### PR TITLE
feat(api): add error handling helper

### DIFF
--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -15,7 +15,10 @@
   },
   "devDependencies": {
     "@types/express": "^4.17.21",
+    "@types/supertest": "^7.2.0",
+    "supertest": "^7.2.2",
     "tsx": "^4.7.1",
-    "typescript": "^5.4.5"
+    "typescript": "^5.4.5",
+    "vitest": "^4.1.8"
   }
 }

--- a/apps/api/src/__tests__/errorHandler.test.ts
+++ b/apps/api/src/__tests__/errorHandler.test.ts
@@ -1,0 +1,91 @@
+import { describe, it, expect } from 'vitest'
+import request from 'supertest'
+import express from 'express'
+import usersRouter from '../routes/users'
+import { errorHandler, apiError, asyncHandler } from '../middleware/errorHandler'
+
+function createApp() {
+  const app = express()
+  app.use(express.json())
+  app.use('/users', usersRouter)
+  app.use(errorHandler)
+  return app
+}
+
+describe('Error handler middleware', () => {
+  it('should return 500 for unknown errors', async () => {
+    const app = express()
+    app.get('/boom', () => {
+      throw new Error('something broke')
+    })
+    app.use(errorHandler)
+
+    const res = await request(app).get('/boom')
+    expect(res.status).toBe(500)
+    expect(res.body.error.message).toBe('Internal server error')
+  })
+
+  it('should handle apiError with custom status and message', async () => {
+    const app = express()
+    app.get('/not-found', (_req, _res, next) => {
+      next(apiError(404, 'Resource not found', { id: '123' }))
+    })
+    app.use(errorHandler)
+
+    const res = await request(app).get('/not-found')
+    expect(res.status).toBe(404)
+    expect(res.body.error.message).toBe('Resource not found')
+    expect(res.body.error.details).toEqual({ id: '123' })
+  })
+
+  it('should handle apiError without details', async () => {
+    const app = express()
+    app.get('/bad-request', (_req, _res, next) => {
+      next(apiError(400, 'Bad request'))
+    })
+    app.use(errorHandler)
+
+    const res = await request(app).get('/bad-request')
+    expect(res.status).toBe(400)
+    expect(res.body.error.message).toBe('Bad request')
+    expect(res.body.error.details).toBeUndefined()
+  })
+
+  it('should work with asyncHandler', async () => {
+    const app = express()
+    app.get('/async-ok', asyncHandler(async (_req, res) => {
+      res.json({ ok: true })
+    }))
+    app.get('/async-err', asyncHandler(async () => {
+      throw apiError(503, 'Service unavailable')
+    }))
+    app.use(errorHandler)
+
+    const ok = await request(app).get('/async-ok')
+    expect(ok.status).toBe(200)
+
+    const err = await request(app).get('/async-err')
+    expect(err.status).toBe(503)
+    expect(err.body.error.message).toBe('Service unavailable')
+  })
+})
+
+describe('POST /users validation (uses error helper)', () => {
+  it('should return 400 when body is empty', async () => {
+    const app = createApp()
+    const res = await request(app)
+      .post('/users')
+      .send({})
+    expect(res.status).toBe(400)
+    expect(res.body.error.message).toContain('required')
+  })
+
+  it('should return 201 with valid body', async () => {
+    const app = createApp()
+    const res = await request(app)
+      .post('/users')
+      .send({ name: 'test' })
+    expect(res.status).toBe(201)
+    expect(res.body.data.id).toBe('stub-user-id')
+  })
+})

--- a/apps/api/src/middleware/errorHandler.ts
+++ b/apps/api/src/middleware/errorHandler.ts
@@ -1,0 +1,67 @@
+import { Request, Response, NextFunction } from 'express'
+
+export interface ApiError {
+  status: number
+  message: string
+  details?: unknown
+}
+
+/**
+ * Creates a structured API error response.
+ *
+ * Usage:
+ *   throw apiError(400, 'Missing required field: email')
+ *   throw apiError(404, 'User not found', { userId: 'abc' })
+ *   throw apiError(500, 'Database connection failed')
+ */
+export function apiError(status: number, message: string, details?: unknown): ApiError {
+  return { status, message, details }
+}
+
+/**
+ * Express error-handling middleware.
+ * Catches ApiError instances and unknown errors, returning consistent JSON responses.
+ *
+ * Must be registered AFTER all route handlers:
+ *   app.use(errorHandler)
+ */
+export function errorHandler(
+  err: unknown,
+  _req: Request,
+  res: Response,
+  _next: NextFunction
+): void {
+  const apiErr = err as Partial<ApiError>
+
+  if (apiErr.status && apiErr.message) {
+    res.status(apiErr.status).json({
+      error: {
+        message: apiErr.message,
+        ...(apiErr.details ? { details: apiErr.details } : {}),
+      },
+    })
+    return
+  }
+
+  // Unknown error — log and return generic 500
+  console.error('Unhandled error:', err)
+  res.status(500).json({
+    error: {
+      message: 'Internal server error',
+    },
+  })
+}
+
+/**
+ * Simple async route wrapper to forward rejections to error handler.
+ *
+ * Usage:
+ *   router.get('/users', asyncHandler(async (req, res) => { ... }))
+ */
+export function asyncHandler(
+  fn: (req: Request, res: Response, next: NextFunction) => Promise<void>
+) {
+  return (req: Request, res: Response, next: NextFunction) => {
+    fn(req, res, next).catch(next)
+  }
+}

--- a/apps/api/src/routes/users.ts
+++ b/apps/api/src/routes/users.ts
@@ -1,22 +1,30 @@
-import { Router } from "express";
+import { Router } from 'express'
+import { apiError } from '../middleware/errorHandler'
 
-const router = Router();
+const router = Router()
 
-router.get("/", (_req, res) => {
+router.get('/', (_req, res) => {
   res.json({
     data: [],
-    message: "User listing is not implemented yet."
-  });
-});
+    message: 'User listing is not implemented yet.',
+  })
+})
 
-router.post("/", (req, res) => {
+router.post('/', (req, res) => {
+  // Demonstrate error helper: validate required fields
+  if (!req.body || Object.keys(req.body).length === 0) {
+    const err = apiError(400, 'Request body is required')
+    res.status(err.status).json({ error: { message: err.message } })
+    return
+  }
+
   res.status(201).json({
     data: {
-      id: "stub-user-id",
-      ...req.body
+      id: 'stub-user-id',
+      ...req.body,
     },
-    message: "User creation is not implemented yet."
-  });
-});
+    message: 'User creation is not implemented yet.',
+  })
+})
 
-export default router;
+export default router


### PR DESCRIPTION
## Summary
Add structured error handling helpers and integrate with one route.

## Changes
- **errorHandler.ts**: apiError(), errorHandler middleware, asyncHandler wrapper
- **users.ts**: Use apiError for empty body validation
- **errorHandler.test.ts**: 6 test cases covering all error scenarios

## Test Results (6/6)
- Unknown errors → 500 Internal server error
- apiError with status + message + details
- apiError without details
- asyncHandler with success path
- asyncHandler with error path
- POST /users empty body → 400 with error message

Closes #7