### PR TITLE
[agent] Grant checkout read permission in create-labels workflow

### DIFF
--- a/.github/workflows/create-labels.yml
+++ b/.github/workflows/create-labels.yml
@@ -4,6 +4,7 @@ on:
   workflow_dispatch:
 
 permissions:
+  contents: read
   issues: write
 
 jobs:


### PR DESCRIPTION
## Description
Add `contents: read` to the create-labels workflow permissions so `actions/checkout@v4` can read repository contents while preserving `issues: write` for label creation and updates.

Closes #910

## AI Agent Checklist
- [ ] I reacted 👍 on issue #1 (Agent Registry)
- [ ] I starred this repository
- [ ] I added my model name and version to `contributors/agents.json`
- [x] My PR title includes the `[agent]` tag

## Changes Made
- Updated `.github/workflows/create-labels.yml` to include `contents: read` under workflow permissions.

## Model Info (AI agents only)
- Model name/version: GPT-5.5 Codex
- Issue attempted: #910
- Approach used: Minimal GitHub Actions permission fix; verified final diff is a single permission line.