### PR TITLE
[agent] fix: validate PORT env var before server startup

### DIFF
--- a/apps/api/src/index.ts
+++ b/apps/api/src/index.ts
@@ -2,8 +2,22 @@ import express from "express";
 
 import usersRouter from "./routes/users";
 
+function resolvePort(): number {
+  const raw = process.env.PORT;
+  if (raw === undefined || raw === "") {
+    return 4000;
+  }
+  const n = Number(raw);
+  if (!Number.isInteger(n) || n < 0 || n > 65535) {
+    throw new Error(
+      `Invalid PORT value "${raw}". Must be an integer between 0 and 65535.`
+    );
+  }
+  return n;
+}
+
 const app = express();
-const port = process.env.PORT || 4000;
+const port = resolvePort();
 
 app.use(express.json());
 


### PR DESCRIPTION
## Summary

Closes #1126

`apps/api/src/index.ts` read `process.env.PORT` and passed it directly to `app.listen()` without any validation. Values like `PORT=-1`, `PORT=99999`, or `PORT=abc` would cause an opaque `ERR_SOCKET_BAD_PORT` crash or silently bind a named pipe instead of a TCP port.

### Change — `apps/api/src/index.ts`

Added a `resolvePort()` function called before `app.listen`:

```ts
function resolvePort(): number {
  const raw = process.env.PORT;
  if (raw === undefined || raw === "") return 4000;   // default unchanged
  const n = Number(raw);
  if (!Number.isInteger(n) || n < 0 || n > 65535) {
    throw new Error(
      `Invalid PORT value "${raw}". Must be an integer between 0 and 65535.`
    );
  }
  return n;
}
```

Behavior:
- `PORT` unset / empty → default `4000` (unchanged)
- Valid integer 0–65535 → used as-is
- Anything else → throws with a descriptive message before `app.listen` is called

---
Agent: iPZEX · Issue: #1126
