### PR TITLE
feat(api): add request body size limit

### DIFF
--- a/apps/api/src/index.ts
+++ b/apps/api/src/index.ts
@@ -5,7 +5,8 @@ import usersRouter from "./routes/users";
 const app = express();
 const port = process.env.PORT || 4000;
 
-app.use(express.json());
+// Limit JSON body size to 1 MB to prevent resource exhaustion.
+app.use(express.json({ limit: '1mb' }));
 
 app.get("/health", (_req, res) => {
   res.json({ status: "ok", service: "taskflow-api" });


### PR DESCRIPTION
## Summary
Configure a 1 MB JSON body size limit in the Express app.

## Change
- `apps/api/src/index.ts`: `express.json({ limit: '1mb' })` with explanatory comment

This prevents resource exhaustion from excessively large payloads while accommodating normal API request sizes.

Closes #9