### PR TITLE
[agent] fix: return JSON 404 for unknown API routes

### DIFF
--- a/apps/api/scripts/validate-404.mjs
+++ b/apps/api/scripts/validate-404.mjs
@@ -1,0 +1,37 @@
+#!/usr/bin/env node
+import { spawn } from "child_process";
+import { setTimeout as sleep } from "timers/promises";
+
+const PORT = 4098;
+const BASE = `http://localhost:${PORT}`;
+
+const server = spawn(
+  "node",
+  ["--import", "tsx/esm", "src/index.ts"],
+  { cwd: new URL("..", import.meta.url).pathname, env: { ...process.env, PORT: String(PORT) }, stdio: "pipe" }
+);
+
+let failed = false;
+
+async function assert(label, actual, expected) {
+  if (actual !== expected) {
+    console.error(`FAIL [${label}]: expected ${expected}, got ${actual}`);
+    failed = true;
+  } else {
+    console.log(`PASS [${label}]`);
+  }
+}
+
+await sleep(1500);
+
+const res = await fetch(`${BASE}/unknown-route`);
+const body = await res.json();
+await assert("unknown route status 404", res.status, 404);
+await assert("body has error field", typeof body.error, "string");
+await assert("content-type is json", res.headers.get("content-type")?.includes("application/json"), true);
+
+const health = await fetch(`${BASE}/health`);
+await assert("/health still 200", health.status, 200);
+
+server.kill("SIGTERM");
+process.exit(failed ? 1 : 0);

--- a/apps/api/src/index.ts
+++ b/apps/api/src/index.ts
@@ -1,4 +1,4 @@
-import express from "express";
+import express, { Request, Response, NextFunction } from "express";
 
 import usersRouter from "./routes/users";
 
@@ -7,11 +7,16 @@ const port = process.env.PORT || 4000;
 
 app.use(express.json());
 
-app.get("/health", (_req, res) => {
+app.get("/health", (_req: Request, res: Response) => {
   res.json({ status: "ok", service: "taskflow-api" });
 });
 
 app.use("/users", usersRouter);
+
+// JSON 404 fallback for unknown routes
+app.use((_req: Request, res: Response, _next: NextFunction) => {
+  res.status(404).json({ error: "Not found." });
+});
 
 app.listen(port, () => {
   console.log(`TaskFlow API listening on port ${port}`);


### PR DESCRIPTION
## Summary

Closes #1632

Unknown API routes fell through to Express's default HTML 404 handler, breaking API clients that expect consistent JSON responses.

### Change — `apps/api/src/index.ts`

Added a catch-all 404 middleware after all route registrations:

```ts
app.use((_req, res, _next) => {
  res.status(404).json({ error: "Not found." });
});
```

This ensures any unmatched route returns `application/json` with status `404` instead of Express's default HTML error page. Existing `/health` and `/users` behavior is unchanged.

### Change — `apps/api/scripts/validate-404.mjs`

Smoke-test script that starts the server and asserts:
- Unknown route → `404` with `content-type: application/json`
- `/health` still returns `200`

### How to verify

```bash
node --import tsx/esm apps/api/scripts/validate-404.mjs
```

All 4 assertions should print `PASS`.

---
Agent: iPZEX · Issue: #1632
