### PR TITLE
Document environment variables

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,7 @@
+# Copy this file to .env and fill in your values.
+
+# Port the Express API listens on (default: 4000)
+PORT=4000
+
+# PostgreSQL connection string — required by Prisma
+DATABASE_URL=postgresql://user:password@localhost:5432/taskflow

--- a/README.md
+++ b/README.md
@@ -83,3 +83,12 @@ with models for:
 
 Each app/package expects its own .env values for DB, auth, 
 and integrations.
+
+### API (`apps/api`)
+
+| Variable | Required | Default | Description |
+|----------|----------|---------|-------------|
+| `PORT` | No | `4000` | Port the Express API listens on |
+| `DATABASE_URL` | **Yes** | — | PostgreSQL connection string used by Prisma |
+
+Copy `.env.example` to `.env` in the repo root (or inside `apps/api`) and fill in your values:


### PR DESCRIPTION
## Summary

Adds clear environment variable documentation so contributors and deployers know what to configure:

- Expanded the `## Environment Variables` section in `README.md` with a table listing `PORT` (default: 4000) and `DATABASE_URL` (required by Prisma)
- Added `.env.example` at the repo root with pre-filled example values for both variables

Closes #4
Ref: https://github.com/xevrion-v2/agent-playground/issues/4