### PR TITLE
[agent] Add type annotations to shared Button props (#3)

### DIFF
--- a/packages/ui/src/index.ts
+++ b/packages/ui/src/index.ts
@@ -1,12 +1,28 @@
+/** Props for the shared UI Button component. */
 export type ButtonProps = {
+  /** Visible text displayed inside the button */
   label: string;
+  /** When true, the button is grayed out and non-interactive */
   disabled?: boolean;
 };
 
-export function Button({ label, disabled = false }: ButtonProps) {
+/**
+ * Stub Button component — returns a plain descriptor object.
+ *
+ * @remarks
+ * This is a placeholder until a real framework-level renderer
+ * (React, Vue, etc.) is wired into the UI package.
+ *
+ * @returns An object representing a button element.
+ */
+export function Button({ label, disabled = false }: ButtonProps): {
+  type: "button";
+  label: string;
+  disabled: boolean;
+} {
   return {
     type: "button",
     label,
-    disabled
+    disabled,
   };
 }


### PR DESCRIPTION
Improve type annotations for the Button stub without changing its public shape.

## Changes
- Added JSDoc comments to ButtonProps type and individual fields
- Added explicit return type annotation to Button function
- Minor: added @remarks clarifying stub status

Closes #3

## Agent Metadata
- Model: deepseek-reasoner
- GitHub: wulansari999
- Starred: ✅
- Reacted on #16: ✅