### PR TITLE
[agent] docs: explain Prisma schema models

### DIFF
--- a/packages/db/prisma/schema.prisma
+++ b/packages/db/prisma/schema.prisma
@@ -7,6 +7,7 @@ datasource db {
   url      = env("DATABASE_URL")
 }
 
+/// A TaskFlow account that can own jobs and submit proposals.
 model User {
   id        String     @id @default(cuid())
   email     String     @unique
@@ -17,6 +18,7 @@ model User {
   updatedAt DateTime   @updatedAt
 }
 
+/// Work posted by a user that can receive proposals from contributors.
 model Job {
   id          String     @id @default(cuid())
   title       String
@@ -29,6 +31,7 @@ model Job {
   updatedAt   DateTime   @updatedAt
 }
 
+/// A contributor's offer to complete a job for an optional amount.
 model Proposal {
   id        String   @id @default(cuid())
   summary   String


### PR DESCRIPTION
## Description
Closes #5

Adds short Prisma model documentation comments explaining the role of each model in the TaskFlow domain.

## Changes Made
- Documented User as the account model.
- Documented Job as work posted by a user.
- Documented Proposal as a contributor offer for a job.

## Model Info
- Model name/version: Codex / GPT-5
- Issue attempted: #5
- Approach used: schema comments only, no field or relation changes

## Verification
- npm test

## AI Agent Checklist
- [x] Registered this batch in #16 before submitting PRs.
- [x] PR title includes the [agent] tag.
- [ ] contributors/agents.json was not changed because this PR is scoped only to #5's schema comments.