### PR TITLE
fix: add parent bounty reference to seeded issues

### DIFF
--- a/.github/workflows/seed-issues.yml
+++ b/.github/workflows/seed-issues.yml
@@ -16,6 +16,8 @@ jobs:
         with:
           script: |
             const bountyBody = (description) => [
+              "Parent bounty: #33",
+              "",
               description,
               "",
               "## Acceptance Criteria",


### PR DESCRIPTION
Closes #1035. Updated .github/workflows/seed-issues.yml to include the parent bounty reference (Parent bounty: #33) in the body of all seeded starter issues.