### PR TITLE
feat(api): add 1MB request body size limit

### DIFF
--- a/apps/api/README.md
+++ b/apps/api/README.md
@@ -1,0 +1,36 @@
+﻿# Request Body Size Limit
+
+## Change Summary
+
+Configured a conservative JSON request body size limit on the Express app to prevent abuse from oversized payloads.
+
+## What Changed
+
+- `apps/api/src/index.ts`: Replaced `express.json()` with `express.json({ limit: "1mb" })`
+- All POST/PUT/PATCH requests with JSON bodies are now capped at **1 MB**
+- Returns `413 Payload Too Large` when the limit is exceeded
+
+## Why 1 MB?
+
+- Typical API payloads (user profiles, job postings, proposals) are well under 100 KB
+- 1 MB provides ample room for nested objects and arrays while protecting against DoS via oversized requests
+- Aligns with Express.js best practices for production APIs
+
+## Verification
+
+```bash
+# Start the API
+npm run dev --workspace=@taskflow/api
+
+# Test normal payload (should succeed)
+curl -X POST http://localhost:4000/users \
+  -H "Content-Type: application/json" \
+  -d '{"name": "Test", "email": "test@example.com"}'
+
+# Test oversized payload (should return 413)
+python3 -c "import json; print(json.dumps({'data': 'x' * 2000000}))" | \
+  curl -X POST http://localhost:4000/users \
+  -H "Content-Type: application/json" \
+  --data-binary @-
+# Expected: 413 Payload Too Large
+```

--- a/apps/api/src/index.ts
+++ b/apps/api/src/index.ts
@@ -1,11 +1,12 @@
-import express from "express";
+﻿import express from "express";
 
 import usersRouter from "./routes/users";
 
 const app = express();
 const port = process.env.PORT || 4000;
 
-app.use(express.json());
+// Limit request body size to prevent abuse (1 MB default)
+app.use(express.json({ limit: "1mb" }));
 
 app.get("/health", (_req, res) => {
   res.json({ status: "ok", service: "taskflow-api" });


### PR DESCRIPTION
## What Changed

- Configured express.json({ limit: '1mb' }) to prevent oversized JSON payloads
- All POST/PUT/PATCH requests are now capped at 1 MB
- Returns 413 Payload Too Large when the limit is exceeded

## Why 1 MB?

- Typical API payloads (user profiles, job postings, proposals) are well under 100 KB
- 1 MB provides ample room while protecting against DoS via oversized requests
- Aligns with Express.js best practices for production APIs

## Files Modified

- pps/api/src/index.ts — added body size limit
- pps/api/README.md — documentation with verification steps

## Linked Issue

Fixes #9