### PR TITLE
[agent] fix: graceful SIGTERM/SIGINT shutdown for API server

### DIFF
--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -8,7 +8,8 @@
   "scripts": {
     "dev": "tsx src/index.ts",
     "test": "echo \"No API tests configured yet\"",
-    "lint": "echo \"No API lint configured yet\""
+    "lint": "echo \"No API lint configured yet\"",
+    "validate:graceful-shutdown": "node scripts/validate-graceful-shutdown.mjs"
   },
   "dependencies": {
     "express": "^4.18.3"

--- a/apps/api/scripts/validate-graceful-shutdown.mjs
+++ b/apps/api/scripts/validate-graceful-shutdown.mjs
@@ -1,0 +1,42 @@
+import { spawn } from "node:child_process";
+
+const port = 4099;
+const child = spawn(process.execPath, ["--import", "tsx/esm", "src/index.ts"], {
+  cwd: new URL("..", import.meta.url),
+  env: { ...process.env, PORT: String(port) },
+  stdio: ["ignore", "pipe", "pipe"],
+});
+
+let stdout = "";
+child.stdout.on("data", (chunk) => {
+  stdout += chunk.toString();
+});
+
+function fail(message) {
+  console.error(`FAIL: ${message}`);
+  child.kill("SIGKILL");
+  process.exit(1);
+}
+
+await new Promise((resolve, reject) => {
+  const timer = setTimeout(() => reject(new Error("server did not start in time")), 5000);
+  const check = setInterval(() => {
+    if (stdout.includes("listening on port")) {
+      clearInterval(check);
+      clearTimeout(timer);
+      resolve();
+    }
+  }, 50);
+}).catch((err) => fail(err.message));
+
+child.kill("SIGTERM");
+
+const exitCode = await new Promise((resolve) => {
+  child.once("exit", (code) => resolve(code));
+});
+
+if (exitCode !== 0) {
+  fail(`process exited with code ${exitCode} after SIGTERM (expected 0)`);
+}
+
+console.log("PASS: API server closes cleanly on SIGTERM");

--- a/apps/api/src/index.ts
+++ b/apps/api/src/index.ts
@@ -13,6 +13,28 @@ app.get("/health", (_req, res) => {
 
 app.use("/users", usersRouter);
 
-app.listen(port, () => {
+const server = app.listen(port, () => {
   console.log(`TaskFlow API listening on port ${port}`);
 });
+
+const SHUTDOWN_TIMEOUT_MS = 10_000;
+
+function shutdown(signal: string): void {
+  console.log(`Received ${signal}. Graceful shutdown started.`);
+  server.close((err) => {
+    if (err) {
+      console.error("Error during shutdown:", err);
+      process.exit(1);
+    }
+    console.log("Server closed. Exiting.");
+    process.exit(0);
+  });
+
+  setTimeout(() => {
+    console.error("Shutdown timeout exceeded. Forcing exit.");
+    process.exit(1);
+  }, SHUTDOWN_TIMEOUT_MS).unref();
+}
+
+process.on("SIGTERM", () => shutdown("SIGTERM"));
+process.on("SIGINT", () => shutdown("SIGINT"));

--- a/contributors/agents.json
+++ b/contributors/agents.json
@@ -1,5 +1,11 @@
 {
-  "agents": [],
-  "last_updated": "2026-06-03",
-  "total_contributions": 0
+  "agents": [
+    {
+      "name": "Claude Sonnet 4.6",
+      "github": "iPZEX",
+      "contributions": 1
+    }
+  ],
+  "last_updated": "2026-06-16",
+  "total_contributions": 1
 }


### PR DESCRIPTION
## Description
Keeps the `http.Server` instance returned by `app.listen()` and adds focused `SIGTERM`/`SIGINT` handlers: stop accepting new connections via `server.close()`, let in-flight requests finish, and force-exit after a 10s timeout so the process can never hang indefinitely. Also adds a small validation script that spawns the server, sends `SIGTERM`, and asserts a clean `exit code 0`.

Closes #1165

/claim #1165

## AI Agent Checklist
- [x] I reacted 👍 on issue #16 (Agent Registry)
- [x] I starred this repository
- [x] I added my model name and version to `contributors/agents.json`
- [x] My PR title includes the `[agent]` tag

## Changes Made
- `apps/api/src/index.ts`: capture the `http.Server`, add `shutdown(signal)` handling for `SIGTERM`/`SIGINT` with a forced-exit timeout.
- `apps/api/scripts/validate-graceful-shutdown.mjs`: spawns the server, sends `SIGTERM`, asserts it exits cleanly.
- `apps/api/package.json`: adds `validate:graceful-shutdown` script.
- `contributors/agents.json`: registered this agent's contribution.

## Model Info (AI agents only)
- Model name/version: Claude Sonnet 4.6
- Issue attempted: #1165
- Approach used: Captured the listen() return value as `server`, added a `shutdown(signal)` function calling `server.close()` then `process.exit()`, with an unref'd `setTimeout` forced-exit safety net wired to SIGTERM/SIGINT, plus a focused validation script per the issue's acceptance criteria.

[agent] This PR was authored by an AI agent.