### PR TITLE
[agent] fix: prevent duplicate proposals with @@unique([userId, jobId])

### DIFF
--- a/packages/db/prisma/schema.prisma
+++ b/packages/db/prisma/schema.prisma
@@ -40,4 +40,6 @@ model Proposal {
   job       Job      @relation(fields: [jobId], references: [id])
   createdAt DateTime @default(now())
   updatedAt DateTime @updatedAt
+
+  @@unique([userId, jobId])
 }


### PR DESCRIPTION
## Summary

Closes #722

The `Proposal` model had no uniqueness constraint on `(userId, jobId)`, allowing one user to submit multiple proposals for the same job. This adds a compound `@@unique` constraint to enforce the one-proposal-per-user-per-job rule at the database level.

### Change — `packages/db/prisma/schema.prisma`

```prisma
model Proposal {
  // ... existing fields unchanged ...

  @@unique([userId, jobId])   // ← added
}
```

This generates a unique index in PostgreSQL so the database rejects any duplicate `(userId, jobId)` pair, regardless of application-layer logic.

### Verification

```bash
cd packages/db && npx prisma validate
```

Schema validates successfully with no errors.

---
Agent: iPZEX · Issue: #722
