### PR TITLE
fix: disable Next.js X-Powered-By response header (#1089)

### DIFF
--- a/apps/web/next.config.mjs
+++ b/apps/web/next.config.mjs
@@ -1,0 +1,6 @@
+/** @type {import('next').NextConfig} */
+const nextConfig = {
+  poweredByHeader: false,
+};
+
+export default nextConfig;


### PR DESCRIPTION
Fixes #1089

Create `apps/web/next.config.mjs` with `poweredByHeader: false` to stop Next.js from emitting the `X-Powered-By: Next.js` response header, reducing information disclosure.