### PR TITLE
fix: validate PORT env var, fall back to 4000 on invalid value

### DIFF
--- a/apps/api/src/index.ts
+++ b/apps/api/src/index.ts
@@ -3,7 +3,9 @@ import express from "express";
 import usersRouter from "./routes/users";
 
 const app = express();
-const port = process.env.PORT || 4000;
+const rawPort = process.env.PORT;
+const parsedPort = rawPort !== undefined ? parseInt(rawPort, 10) : NaN;
+const port = (rawPort === undefined || isNaN(parsedPort) || parsedPort < 0 || parsedPort > 65535) ? 4000 : parsedPort;
 
 app.use(express.json());
 


### PR DESCRIPTION
Fixes #1126

Replaced the simple `process.env.PORT || 4000` with proper validation: parses the env var as an integer and falls back to port 4000 if the value is absent, NaN, or out of the valid 0–65535 range. This prevents a crash on startup when PORT is set to a non-numeric string.