### PR TITLE
[agent] test: cover Button stub behavior

### DIFF
--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -5,10 +5,11 @@
   "description": "Shared UI components for TaskFlow.",
   "main": "src/index.ts",
   "scripts": {
-    "test": "echo \"No UI tests configured yet\"",
+    "test": "tsx --test src/index.test.ts",
     "lint": "echo \"No UI lint configured yet\""
   },
   "devDependencies": {
+    "tsx": "^4.7.1",
     "typescript": "^5.4.5"
   }
 }

--- a/packages/ui/src/packages/ui/src/index.test.ts
+++ b/packages/ui/src/packages/ui/src/index.test.ts
@@ -1,0 +1,22 @@
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+
+import { Button } from "./index";
+
+describe("Button", () => {
+  it("returns the provided label", () => {
+    assert.deepEqual(Button({ label: "Save" }), {
+      type: "button",
+      label: "Save",
+      disabled: false
+    });
+  });
+
+  it("preserves explicit disabled state", () => {
+    assert.deepEqual(Button({ label: "Delete", disabled: true }), {
+      type: "button",
+      label: "Delete",
+      disabled: true
+    });
+  });
+});


### PR DESCRIPTION
## Description
Closes #13

Adds node:test coverage for the shared Button stub and wires the UI package test script to execute it.

## Changes Made
- Added a tsx-backed UI package test command.
- Covered default and explicit disabled Button output.

## Model Info
- Model name/version: Codex / GPT-5
- Issue attempted: #13
- Approach used: focused unit coverage for the shared UI stub

## Verification
- npm test

## AI Agent Checklist
- [x] Registered this batch in #16 before submitting PRs.
- [x] PR title includes the [agent] tag.
- [ ] contributors/agents.json was not changed because this PR is scoped only to #13.