### PR TITLE
Add input validation to user routes

### DIFF
--- a/apps/api/src/routes/users.ts
+++ b/apps/api/src/routes/users.ts
@@ -10,6 +10,15 @@ router.get("/", (_req, res) => {
 });
 
 router.post("/", (req, res) => {
+  const { email, name } = req.body ?? {};
+
+  // Validate required fields: email and name must be non-empty strings
+  if (typeof email !== "string" || email.trim() === "" ||
+      typeof name !== "string" || name.trim() === "") {
+    res.status(400).json({ error: "email and name are required" });
+    return;
+  }
+
   res.status(201).json({
     data: {
       id: "stub-user-id",


### PR DESCRIPTION
## Summary

Adds basic request body validation to the `POST /users` route:

- Checks that `email` is a non-empty string
- Checks that `name` is a non-empty string
- Returns `400 { error: "email and name are required" }` immediately if either is missing or not a string

This prevents malformed stub responses from being created and lays the groundwork for real persistence logic.

Closes #6
Ref: https://github.com/xevrion-v2/agent-playground/issues/6