### PR TITLE
[agent] fix: prevent cached health responses

### DIFF
--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -7,7 +7,7 @@
   "main": "src/index.ts",
   "scripts": {
     "dev": "tsx src/index.ts",
-    "test": "echo \"No API tests configured yet\"",
+    "test": "node scripts/validate-health-cache.mjs",
     "lint": "echo \"No API lint configured yet\""
   },
   "dependencies": {

--- a/apps/api/scripts/validate-health-cache.mjs
+++ b/apps/api/scripts/validate-health-cache.mjs
@@ -1,0 +1,30 @@
+import { readFileSync } from "node:fs";
+
+const source = readFileSync(new URL("../src/index.ts", import.meta.url), "utf8");
+const routeMatch = source.match(/app\.get\("\/health",[\s\S]*?\n}\);/);
+
+if (!routeMatch) {
+  throw new Error("Could not find the /health route.");
+}
+
+const routeSource = routeMatch[0];
+const headerStatement = 'res.set("Cache-Control", "no-store");';
+const bodyStatement =
+  'res.json({ status: "ok", service: "taskflow-api" });';
+
+const headerIndex = routeSource.indexOf(headerStatement);
+const bodyIndex = routeSource.indexOf(bodyStatement);
+
+if (headerIndex === -1) {
+  throw new Error("The /health route does not set Cache-Control: no-store.");
+}
+
+if (bodyIndex === -1) {
+  throw new Error("The /health response body shape changed.");
+}
+
+if (headerIndex > bodyIndex) {
+  throw new Error("Cache-Control must be set before the /health JSON body.");
+}
+
+console.log("health cache policy ok");

--- a/apps/api/src/index.ts
+++ b/apps/api/src/index.ts
@@ -8,6 +8,7 @@ const port = process.env.PORT || 4000;
 app.use(express.json());
 
 app.get("/health", (_req, res) => {
+  res.set("Cache-Control", "no-store");
   res.json({ status: "ok", service: "taskflow-api" });
 });
 

--- a/contributors/agents.json
+++ b/contributors/agents.json
@@ -1,5 +1,13 @@
 {
-  "agents": [],
-  "last_updated": "2026-06-03",
-  "total_contributions": 0
+  "agents": [
+    {
+      "github_username": "snkk2x-collab",
+      "model": "GPT-5 Codex",
+      "version": "2026-06-18",
+      "pr_number": 0,
+      "issue_number": 1253
+    }
+  ],
+  "last_updated": "2026-06-18",
+  "total_contributions": 1
 }

--- a/contributors/agents.json
+++ b/contributors/agents.json
@@ -4,7 +4,7 @@
       "github_username": "snkk2x-collab",
       "model": "GPT-5 Codex",
       "version": "2026-06-18",
-      "pr_number": 0,
+      "pr_number": 2022,
       "issue_number": 1253
     }
   ],


### PR DESCRIPTION
## Summary
- Add `Cache-Control: no-store` to the existing `/health` response.
- Preserve the current `/health` JSON response shape.
- Add a focused validation script for the header and response body shape.
- Add the required AI-agent contribution metadata.

## Validation
- `/Users/sun/.cache/codex-runtimes/codex-primary-runtime/dependencies/node/bin/node apps/api/scripts/validate-health-cache.mjs`
- `/Users/sun/.cache/codex-runtimes/codex-primary-runtime/dependencies/node/bin/node -e "for (const f of ['contributors/agents.json','apps/api/package.json']) JSON.parse(require('fs').readFileSync(f,'utf8')); console.log('json ok')"`
- `git diff --check`

No UI demo video is attached because this is an API header behavior change with no UI.

Closes #1253
/claim #1253