### PR TITLE
fix: split API app startup from construction

### DIFF
--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -7,7 +7,7 @@
   "main": "src/index.ts",
   "scripts": {
     "dev": "tsx src/index.ts",
-    "test": "echo \"No API tests configured yet\"",
+    "test": "node --import tsx --test \"src/**/*.test.ts\"",
     "lint": "echo \"No API lint configured yet\""
   },
   "dependencies": {

--- a/apps/api/src/app.test.ts
+++ b/apps/api/src/app.test.ts
@@ -1,0 +1,23 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import express from "express";
+
+test("app module can be imported without starting a listener", async () => {
+  const originalListen = express.application.listen;
+  let listenCalls = 0;
+
+  express.application.listen = function patchedListen(...args: Parameters<typeof originalListen>) {
+    listenCalls += 1;
+    return originalListen.apply(this, args);
+  };
+
+  try {
+    const { app } = await import("./app");
+
+    assert.equal(listenCalls, 0);
+    assert.equal(typeof app.listen, "function");
+  } finally {
+    express.application.listen = originalListen;
+  }
+});

--- a/apps/api/src/app.ts
+++ b/apps/api/src/app.ts
@@ -1,0 +1,15 @@
+import express from "express";
+
+import usersRouter from "./routes/users";
+
+export const app = express();
+
+app.use(express.json());
+
+app.get("/health", (_req, res) => {
+  res.json({ status: "ok", service: "taskflow-api" });
+});
+
+app.use("/users", usersRouter);
+
+export default app;

--- a/apps/api/src/index.ts
+++ b/apps/api/src/index.ts
@@ -1,17 +1,6 @@
-import express from "express";
+import { app } from "./app";
 
-import usersRouter from "./routes/users";
-
-const app = express();
 const port = process.env.PORT || 4000;
-
-app.use(express.json());
-
-app.get("/health", (_req, res) => {
-  res.json({ status: "ok", service: "taskflow-api" });
-});
-
-app.use("/users", usersRouter);
 
 app.listen(port, () => {
   console.log(`TaskFlow API listening on port ${port}`);

--- a/contributors/agents.json
+++ b/contributors/agents.json
@@ -4,7 +4,7 @@
       "github_username": "LukastGeorge",
       "model": "GPT-5 Codex",
       "version": "2026-06-16",
-      "pr_number": 0,
+      "pr_number": 1773,
       "issue_number": 1771
     }
   ],

--- a/contributors/agents.json
+++ b/contributors/agents.json
@@ -1,5 +1,13 @@
 {
-  "agents": [],
-  "last_updated": "2026-06-03",
-  "total_contributions": 0
+  "agents": [
+    {
+      "github_username": "LukastGeorge",
+      "model": "GPT-5 Codex",
+      "version": "2026-06-16",
+      "pr_number": 0,
+      "issue_number": 1771
+    }
+  ],
+  "last_updated": "2026-06-16",
+  "total_contributions": 1
 }


### PR DESCRIPTION
## Summary

- Split Express app construction into `apps/api/src/app.ts`.
- Keep `apps/api/src/index.ts` focused on runtime `app.listen(...)` startup.
- Add a focused Node test proving the app module imports without calling `listen`.
- Update the API workspace test script so the new test runs in `npm test`.

Closes #1771.

## Validation

- `npm test -w apps/api`
- `npm test`
- `node -e "JSON.parse(require('fs').readFileSync('contributors/agents.json','utf8')); console.log('agents json ok')"`
- `git diff --check`
