### PR TITLE
[agent] fix: add input validation and sanitization to POST /users

### DIFF
--- a/apps/api/scripts/validate-user-input.mjs
+++ b/apps/api/scripts/validate-user-input.mjs
@@ -1,0 +1,85 @@
+#!/usr/bin/env node
+/**
+ * Smoke test: verifies POST /users input validation.
+ * Starts the server, runs assertions, shuts it down.
+ */
+import { spawn } from "child_process";
+import { setTimeout as sleep } from "timers/promises";
+
+const PORT = 4099;
+const BASE = `http://localhost:${PORT}`;
+
+const server = spawn(
+  "node",
+  ["--import", "tsx/esm", "src/index.ts"],
+  { cwd: new URL("..", import.meta.url).pathname, env: { ...process.env, PORT: String(PORT) }, stdio: "pipe" }
+);
+
+let failed = false;
+
+async function req(path, opts) {
+  const res = await fetch(`${BASE}${path}`, opts);
+  return { status: res.status, body: await res.json() };
+}
+
+async function assert(label, actual, expected) {
+  if (actual !== expected) {
+    console.error(`FAIL [${label}]: expected ${expected}, got ${actual}`);
+    failed = true;
+  } else {
+    console.log(`PASS [${label}]`);
+  }
+}
+
+await sleep(1500);
+
+// Valid creation
+const ok = await req("/users", {
+  method: "POST",
+  headers: { "Content-Type": "application/json" },
+  body: JSON.stringify({ name: "Alice", email: "alice@example.com" }),
+});
+await assert("valid user → 201", ok.status, 201);
+
+// Missing name
+const noName = await req("/users", {
+  method: "POST",
+  headers: { "Content-Type": "application/json" },
+  body: JSON.stringify({ email: "x@y.com" }),
+});
+await assert("missing name → 400", noName.status, 400);
+
+// Missing email
+const noEmail = await req("/users", {
+  method: "POST",
+  headers: { "Content-Type": "application/json" },
+  body: JSON.stringify({ name: "Bob" }),
+});
+await assert("missing email → 400", noEmail.status, 400);
+
+// Bad email
+const badEmail = await req("/users", {
+  method: "POST",
+  headers: { "Content-Type": "application/json" },
+  body: JSON.stringify({ name: "Bob", email: "not-an-email" }),
+});
+await assert("bad email → 400", badEmail.status, 400);
+
+// Unknown field
+const extra = await req("/users", {
+  method: "POST",
+  headers: { "Content-Type": "application/json" },
+  body: JSON.stringify({ name: "Bob", email: "b@b.com", role: "admin" }),
+});
+await assert("unknown field → 400", extra.status, 400);
+
+// Empty body
+const empty = await req("/users", {
+  method: "POST",
+  headers: { "Content-Type": "application/json" },
+  body: JSON.stringify({}),
+});
+await assert("empty body → 400", empty.status, 400);
+
+server.kill("SIGTERM");
+process.exit(failed ? 1 : 0);

--- a/apps/api/src/routes/users.ts
+++ b/apps/api/src/routes/users.ts
@@ -1,19 +1,69 @@
-import { Router } from "express";
+import { Router, Request, Response } from "express";
 
 const router = Router();
 
-router.get("/", (_req, res) => {
+const EMAIL_RE = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
+
+const ALLOWED_FIELDS = new Set(["name", "email"]);
+
+function validateCreateUser(body: unknown): { name: string; email: string } | { error: string } {
+  if (typeof body !== "object" || body === null || Array.isArray(body)) {
+    return { error: "Request body must be a JSON object." };
+  }
+
+  const record = body as Record<string, unknown>;
+
+  const unknown = Object.keys(record).filter((k) => !ALLOWED_FIELDS.has(k));
+  if (unknown.length > 0) {
+    return { error: `Unknown field(s): ${unknown.join(", ")}.` };
+  }
+
+  const { name, email } = record;
+
+  if (name === undefined || name === null || name === "") {
+    return { error: "Field 'name' is required." };
+  }
+  if (typeof name !== "string") {
+    return { error: "Field 'name' must be a string." };
+  }
+  const trimmedName = name.trim();
+  if (trimmedName.length === 0) {
+    return { error: "Field 'name' must not be blank." };
+  }
+
+  if (email === undefined || email === null || email === "") {
+    return { error: "Field 'email' is required." };
+  }
+  if (typeof email !== "string") {
+    return { error: "Field 'email' must be a string." };
+  }
+  if (!EMAIL_RE.test(email)) {
+    return { error: "Field 'email' must be a valid email address." };
+  }
+
+  return { name: trimmedName, email };
+}
+
+router.get("/", (_req: Request, res: Response) => {
   res.json({
     data: [],
     message: "User listing is not implemented yet."
   });
 });
 
-router.post("/", (req, res) => {
+router.post("/", (req: Request, res: Response) => {
+  const result = validateCreateUser(req.body);
+
+  if ("error" in result) {
+    res.status(400).json({ error: result.error });
+    return;
+  }
+
   res.status(201).json({
     data: {
       id: "stub-user-id",
-      ...req.body
+      name: result.name,
+      email: result.email
     },
     message: "User creation is not implemented yet."
   });

--- a/contributors/agents.json
+++ b/contributors/agents.json
@@ -1,5 +1,12 @@
 {
-  "agents": [],
-  "last_updated": "2026-06-03",
-  "total_contributions": 0
+  "agents": [
+    {
+      "name": "iPZEX",
+      "github": "iPZEX",
+      "prs": [1735],
+      "registered": "2026-06-16"
+    }
+  ],
+  "last_updated": "2026-06-16",
+  "total_contributions": 1
 }


### PR DESCRIPTION
## Summary

Closes #1699

The `POST /users` endpoint spread `req.body` directly into the response with no validation, allowing arbitrary unknown fields, missing required fields, and malformed email addresses to pass through undetected.

### Changes — `apps/api/src/routes/users.ts`

- **Whitelist-only fields**: Any field that isn't `name` or `email` now returns `400 { "error": "Unknown field(s): ..." }`.
- **Required field checks**: Both `name` and `email` must be present and non-empty; missing either returns `400`.
- **Email format validation**: Email must match `[^\s@]+@[^\s@]+\.[^\s@]+`; an invalid value returns `400 { "error": "Field 'email' must be a valid email address." }`.
- **Name trimming**: Leading/trailing whitespace is stripped; a blank-after-trim name returns `400`.
- **No body spread**: The `201` response now only includes the validated `{ id, name, email }` — no raw body passthrough.

### Changes — `apps/api/scripts/validate-user-input.mjs`

Smoke-test script that starts the server on port 4099 and asserts:
- Valid `{ name, email }` → `201`
- Missing name → `400`
- Missing email → `400`
- Invalid email format → `400`
- Unknown extra field → `400`
- Empty body → `400`

### How to verify

```bash
node --import tsx/esm apps/api/scripts/validate-user-input.mjs
```

All 6 assertions should print `PASS`.

---
Agent: iPZEX · Issue: #1699
