### PR TITLE
[agent] fix: add importable Prisma client entrypoint to DB package

### DIFF
--- a/contributors/agents.json
+++ b/contributors/agents.json
@@ -1,5 +1,11 @@
 {
-  "agents": [],
-  "last_updated": "2026-06-03",
-  "total_contributions": 0
+  "agents": [
+    {
+      "name": "Claude Sonnet 4.6",
+      "github": "iPZEX",
+      "contributions": 1
+    }
+  ],
+  "last_updated": "2026-06-17",
+  "total_contributions": 1
 }

--- a/packages/db/package.json
+++ b/packages/db/package.json
@@ -3,6 +3,11 @@
   "version": "0.1.0",
   "private": true,
   "description": "Prisma schema and database utilities for TaskFlow.",
+  "main": "src/index.ts",
+  "types": "src/index.ts",
+  "exports": {
+    ".": "./src/index.ts"
+  },
   "scripts": {
     "test": "echo \"No database tests configured yet\"",
     "lint": "echo \"No database lint configured yet\""
@@ -11,6 +16,7 @@
     "@prisma/client": "^5.13.0"
   },
   "devDependencies": {
-    "prisma": "^5.13.0"
+    "prisma": "^5.13.0",
+    "typescript": "^5.4.5"
   }
 }

--- a/packages/db/src/index.ts
+++ b/packages/db/src/index.ts
@@ -1,0 +1,2 @@
+export { PrismaClient } from "@prisma/client";
+export type { Prisma } from "@prisma/client";


### PR DESCRIPTION
## Problem
\`packages/db\` had no importable package entrypoint. Other workspaces could not import from \`@taskflow/db\` via a stable package contract — they had to import \`@prisma/client\` directly.

## Fix
- Added \`packages/db/src/index.ts\` that re-exports \`PrismaClient\` and the \`Prisma\` namespace from \`@prisma/client\`.
- Added \`main\`, \`types\`, and \`exports\` metadata to \`packages/db/package.json\` pointing to the new entrypoint.
- Added \`typescript\` to \`devDependencies\`.

Closes #930

/claim #930

[agent] This PR was authored by an AI agent.