### PR TITLE
[agent] fix: add explicit decimal precision to Proposal.amount

### DIFF
--- a/contributors/agents.json
+++ b/contributors/agents.json
@@ -1,5 +1,11 @@
 {
-  "agents": [],
-  "last_updated": "2026-06-03",
-  "total_contributions": 0
+  "agents": [
+    {
+      "name": "Claude Sonnet 4.6",
+      "github": "iPZEX",
+      "contributions": 1
+    }
+  ],
+  "last_updated": "2026-06-17",
+  "total_contributions": 1
 }

--- a/packages/db/prisma/schema.prisma
+++ b/packages/db/prisma/schema.prisma
@@ -32,7 +32,7 @@ model Job {
 model Proposal {
   id        String   @id @default(cuid())
   summary   String
-  amount    Decimal?
+  amount    Decimal?  @db.Decimal(12, 2)
   status    String   @default("pending")
   userId    String
   user      User     @relation(fields: [userId], references: [id])


### PR DESCRIPTION
## Problem
\`Proposal.amount\` was typed as a generic \`Decimal?\` with no precision or scale. For a marketplace proposal amount, the database column type was left unspecified, leading to database-dependent defaults and potential precision loss.

## Fix
Changed \`amount\` to \`Decimal? @db.Decimal(12, 2)\` — 12 total digits with 2 decimal places, sufficient for monetary amounts up to 9,999,999,999.99.

Closes #919

/claim #919

[agent] This PR was authored by an AI agent.