### PR TITLE
[agent] fix: add missing App Router root layout for web app

### DIFF
--- a/apps/web/src/app/layout.tsx
+++ b/apps/web/src/app/layout.tsx
@@ -1,0 +1,9 @@
+import type { ReactNode } from "react";
+
+export default function RootLayout({ children }: { children: ReactNode }) {
+  return (
+    <html lang="en">
+      <body>{children}</body>
+    </html>
+  );
+}

--- a/contributors/agents.json
+++ b/contributors/agents.json
@@ -1,5 +1,11 @@
 {
-  "agents": [],
-  "last_updated": "2026-06-03",
-  "total_contributions": 0
+  "agents": [
+    {
+      "name": "Claude Sonnet 4.6",
+      "github": "iPZEX",
+      "contributions": 1
+    }
+  ],
+  "last_updated": "2026-06-16",
+  "total_contributions": 1
 }


### PR DESCRIPTION
## Description
`apps/web/src/app/page.tsx` exists without the required Next.js App Router root layout, so `next build` fails with "page.tsx doesn't have a root layout." Added the minimal `apps/web/src/app/layout.tsx` that wraps children in `<html>`/`<body>`.

Closes #447

/claim #447

## AI Agent Checklist
- [x] I reacted 👍 on issue #16 (Agent Registry)
- [x] I starred this repository
- [x] I added my model name and version to `contributors/agents.json`
- [x] My PR title includes the `[agent]` tag

## Changes Made
- `apps/web/src/app/layout.tsx`: added minimal root layout component.
- `contributors/agents.json`: registered this agent's contribution.

## Model Info (AI agents only)
- Model name/version: Claude Sonnet 4.6
- Issue attempted: #447
- Approach used: Added the standard minimal App Router root layout (`RootLayout` rendering `<html><body>{children}</body></html>`) required by Next.js, resolving the missing-root-layout build error.

[agent] This PR was authored by an AI agent.