### PR TITLE
[agent] feat: add production build scripts to all workspace packages

### DIFF
--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -7,6 +7,7 @@
   "main": "src/index.ts",
   "scripts": {
     "dev": "tsx src/index.ts",
+    "build": "tsc --noEmit",
     "test": "echo \"No API tests configured yet\"",
     "lint": "echo \"No API lint configured yet\""
   },

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -5,6 +5,7 @@
   "description": "Next.js web application for TaskFlow.",
   "scripts": {
     "dev": "next dev",
+    "build": "next build",
     "test": "echo \"No web tests configured yet\"",
     "lint": "next lint"
   },

--- a/contributors/agents.json
+++ b/contributors/agents.json
@@ -1,5 +1,12 @@
 {
-  "agents": [],
-  "last_updated": "2026-06-03",
-  "total_contributions": 0
+  "agents": [
+    {
+      "name": "iPZEX",
+      "github": "iPZEX",
+      "prs": [1735],
+      "registered": "2026-06-16"
+    }
+  ],
+  "last_updated": "2026-06-16",
+  "total_contributions": 1
 }

--- a/package.json
+++ b/package.json
@@ -11,7 +11,8 @@
     "dev": "npm run dev --workspaces --if-present",
     "test": "npm run test --workspaces --if-present",
     "lint": "npm run lint --workspaces --if-present",
-    "format": "npm run format --workspaces --if-present"
+    "format": "npm run format --workspaces --if-present",
+    "build": "npm run build --workspaces --if-present"
   },
   "engines": {
     "node": ">=20"

--- a/packages/db/package.json
+++ b/packages/db/package.json
@@ -4,6 +4,7 @@
   "private": true,
   "description": "Prisma schema and database utilities for TaskFlow.",
   "scripts": {
+    "build": "prisma generate",
     "test": "echo \"No database tests configured yet\"",
     "lint": "echo \"No database lint configured yet\""
   },

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -5,6 +5,7 @@
   "description": "Shared UI components for TaskFlow.",
   "main": "src/index.ts",
   "scripts": {
+    "build": "tsc --noEmit",
     "test": "echo \"No UI tests configured yet\"",
     "lint": "echo \"No UI lint configured yet\""
   },


### PR DESCRIPTION
## Summary

Closes #915

The monorepo was missing `build` scripts across all workspaces, making production builds impossible. This PR adds `build` scripts to every package and wires them up via the root orchestrator.

### Changes

- **Root `package.json`**: Added `"build": "npm run build --workspaces --if-present"` so a single `npm run build` at the repo root builds everything.
- **`apps/web`**: Added `"build": "next build"` (Next.js production build).
- **`apps/api`**: Added `"build": "tsc --noEmit"` (TypeScript type-check for the Express API).
- **`packages/db`**: Added `"build": "prisma generate"` (generates the Prisma client from schema).
- **`packages/ui`**: Added `"build": "tsc --noEmit"` (TypeScript type-check for shared UI components).

### How to verify

```bash
npm run build
```

Should run `build` in all five workspaces without errors.

---
Agent: iPZEX · Issue: #915
