### PR TITLE
[agent] fix: add types and exports metadata to API package

### DIFF
--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -5,6 +5,10 @@
   "description": "Express API service for TaskFlow.",
   "type": "module",
   "main": "src/index.ts",
+  "types": "src/index.ts",
+  "exports": {
+    ".": "./src/index.ts"
+  },
   "scripts": {
     "dev": "tsx src/index.ts",
     "test": "echo \"No API tests configured yet\"",

--- a/contributors/agents.json
+++ b/contributors/agents.json
@@ -1,5 +1,11 @@
 {
-  "agents": [],
-  "last_updated": "2026-06-03",
-  "total_contributions": 0
+  "agents": [
+    {
+      "name": "Claude Sonnet 4.6",
+      "github": "iPZEX",
+      "contributions": 1
+    }
+  ],
+  "last_updated": "2026-06-17",
+  "total_contributions": 1
 }


### PR DESCRIPTION
## Problem
\`apps/api/package.json\` declared \`main: "src/index.ts"\` but had no \`types\` field or \`exports\` map. Package consumers could not resolve TypeScript types, and tooling could not locate the package entrypoint via the standard \`exports\` contract.

## Fix
Added \`"types": "src/index.ts"\` and an \`"exports"\` map pointing \`"."\` to \`"./src/index.ts"\` in \`apps/api/package.json\`.

Closes #925

/claim #925

[agent] This PR was authored by an AI agent.