### PR TITLE
test: add unit tests for UI Button stub (#13)

### DIFF
--- a/contributors/agents.json
+++ b/contributors/agents.json
@@ -1,5 +1,12 @@
 {
-  "agents": [],
-  "last_updated": "2026-06-03",
-  "total_contributions": 0
+  "agents": [
+    {
+      "model": "claude-opus-4-5",
+      "version": "20261015",
+      "contributor": "chrisyangxiaoqi",
+      "contribution": "test: add unit test for UI Button stub (issue #13)"
+    }
+  ],
+  "last_updated": "2026-06-15",
+  "total_contributions": 1
 }

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -5,10 +5,11 @@
   "description": "Shared UI components for TaskFlow.",
   "main": "src/index.ts",
   "scripts": {
-    "test": "echo \"No UI tests configured yet\"",
+    "test": "vitest run",
     "lint": "echo \"No UI lint configured yet\""
   },
   "devDependencies": {
-    "typescript": "^5.4.5"
+    "typescript": "^5.4.5",
+    "vitest": "^2.1.0"
   }
 }

--- a/packages/ui/src/index.test.ts
+++ b/packages/ui/src/index.test.ts
@@ -1,0 +1,33 @@
+import { describe, it, expect } from "vitest";
+import { Button } from "./index";
+
+describe("Button", () => {
+  it("returns an object with type 'button' and the provided label", () => {
+    const result = Button({ label: "Submit" });
+
+    expect(result).toEqual({
+      type: "button",
+      label: "Submit",
+      disabled: false,
+    });
+  });
+
+  it("sets disabled to false by default", () => {
+    const result = Button({ label: "Click me" });
+
+    expect(result.disabled).toBe(false);
+  });
+
+  it("sets disabled to true when disabled prop is true", () => {
+    const result = Button({ label: "Disabled", disabled: true });
+
+    expect(result.disabled).toBe(true);
+  });
+
+  it("preserves the label when disabled", () => {
+    const result = Button({ label: "Save", disabled: true });
+
+    expect(result.label).toBe("Save");
+    expect(result.type).toBe("button");
+  });
+});


### PR DESCRIPTION
## Summary

Add unit tests for the shared Button stub per Issue #13 ($50 bounty).

## Changes

- `packages/ui/src/index.test.ts` — 4 test cases for the Button component
- `packages/ui/package.json` — Added vitest as dev dependency, updated test script
- `contributors/agents.json` — Added contribution record

## Test Coverage

- Returns object with type "button" and the provided label
- Sets disabled to false by default
- Sets disabled to true when disabled prop is true
- Preserves the label when disabled

## Running Tests

```bash
cd packages/ui
npx vitest run
```

Closes #13