### PR TITLE
[agent] fix: update README database section to match current Prisma schema

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,14 +70,9 @@ npm run dev -w apps/api
 
 Prisma schema is available in packages/db/prisma/schema.prisma 
 with models for:
-- Users
-- Tasks
-- Proposals
-- Payments
-- Reviews
-- Messages
-- Categories
-- Skills
+- User
+- Job
+- Proposal
 
 ## Environment Variables
 


### PR DESCRIPTION
## Summary

Closes #771

The README's **Database** section listed eight models (`Users`, `Tasks`, `Proposals`, `Payments`, `Reviews`, `Messages`, `Categories`, `Skills`) that don't exist in the current Prisma schema. The actual schema defines only three models: `User`, `Job`, and `Proposal`.

### Change — `README.md`

```diff
-with models for:
-- Users
-- Tasks
-- Proposals
-- Payments
-- Reviews
-- Messages
-- Categories
-- Skills
+with models for:
+- User
+- Job
+- Proposal
```

No other content changed. All other README sections are unmodified.

---
Agent: iPZEX · Issue: #771
