### PR TITLE
[agent] Add explicit type annotations to Button component

### DIFF
--- a/contributors/agents.json
+++ b/contributors/agents.json
@@ -1,5 +1,13 @@
 {
-  "agents": [],
-  "last_updated": "2026-06-03",
-  "total_contributions": 0
+  "agents": [
+    {
+      "github_username": "GautamKumarOffical",
+      "model": "mimo-v2.5-free",
+      "version": "latest",
+      "pr_number": null,
+      "issue_number": 3
+    }
+  ],
+  "last_updated": "2026-06-19",
+  "total_contributions": 1
 }

--- a/packages/ui/src/index.ts
+++ b/packages/ui/src/index.ts
@@ -1,9 +1,24 @@
 export type ButtonProps = {
+  /** The text displayed inside the button. */
   label: string;
+  /** Whether the button is disabled. Defaults to false. */
   disabled?: boolean;
 };
 
-export function Button({ label, disabled = false }: ButtonProps) {
+/** The object returned by the Button component. */
+export type ButtonResult = {
+  type: "button";
+  label: string;
+  disabled: boolean;
+};
+
+/**
+ * Creates a button object with the given label and disabled state.
+ *
+ * @param props - Button configuration.
+ * @returns A {@link ButtonResult} describing the button.
+ */
+export function Button({ label, disabled = false }: ButtonProps): ButtonResult {
   return {
     type: "button",
     label,


### PR DESCRIPTION
## Summary

This PR improves type safety for the shared Button component by adding explicit type annotations without changing its public shape.

### Changes

- **`packages/ui/src/index.ts`**:
  - Exported a new `ButtonResult` type that mirrors the runtime return shape (`{ type: "button", label: string, disabled: boolean }`).
  - Added an explicit return type annotation to the `Button` function.
  - Added JSDoc comments to `ButtonProps` fields and the `Button` function.

- **`contributors/agents.json`**: Added agent metadata entry as required by CONTRIBUTING.md.

### What stays the same

- The `Button` function still returns the same `{ type, label, disabled }` object — no runtime behavior changed.
- The public `ButtonProps` type keeps the same shape.

Closes #3