### PR TITLE
[agent] fix: update README to accurately reflect implemented frontend pages and API routes

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,35 +15,19 @@ with a modern TypeScript-first architecture.
 
 ## Frontend
 
-The web app includes pages for:
-- Landing
-- Task boards and task detail
-- Create a task
-- User profiles and user search
-- Client and freelancer dashboards
-- Messaging
-- Notifications
-- Settings
-- Billing
-- Admin panel
+The web app currently includes:
+- Landing page (`/`)
+
+Additional pages are planned but not yet implemented.
 
 ## Backend
 
-The API includes:
-- Auth routes (register, login, OAuth callback, JWT refresh)
-- CRUD routes for users, tasks, and proposals
-- Payments routes (Stripe-focused service placeholder)
-- Reviews, messaging, notifications
-- File uploads and search
-- Admin routes
+The API currently includes:
+- `GET /health` — service health check
+- `GET /users` — user listing stub
+- `POST /users` — user creation stub
 
-Backend architecture follows:
-- Middleware layer (auth, rate limiting, error handling)
-- Controller layer
-- Service layer
-- Route layer
-- Validation schemas (Zod)
-- Utility helpers
+Additional routes are planned but not yet implemented.
 
 ## Getting Started
 
@@ -70,14 +54,9 @@ npm run dev -w apps/api
 
 Prisma schema is available in packages/db/prisma/schema.prisma 
 with models for:
-- Users
-- Tasks
-- Proposals
-- Payments
-- Reviews
-- Messages
-- Categories
-- Skills
+- User
+- Job
+- Proposal
 
 ## Environment Variables
 


### PR DESCRIPTION
## Summary

Closes #773

The README's **Frontend** and **Backend** sections described many pages and routes that don't exist in the current codebase, misleading contributors about the implemented surface area.

### Evidence

- `apps/web/src/app/` contains only `page.tsx` (the landing page).
- `apps/api/src/index.ts` exposes only `GET /health` and mounts `/users`.
- `apps/api/src/routes/users.ts` implements only `GET /users` and `POST /users` stubs.

### Changes — `README.md`

**Frontend** — removed non-existent pages (task boards, dashboards, messaging, billing, admin panel, etc.) and replaced with the accurate list: landing page only, with a note that more are planned.

**Backend** — removed non-existent routes (auth, payments, reviews, file uploads, search, admin) and replaced with the actual three endpoints. Also removed the false architecture description (controller/service/Zod layers that don't exist).

**Database** — updated the model list from the eight non-existent models to the three real ones (`User`, `Job`, `Proposal`), resolving overlap with #771.

No code was changed — only documentation.

---
Agent: iPZEX · Issue: #773
