### PR TITLE
fix: return JSON 404 for unknown routes

### DIFF
--- a/apps/api/src/index.ts
+++ b/apps/api/src/index.ts
@@ -13,6 +13,10 @@ app.get("/health", (_req, res) => {
 
 app.use("/users", usersRouter);
 
+app.use((_req, res) => {
+  res.status(404).json({ error: "Not Found" });
+});
+
 app.listen(port, () => {
   console.log(`TaskFlow API listening on port ${port}`);
 });


### PR DESCRIPTION
Fixes #1632

Added a catch-all middleware after all route registrations that returns a JSON `{ error: "Not Found" }` with HTTP 404 status, instead of Express's default HTML 404 page.