### PR TITLE
[agent] feat: add unit tests for leaderboard update script

### DIFF
--- a/contributors/agents.json
+++ b/contributors/agents.json
@@ -1,5 +1,13 @@
 {
-  "agents": [],
+  "agents": [
+    {
+      "github_username": "raushankumar14445-cpu",
+      "model": "claude-3-5-sonnet",
+      "version": "20241022",
+      "pr_number": null,
+      "issue_number": 11
+    }
+  ],
   "last_updated": "2026-06-03",
-  "total_contributions": 0
+  "total_contributions": 1
 }

--- a/scripts/update-leaderboard.test.ts
+++ b/scripts/update-leaderboard.test.ts
@@ -1,0 +1,140 @@
+import { describe, it, expect, beforeEach } from "vitest";
+import {
+  Leaderboard,
+  loadLeaderboard,
+  saveLeaderboard,
+  incrementUser,
+  isAlreadyCounted,
+  getContributor,
+} from "./update-leaderboard";
+import { writeFileSync, unlinkSync, existsSync } from "fs";
+import { join } from "path";
+import { tmpdir } from "os";
+
+describe("Leaderboard Unit Tests", () => {
+  let board: Leaderboard;
+  const TEST_PATH = join(tmpdir(), "test-leaderboard.json");
+
+  beforeEach(() => {
+    board = {};
+    // Clean up test file if it exists
+    if (existsSync(TEST_PATH)) {
+      try {
+        unlinkSync(TEST_PATH);
+      } catch {
+        // ignore
+      }
+    }
+  });
+
+  describe("incrementUser()", () => {
+    it("should increment an existing contributor", () => {
+      board["alice"] = 5;
+      incrementUser(board, "alice");
+      expect(board["alice"]).toBe(6);
+    });
+
+    it("should add a new contributor with count 1", () => {
+      incrementUser(board, "bob");
+      expect(board["bob"]).toBe(1);
+    });
+
+    it("should handle empty username gracefully", () => {
+      incrementUser(board, "");
+      expect(board[""]).toBeUndefined();
+    });
+
+    it("should handle multiple increments correctly", () => {
+      incrementUser(board, "carol");
+      incrementUser(board, "carol");
+      incrementUser(board, "carol");
+      expect(board["carol"]).toBe(3);
+    });
+
+    it("should be case-sensitive with usernames", () => {
+      incrementUser(board, "Alice");
+      incrementUser(board, "alice");
+      expect(board["Alice"]).toBe(1);
+      expect(board["alice"]).toBe(1);
+    });
+  });
+
+  describe("isAlreadyCounted()", () => {
+    it("should return true when PR is already counted", () => {
+      const commits = [
+        "chore: update leaderboard for PR #42",
+        "fix: resolve sorting issue",
+      ];
+      expect(isAlreadyCounted(42, commits)).toBe(true);
+    });
+
+    it("should return false when PR is not counted", () => {
+      const commits = [
+        "fix: resolve sorting issue",
+        "feat: add new feature",
+      ];
+      expect(isAlreadyCounted(99, commits)).toBe(false);
+    });
+
+    it("should return false with empty commits list", () => {
+      expect(isAlreadyCounted(1, [])).toBe(false);
+    });
+
+    it("should not match partial commit messages", () => {
+      const commits = ["chore: update leaderboard for PR #123 (second attempt)"];
+      expect(isAlreadyCounted(123, commits)).toBe(false);
+    });
+  });
+
+  describe("getContributor()", () => {
+    it("should lowercase and trim the username", () => {
+      expect(getContributor("  Alice  ")).toBe("alice");
+    });
+
+    it("should handle already clean usernames", () => {
+      expect(getContributor("bob")).toBe("bob");
+    });
+
+    it("should return 'unknown' for empty input", () => {
+      expect(getContributor("")).toBe("unknown");
+    });
+  });
+
+  describe("loadLeaderboard()", () => {
+    it("should return empty object when file does not exist", () => {
+      const result = loadLeaderboard("/nonexistent/path.json");
+      expect(result).toEqual({});
+    });
+
+    it("should load and parse existing leaderboard", () => {
+      writeFileSync(TEST_PATH, JSON.stringify({ alice: 3, bob: 7 }), "utf-8");
+      const result = loadLeaderboard(TEST_PATH);
+      expect(result).toEqual({ alice: 3, bob: 7 });
+    });
+
+    it("should return empty object on corrupt JSON", () => {
+      writeFileSync(TEST_PATH, "not valid json", "utf-8");
+      const result = loadLeaderboard(TEST_PATH);
+      expect(result).toEqual({});
+    });
+  });
+
+  describe("saveLeaderboard()", () => {
+    it("should save leaderboard to file", () => {
+      const data = { alice: 1, bob: 2 };
+      saveLeaderboard(data, TEST_PATH);
+      const saved = JSON.parse(
+        require("fs").readFileSync(TEST_PATH, "utf-8")
+      );
+      expect(saved).toEqual(data);
+    });
+
+    it("should handle empty leaderboard", () => {
+      saveLeaderboard({}, TEST_PATH);
+      const saved = JSON.parse(
+        require("fs").readFileSync(TEST_PATH, "utf-8")
+      );
+      expect(saved).toEqual({});
+    });
+  });
+});

--- a/scripts/update-leaderboard.ts
+++ b/scripts/update-leaderboard.ts
@@ -1,0 +1,64 @@
+/**
+ * Leaderboard update script for tracking contributor points.
+ * Each merged PR increments the contributor's score by 1.
+ */
+
+import { readFileSync, writeFileSync, existsSync } from "fs";
+import { join, dirname } from "path";
+import { fileURLToPath } from "url";
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = dirname(__filename);
+
+export interface Leaderboard {
+  [contributor: string]: number;
+}
+
+const LEADERBOARD_PATH = join(__dirname, "..", "leaderboard.json");
+
+/**
+ * Load the leaderboard from the JSON file.
+ * Returns an empty object if the file doesn't exist.
+ */
+export function loadLeaderboard(path: string = LEADERBOARD_PATH): Leaderboard {
+  if (!existsSync(path)) return {};
+  try {
+    return JSON.parse(readFileSync(path, "utf-8"));
+  } catch {
+    return {};
+  }
+}
+
+/**
+ * Save the leaderboard to the JSON file.
+ */
+export function saveLeaderboard(board: Leaderboard, path: string = LEADERBOARD_PATH): void {
+  writeFileSync(path, JSON.stringify(board, null, 2) + "\n");
+}
+
+/**
+ * Increment the contribution count for a user.
+ */
+export function incrementUser(board: Leaderboard, user: string): Leaderboard {
+  if (!user) return board;
+  board[user] = (board[user] || 0) + 1;
+  return board;
+}
+
+/**
+ * Check if a PR has already been counted by looking at recent commit messages.
+ */
+export function isAlreadyCounted(
+  prNumber: number,
+  recentCommits: string[] = []
+): boolean {
+  const pattern = \`chore: update leaderboard for PR #\${prNumber}\`;
+  return recentCommits.some((msg) => msg.trim() === pattern);
+}
+
+/**
+ * Get the contributor name from a GitHub username or PR author field.
+ */
+export function getContributor(prAuthor: string): string {
+  return (prAuthor || "unknown").toLowerCase().trim();
+}


### PR DESCRIPTION
## Summary
Adds unit tests for the leaderboard update script covering both new and existing contributors.

## Changes
- `scripts/update-leaderboard.ts` — Extracted leaderboard logic into testable functions
- `scripts/update-leaderboard.test.ts` — 15 unit tests covering all functions
- `contributors/agents.json` — Registered agent

## Test Coverage
- `incrementUser()` — existing, new, empty, multiple, case sensitivity
- `isAlreadyCounted()` — counted, not counted, empty, partial match
- `getContributor()` — trimming, lowercasing, empty fallback
- `loadLeaderboard()` — missing file, valid JSON, corrupt JSON
- `saveLeaderboard()` — normal data, empty data

Closes #11