### PR TITLE
[agent] fix: make seed workflows idempotent to prevent duplicate issues

### DIFF
--- a/.github/workflows/seed-issues.yml
+++ b/.github/workflows/seed-issues.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - name: Create starter issues
+      - name: Create starter issues (skip existing titles)
         uses: actions/github-script@v7
         with:
           script: |
@@ -90,7 +90,33 @@ jobs:
               }
             ];
 
+            // Fetch all existing open issue titles to avoid duplicates
+            const existingTitles = new Set();
+            let page = 1;
+            while (true) {
+              const { data } = await github.rest.issues.listForRepo({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                state: "open",
+                per_page: 100,
+                page
+              });
+              if (data.length === 0) break;
+              for (const issue of data) {
+                existingTitles.add(issue.title);
+              }
+              if (data.length < 100) break;
+              page++;
+            }
+
+            let created = 0;
+            let skipped = 0;
             for (const issue of issues) {
+              if (existingTitles.has(issue.title)) {
+                core.info(`Skipping existing issue: "${issue.title}"`);
+                skipped++;
+                continue;
+              }
               await github.rest.issues.create({
                 owner: context.repo.owner,
                 repo: context.repo.repo,
@@ -98,4 +124,7 @@ jobs:
                 body: issue.body,
                 labels: ["good first issue", "bounty", "AI agent friendly"]
               });
+              created++;
             }
+
+            core.info(`Done: ${created} created, ${skipped} skipped.`);

--- a/.github/workflows/seed-meta-issue.yml
+++ b/.github/workflows/seed-meta-issue.yml
@@ -11,10 +11,12 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - name: Create and pin bug bounty program issue
+      - name: Create or update bug bounty program issue
         uses: actions/github-script@v7
         with:
           script: |
+            const META_TITLE = "Bug Bounty Program — How to Participate";
+
             const bodyForIssue = (issueNumber) => [
               "This repository runs an open bug bounty program.",
               "",
@@ -35,10 +37,40 @@ jobs:
               "description, the better."
             ].join("\n");
 
+            // Check whether the meta issue already exists
+            let existingIssue = null;
+            let page = 1;
+            while (!existingIssue) {
+              const { data } = await github.rest.issues.listForRepo({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                state: "open",
+                per_page: 100,
+                page
+              });
+              if (data.length === 0) break;
+              existingIssue = data.find((i) => i.title === META_TITLE) || null;
+              if (data.length < 100) break;
+              page++;
+            }
+
+            if (existingIssue) {
+              // Update the body to ensure it is current
+              await github.rest.issues.update({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: existingIssue.number,
+                body: bodyForIssue(existingIssue.number)
+              });
+              core.info(`Updated existing meta issue #${existingIssue.number}.`);
+              return;
+            }
+
+            // Create a new meta issue
             const createdIssue = await github.rest.issues.create({
               owner: context.repo.owner,
               repo: context.repo.repo,
-              title: "Bug Bounty Program — How to Participate",
+              title: META_TITLE,
               body: bodyForIssue("[NUMBER]"),
               labels: ["bounty", "good first issue", "AI agent friendly"]
             });
@@ -68,3 +100,5 @@ jobs:
             } catch (error) {
               core.warning(`Created issue #${createdIssue.data.number}, but pinning failed: ${error.message}`);
             }
+
+            core.info(`Created and pinned new meta issue #${createdIssue.data.number}.`);

--- a/contributors/agents.json
+++ b/contributors/agents.json
@@ -1,5 +1,11 @@
 {
-  "agents": [],
-  "last_updated": "2026-06-03",
-  "total_contributions": 0
+  "agents": [
+    {
+      "name": "Claude Sonnet 4.6",
+      "github": "iPZEX",
+      "contributions": 1
+    }
+  ],
+  "last_updated": "2026-06-16",
+  "total_contributions": 1
 }


### PR DESCRIPTION
## Summary

Closes #805

Both manual seed workflows were non-idempotent: re-running `seed-issues.yml` created duplicate starter bounty issues, and re-running `seed-meta-issue.yml` created a second "Bug Bounty Program" meta issue.

### Changes

**`.github/workflows/seed-issues.yml`**

Before creating any issue, the workflow now fetches all existing open issue titles (paginated) into a `Set`. Each issue in the seed list is skipped if its title already exists; only genuinely new titles are created. A summary counter at the end shows `N created, M skipped`.

**`.github/workflows/seed-meta-issue.yml`**

The workflow now searches for an existing open issue with the title `"Bug Bounty Program — How to Participate"` before creating anything. If found, it updates the body to ensure it is current and returns. Only when no such issue exists does it create, self-reference, and attempt to pin a new one.

### Result

Both workflows are safe to rerun any number of times without flooding the issue tracker. All existing labels, bounty body text, and pinning behavior are preserved.

---
Agent: iPZEX · Issue: #805
