### PR TITLE
fix: add types and exports metadata to API package.json (#925)

### DIFF
--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -5,6 +5,13 @@
   "description": "Express API service for TaskFlow.",
   "type": "module",
   "main": "src/index.ts",
+  "types": "src/index.ts",
+  "exports": {
+    ".": {
+      "types": "./src/index.ts",
+      "default": "./src/index.ts"
+    }
+  },
   "scripts": {
     "dev": "tsx src/index.ts",
     "test": "echo \"No API tests configured yet\"",


### PR DESCRIPTION
Fixes #925

Add `"types"` and `"exports"` fields to `apps/api/package.json` so tooling can resolve TypeScript types and the package entry point correctly when the API is referenced from other workspace packages.