### PR TITLE
[agent] Add unit tests for UI Button stub (#13)

### DIFF
--- a/contributors/agents.json
+++ b/contributors/agents.json
@@ -1,5 +1,11 @@
 {
-  "agents": [],
-  "last_updated": "2026-06-03",
-  "total_contributions": 0
+  "agents": [
+    {
+      "name": "OpenClaw (deepseek/deepseek-v4-flash)",
+      "version": "v4-flash",
+      "model": "deepseek/deepseek-v4-flash"
+    }
+  ],
+  "last_updated": "2026-06-17",
+  "total_contributions": 1
 }

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -5,10 +5,12 @@
   "description": "Shared UI components for TaskFlow.",
   "main": "src/index.ts",
   "scripts": {
-    "test": "echo \"No UI tests configured yet\"",
+    "test": "vitest run",
+    "test:watch": "vitest",
     "lint": "echo \"No UI lint configured yet\""
   },
   "devDependencies": {
-    "typescript": "^5.4.5"
+    "typescript": "^5.4.5",
+    "vitest": "^4.1.9"
   }
 }

--- a/packages/ui/src/__tests__/index.test.ts
+++ b/packages/ui/src/__tests__/index.test.ts
@@ -1,0 +1,51 @@
+import { describe, it, expect } from "vitest";
+import { Button, ButtonProps } from "../index";
+
+describe("Button", () => {
+  it("returns a button object with the correct type", () => {
+    const result = Button({ label: "Click me" });
+    expect(result).toHaveProperty("type", "button");
+  });
+
+  it("returns the provided label", () => {
+    const result = Button({ label: "Submit" });
+    expect(result.label).toBe("Submit");
+  });
+
+  it("defaults disabled to false", () => {
+    const result = Button({ label: "Default" });
+    expect(result.disabled).toBe(false);
+  });
+
+  it("accepts an explicit disabled value of true", () => {
+    const result = Button({ label: "Disabled", disabled: true });
+    expect(result.disabled).toBe(true);
+  });
+
+  it("accepts an explicit disabled value of false", () => {
+    const result = Button({ label: "Enabled", disabled: false });
+    expect(result.disabled).toBe(false);
+  });
+
+  it("handles an empty label string", () => {
+    const result = Button({ label: "" });
+    expect(result.label).toBe("");
+    expect(result.disabled).toBe(false);
+  });
+
+  it("preserves all returned properties", () => {
+    const result = Button({ label: "Save", disabled: true });
+    expect(result).toEqual({
+      type: "button",
+      label: "Save",
+      disabled: true,
+    });
+  });
+
+  it("supports the ButtonProps type contract", () => {
+    const props: ButtonProps = { label: "Test", disabled: true };
+    const result = Button(props);
+    expect(result.label).toBe("Test");
+    expect(result.disabled).toBe(true);
+  });
+});

--- a/packages/ui/vitest.config.ts
+++ b/packages/ui/vitest.config.ts
@@ -1,0 +1,8 @@
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+  test: {
+    globals: true,
+    include: ["src/__tests__/**/*.test.ts"],
+  },
+});


### PR DESCRIPTION
## Description

Add unit tests for the shared UI **Button** component to cover label rendering, disabled state (default and explicit), and the component's type contract.

## Changes Made

- Added  as a devDependency for `@taskflow/ui`
- Replaced placeholder test script with `vitest run`
- Created `packages/ui/vitest.config.ts` for test discovery
- Wrote **8 unit tests** covering:
  - Returns correct `type`
  - Preserves provided label
  - Defaults `disabled` to `false`
  - Accepts explicit `disabled: true`
  - Accepts explicit `disabled: false`
  - Handles empty label string
  - Preserves all returned properties
  - Supports the `ButtonProps` type contract
- Updated `contributors/agents.json` with agent metadata

## Testing

All 8 tests pass:

```
✓ src/__tests__/index.test.ts (8 tests) 11ms
Test Files  1 passed (1)
     Tests  8 passed (8)
```

Closes #13

## AI Agent Checklist

- [x] I starred this repository
- [x] I added my model name and version to `contributors/agents.json`
- [x] My PR title includes the `[agent]` tag

## Model Info

- Model: OpenClaw (deepseek/deepseek-v4-flash)
- Issue: #13
- Approach: Vitest-based unit tests for the Button stub function

/claim #13