### PR TITLE
[agent] Add PI spigot verifier package

### DIFF
--- a/contributors/agents.json
+++ b/contributors/agents.json
@@ -1,5 +1,13 @@
 {
-  "agents": [],
-  "last_updated": "2026-06-03",
-  "total_contributions": 0
+  "agents": [
+    {
+      "github_username": "jaxassistant55",
+      "model": "GPT-5 Codex",
+      "version": "2026-06-20",
+      "pr_number": 2059,
+      "issue_number": 17
+    }
+  ],
+  "last_updated": "2026-06-20",
+  "total_contributions": 1
 }

--- a/packages/pi-spigot/README.md
+++ b/packages/pi-spigot/README.md
@@ -1,0 +1,46 @@
+# @taskflow/pi-spigot
+
+`@taskflow/pi-spigot` is a dependency-free PI digit stream for the
+TaskFlow playground. It emits the decimal expansion one digit at a time with
+BigInt integer state instead of using floating point arithmetic or a
+precomputed constant.
+
+PI has no final decimal digit, so this package answers the finite, verifiable
+version of issue #17: produce the exact prefix for a requested number of
+decimal places and include enough metadata to audit that prefix.
+
+## Usage
+
+```bash
+npm run demo -w @taskflow/pi-spigot -- 100
+```
+
+Example output starts with the issue's known 100-digit prefix:
+
+```text
+3.1415926535 8979323846 2643383279 5028841971 6939937510 5820974944 5923078164
+0628620899 8628034825 3421170679
+
+digits_after_decimal=100
+algorithm=unbounded-spigot-bigint
+```
+
+Programmatic API:
+
+```js
+import { createPiCertificate, piDecimalWindow, piPrefix } from "@taskflow/pi-spigot";
+
+console.log(piPrefix(25));
+console.log(piDecimalWindow(10, 10));
+console.log(createPiCertificate(100));
+```
+
+## Validation
+
+```bash
+npm test -w @taskflow/pi-spigot
+```
+
+The tests verify the first 100 decimal places from issue #17, the digit stream
+order, decimal window extraction, certificate metadata, formatting, and input
+validation.

--- a/packages/pi-spigot/package.json
+++ b/packages/pi-spigot/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "@taskflow/pi-spigot",
+  "version": "0.1.0",
+  "private": true,
+  "description": "Dependency-free exact finite PI digit stream for the TaskFlow playground.",
+  "type": "module",
+  "exports": "./src/index.mjs",
+  "scripts": {
+    "demo": "node src/cli.mjs",
+    "test": "node --test test/*.test.mjs"
+  }
+}

--- a/packages/pi-spigot/src/cli.mjs
+++ b/packages/pi-spigot/src/cli.mjs
@@ -1,0 +1,29 @@
+import { createPiCertificate, formatPiPrefix, piPrefix } from "./index.mjs";
+
+function parseIntegerArgument(value, fallback, name) {
+  if (value === undefined) {
+    return fallback;
+  }
+
+  const parsed = Number(value);
+
+  if (!Number.isInteger(parsed)) {
+    throw new RangeError(`${name} must be an integer`);
+  }
+
+  return parsed;
+}
+
+const decimalPlaces = parseIntegerArgument(process.argv[2], 100, "decimalPlaces");
+const groupSize = parseIntegerArgument(process.argv[3], 10, "groupSize");
+const prefix = piPrefix(decimalPlaces);
+const certificate = createPiCertificate(decimalPlaces);
+
+console.log(formatPiPrefix(prefix, groupSize));
+console.log("");
+console.log(`digits_after_decimal=${certificate.decimalPlaces}`);
+console.log(`algorithm=${certificate.algorithm}`);
+console.log(`sha256=${certificate.sha256}`);
+console.log(`last_20_decimals=${certificate.lastTwentyDecimals}`);
+console.log(`known_100_prefix_match=${certificate.known100PrefixMatch}`);
+console.log(`note=${certificate.note}`);

--- a/packages/pi-spigot/src/index.mjs
+++ b/packages/pi-spigot/src/index.mjs
@@ -1,0 +1,137 @@
+import { createHash } from "node:crypto";
+
+export const ISSUE_17_PREFIX_100 =
+  "3.1415926535897932384626433832795028841971693993751058209749445923078164062862089986280348253421170679";
+
+const DEFAULT_DECIMAL_PLACES = 100;
+const MAX_DECIMAL_PLACES = 10000;
+
+function assertNonNegativeInteger(name, value) {
+  if (!Number.isInteger(value) || value < 0) {
+    throw new RangeError(`${name} must be a non-negative integer`);
+  }
+}
+
+function assertDigitBudget(decimalPlaces) {
+  assertNonNegativeInteger("decimalPlaces", decimalPlaces);
+
+  if (decimalPlaces > MAX_DECIMAL_PLACES) {
+    throw new RangeError(`decimalPlaces must be <= ${MAX_DECIMAL_PLACES}`);
+  }
+}
+
+export function* piDigitStream() {
+  let q = 1n;
+  let r = 0n;
+  let t = 1n;
+  let k = 1n;
+  let n = 3n;
+  let l = 3n;
+
+  while (true) {
+    if (4n * q + r - t < n * t) {
+      yield Number(n);
+
+      const nextR = 10n * (r - n * t);
+      const nextN = (10n * (3n * q + r)) / t - 10n * n;
+      q *= 10n;
+      r = nextR;
+      n = nextN;
+    } else {
+      const nextR = (2n * q + r) * l;
+      const nextN = (q * (7n * k) + 2n + r * l) / (t * l);
+      q *= k;
+      t *= l;
+      l += 2n;
+      k += 1n;
+      n = nextN;
+      r = nextR;
+    }
+  }
+}
+
+export function piPrefix(decimalPlaces = DEFAULT_DECIMAL_PLACES) {
+  assertDigitBudget(decimalPlaces);
+
+  const stream = piDigitStream();
+  const integerPart = stream.next().value;
+
+  if (decimalPlaces === 0) {
+    return String(integerPart);
+  }
+
+  const decimals = [];
+
+  for (let index = 0; index < decimalPlaces; index += 1) {
+    decimals.push(String(stream.next().value));
+  }
+
+  return `${integerPart}.${decimals.join("")}`;
+}
+
+export function piDecimalWindow(offset, count) {
+  assertNonNegativeInteger("offset", offset);
+  assertDigitBudget(count);
+
+  if (offset + count > MAX_DECIMAL_PLACES) {
+    throw new RangeError(`offset + count must be <= ${MAX_DECIMAL_PLACES}`);
+  }
+
+  const stream = piDigitStream();
+  stream.next();
+
+  for (let skipped = 0; skipped < offset; skipped += 1) {
+    stream.next();
+  }
+
+  const digits = [];
+
+  for (let index = 0; index < count; index += 1) {
+    digits.push(String(stream.next().value));
+  }
+
+  return digits.join("");
+}
+
+export function createPiCertificate(decimalPlaces = DEFAULT_DECIMAL_PLACES) {
+  const prefix = piPrefix(decimalPlaces);
+  const decimalPart = prefix.includes(".") ? prefix.split(".")[1] : "";
+
+  return {
+    algorithm: "unbounded-spigot-bigint",
+    decimalPlaces,
+    sha256: createHash("sha256").update(prefix).digest("hex"),
+    firstTwenty: prefix.slice(0, 22),
+    lastTwentyDecimals: decimalPart.slice(-20),
+    known100PrefixMatch:
+      decimalPlaces >= 100
+        ? prefix.slice(0, ISSUE_17_PREFIX_100.length) === ISSUE_17_PREFIX_100
+        : null,
+    note:
+      "PI has no final decimal digit; this certifies the exact finite prefix emitted for the requested precision."
+  };
+}
+
+export function formatPiPrefix(prefix, groupSize = 10, groupsPerLine = 7) {
+  assertNonNegativeInteger("groupSize", groupSize);
+  assertNonNegativeInteger("groupsPerLine", groupsPerLine);
+
+  if (groupSize === 0 || groupsPerLine === 0) {
+    throw new RangeError("groupSize and groupsPerLine must be greater than 0");
+  }
+
+  const [integerPart, decimalPart = ""] = prefix.split(".");
+
+  if (decimalPart.length === 0) {
+    return integerPart;
+  }
+
+  const groups = decimalPart.match(new RegExp(`.{1,${groupSize}}`, "g")) ?? [];
+  const lines = [];
+
+  for (let index = 0; index < groups.length; index += groupsPerLine) {
+    lines.push(groups.slice(index, index + groupsPerLine).join(" "));
+  }
+
+  return `${integerPart}.${lines.join("\n")}`;
+}

--- a/packages/pi-spigot/test/pi-spigot.test.mjs
+++ b/packages/pi-spigot/test/pi-spigot.test.mjs
@@ -1,0 +1,48 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import {
+  ISSUE_17_PREFIX_100,
+  createPiCertificate,
+  formatPiPrefix,
+  piDecimalWindow,
+  piDigitStream,
+  piPrefix
+} from "../src/index.mjs";
+
+test("matches the issue's known 100-digit prefix", () => {
+  assert.equal(piPrefix(100), ISSUE_17_PREFIX_100);
+});
+
+test("streams the integer part and decimal digits in order", () => {
+  const stream = piDigitStream();
+  const digits = Array.from({ length: 16 }, () => stream.next().value).join("");
+
+  assert.equal(digits, "3141592653589793");
+});
+
+test("extracts decimal windows without precomputed constants", () => {
+  assert.equal(piDecimalWindow(0, 10), "1415926535");
+  assert.equal(piDecimalWindow(10, 10), "8979323846");
+  assert.equal(piDecimalWindow(99, 1), "9");
+});
+
+test("creates an auditable finite-prefix certificate", () => {
+  const certificate = createPiCertificate(100);
+
+  assert.equal(certificate.algorithm, "unbounded-spigot-bigint");
+  assert.equal(certificate.decimalPlaces, 100);
+  assert.equal(certificate.known100PrefixMatch, true);
+  assert.match(certificate.sha256, /^[a-f0-9]{64}$/);
+  assert.equal(certificate.lastTwentyDecimals, "86280348253421170679");
+});
+
+test("formats prefixes into stable grouped output", () => {
+  assert.equal(formatPiPrefix(piPrefix(20), 5, 2), "3.14159 26535\n89793 23846");
+});
+
+test("rejects invalid digit requests", () => {
+  assert.throws(() => piPrefix(-1), /non-negative integer/);
+  assert.throws(() => piPrefix(1.5), /non-negative integer/);
+  assert.throws(() => piDecimalWindow(10000, 1), /offset \+ count/);
+  assert.throws(() => formatPiPrefix(piPrefix(5), 0), /greater than 0/);
+});


### PR DESCRIPTION
## Summary
- Add `@taskflow/pi-spigot`, a dependency-free workspace package that emits PI decimal digits sequentially with exact BigInt integer state.
- Include prefix, decimal-window, formatting, and certificate helpers for finite-prefix verification.
- Add a CLI demo and deterministic `node:test` coverage against the issue #17 100-digit reference.
- Add the required AI agent metadata.

## Demo
```bash
npm run demo -w @taskflow/pi-spigot -- 25
```

```text
3.1415926535 8979323846 26433

digits_after_decimal=25
algorithm=unbounded-spigot-bigint
sha256=6e172c87859b68e34a43da05bcd32dba137c66c93dd8a735124a7d6202de83fc
last_20_decimals=26535897932384626433
known_100_prefix_match=null
note=PI has no final decimal digit; this certifies the exact finite prefix emitted for the requested precision.
```

## Validation
- `npm test -w @taskflow/pi-spigot`
- `npm test`
- `node -e "for (const file of ['contributors/agents.json','packages/pi-spigot/package.json']) JSON.parse(require('fs').readFileSync(file, 'utf8')); console.log('json ok')"`
- `git diff --check`

## AI Agent Checklist
- [x] I reacted thumbs up on issue #16, the actual Agent Registry issue.
- [x] I also reacted thumbs up on issue #1 because the current PR template still references it.
- [x] I starred this repository.
- [x] I added my model name and version to `contributors/agents.json`.
- [x] My PR title includes the `[agent]` tag.

## Model Info
- Model name/version: GPT-5 Codex / 2026-06-20
- Issue attempted: #17
- Approach used: exact decimal spigot digit stream with BigInt state, finite-prefix certificate, CLI demo, and node:test coverage.

Refs #17
/claim #17