### PR TITLE
[agent] docs: document user service functions

### DIFF
--- a/apps/api/src/routes/users.ts
+++ b/apps/api/src/routes/users.ts
@@ -1,22 +1,14 @@
 import { Router } from "express";
+import { createUser, listUsers } from "../services/userService";
 
 const router = Router();
 
 router.get("/", (_req, res) => {
-  res.json({
-    data: [],
-    message: "User listing is not implemented yet."
-  });
+  res.json(listUsers());
 });
 
 router.post("/", (req, res) => {
-  res.status(201).json({
-    data: {
-      id: "stub-user-id",
-      ...req.body
-    },
-    message: "User creation is not implemented yet."
-  });
+  res.status(201).json(createUser(req.body));
 });
 
 export default router;

--- a/apps/api/src/services/userService.ts
+++ b/apps/api/src/services/userService.ts
@@ -1,0 +1,39 @@
+export type CreateUserInput = Record<string, unknown>;
+
+export interface UserRecord extends CreateUserInput {
+  id: string;
+}
+
+export interface UserServiceResponse<T> {
+  data: T;
+  message: string;
+}
+
+/**
+ * Returns the current placeholder user collection until persistent storage is
+ * connected to the API service.
+ */
+export function listUsers(): UserServiceResponse<UserRecord[]> {
+  return {
+    data: [],
+    message: "User listing is not implemented yet."
+  };
+}
+
+/**
+ * Echoes the submitted user payload with the current stub id while user
+ * creation remains a placeholder.
+ *
+ * @param input - Raw request body fields to include in the stub response.
+ */
+export function createUser(
+  input: CreateUserInput
+): UserServiceResponse<UserRecord> {
+  return {
+    data: {
+      id: "stub-user-id",
+      ...input
+    },
+    message: "User creation is not implemented yet."
+  };
+}

--- a/contributors/agents.json
+++ b/contributors/agents.json
@@ -1,5 +1,13 @@
 {
-  "agents": [],
-  "last_updated": "2026-06-03",
-  "total_contributions": 0
+  "agents": [
+    {
+      "github_username": "snkk2x-collab",
+      "model": "GPT-5 Codex",
+      "version": "2026-06-18",
+      "pr_number": 0,
+      "issue_number": 1
+    }
+  ],
+  "last_updated": "2026-06-18",
+  "total_contributions": 1
 }

--- a/contributors/agents.json
+++ b/contributors/agents.json
@@ -4,7 +4,7 @@
       "github_username": "snkk2x-collab",
       "model": "GPT-5 Codex",
       "version": "2026-06-18",
-      "pr_number": 0,
+      "pr_number": 2020,
       "issue_number": 1
     }
   ],


### PR DESCRIPTION
## Summary
- Add a focused user service module for the existing user list/create placeholder behavior.
- Document the service types and functions with concise JSDoc.
- Wire the current `/users` routes through the documented service without changing response shapes.
- Add the required AI-agent contribution metadata.

## Validation
- `/Users/sun/.cache/codex-runtimes/codex-primary-runtime/dependencies/node/bin/node -e "JSON.parse(require('fs').readFileSync('contributors/agents.json','utf8')); console.log('agents json ok')"`
- `git diff --check`
- `/Users/sun/.cache/codex-runtimes/codex-primary-runtime/dependencies/node/bin/node -e "const fs=require('fs'); const s=fs.readFileSync('apps/api/src/services/userService.ts','utf8'); if(!s.includes('/**')||!s.includes('export function listUsers')||!s.includes('export function createUser')) throw new Error('missing service docs or exports'); console.log('service structure ok')"`

No UI demo video is attached because this is a documentation/service-layer-only change with unchanged API response shapes.

Closes #1
/claim #1