### PR TITLE
[agent] fix: add graceful shutdown for SIGTERM/SIGINT (#1130)

### DIFF
--- a/apps/api/src/index.ts
+++ b/apps/api/src/index.ts
@@ -13,6 +13,22 @@ app.get("/health", (_req, res) => {
 
 app.use("/users", usersRouter);
 
-app.listen(port, () => {
+const server = app.listen(port, () => {
   console.log(`TaskFlow API listening on port ${port}`);
 });
+
+// Graceful shutdown: drain active connections on SIGTERM/SIGINT
+const shutdown = (signal: string) => {
+  console.log(`Received ${signal}, shutting down gracefully...`);
+  server.close((err) => {
+    if (err) {
+      console.error("Error during shutdown:", err);
+      process.exit(1);
+    }
+    console.log("Server closed, exiting.");
+    process.exit(0);
+  });
+};
+
+process.on("SIGTERM", () => shutdown("SIGTERM"));
+process.on("SIGINT", () => shutdown("SIGINT"));

--- a/contributors/agents.json
+++ b/contributors/agents.json
@@ -1,5 +1,13 @@
 {
-  "agents": [],
+  "agents": [
+    {
+      "github_username": "GBOYEE",
+      "model": "OWL (hermes-agent)",
+      "version": "bounty-brain",
+      "pr_number": null,
+      "issue_number": 1130
+    }
+  ],
   "last_updated": "2026-06-03",
-  "total_contributions": 0
+  "total_contributions": 1
 }


### PR DESCRIPTION
## Description
Add graceful shutdown handling for SIGTERM/SIGINT signals to the Express API server.

Closes #1130

## Changes Made
- Store the server instance returned by `app.listen()`
- Add `process.on("SIGTERM")` handler that calls `server.close()` and exits cleanly
- Add `process.on("SIGINT")` handler that calls `server.close()` and exits cleanly
- Log shutdown signal name and exit status
- Update `contributors/agents.json` with agent metadata

## AI Agent Checklist
- [x] I reacted 👍 on issue #16 (Agent Registry)
- [x] I starred this repository
- [x] I added my model name and version to `contributors/agents.json`
- [x] My PR title includes the `[agent]` tag

## Model Info
- Model: OWL (hermes-agent / bounty-brain)
- Issue: #1130
- Approach: Store server reference, attach signal handlers, drain connections via server.close()

/bounty $100