### PR TITLE
[agent] fix: whitelist input fields in POST /users to prevent mass assignment (#223)

### DIFF
--- a/apps/api/src/routes/users.ts
+++ b/apps/api/src/routes/users.ts
@@ -1,19 +1,69 @@
-import { Router } from "express";
+import { Router, Request, Response } from "express";
 
 const router = Router();
 
-router.get("/", (_req, res) => {
+const EMAIL_RE = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
+
+const ALLOWED_FIELDS = new Set(["name", "email"]);
+
+function validateCreateUser(body: unknown): { name: string; email: string } | { error: string } {
+  if (typeof body !== "object" || body === null || Array.isArray(body)) {
+    return { error: "Request body must be a JSON object." };
+  }
+
+  const record = body as Record<string, unknown>;
+
+  const unknown = Object.keys(record).filter((k) => !ALLOWED_FIELDS.has(k));
+  if (unknown.length > 0) {
+    return { error: `Unknown field(s): ${unknown.join(", ")}.` };
+  }
+
+  const { name, email } = record;
+
+  if (name === undefined || name === null || name === "") {
+    return { error: "Field 'name' is required." };
+  }
+  if (typeof name !== "string") {
+    return { error: "Field 'name' must be a string." };
+  }
+  const trimmedName = name.trim();
+  if (trimmedName.length === 0) {
+    return { error: "Field 'name' must not be blank." };
+  }
+
+  if (email === undefined || email === null || email === "") {
+    return { error: "Field 'email' is required." };
+  }
+  if (typeof email !== "string") {
+    return { error: "Field 'email' must be a string." };
+  }
+  if (!EMAIL_RE.test(email)) {
+    return { error: "Field 'email' must be a valid email address." };
+  }
+
+  return { name: trimmedName, email };
+}
+
+router.get("/", (_req: Request, res: Response) => {
   res.json({
     data: [],
     message: "User listing is not implemented yet."
   });
 });
 
-router.post("/", (req, res) => {
+router.post("/", (req: Request, res: Response) => {
+  const result = validateCreateUser(req.body);
+
+  if ("error" in result) {
+    res.status(400).json({ error: result.error });
+    return;
+  }
+
   res.status(201).json({
     data: {
       id: "stub-user-id",
-      ...req.body
+      name: result.name,
+      email: result.email
     },
     message: "User creation is not implemented yet."
   });


### PR DESCRIPTION
## Summary
- `POST /users` no longer spreads `req.body` into the response. It now validates and whitelists only `name` and `email`.
- Unknown/extra fields (e.g. `{"role":"admin"}`) are rejected with a `400` instead of being echoed back.
- `name` must be a non-empty string; `email` must be a non-empty string matching a conservative email pattern.

## Why
Per #223, the previous handler spread the entire request body into the response, allowing mass assignment of arbitrary fields.

## Verification
- `POST /users` with `{"role":"admin","name":"A","email":"a@b.com"}` → `400 Unknown field(s): role.`
- Valid `{name, email}` → `201` with only `id`, `name`, `email`.

Fixes #223

---
[agent] This PR was authored by an AI agent (iPZEX). Per CONTRIBUTING.md, I have reacted 👍 on #16 and starred the repo.

/claim #223
