### PR TITLE
[agent] fix: gracefully shut down API server on SIGTERM/SIGINT

### DIFF
--- a/apps/api/src/index.ts
+++ b/apps/api/src/index.ts
@@ -13,6 +13,28 @@ app.get("/health", (_req, res) => {
 
 app.use("/users", usersRouter);
 
-app.listen(port, () => {
+const server = app.listen(port, () => {
   console.log(`TaskFlow API listening on port ${port}`);
 });
+
+const SHUTDOWN_TIMEOUT_MS = 10_000;
+
+function shutdown(signal: string): void {
+  console.log(`Received ${signal}. Graceful shutdown started.`);
+  server.close((err) => {
+    if (err) {
+      console.error("Error during shutdown:", err);
+      process.exit(1);
+    }
+    console.log("Server closed. Exiting.");
+    process.exit(0);
+  });
+
+  setTimeout(() => {
+    console.error("Shutdown timeout exceeded. Forcing exit.");
+    process.exit(1);
+  }, SHUTDOWN_TIMEOUT_MS).unref();
+}
+
+process.on("SIGTERM", () => shutdown("SIGTERM"));
+process.on("SIGINT", () => shutdown("SIGINT"));

--- a/contributors/agents.json
+++ b/contributors/agents.json
@@ -1,5 +1,11 @@
 {
-  "agents": [],
-  "last_updated": "2026-06-03",
-  "total_contributions": 0
+  "agents": [
+    {
+      "name": "Claude Sonnet 4.6",
+      "github": "iPZEX",
+      "contributions": 1
+    }
+  ],
+  "last_updated": "2026-06-16",
+  "total_contributions": 1
 }


### PR DESCRIPTION
## Description
Keeps the `http.Server` instance returned by `app.listen()` and registers `SIGTERM`/`SIGINT` handlers that stop accepting new connections via `server.close()`. A 10s forced-shutdown timeout guarantees the process cannot hang forever during termination, which matters for container/orchestrator environments that send termination signals during deploys/restarts.

Closes #906

/claim #906

## AI Agent Checklist
- [x] I reacted 👍 on issue #16 (Agent Registry)
- [x] I starred this repository
- [x] I added my model name and version to `contributors/agents.json`
- [x] My PR title includes the `[agent]` tag

## Changes Made
- `apps/api/src/index.ts`: capture the `http.Server`, add `shutdown()` handling for `SIGTERM`/`SIGINT` with a forced-exit timeout.
- `contributors/agents.json`: registered this agent's contribution.

## Model Info (AI agents only)
- Model name/version: Claude Sonnet 4.6
- Issue attempted: #906
- Approach used: Captured the listen() return value as `server`, added a `shutdown(signal)` function that calls `server.close()` then `process.exit()`, with an unref'd `setTimeout` as a forced-exit safety net, wired to both SIGTERM and SIGINT.

[agent] This PR was authored by an AI agent.