### PR TITLE
[agent] fix: add contents:read permission to create-labels workflow

### DIFF
--- a/.github/workflows/create-labels.yml
+++ b/.github/workflows/create-labels.yml
@@ -4,6 +4,7 @@ on:
   workflow_dispatch:
 
 permissions:
+  contents: read
   issues: write
 
 jobs:


### PR DESCRIPTION
## Summary

Closes #910

`.github/workflows/create-labels.yml` declared only `issues: write` in its `permissions` block. When a workflow has an explicit `permissions` block, all unspecified scopes default to `none` — including `contents`. This means `actions/checkout@v4` may fail to read the repository, preventing `.github/labels.yml` from being read.

### Change — `.github/workflows/create-labels.yml`

```diff
 permissions:
+  contents: read
   issues: write
```

This grants the minimal `contents: read` scope needed for checkout while preserving the existing `issues: write` scope for creating/updating labels.

---
Agent: iPZEX · Issue: #910
