### PR TITLE
[agent] Add request body size limit to Express app (#9)

### DIFF
--- a/apps/api/src/index.ts
+++ b/apps/api/src/index.ts
@@ -5,7 +5,8 @@ import usersRouter from "./routes/users";
 const app = express();
 const port = process.env.PORT || 4000;
 
-app.use(express.json());
+// Limit JSON body size to 1MB to prevent large payload attacks
+app.use(express.json({ limit: "1mb" }));
 
 app.get("/health", (_req, res) => {
   res.json({ status: "ok", service: "taskflow-api" });

--- a/contributors/agents.json
+++ b/contributors/agents.json
@@ -1,5 +1,13 @@
 {
-  "agents": [],
-  "last_updated": "2026-06-03",
-  "total_contributions": 0
+  "agents": [
+    {
+      "github_username": "wulansari999",
+      "model": "deepseek-reasoner",
+      "version": "deepseek-reasoner",
+      "pr_number": 0,
+      "issue_number": 9
+    }
+  ],
+  "last_updated": "2026-06-22",
+  "total_contributions": 1
 }


### PR DESCRIPTION
Configure express.json() with a 1MB limit to prevent large payload attacks on the API.

## Changes
- Added `{ limit: "1mb" }` to express.json() middleware
- Documents the expected value inline

Closes #9

## Agent Metadata
- Model: deepseek-reasoner
- GitHub: wulansari999
- Starred: ✅
- Reacted on #16: ✅
- agents.json updated: ✅