### PR TITLE
Fix seed workflows label bootstrap

### DIFF
--- a/.github/scripts/labels.js
+++ b/.github/scripts/labels.js
@@ -1,0 +1,87 @@
+const fs = require("fs");
+
+function stripQuotes(value) {
+  return value.trim().replace(/^"|"$/g, "");
+}
+
+function parseLabels(content) {
+  const labels = [];
+  let current = null;
+
+  for (const rawLine of content.split(/\r?\n/)) {
+    const line = rawLine.trim();
+
+    if (!line) {
+      continue;
+    }
+
+    if (line.startsWith("- name:")) {
+      if (current) {
+        labels.push(current);
+      }
+
+      current = {
+        name: stripQuotes(line.replace("- name:", ""))
+      };
+      continue;
+    }
+
+    if (!current) {
+      continue;
+    }
+
+    const separatorIndex = line.indexOf(":");
+
+    if (separatorIndex === -1) {
+      continue;
+    }
+
+    const key = line.slice(0, separatorIndex).trim();
+    const value = stripQuotes(line.slice(separatorIndex + 1));
+    current[key] = value;
+  }
+
+  if (current) {
+    labels.push(current);
+  }
+
+  return labels;
+}
+
+async function ensureLabels({ github, context, core, labelsPath = ".github/labels.yml" }) {
+  const labels = parseLabels(fs.readFileSync(labelsPath, "utf8"));
+
+  for (const label of labels) {
+    const color = label.color.replace(/^#/, "");
+    const description = label.description || "";
+
+    try {
+      await github.rest.issues.createLabel({
+        owner: context.repo.owner,
+        repo: context.repo.repo,
+        name: label.name,
+        color,
+        description
+      });
+      core.info(`Created label: ${label.name}`);
+    } catch (error) {
+      if (error.status !== 422) {
+        throw error;
+      }
+
+      await github.rest.issues.updateLabel({
+        owner: context.repo.owner,
+        repo: context.repo.repo,
+        name: label.name,
+        color,
+        description
+      });
+      core.info(`Updated label: ${label.name}`);
+    }
+  }
+}
+
+module.exports = {
+  ensureLabels,
+  parseLabels
+};

--- a/.github/workflows/create-labels.yml
+++ b/.github/workflows/create-labels.yml
@@ -4,6 +4,7 @@ on:
   workflow_dispatch:
 
 permissions:
+  contents: read
   issues: write
 
 jobs:
@@ -18,71 +19,6 @@ jobs:
         uses: actions/github-script@v7
         with:
           script: |
-            const fs = require("fs");
+            const { ensureLabels } = require("./.github/scripts/labels");
 
-            const content = fs.readFileSync(".github/labels.yml", "utf8");
-            const labels = [];
-            let current = null;
-
-            for (const rawLine of content.split(/\r?\n/)) {
-              const line = rawLine.trim();
-
-              if (!line) {
-                continue;
-              }
-
-              if (line.startsWith("- name:")) {
-                if (current) {
-                  labels.push(current);
-                }
-
-                current = {
-                  name: line.replace("- name:", "").trim().replace(/^"|"$/g, "")
-                };
-                continue;
-              }
-
-              if (!current) {
-                continue;
-              }
-
-              const separatorIndex = line.indexOf(":");
-
-              if (separatorIndex === -1) {
-                continue;
-              }
-
-              const key = line.slice(0, separatorIndex).trim();
-              const value = line.slice(separatorIndex + 1).trim().replace(/^"|"$/g, "");
-              current[key] = value;
-            }
-
-            if (current) {
-              labels.push(current);
-            }
-
-            for (const label of labels) {
-              const color = label.color.replace(/^#/, "");
-
-              try {
-                await github.rest.issues.createLabel({
-                  owner: context.repo.owner,
-                  repo: context.repo.repo,
-                  name: label.name,
-                  color,
-                  description: label.description || ""
-                });
-              } catch (error) {
-                if (error.status !== 422) {
-                  throw error;
-                }
-
-                await github.rest.issues.updateLabel({
-                  owner: context.repo.owner,
-                  repo: context.repo.repo,
-                  name: label.name,
-                  color,
-                  description: label.description || ""
-                });
-              }
-            }
+            await ensureLabels({ github, context, core });

--- a/.github/workflows/seed-issues.yml
+++ b/.github/workflows/seed-issues.yml
@@ -4,6 +4,7 @@ on:
   workflow_dispatch:
 
 permissions:
+  contents: read
   issues: write
 
 jobs:
@@ -11,6 +12,17 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Ensure issue labels exist
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const { ensureLabels } = require("./.github/scripts/labels");
+
+            await ensureLabels({ github, context, core });
+
       - name: Create starter issues
         uses: actions/github-script@v7
         with:

--- a/.github/workflows/seed-meta-issue.yml
+++ b/.github/workflows/seed-meta-issue.yml
@@ -4,6 +4,7 @@ on:
   workflow_dispatch:
 
 permissions:
+  contents: read
   issues: write
 
 jobs:
@@ -11,6 +12,17 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Ensure issue labels exist
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const { ensureLabels } = require("./.github/scripts/labels");
+
+            await ensureLabels({ github, context, core });
+
       - name: Create and pin bug bounty program issue
         uses: actions/github-script@v7
         with:


### PR DESCRIPTION
## Summary
- add a shared label helper that reads `.github/labels.yml` and creates or updates repository labels
- reuse the helper from `create-labels.yml`
- bootstrap required labels before both seed workflows create labeled issues
- add `contents: read` where checkout is required under explicit workflow permissions

## Validation
- `node -c .github/scripts/labels.js`
- `node` parser check against `.github/labels.yml`
- `ruby` YAML parse for the updated workflow files and label file
- `npm test -- --if-present`

`npm run lint -- --if-present` was also attempted, but the local checkout does not have the `next` binary installed for the web workspace.

Fixes #957

Payout address (Base USDC): 0xe87b4889baeee4ed60a1b2bfc7b3a6a17bce4ad6
