### PR TITLE
[agent] feat: add finite pi prefix package

### DIFF
--- a/contributors/agents.json
+++ b/contributors/agents.json
@@ -4,7 +4,7 @@
       "github_username": "snkk2x-collab",
       "model": "GPT-5 Codex",
       "version": "2026-06-18",
-      "pr_number": 0,
+      "pr_number": 2023,
       "issue_number": 17
     }
   ],

--- a/contributors/agents.json
+++ b/contributors/agents.json
@@ -1,5 +1,13 @@
 {
-  "agents": [],
-  "last_updated": "2026-06-03",
-  "total_contributions": 0
+  "agents": [
+    {
+      "github_username": "snkk2x-collab",
+      "model": "GPT-5 Codex",
+      "version": "2026-06-18",
+      "pr_number": 0,
+      "issue_number": 17
+    }
+  ],
+  "last_updated": "2026-06-18",
+  "total_contributions": 1
 }

--- a/packages/pi-prefix/README.md
+++ b/packages/pi-prefix/README.md
@@ -1,0 +1,27 @@
+# @taskflow/pi-prefix
+
+Calculates exact finite decimal prefixes of pi with integer-only BigInt
+arithmetic.
+
+Pi does not have a final decimal point, so no finite program can print its
+complete infinite expansion. This package makes the practical target explicit:
+given a requested number of decimal places, it returns the exact finite prefix
+for that precision.
+
+## Usage
+
+```js
+import { calculatePiPrefix, createPiCertificate } from "@taskflow/pi-prefix";
+
+console.log(calculatePiPrefix(10));
+console.log(createPiCertificate(100));
+```
+
+## Demo
+
+```sh
+npm run demo -w @taskflow/pi-prefix -- 100
+```
+
+The demo prints the requested finite prefix plus a SHA-256 certificate that can
+be used to compare generated output across environments.

--- a/packages/pi-prefix/package.json
+++ b/packages/pi-prefix/package.json
@@ -1,0 +1,15 @@
+{
+  "name": "@taskflow/pi-prefix",
+  "version": "0.1.0",
+  "private": true,
+  "type": "module",
+  "description": "Exact finite decimal prefixes of pi using BigInt arithmetic.",
+  "main": "src/index.mjs",
+  "scripts": {
+    "demo": "node src/demo.mjs 100",
+    "test": "node --test test/*.test.mjs"
+  },
+  "engines": {
+    "node": ">=20"
+  }
+}

--- a/packages/pi-prefix/src/demo.mjs
+++ b/packages/pi-prefix/src/demo.mjs
@@ -1,0 +1,9 @@
+import { createPiCertificate, chunkPiPrefix } from "./index.mjs";
+
+const digits = Number.parseInt(process.argv[2] ?? "100", 10);
+const certificate = createPiCertificate(digits);
+const { whole, chunks } = chunkPiPrefix(certificate.prefix, 50);
+
+console.log(`pi finite prefix digits: ${certificate.decimalDigits}`);
+console.log(`sha256: ${certificate.sha256}`);
+console.log(`${whole}.${chunks.join(" ")}`);

--- a/packages/pi-prefix/src/index.mjs
+++ b/packages/pi-prefix/src/index.mjs
@@ -1,0 +1,86 @@
+import { createHash } from "node:crypto";
+
+const MAX_DIGITS = 100_000;
+
+function assertDigitCount(digits) {
+  if (!Number.isInteger(digits) || digits < 0 || digits > MAX_DIGITS) {
+    throw new RangeError(
+      `digits must be an integer between 0 and ${MAX_DIGITS}`
+    );
+  }
+}
+
+function pow10(exponent) {
+  return 10n ** BigInt(exponent);
+}
+
+function arctanInverse(invX, scale) {
+  const x = BigInt(invX);
+  const xSquared = x * x;
+  let term = scale / x;
+  let sum = term;
+  let denominator = 3n;
+  let sign = -1n;
+
+  while (term !== 0n) {
+    term /= xSquared;
+    const contribution = term / denominator;
+
+    if (contribution === 0n) {
+      break;
+    }
+
+    sum += sign * contribution;
+    sign *= -1n;
+    denominator += 2n;
+  }
+
+  return sum;
+}
+
+export function calculatePiPrefix(digits = 100) {
+  assertDigitCount(digits);
+
+  const guardDigits = Math.max(12, Math.ceil(digits / 8));
+  const scale = pow10(digits + guardDigits);
+  const piScaled =
+    16n * arctanInverse(5, scale) - 4n * arctanInverse(239, scale);
+  const trimmed = piScaled / pow10(guardDigits);
+
+  if (digits === 0) {
+    return (trimmed / pow10(0)).toString();
+  }
+
+  const decimalScale = pow10(digits);
+  const whole = trimmed / decimalScale;
+  const fractional = (trimmed % decimalScale).toString().padStart(digits, "0");
+
+  return `${whole}.${fractional}`;
+}
+
+export function chunkPiPrefix(prefix, chunkSize = 50) {
+  if (!Number.isInteger(chunkSize) || chunkSize <= 0) {
+    throw new RangeError("chunkSize must be a positive integer");
+  }
+
+  const [whole, fractional = ""] = prefix.split(".");
+  const chunks = [];
+
+  for (let index = 0; index < fractional.length; index += chunkSize) {
+    chunks.push(fractional.slice(index, index + chunkSize));
+  }
+
+  return { whole, chunks };
+}
+
+export function createPiCertificate(digits = 100) {
+  const prefix = calculatePiPrefix(digits);
+  const hash = createHash("sha256").update(prefix).digest("hex");
+
+  return {
+    digits,
+    prefix,
+    decimalDigits: digits,
+    sha256: hash
+  };
+}

--- a/packages/pi-prefix/test/pi-prefix.test.mjs
+++ b/packages/pi-prefix/test/pi-prefix.test.mjs
@@ -1,0 +1,40 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+
+import {
+  calculatePiPrefix,
+  chunkPiPrefix,
+  createPiCertificate
+} from "../src/index.mjs";
+
+const KNOWN_100_DIGITS =
+  "3.1415926535897932384626433832795028841971693993751058209749445923078164062862089986280348253421170679";
+
+test("calculates exact finite pi prefixes", () => {
+  assert.equal(calculatePiPrefix(0), "3");
+  assert.equal(calculatePiPrefix(1), "3.1");
+  assert.equal(calculatePiPrefix(10), "3.1415926535");
+  assert.equal(calculatePiPrefix(100), KNOWN_100_DIGITS);
+});
+
+test("rejects unsupported digit counts", () => {
+  assert.throws(() => calculatePiPrefix(-1), RangeError);
+  assert.throws(() => calculatePiPrefix(1.5), RangeError);
+  assert.throws(() => calculatePiPrefix(100_001), RangeError);
+});
+
+test("chunks only the decimal portion", () => {
+  assert.deepEqual(chunkPiPrefix("3.141592", 3), {
+    whole: "3",
+    chunks: ["141", "592"]
+  });
+});
+
+test("creates a stable verification certificate", () => {
+  const certificate = createPiCertificate(10);
+
+  assert.equal(certificate.digits, 10);
+  assert.equal(certificate.decimalDigits, 10);
+  assert.equal(certificate.prefix, "3.1415926535");
+  assert.match(certificate.sha256, /^[a-f0-9]{64}$/);
+});


### PR DESCRIPTION
## Summary
- Add `@taskflow/pi-prefix`, a dependency-free workspace package for exact finite decimal prefixes of pi using BigInt integer arithmetic.
- Expose prefix, chunking, and SHA-256 certificate helpers for auditable demo output.
- Include a CLI demo command and deterministic `node:test` coverage against the known 100-digit prefix from the issue.
- Document that pi has no final decimal digit, so the package returns exact requested finite prefixes instead of pretending the infinite expansion can terminate.
- Add the required AI-agent contribution metadata.

## Demo
`/Users/sun/.cache/codex-runtimes/codex-primary-runtime/dependencies/node/bin/node packages/pi-prefix/src/demo.mjs 25`

```text
pi finite prefix digits: 25
sha256: 6e172c87859b68e34a43da05bcd32dba137c66c93dd8a735124a7d6202de83fc
3.1415926535897932384626433
```

## Validation
- `/Users/sun/.cache/codex-runtimes/codex-primary-runtime/dependencies/node/bin/node --test packages/pi-prefix/test/*.test.mjs`
- `/Users/sun/.cache/codex-runtimes/codex-primary-runtime/dependencies/node/bin/node packages/pi-prefix/src/demo.mjs 25`
- `/Users/sun/.cache/codex-runtimes/codex-primary-runtime/dependencies/node/bin/node -e "for (const f of ['contributors/agents.json','packages/pi-prefix/package.json']) JSON.parse(require('fs').readFileSync(f,'utf8')); console.log('json ok')"`
- `git diff --check`

Closes #17
/claim #17