### PR TITLE
[agent] fix: validate PORT env var before API server startup

### DIFF
--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -8,7 +8,8 @@
   "scripts": {
     "dev": "tsx src/index.ts",
     "test": "echo \"No API tests configured yet\"",
-    "lint": "echo \"No API lint configured yet\""
+    "lint": "echo \"No API lint configured yet\"",
+    "validate:port-config": "node scripts/validate-port-config.mjs"
   },
   "dependencies": {
     "express": "^4.18.3"

--- a/apps/api/scripts/validate-port-config.mjs
+++ b/apps/api/scripts/validate-port-config.mjs
@@ -1,0 +1,29 @@
+import { spawnSync } from "node:child_process";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const root = path.resolve(fileURLToPath(import.meta.url), "../../../../");
+
+function runTsx(port) {
+  return spawnSync("npx", ["tsx", "apps/api/src/index.ts"], {
+    env: { ...process.env, PORT: port },
+    timeout: 3000,
+    cwd: root,
+    shell: true,
+    encoding: "utf8",
+  });
+}
+
+function expectFail(port) {
+  const r = runTsx(port);
+  const out = (r.stdout ?? "") + (r.stderr ?? "");
+  if (r.status === 0) throw new Error(`Expected failure for PORT=${port} but exited 0`);
+  if (!out.includes("Invalid PORT")) throw new Error(`No "Invalid PORT" message for PORT=${port}. Got: ${out.slice(0, 200)}`);
+}
+
+expectFail("-1");
+expectFail("99999");
+expectFail("abc");
+
+console.log("OK: invalid PORT values correctly rejected with clear error messages.");
+process.exit(0);

--- a/apps/api/src/index.ts
+++ b/apps/api/src/index.ts
@@ -2,8 +2,17 @@ import express from "express";
 
 import usersRouter from "./routes/users";
 
+function parsePort(value: string | undefined): number {
+  if (value === undefined || value === "") return 4000;
+  const n = Number(value);
+  if (!Number.isInteger(n) || n < 0 || n > 65535) {
+    throw new Error(`Invalid PORT value: "${value}". Expected an integer between 0 and 65535.`);
+  }
+  return n;
+}
+
 const app = express();
-const port = process.env.PORT || 4000;
+const port = parsePort(process.env.PORT);
 
 app.use(express.json());
 

--- a/contributors/agents.json
+++ b/contributors/agents.json
@@ -1,5 +1,11 @@
 {
-  "agents": [],
-  "last_updated": "2026-06-03",
-  "total_contributions": 0
+  "agents": [
+    {
+      "name": "Claude Sonnet 4.6",
+      "github": "iPZEX",
+      "contributions": 1
+    }
+  ],
+  "last_updated": "2026-06-17",
+  "total_contributions": 1
 }


### PR DESCRIPTION
## Problem
`apps/api/src/index.ts` read `process.env.PORT` without validation. Invalid values like `PORT=-1`, `PORT=99999`, or `PORT=abc` would crash Node with an opaque `ERR_SOCKET_BAD_PORT` or silently bind a named socket instead of a TCP port.

## Fix
- Added a `parsePort` helper that defaults to `4000` when `PORT` is unset, and throws a clear startup error if the value is not an integer in `[0, 65535]`.
- Added `apps/api/scripts/validate-port-config.mjs` (and `validate:port-config` npm script) that verifies invalid PORT values are rejected with a readable error message.

Closes #1126

/claim #1126

[agent] This PR was authored by an AI agent.