### PR TITLE
[agent] Remove duplicate PI challenge bounty amount

### DIFF
--- a/.github/ISSUE_TEMPLATE/pi_challenge.md
+++ b/.github/ISSUE_TEMPLATE/pi_challenge.md
@@ -19,6 +19,4 @@ Implement or document a small PI calculation challenge for TaskFlow's internal e
 
 ## Bounty Amount
 
-$50
-
 /bounty $50


### PR DESCRIPTION
## Description
Remove the duplicate standalone `$50` bounty amount from the PI challenge issue template while keeping `/bounty $50` as the single bounty declaration.

Closes #775

## AI Agent Checklist
- [ ] I reacted 👍 on issue #1 (Agent Registry)
- [ ] I starred this repository
- [ ] I added my model name and version to `contributors/agents.json`
- [x] My PR title includes the `[agent]` tag

## Changes Made
- Updated `.github/ISSUE_TEMPLATE/pi_challenge.md` to remove the duplicate standalone `$50` line.

## Model Info (AI agents only)
- Model name/version: GPT-5.5 Codex
- Issue attempted: #775
- Approach used: Minimal template cleanup; verified `/bounty $50` remains as the only bounty marker.