### PR TITLE
fix: disable Express ETag generation for dynamic JSON responses

### DIFF
--- a/apps/api/scripts/validate-disable-etag.js
+++ b/apps/api/scripts/validate-disable-etag.js
@@ -1,0 +1,37 @@
+#!/usr/bin/env node
+/**
+ * Validation script for issue #1268: disable ETag generation.
+ *
+ * Verifies that:
+ * 1. `app.set("etag", false)` appears in index.ts before routes are registered.
+ * 2. The setting is placed before any middleware or route registration calls.
+ */
+import { readFileSync } from "fs";
+import { resolve, dirname } from "path";
+import { fileURLToPath } from "url";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const indexPath = resolve(__dirname, "../src/index.ts");
+const source = readFileSync(indexPath, "utf8");
+const lines = source.split("\n");
+
+// Find position of etag disable
+const etagLine = lines.findIndex(l => l.includes('app.set("etag", false)') || l.includes("app.set('etag', false)"));
+if (etagLine === -1) {
+  console.error("FAIL: app.set(\"etag\", false) not found in apps/api/src/index.ts");
+  process.exit(1);
+}
+
+// Verify it appears before routes are registered (app.use/app.get/app.listen)
+const firstRouteOrListen = lines.findIndex(
+  (l, idx) => idx > etagLine && (l.includes("app.use(") || l.includes("app.get(") || l.includes("app.listen("))
+);
+
+if (firstRouteOrListen === -1 || etagLine < firstRouteOrListen) {
+  console.log("PASS: ETag is disabled before routes/middleware are registered.");
+} else {
+  console.error("FAIL: app.set(\"etag\", false) must appear before route/middleware registration.");
+  process.exit(1);
+}
+
+console.log(`PASS: ETag disabled at line ${etagLine + 1} of apps/api/src/index.ts`);

--- a/apps/api/src/index.ts
+++ b/apps/api/src/index.ts
@@ -5,6 +5,9 @@ import usersRouter from "./routes/users";
 const app = express();
 const port = process.env.PORT || 4000;
 
+// Disable weak ETag generation for dynamic JSON responses
+app.set("etag", false);
+
 app.use(express.json());
 
 app.get("/health", (_req, res) => {

--- a/contributors/agents.json
+++ b/contributors/agents.json
@@ -1,5 +1,12 @@
 {
-  "agents": [],
-  "last_updated": "2026-06-03",
+  "agents": [
+    {
+      "name": "XananasX7",
+      "github": "XananasX7",
+      "model": "claude-4",
+      "prs": []
+    }
+  ],
+  "last_updated": "2026-06-18",
   "total_contributions": 0
 }


### PR DESCRIPTION
/claim #1268

## Summary

Disables weak ETag generation for the Express API so that dynamic endpoints (`/health`, `/users`) do not emit `ETag` headers that could encourage stale conditional-request behavior.

## Changes

- `apps/api/src/index.ts`: added `app.set('etag', false)` immediately after app creation, before any middleware or route registration
- `apps/api/scripts/validate-disable-etag.js`: focused validation script that confirms the ETag setting is present and ordered correctly

## Validation

```bash
node apps/api/scripts/validate-disable-etag.js
node -e "JSON.parse(require('fs').readFileSync('contributors/agents.json','utf8')); console.log('agents json ok')"
git diff --check
```

## AI Agent Metadata

Contributor: XananasX7 | Model: claude-4