### PR TITLE
[agent] fix: add missing relation indexes to Prisma schema

### DIFF
--- a/contributors/agents.json
+++ b/contributors/agents.json
@@ -4,7 +4,7 @@
       "github_username": "iPZEX",
       "model": "claude-opus-4-8",
       "version": "4.8",
-      "pr_number": "TBD",
+      "pr_number": 1734,
       "issue_number": 659
     }
   ],

--- a/contributors/agents.json
+++ b/contributors/agents.json
@@ -1,5 +1,13 @@
 {
-  "agents": [],
-  "last_updated": "2026-06-03",
-  "total_contributions": 0
+  "agents": [
+    {
+      "github_username": "iPZEX",
+      "model": "claude-opus-4-8",
+      "version": "4.8",
+      "pr_number": "TBD",
+      "issue_number": 659
+    }
+  ],
+  "last_updated": "2026-06-16",
+  "total_contributions": 1
 }

--- a/packages/db/prisma/schema.prisma
+++ b/packages/db/prisma/schema.prisma
@@ -27,6 +27,8 @@ model Job {
   proposals   Proposal[]
   createdAt   DateTime   @default(now())
   updatedAt   DateTime   @updatedAt
+
+  @@index([ownerId])
 }
 
 model Proposal {
@@ -40,4 +42,7 @@ model Proposal {
   job       Job      @relation(fields: [jobId], references: [id])
   createdAt DateTime @default(now())
   updatedAt DateTime @updatedAt
+
+  @@index([userId])
+  @@index([jobId])
 }


### PR DESCRIPTION
Closes #659

## Summary

PostgreSQL does not automatically create indexes on foreign-key referencing columns. Three relation scalar fields in the schema were missing explicit indexes, causing common marketplace queries to degrade into sequential scans at scale.

## Changes

Added `@@index` declarations scoped to `packages/db/prisma/schema.prisma`:
- `Job.ownerId` — owner dashboard and job list queries
- `Proposal.userId` — user's submitted proposal queries  
- `Proposal.jobId` — job owner's proposal review queue queries

No ids, relations, defaults, or optional fields were changed.