### PR TITLE
fix: return JSON 400 for malformed request bodies

### DIFF
--- a/apps/api/src/index.ts
+++ b/apps/api/src/index.ts
@@ -7,6 +7,13 @@ const port = process.env.PORT || 4000;
 
 app.use(express.json());
 
+app.use((err: Error, _req: express.Request, res: express.Response, next: express.NextFunction) => {
+  if (err instanceof SyntaxError && "body" in err) {
+    return res.status(400).json({ error: "Invalid JSON" });
+  }
+  next(err);
+});
+
 app.get("/health", (_req, res) => {
   res.json({ status: "ok", service: "taskflow-api" });
 });


### PR DESCRIPTION
Fixes #1248

Added a 4-argument Express error handler immediately after `express.json()` middleware. When a `SyntaxError` with a `body` property is thrown (Express's signal for a JSON parse failure), it intercepts the error and responds with `{ error: "Invalid JSON" }` and HTTP 400, instead of letting Express fall through to its default HTML error page.