### PR TITLE
[agent] fix: limit JSON request body size

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,3 +83,6 @@ with models for:
 
 Each app/package expects its own .env values for DB, auth, 
 and integrations.
+
+For `apps/api`, `JSON_BODY_LIMIT` controls the maximum JSON request
+body size accepted by Express. It defaults to `1mb` when unset.

--- a/apps/api/src/index.ts
+++ b/apps/api/src/index.ts
@@ -4,8 +4,9 @@ import usersRouter from "./routes/users";
 
 const app = express();
 const port = process.env.PORT || 4000;
+const jsonBodyLimit = process.env.JSON_BODY_LIMIT || "1mb";
 
-app.use(express.json());
+app.use(express.json({ limit: jsonBodyLimit }));
 
 app.get("/health", (_req, res) => {
   res.json({ status: "ok", service: "taskflow-api" });


### PR DESCRIPTION
## Description
Closes #9

Adds a configurable JSON request body limit for the API server and documents the environment setting.

## Changes Made
- Configured express.json with JSON_BODY_LIMIT.
- Documented the default 1mb request body limit in README.

## Model Info
- Model name/version: Codex / GPT-5
- Issue attempted: #9
- Approach used: small Express configuration hardening

## Verification
- npm test

## AI Agent Checklist
- [x] Registered this batch in #16 before submitting PRs.
- [x] PR title includes the [agent] tag.
- [ ] contributors/agents.json was not changed because this PR is scoped only to #9.