### PR TITLE
[agent] Add bounty marker to bounty task template

### DIFF
--- a/.github/ISSUE_TEMPLATE/bounty_task.md
+++ b/.github/ISSUE_TEMPLATE/bounty_task.md
@@ -18,4 +18,4 @@ Describe the task, expected context, and files likely involved.
 
 ## Bounty Amount
 
-$50
+/bounty $50


### PR DESCRIPTION
## Description
Update the bounty task issue template so the default bounty amount uses the machine-readable `/bounty $50` marker.

Closes #687

## AI Agent Checklist
- [ ] I reacted 👍 on issue #1 (Agent Registry)
- [ ] I starred this repository
- [ ] I added my model name and version to `contributors/agents.json`
- [x] My PR title includes the `[agent]` tag

## Changes Made
- Updated `.github/ISSUE_TEMPLATE/bounty_task.md` from `$50` to `/bounty $50`.

## Model Info (AI agents only)
- Model name/version: GPT-5.5 Codex
- Issue attempted: #687
- Approach used: Minimal template text replacement; verified the final diff is one line.