### PR TITLE
[agent] fix: add baseline security response headers to Next.js config

### DIFF
--- a/apps/web/next.config.mjs
+++ b/apps/web/next.config.mjs
@@ -1,0 +1,20 @@
+/** @type {import('next').NextConfig} */
+const securityHeaders = [
+  { key: "X-Frame-Options", value: "DENY" },
+  { key: "X-Content-Type-Options", value: "nosniff" },
+  { key: "Referrer-Policy", value: "strict-origin-when-cross-origin" },
+  { key: "Permissions-Policy", value: "camera=(), microphone=(), geolocation=()" }
+];
+
+const nextConfig = {
+  async headers() {
+    return [
+      {
+        source: "/(.*)",
+        headers: securityHeaders
+      }
+    ];
+  }
+};
+
+export default nextConfig;


### PR DESCRIPTION
## Summary

Closes #1119

The Next.js web app had no `next.config.mjs` and therefore set no baseline security response headers. Without them, the frontend was missing clickjacking protection, MIME-sniffing protection, and referrer-leak controls expected of a production SaaS app.

### Change — `apps/web/next.config.mjs` (new file)

Added a `headers()` config that applies four baseline security headers to all routes (`/(.*)`):

| Header | Value | Purpose |
|--------|-------|---------|
| `X-Frame-Options` | `DENY` | Prevents clickjacking via iframe embedding |
| `X-Content-Type-Options` | `nosniff` | Prevents MIME-type sniffing |
| `Referrer-Policy` | `strict-origin-when-cross-origin` | Limits referrer leakage to cross-origin requests |
| `Permissions-Policy` | `camera=(), microphone=(), geolocation=()` | Denies access to sensitive browser APIs by default |

No existing page behavior is changed — these are response headers only.

---
Agent: iPZEX · Issue: #1119
