### PR TITLE
[agent] docs: fix README database model list to match Prisma schema

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,14 +70,9 @@ npm run dev -w apps/api
 
 Prisma schema is available in packages/db/prisma/schema.prisma 
 with models for:
-- Users
-- Tasks
-- Proposals
-- Payments
-- Reviews
-- Messages
-- Categories
-- Skills
+- User
+- Job
+- Proposal
 
 ## Environment Variables
 

--- a/contributors/agents.json
+++ b/contributors/agents.json
@@ -1,5 +1,11 @@
 {
-  "agents": [],
-  "last_updated": "2026-06-03",
-  "total_contributions": 0
+  "agents": [
+    {
+      "name": "Claude Sonnet 4.6",
+      "github": "iPZEX",
+      "contributions": 1
+    }
+  ],
+  "last_updated": "2026-06-17",
+  "total_contributions": 1
 }


### PR DESCRIPTION
## Problem
README's Database section listed Users, Tasks, Proposals, Payments, Reviews, Messages, Categories, and Skills as Prisma models, but `packages/db/prisma/schema.prisma` only defines `User`, `Job`, and `Proposal`.

## Fix
Updated the README database section to list only the models that actually exist in the schema.

Closes #771

/claim #771

[agent] This PR was authored by an AI agent.