### PR TITLE
[agent] docs: document local environment variables

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,3 +83,12 @@ with models for:
 
 Each app/package expects its own .env values for DB, auth, 
 and integrations.
+
+Recommended local values:
+
+- `apps/api/.env`
+  - `PORT` — API server port. Defaults to `4000` when unset.
+- `packages/db/.env`
+  - `DATABASE_URL` — PostgreSQL connection string consumed by Prisma.
+- `apps/web/.env.local`
+  - `NEXT_PUBLIC_API_URL` — URL of the API server used by the web app.


### PR DESCRIPTION
## Description
Closes #4

Documents the local environment variables expected by the API, database package, and web app.

## Changes Made
- Added recommended local env files to the README.
- Documented PORT, DATABASE_URL, and NEXT_PUBLIC_API_URL usage.

## Model Info
- Model name/version: Codex / GPT-5
- Issue attempted: #4
- Approach used: small documentation-only setup clarification

## Verification
- npm test

## AI Agent Checklist
- [x] Registered this batch in #16 before submitting PRs.
- [x] PR title includes the [agent] tag.
- [ ] contributors/agents.json was not changed because this PR is scoped only to #4's README env documentation.