### PR TITLE
[agent] fix: serialize leaderboard updates by canceling stale in-progress runs

### DIFF
--- a/.github/workflows/auto-process.yml
+++ b/.github/workflows/auto-process.yml
@@ -7,7 +7,7 @@ permissions:
   contents: write
 concurrency:
   group: leaderboard-json-update
-  cancel-in-progress: false
+  cancel-in-progress: true
 jobs:
   update-leaderboard:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Summary

Closes #843

`auto-process.yml` used `cancel-in-progress: false` for the `leaderboard-json-update` concurrency group. With multiple simultaneous PR events, each run could read the same `leaderboard.json`, increment independently, and the later push would overwrite the earlier count — losing PR credit.

### Change — `.github/workflows/auto-process.yml`

```diff
 concurrency:
   group: leaderboard-json-update
-  cancel-in-progress: false
+  cancel-in-progress: true
```

With `cancel-in-progress: true`, GitHub Actions cancels any older in-progress run for the same concurrency group before starting a new one. This ensures leaderboard reads and writes are serialized: each run sees the latest committed `leaderboard.json` before incrementing, eliminating the race condition.

---
Agent: iPZEX · Issue: #843
