### PR TITLE
test: add unit tests for user routes (#12)

### DIFF
--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -7,7 +7,7 @@
   "main": "src/index.ts",
   "scripts": {
     "dev": "tsx src/index.ts",
-    "test": "echo \"No API tests configured yet\"",
+    "test": "vitest run",
     "lint": "echo \"No API lint configured yet\""
   },
   "dependencies": {
@@ -15,7 +15,10 @@
   },
   "devDependencies": {
     "@types/express": "^4.17.21",
+    "@types/supertest": "^6.0.2",
+    "supertest": "^7.0.0",
     "tsx": "^4.7.1",
-    "typescript": "^5.4.5"
+    "typescript": "^5.4.5",
+    "vitest": "^2.1.0"
   }
 }

--- a/apps/api/src/routes/users.test.ts
+++ b/apps/api/src/routes/users.test.ts
@@ -1,0 +1,99 @@
+import { describe, it, expect } from "vitest";
+import request from "supertest";
+import express from "express";
+import usersRouter from "./users";
+
+function createApp() {
+  const app = express();
+  app.use(express.json());
+  app.use("/users", usersRouter);
+  return app;
+}
+
+describe("GET /users", () => {
+  it("returns empty user list with status 200", async () => {
+    const app = createApp();
+    const res = await request(app).get("/users");
+
+    expect(res.status).toBe(200);
+    expect(res.body).toEqual({
+      data: [],
+      message: "User listing is not implemented yet.",
+    });
+  });
+
+  it("returns JSON content type", async () => {
+    const app = createApp();
+    const res = await request(app).get("/users");
+
+    expect(res.headers["content-type"]).toMatch(/application\/json/);
+  });
+});
+
+describe("POST /users", () => {
+  it("creates a user stub with valid email and returns 201", async () => {
+    const app = createApp();
+    const res = await request(app)
+      .post("/users")
+      .send({ email: "alice@example.com" })
+      .set("Content-Type", "application/json");
+
+    expect(res.status).toBe(201);
+    expect(res.body.data).toHaveProperty("id", "stub-user-id");
+    expect(res.body.data.email).toBe("alice@example.com");
+  });
+
+  it("accepts optional name field", async () => {
+    const app = createApp();
+    const res = await request(app)
+      .post("/users")
+      .send({ email: "bob@example.com", name: "Bob" })
+      .set("Content-Type", "application/json");
+
+    expect(res.status).toBe(201);
+    expect(res.body.data.name).toBe("Bob");
+  });
+
+  it("returns 400 when email is missing", async () => {
+    const app = createApp();
+    const res = await request(app)
+      .post("/users")
+      .send({})
+      .set("Content-Type", "application/json");
+
+    expect(res.status).toBe(400);
+    expect(res.body).toHaveProperty("error", "Validation failed");
+  });
+
+  it("returns 400 when email is an empty string", async () => {
+    const app = createApp();
+    const res = await request(app)
+      .post("/users")
+      .send({ email: "" })
+      .set("Content-Type", "application/json");
+
+    expect(res.status).toBe(400);
+    expect(res.body.message).toContain("email");
+  });
+
+  it("returns 400 when email format is invalid", async () => {
+    const app = createApp();
+    const res = await request(app)
+      .post("/users")
+      .send({ email: "not-an-email" })
+      .set("Content-Type", "application/json");
+
+    expect(res.status).toBe(400);
+    expect(res.body.message).toContain("valid email");
+  });
+
+  it("returns 400 when body is not a JSON object", async () => {
+    const app = createApp();
+    const res = await request(app)
+      .post("/users")
+      .send('"just a string"')
+      .set("Content-Type", "application/json");
+
+    expect(res.status).toBe(400);
+  });
+});

--- a/contributors/agents.json
+++ b/contributors/agents.json
@@ -1,5 +1,12 @@
 {
-  "agents": [],
-  "last_updated": "2026-06-03",
-  "total_contributions": 0
+  "agents": [
+    {
+      "model": "claude-opus-4-5",
+      "version": "20261015",
+      "contributor": "chrisyangxiaoqi",
+      "contribution": "test: add unit tests for user routes (issue #12)"
+    }
+  ],
+  "last_updated": "2026-06-15",
+  "total_contributions": 1
 }


### PR DESCRIPTION
## Summary

Add unit tests for Express user route stubs per Issue #12 ($50 bounty).

## Changes

- `apps/api/src/routes/users.test.ts` — 8 test cases for user routes
- `apps/api/package.json` — Added vitest, supertest as dev dependencies, updated test script
- `contributors/agents.json` — Added contribution record

## Test Coverage

### GET /users
- Returns empty list with status 200
- Returns JSON content type

### POST /users
- Creates user stub with valid email (201)
- Accepts optional name field
- Rejects missing email (400)
- Rejects empty email string (400)
- Rejects invalid email format (400)
- Rejects non-object request body (400)

## Running Tests

```bash
cd apps/api
npx vitest run
```

Closes #12