### PR TITLE
[agent] Validate user creation input

### DIFF
--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -7,7 +7,7 @@
   "main": "src/index.ts",
   "scripts": {
     "dev": "tsx src/index.ts",
-    "test": "echo \"No API tests configured yet\"",
+    "test": "tsx scripts/validate-user-input.ts",
     "lint": "echo \"No API lint configured yet\""
   },
   "dependencies": {

--- a/apps/api/scripts/validate-user-input.ts
+++ b/apps/api/scripts/validate-user-input.ts
@@ -1,0 +1,76 @@
+import assert from "node:assert/strict";
+
+import app from "../src/app";
+
+const server = app.listen(0);
+
+function baseUrl() {
+  const address = server.address();
+  assert(address && typeof address === "object");
+  return `http://127.0.0.1:${address.port}`;
+}
+
+async function readJson(response: Response) {
+  return response.json() as Promise<Record<string, unknown>>;
+}
+
+async function main() {
+  const root = baseUrl();
+
+  const health = await fetch(`${root}/health`);
+  assert.equal(health.status, 200);
+  assert.equal(health.headers.get("content-type")?.includes("application/json"), true);
+
+  const users = await fetch(`${root}/users`);
+  assert.equal(users.status, 200);
+  const usersJson = await readJson(users);
+  assert.deepEqual(usersJson.data, []);
+
+  const valid = await fetch(`${root}/users`, {
+    body: JSON.stringify({ email: "ADA@Example.COM", name: " Ada Lovelace " }),
+    headers: { "content-type": "application/json" },
+    method: "POST"
+  });
+  assert.equal(valid.status, 201);
+  const validJson = await readJson(valid);
+  assert.deepEqual(validJson.data, {
+    email: "ada@example.com",
+    id: "stub-user-id",
+    name: "Ada Lovelace"
+  });
+
+  const unknownField = await fetch(`${root}/users`, {
+    body: JSON.stringify({
+      email: "ada@example.com",
+      id: "client-owned-id",
+      name: "Ada",
+      role: "admin"
+    }),
+    headers: { "content-type": "application/json" },
+    method: "POST"
+  });
+  assert.equal(unknownField.status, 400);
+  const unknownFieldJson = await readJson(unknownField);
+  assert.equal(unknownFieldJson.error, "Invalid user payload");
+  assert.match(String(unknownFieldJson.message), /Unsupported user field/u);
+
+  const invalidEmail = await fetch(`${root}/users`, {
+    body: JSON.stringify({ email: "not-an-email", name: "Ada" }),
+    headers: { "content-type": "application/json" },
+    method: "POST"
+  });
+  assert.equal(invalidEmail.status, 400);
+
+  const missingName = await fetch(`${root}/users`, {
+    body: JSON.stringify({ email: "ada@example.com", name: "   " }),
+    headers: { "content-type": "application/json" },
+    method: "POST"
+  });
+  assert.equal(missingName.status, 400);
+}
+
+try {
+  await main();
+} finally {
+  server.close();
+}

--- a/apps/api/src/app.ts
+++ b/apps/api/src/app.ts
@@ -1,0 +1,15 @@
+import express from "express";
+
+import usersRouter from "./routes/users";
+
+const app = express();
+
+app.use(express.json());
+
+app.get("/health", (_req, res) => {
+  res.json({ status: "ok", service: "taskflow-api" });
+});
+
+app.use("/users", usersRouter);
+
+export default app;

--- a/apps/api/src/index.ts
+++ b/apps/api/src/index.ts
@@ -1,17 +1,6 @@
-import express from "express";
+import app from "./app";
 
-import usersRouter from "./routes/users";
-
-const app = express();
 const port = process.env.PORT || 4000;
-
-app.use(express.json());
-
-app.get("/health", (_req, res) => {
-  res.json({ status: "ok", service: "taskflow-api" });
-});
-
-app.use("/users", usersRouter);
 
 app.listen(port, () => {
   console.log(`TaskFlow API listening on port ${port}`);

--- a/apps/api/src/routes/users.ts
+++ b/apps/api/src/routes/users.ts
@@ -1,6 +1,15 @@
 import { Router } from "express";
 
 const router = Router();
+const allowedCreateUserFields = new Set(["email", "name"]);
+const emailPattern = /^[^\s@]+@[^\s@]+\.[^\s@]+$/u;
+
+function invalidUserInput(message: string) {
+  return {
+    error: "Invalid user payload",
+    message
+  };
+}
 
 router.get("/", (_req, res) => {
   res.json({
@@ -10,10 +19,36 @@ router.get("/", (_req, res) => {
 });
 
 router.post("/", (req, res) => {
+  if (!req.body || typeof req.body !== "object" || Array.isArray(req.body)) {
+    return res.status(400).json(invalidUserInput("Request body must be an object."));
+  }
+
+  const unknownFields = Object.keys(req.body).filter(
+    (field) => !allowedCreateUserFields.has(field)
+  );
+
+  if (unknownFields.length > 0) {
+    return res
+      .status(400)
+      .json(invalidUserInput(`Unsupported user field: ${unknownFields[0]}`));
+  }
+
+  const name = typeof req.body.name === "string" ? req.body.name.trim() : "";
+  const email = typeof req.body.email === "string" ? req.body.email.trim().toLowerCase() : "";
+
+  if (!name) {
+    return res.status(400).json(invalidUserInput("User name is required."));
+  }
+
+  if (!email || !emailPattern.test(email)) {
+    return res.status(400).json(invalidUserInput("A valid user email is required."));
+  }
+
   res.status(201).json({
     data: {
       id: "stub-user-id",
-      ...req.body
+      email,
+      name
     },
     message: "User creation is not implemented yet."
   });

--- a/contributors/agents.json
+++ b/contributors/agents.json
@@ -1,5 +1,13 @@
 {
-  "agents": [],
-  "last_updated": "2026-06-03",
-  "total_contributions": 0
+    "agents":  [
+                   {
+                       "github_username":  "Errordog2",
+                       "model":  "OpenAI GPT-5 Codex",
+                       "version":  "Codex desktop",
+                       "pr_number":  1725,
+                       "issue_number":  1699
+                   }
+               ],
+    "last_updated":  "2026-06-15",
+    "total_contributions":  1
 }


### PR DESCRIPTION
/claim #1699

## Summary

Adds focused validation for `POST /users` so the endpoint no longer spreads arbitrary `req.body` data into the response.

## Changes

- Accepts only `name` and `email` for user creation.
- Trims `name`, normalizes `email` to lowercase, and validates both fields.
- Rejects unsupported fields such as client-supplied `id` or `role` with HTTP 400.
- Extracts the Express app into `src/app.ts` so API behavior can be validated without starting a long-running server process.
- Replaces the placeholder API test script with a focused validation script covering `/health`, `GET /users`, valid `POST /users`, unsupported fields, invalid email, and blank name.

## Verification

- `npm test -w apps/api`
- `npx tsc --noEmit --module esnext --moduleResolution node --target ES2022 --lib ES2022,DOM --strict --esModuleInterop apps/api/src/app.ts apps/api/src/index.ts apps/api/src/routes/users.ts apps/api/scripts/validate-user-input.ts`
- `npm test --workspaces --if-present`
- `git diff --check`

Payment details can be shared privately after maintainer acceptance.