### PR TITLE
docs: add JSDoc comments to user service routes

### DIFF
--- a/apps/api/src/routes/users.ts
+++ b/apps/api/src/routes/users.ts
@@ -2,6 +2,13 @@ import { Router } from "express";
 
 const router = Router();
 
+/**
+ * GET /users
+ * Returns a list of all users.
+ * Currently returns an empty array (not yet implemented).
+ *
+ * @returns {Object} response with empty data array
+ */
 router.get("/", (_req, res) => {
   res.json({
     data: [],
@@ -9,6 +16,14 @@ router.get("/", (_req, res) => {
   });
 });
 
+/**
+ * POST /users
+ * Creates a new user with the provided body data.
+ * Currently returns a stub response with the request body spread into a fixed ID.
+ *
+ * @param {Object} req.body - User data to create
+ * @returns {Object} response with created user stub (201)
+ */
 router.post("/", (req, res) => {
   res.status(201).json({
     data: {


### PR DESCRIPTION
## Summary

Added concise JSDoc comments to the user service routes (GET /users and POST /users) so future contributors can understand the intended behavior.

## Changes

- Added JSDoc for `GET /` endpoint
- Added JSDoc for `POST /` endpoint with parameter documentation

Fixes #1