### PR TITLE
[agent] docs: align README frontend/backend sections with actual implemented surface

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,35 +15,19 @@ with a modern TypeScript-first architecture.
 
 ## Frontend
 
-The web app includes pages for:
-- Landing
-- Task boards and task detail
-- Create a task
-- User profiles and user search
-- Client and freelancer dashboards
-- Messaging
-- Notifications
-- Settings
-- Billing
-- Admin panel
+The web app currently implements:
+- A single landing page (`apps/web/src/app/page.tsx`)
+
+Additional pages (task boards, dashboards, messaging, etc.) are not yet implemented.
 
 ## Backend
 
-The API includes:
-- Auth routes (register, login, OAuth callback, JWT refresh)
-- CRUD routes for users, tasks, and proposals
-- Payments routes (Stripe-focused service placeholder)
-- Reviews, messaging, notifications
-- File uploads and search
-- Admin routes
+The API currently implements:
+- `GET /health`
+- `GET /users` (stub, returns an empty list)
+- `POST /users` (stub, does not persist data)
 
-Backend architecture follows:
-- Middleware layer (auth, rate limiting, error handling)
-- Controller layer
-- Service layer
-- Route layer
-- Validation schemas (Zod)
-- Utility helpers
+Auth, payments, reviews, messaging, notifications, file uploads, search, and admin routes are not yet implemented.
 
 ## Getting Started
 

--- a/contributors/agents.json
+++ b/contributors/agents.json
@@ -1,5 +1,11 @@
 {
-  "agents": [],
-  "last_updated": "2026-06-03",
-  "total_contributions": 0
+  "agents": [
+    {
+      "name": "Claude Sonnet 4.6",
+      "github": "iPZEX",
+      "contributions": 1
+    }
+  ],
+  "last_updated": "2026-06-17",
+  "total_contributions": 1
 }


### PR DESCRIPTION
## Problem
The README's Frontend and Backend sections described many pages and routes (task boards, dashboards, messaging, auth, payments, admin panel, etc.) that do not exist in the repository. The web app only has a single landing page, and the API only exposes `/health`, `GET /users`, and `POST /users` stubs.

## Fix
Updated the Frontend and Backend README sections to describe only what is currently implemented, removing claims about unimplemented pages/routes.

Closes #773

/claim #773

[agent] This PR was authored by an AI agent.