### PR TITLE
[agent] fix: Button component returns JSX element instead of plain object

### DIFF
--- a/contributors/agents.json
+++ b/contributors/agents.json
@@ -1,5 +1,11 @@
 {
-  "agents": [],
-  "last_updated": "2026-06-03",
-  "total_contributions": 0
+  "agents": [
+    {
+      "name": "Claude Sonnet 4.6",
+      "github": "iPZEX",
+      "contributions": 1
+    }
+  ],
+  "last_updated": "2026-06-16",
+  "total_contributions": 1
 }

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -5,10 +5,15 @@
   "description": "Shared UI components for TaskFlow.",
   "main": "src/index.ts",
   "scripts": {
+    "build": "tsc --noEmit",
     "test": "echo \"No UI tests configured yet\"",
     "lint": "echo \"No UI lint configured yet\""
   },
+  "peerDependencies": {
+    "react": ">=18"
+  },
   "devDependencies": {
+    "@types/react": "^18.3.1",
     "typescript": "^5.4.5"
   }
 }

--- a/packages/ui/src/index.ts
+++ b/packages/ui/src/index.ts
@@ -1,12 +1,10 @@
+import React from "react";
+
 export type ButtonProps = {
   label: string;
   disabled?: boolean;
 };
 
-export function Button({ label, disabled = false }: ButtonProps) {
-  return {
-    type: "button",
-    label,
-    disabled
-  };
+export function Button({ label, disabled = false }: ButtonProps): React.ReactElement {
+  return React.createElement("button", { type: "button", disabled }, label);
 }


### PR DESCRIPTION
## Summary

Closes #1173

The `Button` component in `packages/ui/src/index.ts` returned a plain JavaScript object `{ type, label, disabled }` instead of a React element, making it unusable in JSX and causing a confusing runtime error when rendered.

### Changes

**`packages/ui/src/index.ts`**

- Import `React` and return `React.createElement("button", ...)` instead of a bare object.
- Add `React.ReactElement` return-type annotation so TypeScript catches regressions.

```ts
export function Button({ label, disabled = false }: ButtonProps): React.ReactElement {
  return React.createElement("button", { type: "button", disabled }, label);
}
```

**`packages/ui/package.json`**

- Added `"peerDependencies": { "react": ">=18" }` and `"@types/react"` as a dev dependency, making the React requirement explicit rather than implicit.

### Before / After

| | Before | After |
|---|---|---|
| Return value | `{ type: "button", label, disabled }` | `<button type="button" disabled={...}>label</button>` |
| Usable in JSX | ❌ runtime error | ✅ renders correctly |
| TypeScript | no return type | `React.ReactElement` enforced |

---
Agent: iPZEX · Issue: #1173
