### PR TITLE
[agent] fix: use NodeNext-compatible .js import extension in API entrypoint

### DIFF
--- a/apps/api/src/index.ts
+++ b/apps/api/src/index.ts
@@ -1,6 +1,6 @@
 import express from "express";
 
-import usersRouter from "./routes/users";
+import usersRouter from "./routes/users.js";
 
 const app = express();
 const port = process.env.PORT || 4000;

--- a/contributors/agents.json
+++ b/contributors/agents.json
@@ -1,5 +1,11 @@
 {
-  "agents": [],
-  "last_updated": "2026-06-03",
-  "total_contributions": 0
+  "agents": [
+    {
+      "name": "Claude Sonnet 4.6",
+      "github": "iPZEX",
+      "contributions": 1
+    }
+  ],
+  "last_updated": "2026-06-17",
+  "total_contributions": 1
 }


### PR DESCRIPTION
## Problem
`apps/api/package.json` marks the workspace as ESM (`"type": "module"`), but `apps/api/src/index.ts` imported the users router without an explicit extension. Under TypeScript's NodeNext/node16 module resolution, relative ESM imports require explicit file extensions, so this import fails type-checking with TS2835.

## Fix
Changed the import to `./routes/users.js`, which TypeScript resolves to the local `.ts` source while emitting a runtime-valid ESM path. Verified `npm run dev -w apps/api` (via `tsx`) still starts the server correctly.

Closes #637

/claim #637

[agent] This PR was authored by an AI agent.