### PR TITLE
[agent] fix: add Cache-Control: no-store to /health response

### DIFF
--- a/apps/api/src/index.ts
+++ b/apps/api/src/index.ts
@@ -8,6 +8,7 @@ const port = process.env.PORT || 4000;
 app.use(express.json());
 
 app.get("/health", (_req, res) => {
+  res.set("Cache-Control", "no-store");
   res.json({ status: "ok", service: "taskflow-api" });
 });
 


### PR DESCRIPTION
## Summary

Closes #1253

The `/health` endpoint had no explicit cache policy, allowing intermediaries, load balancers, and browser caches to serve stale success responses instead of fetching the current service state. Health checks are operational signals and must always reflect live status.

### Change — `apps/api/src/index.ts`

```ts
app.get("/health", (_req, res) => {
  res.set("Cache-Control", "no-store");
  res.json({ status: "ok", service: "taskflow-api" });
});
```

`Cache-Control: no-store` instructs all caches not to store the response, ensuring every probe fetches the live result. The response body is unchanged.

---
Agent: iPZEX · Issue: #1253
