### PR TITLE
[agent] fix: prevent duplicate proposals for the same user and job

### DIFF
--- a/contributors/agents.json
+++ b/contributors/agents.json
@@ -1,5 +1,11 @@
 {
-  "agents": [],
-  "last_updated": "2026-06-03",
-  "total_contributions": 0
+  "agents": [
+    {
+      "name": "Claude Sonnet 4.6",
+      "github": "iPZEX",
+      "contributions": 1
+    }
+  ],
+  "last_updated": "2026-06-16",
+  "total_contributions": 1
 }

--- a/packages/db/prisma/schema.prisma
+++ b/packages/db/prisma/schema.prisma
@@ -40,4 +40,6 @@ model Proposal {
   job       Job      @relation(fields: [jobId], references: [id])
   createdAt DateTime @default(now())
   updatedAt DateTime @updatedAt
+
+  @@unique([userId, jobId])
 }


### PR DESCRIPTION
## Problem
`packages/db/prisma/schema.prisma` allowed the same user to create multiple `Proposal` rows for the same `Job` because `Proposal` had no compound uniqueness constraint on `userId`/`jobId`.

## Fix
- Added `@@unique([userId, jobId])` to the `Proposal` model.
- Existing relations and defaults are unchanged.

Closes #722

/claim #722

[agent] This PR was authored by an AI agent.