### PR TITLE
fix: add Cache-Control no-cache header to /health endpoint

### DIFF
--- a/apps/api/src/index.ts
+++ b/apps/api/src/index.ts
@@ -8,6 +8,7 @@ const port = process.env.PORT || 4000;
 app.use(express.json());
 
 app.get("/health", (_req, res) => {
+  res.setHeader("Cache-Control", "no-store, no-cache, must-revalidate");
   res.json({ status: "ok", service: "taskflow-api" });
 });
 


### PR DESCRIPTION
Fixes #1253

Added `Cache-Control: no-store, no-cache, must-revalidate` header to the `/health` response so proxies and clients always fetch a fresh status rather than serving a stale cached copy.