### PR TITLE
fix: reject invalid email values in POST /users (#1357)

### DIFF
--- a/apps/api/src/routes/users.ts
+++ b/apps/api/src/routes/users.ts
@@ -10,11 +10,12 @@ router.get("/", (_req, res) => {
 });
 
 router.post("/", (req, res) => {
+  const { email } = req.body ?? {};
+  if (!email || typeof email !== "string" || !/^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(email)) {
+    return res.status(400).json({ error: "Invalid email" });
+  }
   res.status(201).json({
-    data: {
-      id: "stub-user-id",
-      ...req.body
-    },
+    data: { id: "stub-user-id", ...req.body },
     message: "User creation is not implemented yet."
   });
 });


### PR DESCRIPTION
Fixes #1357

Add email validation to the POST /users handler. Requests with a missing, non-string, or malformed email field now receive a 400 response with `{ error: "Invalid email" }` instead of being accepted blindly.