### PR TITLE
fix: JSON 404 fallback for unknown routes

### DIFF
--- a/apps/api/src/index.ts
+++ b/apps/api/src/index.ts
@@ -13,6 +13,10 @@ app.get("/health", (_req, res) => {
 
 app.use("/users", usersRouter);
 
+app.use((_req, res) => {
+  res.status(404).json({ error: "Not Found" });
+});
+
 app.listen(port, () => {
   console.log(`TaskFlow API listening on port ${port}`);
 });

--- a/apps/api/validate-404.ts
+++ b/apps/api/validate-404.ts
@@ -1,0 +1,46 @@
+import { spawn } from "child_process";
+
+async function run() {
+  console.log("Starting server...");
+  const server = spawn("npm", ["run", "dev"], {
+    stdio: "pipe",
+  });
+
+  server.stdout.on("data", (data) => {
+    console.log(`[server stdout]: ${data}`);
+  });
+
+  server.stderr.on("data", (data) => {
+    console.error(`[server stderr]: ${data}`);
+  });
+
+  // Wait for server to start
+  await new Promise((resolve) => setTimeout(resolve, 2000));
+
+  console.log("Testing unknown route...");
+  try {
+    const res = await fetch("http://localhost:4000/some-unknown-route");
+    const text = await res.text();
+    const isJson = res.headers.get("content-type")?.includes("application/json");
+
+    console.log(`Status: ${res.status}`);
+    console.log(`Content-Type: ${res.headers.get("content-type")}`);
+    console.log(`Body: ${text}`);
+
+    if (res.status === 404 && isJson) {
+      console.log("✅ Validation passed: Unknown route returned 404 JSON.");
+      server.kill();
+      process.exit(0);
+    } else {
+      console.error("❌ Validation failed.");
+      server.kill();
+      process.exit(1);
+    }
+  } catch (error) {
+    console.error("❌ Request failed:", error);
+    server.kill();
+    process.exit(1);
+  }
+}
+
+run();


### PR DESCRIPTION
Closes #1632 

This PR adds a global 404 fallback middleware to the Express API so that unknown routes properly return a JSON error instead of Express's default HTML response. Existing routes (\/health\ and \/users\) remain fully functional.

It also includes \pps/api/validate-404.ts\ to prove the expected behavior.

Twitter: @HELIOOOSSSSS
Wallet: 0x43991A9dC8Ddf492eab6E55685644c2cb9B001D2