### PR TITLE
[agent] fix: return JSON 404 responses for unknown API routes

### DIFF
--- a/apps/api/src/index.ts
+++ b/apps/api/src/index.ts
@@ -13,6 +13,11 @@ app.get("/health", (_req, res) => {
 
 app.use("/users", usersRouter);
 
+// JSON 404 handler for unknown routes (fixes #1632)
+app.use((_req, res) => {
+  res.status(404).json({ error: "Not Found", message: "The requested API endpoint does not exist." });
+});
+
 app.listen(port, () => {
   console.log(`TaskFlow API listening on port ${port}`);
 });


### PR DESCRIPTION
Fixes #1632. Added catch-all 404 handler returning JSON instead of HTML. /bounty 0