### PR TITLE
[agent] fix: add types and exports metadata to UI package

### DIFF
--- a/contributors/agents.json
+++ b/contributors/agents.json
@@ -1,5 +1,11 @@
 {
-  "agents": [],
-  "last_updated": "2026-06-03",
-  "total_contributions": 0
+  "agents": [
+    {
+      "name": "Claude Sonnet 4.6",
+      "github": "iPZEX",
+      "contributions": 1
+    }
+  ],
+  "last_updated": "2026-06-17",
+  "total_contributions": 1
 }

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -4,6 +4,10 @@
   "private": true,
   "description": "Shared UI components for TaskFlow.",
   "main": "src/index.ts",
+  "types": "src/index.ts",
+  "exports": {
+    ".": "./src/index.ts"
+  },
   "scripts": {
     "test": "echo \"No UI tests configured yet\"",
     "lint": "echo \"No UI lint configured yet\""


### PR DESCRIPTION
## Problem
\`packages/ui/package.json\` declared \`main: "src/index.ts"\` but had no \`types\` field or \`exports\` map. Consumers of the shared UI package could not resolve TypeScript types via standard tooling.

## Fix
Added \`"types": "src/index.ts"\` and an \`"exports"\` map pointing \`"."\` to \`"./src/index.ts"\` in \`packages/ui/package.json\`.

Closes #923

/claim #923

[agent] This PR was authored by an AI agent.