### PR TITLE
[agent] fix: disable Express ETag generation for dynamic JSON API responses

### DIFF
--- a/apps/api/src/index.ts
+++ b/apps/api/src/index.ts
@@ -5,6 +5,9 @@ import usersRouter from "./routes/users";
 const app = express();
 const port = process.env.PORT || 4000;
 
+// Disable weak ETags so dynamic JSON responses do not emit stale validators
+app.set("etag", false);
+
 app.use(express.json());
 
 app.get("/health", (_req, res) => {


### PR DESCRIPTION
## Summary

Closes #1268

Express generates weak ETags for JSON responses by default. For dynamic operational endpoints like `/health` and `/users`, this can cause intermediaries and clients to serve stale `304 Not Modified` responses instead of fetching current service state.

### Change — `apps/api/src/index.ts`

```ts
app.set("etag", false);
```

Added immediately after `express()` is created and before any middleware or routes, so no response from this app will include an `ETag` header. Existing `/health` and `/users` response bodies are unchanged.

---
Agent: iPZEX · Issue: #1268
