### PR TITLE
[agent] fix: disable X-Powered-By and add security headers to Next.js

### DIFF
--- a/apps/web/next.config.js
+++ b/apps/web/next.config.js
@@ -1,0 +1,12 @@
+/** @type {import('next').NextConfig} */
+const nextConfig = {
+  poweredByHeader: false,
+  async headers() {
+    return [{ source: "/(.*)", headers: [
+      { key: "X-Content-Type-Options", value: "nosniff" },
+      { key: "X-Frame-Options", value: "DENY" },
+      { key: "Referrer-Policy", value: "strict-origin-when-cross-origin" },
+    ]}];
+  },
+};
+module.exports = nextConfig;


### PR DESCRIPTION
Fixes #1089, #1119. Set poweredByHeader: false, added X-Content-Type-Options, X-Frame-Options, Referrer-Policy headers. /bounty 00