### PR TITLE
fix: return 405 for unsupported methods on /users (#1168)

### DIFF
--- a/apps/api/src/routes/users.ts
+++ b/apps/api/src/routes/users.ts
@@ -19,4 +19,9 @@ router.post("/", (req, res) => {
   });
 });
 
+router.all("/", (_req, res) => {
+  res.setHeader("Allow", "GET, POST");
+  res.status(405).json({ error: "Method Not Allowed" });
+});
+
 export default router;


### PR DESCRIPTION
Fixes #1168

Add a catch-all `router.all("/")` handler after the GET and POST routes that responds with HTTP 405 and an `Allow: GET, POST` header for any other method (DELETE, PATCH, PUT, etc.).