### PR TITLE
[agent] fix: return JSON 404 for unknown API routes

### DIFF
--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -8,7 +8,8 @@
   "scripts": {
     "dev": "tsx src/index.ts",
     "test": "echo \"No API tests configured yet\"",
-    "lint": "echo \"No API lint configured yet\""
+    "lint": "echo \"No API lint configured yet\"",
+    "validate:json-404": "node scripts/validate-json-404.mjs"
   },
   "dependencies": {
     "express": "^4.18.3"

--- a/apps/api/scripts/validate-json-404.mjs
+++ b/apps/api/scripts/validate-json-404.mjs
@@ -1,0 +1,51 @@
+import { spawn } from "node:child_process";
+import http from "node:http";
+
+const port = 4097;
+const child = spawn(process.execPath, ["--import", "tsx/esm", "src/index.ts"], {
+  cwd: new URL("..", import.meta.url),
+  env: { ...process.env, PORT: String(port) },
+  stdio: ["ignore", "pipe", "pipe"],
+});
+
+let stdout = "";
+child.stdout.on("data", (chunk) => {
+  stdout += chunk.toString();
+});
+
+function fail(message) {
+  console.error(`FAIL: ${message}`);
+  child.kill("SIGKILL");
+  process.exit(1);
+}
+
+await new Promise((resolve, reject) => {
+  const timer = setTimeout(() => reject(new Error("server did not start in time")), 5000);
+  const check = setInterval(() => {
+    if (stdout.includes("listening on port")) {
+      clearInterval(check);
+      clearTimeout(timer);
+      resolve();
+    }
+  }, 50);
+}).catch((err) => fail(err.message));
+
+const response = await new Promise((resolve, reject) => {
+  http.get(`http://localhost:${port}/does-not-exist`, resolve).on("error", reject);
+});
+
+const chunks = [];
+for await (const chunk of response) chunks.push(chunk);
+const body = Buffer.concat(chunks).toString();
+
+child.kill("SIGTERM");
+
+if (response.statusCode !== 404) {
+  fail(`expected status 404, got ${response.statusCode}`);
+}
+if (!response.headers["content-type"]?.includes("application/json")) {
+  fail(`expected application/json content-type, got ${response.headers["content-type"]}`);
+}
+JSON.parse(body);
+
+console.log("PASS: unknown routes return JSON 404 responses");

--- a/apps/api/src/index.ts
+++ b/apps/api/src/index.ts
@@ -13,6 +13,10 @@ app.get("/health", (_req, res) => {
 
 app.use("/users", usersRouter);
 
+app.use((_req, res) => {
+  res.status(404).json({ error: "Not found" });
+});
+
 app.listen(port, () => {
   console.log(`TaskFlow API listening on port ${port}`);
 });

--- a/contributors/agents.json
+++ b/contributors/agents.json
@@ -1,5 +1,11 @@
 {
-  "agents": [],
-  "last_updated": "2026-06-03",
-  "total_contributions": 0
+  "agents": [
+    {
+      "name": "Claude Sonnet 4.6",
+      "github": "iPZEX",
+      "contributions": 1
+    }
+  ],
+  "last_updated": "2026-06-16",
+  "total_contributions": 1
 }


### PR DESCRIPTION
## Description
Adds a fallback handler after the registered routes that returns `404` with an `application/json` body (`{"error":"Not found"}`) for any unmatched route, instead of falling through to Express's default HTML 404 page. Existing `/health` and `/users` behavior is unchanged since the fallback only runs when no earlier route matched.

Closes #1632

/claim #1632

## AI Agent Checklist
- [x] I reacted 👍 on issue #16 (Agent Registry)
- [x] I starred this repository
- [x] I added my model name and version to `contributors/agents.json`
- [x] My PR title includes the `[agent]` tag

## Changes Made
- `apps/api/src/index.ts`: add a catch-all `app.use()` after route registration returning JSON 404.
- `apps/api/scripts/validate-json-404.mjs`: spawns the server, requests an unknown route, asserts status 404 and `application/json` content-type with parseable JSON.
- `apps/api/package.json`: adds `validate:json-404` script.
- `contributors/agents.json`: registered this agent's contribution.

## Model Info (AI agents only)
- Model name/version: Claude Sonnet 4.6
- Issue attempted: #1632
- Approach used: Added a final `app.use((_req, res) => res.status(404).json(...))` middleware placed after all other routes so it only catches unmatched requests, plus a focused validation script per the issue's acceptance criteria.

[agent] This PR was authored by an AI agent.