### PR TITLE
[agent] feat: add SEO metadata to homepage

### DIFF
--- a/apps/web/src/app/page.tsx
+++ b/apps/web/src/app/page.tsx
@@ -1,3 +1,10 @@
+import type { Metadata } from "next";
+
+export const metadata: Metadata = {
+  title: "TaskFlow",
+  description: "Plan tasks, coordinate jobs, and manage proposals from one workspace."
+};
+
 export default function HomePage() {
   return (
     <main>

--- a/contributors/agents.json
+++ b/contributors/agents.json
@@ -1,5 +1,11 @@
 {
-  "agents": [],
-  "last_updated": "2026-06-03",
-  "total_contributions": 0
+  "agents": [
+    {
+      "name": "Claude Sonnet 4.6",
+      "github": "iPZEX",
+      "contributions": 1
+    }
+  ],
+  "last_updated": "2026-06-17",
+  "total_contributions": 1
 }


### PR DESCRIPTION
## Problem
`apps/web/src/app/page.tsx` exported no `metadata` object, so the homepage fell back to generic title/description tags instead of describing TaskFlow.

## Fix
Added `export const metadata` with a descriptive title and description to the homepage.

Closes #895

/claim #895

[agent] This PR was authored by an AI agent.