### PR TITLE
fix: disable X-Powered-By header

### DIFF
--- a/apps/api/src/index.ts
+++ b/apps/api/src/index.ts
@@ -3,6 +3,7 @@ import express from "express";
 import usersRouter from "./routes/users";
 
 const app = express();
+app.disable("x-powered-by");
 const port = process.env.PORT || 4000;
 
 app.use(express.json());


### PR DESCRIPTION
Fixes #1072

Called `app.disable("x-powered-by")` immediately after creating the Express app to prevent Express from advertising itself via the `X-Powered-By: Express` response header, reducing information leakage.