### PR TITLE
[agent] fix: validate POST /users body instead of spreading req.body

### DIFF
--- a/apps/api/src/routes/users.ts
+++ b/apps/api/src/routes/users.ts
@@ -1,19 +1,69 @@
-import { Router } from "express";
+import { Router, Request, Response } from "express";
 
 const router = Router();
 
-router.get("/", (_req, res) => {
+const EMAIL_RE = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
+
+const ALLOWED_FIELDS = new Set(["name", "email"]);
+
+function validateCreateUser(body: unknown): { name: string; email: string } | { error: string } {
+  if (typeof body !== "object" || body === null || Array.isArray(body)) {
+    return { error: "Request body must be a JSON object." };
+  }
+
+  const record = body as Record<string, unknown>;
+
+  const unknown = Object.keys(record).filter((k) => !ALLOWED_FIELDS.has(k));
+  if (unknown.length > 0) {
+    return { error: `Unknown field(s): ${unknown.join(", ")}.` };
+  }
+
+  const { name, email } = record;
+
+  if (name === undefined || name === null || name === "") {
+    return { error: "Field 'name' is required." };
+  }
+  if (typeof name !== "string") {
+    return { error: "Field 'name' must be a string." };
+  }
+  const trimmedName = name.trim();
+  if (trimmedName.length === 0) {
+    return { error: "Field 'name' must not be blank." };
+  }
+
+  if (email === undefined || email === null || email === "") {
+    return { error: "Field 'email' is required." };
+  }
+  if (typeof email !== "string") {
+    return { error: "Field 'email' must be a string." };
+  }
+  if (!EMAIL_RE.test(email)) {
+    return { error: "Field 'email' must be a valid email address." };
+  }
+
+  return { name: trimmedName, email };
+}
+
+router.get("/", (_req: Request, res: Response) => {
   res.json({
     data: [],
     message: "User listing is not implemented yet."
   });
 });
 
-router.post("/", (req, res) => {
+router.post("/", (req: Request, res: Response) => {
+  const result = validateCreateUser(req.body);
+
+  if ("error" in result) {
+    res.status(400).json({ error: result.error });
+    return;
+  }
+
   res.status(201).json({
     data: {
       id: "stub-user-id",
-      ...req.body
+      name: result.name,
+      email: result.email
     },
     message: "User creation is not implemented yet."
   });

--- a/contributors/agents.json
+++ b/contributors/agents.json
@@ -1,5 +1,11 @@
 {
-  "agents": [],
-  "last_updated": "2026-06-03",
-  "total_contributions": 0
+  "agents": [
+    {
+      "name": "Claude Sonnet 4.6",
+      "github": "iPZEX",
+      "contributions": 1
+    }
+  ],
+  "last_updated": "2026-06-16",
+  "total_contributions": 1
 }


### PR DESCRIPTION
## Problem
`POST /users` in `apps/api/src/routes/users.ts` spread `req.body` directly into the response without any validation, allowing arbitrary client-controlled fields to flow through unchecked.

## Fix
- Added explicit `validateCreateUser` that only accepts `name` and `email`, rejects unknown fields, requires non-blank `name`, and validates `email` format.
- Route now constructs the response from validated fields instead of spreading the raw request body.

Closes #1699

/claim #1699

[agent] This PR was authored by an AI agent.