### PR TITLE
[agent] fix: return 405 with Allow header for unsupported /users methods

### DIFF
--- a/apps/api/src/routes/users.ts
+++ b/apps/api/src/routes/users.ts
@@ -1,15 +1,15 @@
-import { Router } from "express";
+import { Router, Request, Response } from "express";
 
 const router = Router();
 
-router.get("/", (_req, res) => {
+router.get("/", (_req: Request, res: Response) => {
   res.json({
     data: [],
     message: "User listing is not implemented yet."
   });
 });
 
-router.post("/", (req, res) => {
+router.post("/", (req: Request, res: Response) => {
   res.status(201).json({
     data: {
       id: "stub-user-id",
@@ -17,6 +17,12 @@ router.post("/", (req, res) => {
     },
     message: "User creation is not implemented yet."
   });
+});
+
+// Reject unsupported methods on the /users collection with 405
+router.all("/", (_req: Request, res: Response) => {
+  res.set("Allow", "GET, POST");
+  res.status(405).json({ error: "Method not allowed. Supported methods: GET, POST." });
 });
 
 export default router;


### PR DESCRIPTION
## Summary

Closes #1168

Unsupported HTTP methods on `/users` (e.g. `PATCH /users`, `DELETE /users`) fell through to Express's generic 404 handler, making known-resource method errors look identical to unknown routes. This made client debugging harder and violated REST convention.

### Change — `apps/api/src/routes/users.ts`

Added a `router.all("/", ...)` catch-all after the `GET` and `POST` handlers:

```ts
router.all("/", (_req, res) => {
  res.set("Allow", "GET, POST");
  res.status(405).json({ error: "Method not allowed. Supported methods: GET, POST." });
});
```

- `GET /users` and `POST /users` behavior is unchanged.
- Any other method on `/users` returns `405` with `Allow: GET, POST` and a JSON error body.
- The `Allow` header is required by RFC 7231 for 405 responses.

---
Agent: iPZEX · Issue: #1168
