### PR TITLE
refactor(api): normalize health check response envelope

### DIFF
--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -15,7 +15,10 @@
   },
   "devDependencies": {
     "@types/express": "^4.17.21",
+    "@types/supertest": "^7.2.0",
+    "supertest": "^7.2.2",
     "tsx": "^4.7.1",
-    "typescript": "^5.4.5"
+    "typescript": "^5.4.5",
+    "vitest": "^4.1.8"
   }
 }

--- a/apps/api/src/__tests__/health.test.ts
+++ b/apps/api/src/__tests__/health.test.ts
@@ -1,0 +1,43 @@
+import { describe, it, expect } from 'vitest'
+import request from 'supertest'
+import express from 'express'
+import usersRouter from '../routes/users'
+
+function createApp() {
+  const app = express()
+  app.use(express.json({ limit: '1mb' }))
+
+  app.get('/health', (_req, res) => {
+    res.json({
+      status: 'ok',
+      data: {
+        service: 'taskflow-api',
+      },
+    })
+  })
+
+  app.use('/users', usersRouter)
+  return app
+}
+
+describe('GET /health', () => {
+  it('should return status 200', async () => {
+    const app = createApp()
+    const res = await request(app).get('/health')
+    expect(res.status).toBe(200)
+  })
+
+  it('should use consistent envelope with status field', async () => {
+    const app = createApp()
+    const res = await request(app).get('/health')
+    expect(res.body).toHaveProperty('status')
+    expect(res.body.status).toBe('ok')
+  })
+
+  it('should wrap service info in data field', async () => {
+    const app = createApp()
+    const res = await request(app).get('/health')
+    expect(res.body).toHaveProperty('data')
+    expect(res.body.data).toEqual({ service: 'taskflow-api' })
+  })
+})

--- a/apps/api/src/index.ts
+++ b/apps/api/src/index.ts
@@ -8,7 +8,12 @@ const port = process.env.PORT || 4000;
 app.use(express.json());
 
 app.get("/health", (_req, res) => {
-  res.json({ status: "ok", service: "taskflow-api" });
+  res.json({
+    status: "ok",
+    data: {
+      service: "taskflow-api",
+    },
+  });
 });
 
 app.use("/users", usersRouter);


### PR DESCRIPTION
## Summary
Update health check response to use a consistent envelope with status and data fields.

**Before:**
```json
{ "status": "ok", "service": "taskflow-api" }
```

**After:**
```json
{ "status": "ok", "data": { "service": "taskflow-api" } }
```

Closes #8