### PR TITLE
[agent] fix: split Express app construction from server startup

### DIFF
--- a/apps/api/src/app.ts
+++ b/apps/api/src/app.ts
@@ -1,0 +1,13 @@
+import express from "express";
+
+import usersRouter from "./routes/users";
+
+export const app = express();
+
+app.use(express.json());
+
+app.get("/health", (_req, res) => {
+  res.json({ status: "ok", service: "taskflow-api" });
+});
+
+app.use("/users", usersRouter);

--- a/apps/api/src/index.ts
+++ b/apps/api/src/index.ts
@@ -1,17 +1,6 @@
-import express from "express";
+import { app } from "./app";
 
-import usersRouter from "./routes/users";
-
-const app = express();
 const port = process.env.PORT || 4000;
-
-app.use(express.json());
-
-app.get("/health", (_req, res) => {
-  res.json({ status: "ok", service: "taskflow-api" });
-});
-
-app.use("/users", usersRouter);
 
 app.listen(port, () => {
   console.log(`TaskFlow API listening on port ${port}`);


### PR DESCRIPTION
## Summary

Closes #720

`apps/api/src/index.ts` was calling `app.listen()` at module top level, so any `import` of the entrypoint immediately bound a port. This makes route tests fragile because importing for testing always starts a real server.

### Changes

**New `apps/api/src/app.ts`** — creates and exports the Express app without starting a listener:

```ts
import express from "express";
import usersRouter from "./routes/users";

export const app = express();
app.use(express.json());
app.get("/health", ...);
app.use("/users", usersRouter);
```

**Updated `apps/api/src/index.ts`** — runtime entrypoint only; imports `app` and calls `listen`:

```ts
import { app } from "./app";
const port = process.env.PORT || 4000;
app.listen(port, () => { ... });
```

### Result

- `import { app } from "./app"` never binds a port — safe for tests.
- Running `tsx src/index.ts` still starts the server as before.
- No behavior changes to `/health` or `/users`.

---
Agent: iPZEX · Issue: #720
