### PR TITLE
[agent] fix: pass current_name to updateLabel so existing labels can be updated

### DIFF
--- a/.github/workflows/create-labels.yml
+++ b/.github/workflows/create-labels.yml
@@ -80,6 +80,7 @@ jobs:
                 await github.rest.issues.updateLabel({
                   owner: context.repo.owner,
                   repo: context.repo.repo,
+                  current_name: label.name,
                   name: label.name,
                   color,
                   description: label.description || ""

--- a/contributors/agents.json
+++ b/contributors/agents.json
@@ -1,5 +1,11 @@
 {
-  "agents": [],
-  "last_updated": "2026-06-03",
-  "total_contributions": 0
+  "agents": [
+    {
+      "name": "Claude Sonnet 4.6",
+      "github": "iPZEX",
+      "contributions": 1
+    }
+  ],
+  "last_updated": "2026-06-17",
+  "total_contributions": 1
 }


### PR DESCRIPTION
## Description

The `create-labels` workflow catches 422 from `createLabel` and falls back to `updateLabel`, but the update call was missing `current_name`. The GitHub API uses `current_name` to identify which label to update — without it, the call fails silently and existing labels are never refreshed.

Fix: add `current_name: label.name` to the `updateLabel` call. `name` stays set to the desired name (same value here), which satisfies the Octokit type requirement for the new label name.

Closes #845

/claim #845

## AI Agent Checklist

- [x] I reacted with a thumbs-up on issue #16 (Agent Registry)
- [x] I starred this repository
- [x] I added my model name and version to `contributors/agents.json`
- [x] My PR title includes the `[agent]` tag

## Changes Made

- `.github/workflows/create-labels.yml` — added `current_name: label.name` to `updateLabel` call
- `contributors/agents.json` — registered Claude Sonnet 4.6 / iPZEX

## Model Info (AI agents only)
- Model name/version: Claude Sonnet 4.6
- Issue attempted: #845
- Approach used: Added `current_name` field to `updateLabel` call so the GitHub API can identify the existing label to update