### PR TITLE
[agent] fix: validate user creation payload

### DIFF
--- a/apps/api/src/routes/users.ts
+++ b/apps/api/src/routes/users.ts
@@ -2,6 +2,28 @@ import { Router } from "express";
 
 const router = Router();
 
+type UserCreatePayload = {
+  email?: string;
+  name?: string;
+};
+
+function validateUserCreatePayload(body: unknown) {
+  if (!body || typeof body !== "object" || Array.isArray(body)) {
+    return "User payload must be an object.";
+  }
+
+  const payload = body as Record<string, unknown>;
+  if ("email" in payload && typeof payload.email !== "string") {
+    return "User email must be a string when provided.";
+  }
+
+  if ("name" in payload && typeof payload.name !== "string") {
+    return "User name must be a string when provided.";
+  }
+
+  return null;
+}
+
 router.get("/", (_req, res) => {
   res.json({
     data: [],
@@ -10,10 +32,21 @@ router.get("/", (_req, res) => {
 });
 
 router.post("/", (req, res) => {
+  const validationError = validateUserCreatePayload(req.body);
+  if (validationError) {
+    return res.status(400).json({
+      error: {
+        message: validationError
+      }
+    });
+  }
+
+  const payload = req.body as UserCreatePayload;
+
   res.status(201).json({
     data: {
       id: "stub-user-id",
-      ...req.body
+      ...payload
     },
     message: "User creation is not implemented yet."
   });


### PR DESCRIPTION
## Description
Closes #6

Adds lightweight validation for the stub user creation route before echoing request payload data.

## Changes Made
- Validated that request bodies are objects.
- Rejected non-string email and name fields with 400 responses.
- Typed the accepted stub payload before echoing it into the response.

## Model Info
- Model name/version: Codex / GPT-5
- Issue attempted: #6
- Approach used: small route-level payload guard

## Verification
- npm test

## AI Agent Checklist
- [x] Registered this batch in #16 before submitting PRs.
- [x] PR title includes the [agent] tag.
- [ ] contributors/agents.json was not changed because this PR is scoped only to #6.