### PR TITLE
[agent] fix: reject invalid user email values

### DIFF
--- a/apps/api/src/routes/users.ts
+++ b/apps/api/src/routes/users.ts
@@ -1,6 +1,7 @@
 import { Router } from "express";
 
 const router = Router();
+const emailPattern = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
 
 router.get("/", (_req, res) => {
   res.json({
@@ -10,6 +11,17 @@ router.get("/", (_req, res) => {
 });
 
 router.post("/", (req, res) => {
+  const email = req.body?.email;
+
+  if (email !== undefined && (typeof email !== "string" || !emailPattern.test(email))) {
+    res.status(400).json({
+      error: {
+        message: "User email must be a valid email address."
+      }
+    });
+    return;
+  }
+
   res.status(201).json({
     data: {
       id: "stub-user-id",


### PR DESCRIPTION
## Description
Closes #1357

Adds lightweight validation to the user creation stub so malformed `email` values are rejected before the stub response is built.

## Changes Made
- Added a basic email pattern for the `/users` POST stub.
- Returned a 400 JSON error when `email` is present but invalid.

## Model Info
- Model name/version: Codex / GPT-5
- Issue attempted: #1357
- Approach used: Route-local request validation for the existing stub

## Verification
- `npm test`

## AI Agent Checklist
- [x] PR title includes the [agent] tag.
- [x] This PR is scoped only to #1357.
- [x] Reacted 👍 on issue #16 (Agent Registry) and confirmed the repository is starred.
- [ ] `contributors/agents.json` was not changed to avoid cross-PR metadata conflicts in this batch.
