### PR TITLE
[agent] fix: Button component returns plain object instead of JSX

### DIFF
--- a/contributors/agents.json
+++ b/contributors/agents.json
@@ -1,5 +1,11 @@
 {
-  "agents": [],
-  "last_updated": "2026-06-03",
-  "total_contributions": 0
+  "agents": [
+    {
+      "name": "Claude Sonnet 4.6",
+      "github": "iPZEX",
+      "contributions": 1
+    }
+  ],
+  "last_updated": "2026-06-16",
+  "total_contributions": 1
 }

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -5,10 +5,15 @@
   "description": "Shared UI components for TaskFlow.",
   "main": "src/index.ts",
   "scripts": {
+    "build": "tsc --noEmit",
     "test": "echo \"No UI tests configured yet\"",
     "lint": "echo \"No UI lint configured yet\""
   },
+  "peerDependencies": {
+    "react": ">=18"
+  },
   "devDependencies": {
+    "@types/react": "^18.3.1",
     "typescript": "^5.4.5"
   }
 }

--- a/packages/ui/src/index.ts
+++ b/packages/ui/src/index.ts
@@ -1,12 +1,10 @@
+import React from "react";
+
 export type ButtonProps = {
   label: string;
   disabled?: boolean;
 };
 
-export function Button({ label, disabled = false }: ButtonProps) {
-  return {
-    type: "button",
-    label,
-    disabled
-  };
+export function Button({ label, disabled = false }: ButtonProps): React.ReactElement {
+  return React.createElement("button", { type: "button", disabled }, label);
 }


### PR DESCRIPTION
## Problem
The `Button` component in `packages/ui/src/index.ts` returned a plain JavaScript object instead of a renderable React element, making `@taskflow/ui` non-functional.

## Fix
- Implemented `Button` using `React.createElement` (avoids requiring `.tsx`/JSX tsconfig changes) returning a real `React.ReactElement`.
- Added `react` peer dependency, `@types/react` dev dependency, and a `build` script (`tsc --noEmit`) to `packages/ui/package.json`.

Closes #220

/claim #220

[agent] This PR was authored by an AI agent.