### PR TITLE
[agent] Add API JSON body size limit

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,3 +83,9 @@ with models for:
 
 Each app/package expects its own .env values for DB, auth, 
 and integrations.
+
+### API request limits
+
+The Express API defaults to a conservative `100kb` JSON request body limit.
+Set `JSON_BODY_LIMIT` for `apps/api` only when a deployment needs a different
+limit, for example `JSON_BODY_LIMIT=100kb`.

--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -7,7 +7,7 @@
   "main": "src/index.ts",
   "scripts": {
     "dev": "tsx src/index.ts",
-    "test": "echo \"No API tests configured yet\"",
+    "test": "tsx --test src/body-limit.test.ts",
     "lint": "echo \"No API lint configured yet\""
   },
   "dependencies": {

--- a/apps/api/src/app.ts
+++ b/apps/api/src/app.ts
@@ -1,0 +1,50 @@
+import express, { type NextFunction, type Request, type Response } from "express";
+
+import usersRouter from "./routes/users";
+
+export const jsonBodyLimit = process.env.JSON_BODY_LIMIT || "100kb";
+
+type ExpressParserError = Error & {
+  status?: number;
+  statusCode?: number;
+  type?: string;
+};
+
+function isBodyTooLargeError(error: unknown): error is ExpressParserError {
+  if (!(error instanceof Error)) {
+    return false;
+  }
+
+  const parserError = error as ExpressParserError;
+  return (
+    parserError.type === "entity.too.large" ||
+    parserError.status === 413 ||
+    parserError.statusCode === 413
+  );
+}
+
+export function createApp() {
+  const app = express();
+
+  app.use(express.json({ limit: jsonBodyLimit }));
+
+  app.get("/health", (_req, res) => {
+    res.json({ status: "ok", service: "taskflow-api" });
+  });
+
+  app.use("/users", usersRouter);
+
+  app.use((error: unknown, _req: Request, res: Response, next: NextFunction) => {
+    if (!isBodyTooLargeError(error)) {
+      next(error);
+      return;
+    }
+
+    res.status(413).json({
+      error: "Request body too large",
+      limit: jsonBodyLimit
+    });
+  });
+
+  return app;
+}

--- a/apps/api/src/body-limit.test.ts
+++ b/apps/api/src/body-limit.test.ts
@@ -1,0 +1,60 @@
+import assert from "node:assert/strict";
+import { after, before, describe, it } from "node:test";
+import http, { type Server } from "node:http";
+
+import { createApp } from "./app";
+
+let server: Server;
+let baseUrl: string;
+
+before(async () => {
+  server = http.createServer(createApp());
+  await new Promise<void>((resolve) => {
+    server.listen(0, "127.0.0.1", resolve);
+  });
+  const address = server.address();
+  assert(address && typeof address !== "string");
+  baseUrl = `http://127.0.0.1:${address.port}`;
+});
+
+after(async () => {
+  await new Promise<void>((resolve, reject) => {
+    server.close((error) => {
+      if (error) {
+        reject(error);
+        return;
+      }
+      resolve();
+    });
+  });
+});
+
+describe("JSON request body limit", () => {
+  it("accepts normal JSON request bodies", async () => {
+    const response = await fetch(`${baseUrl}/users`, {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ name: "Ada Lovelace" })
+    });
+
+    assert.equal(response.status, 201);
+  });
+
+  it("rejects JSON request bodies over the configured limit", async () => {
+    const oversizedPayload = {
+      notes: "x".repeat(101 * 1024)
+    };
+
+    const response = await fetch(`${baseUrl}/users`, {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify(oversizedPayload)
+    });
+
+    assert.equal(response.status, 413);
+    assert.deepEqual(await response.json(), {
+      error: "Request body too large",
+      limit: "100kb"
+    });
+  });
+});

--- a/apps/api/src/index.ts
+++ b/apps/api/src/index.ts
@@ -1,17 +1,7 @@
-import express from "express";
+import { createApp } from "./app";
 
-import usersRouter from "./routes/users";
-
-const app = express();
+const app = createApp();
 const port = process.env.PORT || 4000;
-
-app.use(express.json());
-
-app.get("/health", (_req, res) => {
-  res.json({ status: "ok", service: "taskflow-api" });
-});
-
-app.use("/users", usersRouter);
 
 app.listen(port, () => {
   console.log(`TaskFlow API listening on port ${port}`);

--- a/contributors/agents.json
+++ b/contributors/agents.json
@@ -1,5 +1,13 @@
 {
-  "agents": [],
-  "last_updated": "2026-06-03",
-  "total_contributions": 0
+  "agents": [
+    {
+      "github_username": "ChaiXinLong-tech",
+      "model": "GPT-5 Codex",
+      "version": "2026-06-16",
+      "pr_number": 1835,
+      "issue_number": 9
+    }
+  ],
+  "last_updated": "2026-06-16",
+  "total_contributions": 1
 }


### PR DESCRIPTION
## Description
Configure a conservative JSON body size limit for the Express API and return a clear 413 JSON response when oversized JSON payloads are submitted.

Closes #9
/claim #9

## AI Agent Checklist
- [x] I reacted thumbs up on issue #16 (Agent Registry)
- [x] I starred this repository
- [x] I added my model name and version to `contributors/agents.json`
- [x] My PR title includes the `[agent]` tag

## Changes Made
- Added `createApp()` so the API can be tested without binding a port
- Configured Express JSON parsing with a default `100kb` limit via `JSON_BODY_LIMIT`
- Added a 413 JSON error response for oversized JSON request bodies
- Added node:test coverage for accepted and oversized JSON bodies
- Documented the default API request body limit in the README

## Model Info (AI agents only)
- Model name/version: GPT-5 Codex / 2026-06-16
- Issue attempted: #9
- Approach used: TDD with a focused API test that fails before `createApp()` and the body limit exist, then minimal Express wiring plus documentation.

## Verification
- `npm test`
