### PR TITLE
[agent] docs: fix agent metadata example

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -30,14 +30,21 @@ If you are an LLM, AI coding agent, or automated system:
 You **MUST** do all of the following or your PR will be closed 
 without bounty processing:
 
-1. Add your model name and version to `contributors/agents.json`:
+1. Add or update your model metadata inside the `agents` array in
+   `contributors/agents.json`. Keep the root object shape and summary fields:
 ```json
 {
-  "github_username": "your-username",
-  "model": "gpt-4o / claude-3-5-sonnet / gemini-2.0 / etc",
-  "version": "your version if known",
-  "pr_number": 123,
-  "issue_number": 456
+  "agents": [
+    {
+      "github_username": "your-username",
+      "model": "gpt-4o / claude-3-5-sonnet / gemini-2.0 / etc",
+      "version": "your version if known",
+      "pr_number": 123,
+      "issue_number": 456
+    }
+  ],
+  "last_updated": "YYYY-MM-DD",
+  "total_contributions": 1
 }
 ```
 2. Include `[agent]` tag in your PR title

--- a/contributors/agents.json
+++ b/contributors/agents.json
@@ -1,5 +1,13 @@
 {
-  "agents": [],
-  "last_updated": "2026-06-03",
-  "total_contributions": 0
+  "agents": [
+    {
+      "github_username": "snkk2x-collab",
+      "model": "GPT-5 Codex",
+      "version": "2026-06-18",
+      "pr_number": 0,
+      "issue_number": 1255
+    }
+  ],
+  "last_updated": "2026-06-18",
+  "total_contributions": 1
 }

--- a/contributors/agents.json
+++ b/contributors/agents.json
@@ -4,7 +4,7 @@
       "github_username": "snkk2x-collab",
       "model": "GPT-5 Codex",
       "version": "2026-06-18",
-      "pr_number": 0,
+      "pr_number": 2021,
       "issue_number": 1255
     }
   ],


### PR DESCRIPTION
## Summary
- Update the AI-agent metadata example in `CONTRIBUTING.md` so it matches the real `contributors/agents.json` root object shape.
- Clarify that agents should add or update entries inside the `agents` array instead of replacing the file with a bare object.
- Add the required AI-agent metadata for this PR.

## Validation
- `/Users/sun/.cache/codex-runtimes/codex-primary-runtime/dependencies/node/bin/node -e "JSON.parse(require('fs').readFileSync('contributors/agents.json','utf8')); console.log('agents json ok')"`
- `git diff --check`

No UI demo video is attached because this is a contribution-docs-only change.

Closes #1255
/claim #1255