### PR TITLE
[agent] fix: add graceful SIGTERM/SIGINT shutdown to API server

### DIFF
--- a/apps/api/src/index.ts
+++ b/apps/api/src/index.ts
@@ -13,6 +13,27 @@ app.get("/health", (_req, res) => {
 
 app.use("/users", usersRouter);
 
-app.listen(port, () => {
+const server = app.listen(port, () => {
   console.log(`TaskFlow API listening on port ${port}`);
 });
+
+const SHUTDOWN_TIMEOUT_MS = 10_000;
+
+function shutdown(signal: string): void {
+  console.log(`Received ${signal}. Graceful shutdown started.`);
+  server.close((err) => {
+    if (err) {
+      console.error("Error during shutdown:", err);
+      process.exit(1);
+    }
+    console.log("Server closed. Exiting.");
+    process.exit(0);
+  });
+  setTimeout(() => {
+    console.error("Shutdown timeout exceeded. Forcing exit.");
+    process.exit(1);
+  }, SHUTDOWN_TIMEOUT_MS).unref();
+}
+
+process.on("SIGTERM", () => shutdown("SIGTERM"));
+process.on("SIGINT", () => shutdown("SIGINT"));


### PR DESCRIPTION
## Summary

Closes #1437

`apps/api/src/index.ts` called `app.listen()` but never handled `SIGTERM` or `SIGINT`. On container shutdown or deploy restarts the process would exit immediately, dropping any in-flight requests.

### Change — `apps/api/src/index.ts`

Retained the `http.Server` instance from `app.listen()` and added a `shutdown()` helper that:

1. Calls `server.close()` to stop accepting new connections and waits for existing requests to drain.
2. Arms a 10-second forced-exit timeout (`.unref()` so it doesn't keep the process alive if `server.close()` resolves cleanly).
3. Exits with code `0` on clean shutdown or `1` on error/timeout.

Both `SIGTERM` (container/orchestrator) and `SIGINT` (Ctrl-C / local dev) are handled.

```ts
const server = app.listen(port, () => { ... });

function shutdown(signal: string): void {
  server.close((err) => { ... });
  setTimeout(() => { process.exit(1); }, 10_000).unref();
}

process.on("SIGTERM", () => shutdown("SIGTERM"));
process.on("SIGINT",  () => shutdown("SIGINT"));
```

---
Agent: iPZEX · Issue: #1437
