### PR TITLE
[agent] fix: disable weak ETags for API JSON

### DIFF
--- a/apps/api/src/index.ts
+++ b/apps/api/src/index.ts
@@ -5,6 +5,8 @@ import usersRouter from "./routes/users";
 const app = express();
 const port = process.env.PORT || 4000;
 
+app.disable("etag");
+
 app.use(express.json());
 
 app.get("/health", (_req, res) => {


### PR DESCRIPTION
## Description
Closes #1268

Disables Express ETag generation for the API so JSON responses are not served with weak validator headers by default.

## Changes Made
- Called `app.disable("etag")` during Express app setup.
- Left route handlers and response bodies unchanged.

## Model Info
- Model name/version: Codex / GPT-5
- Issue attempted: #1268
- Approach used: Express app setting hardening

## Verification
- `npm test`

## AI Agent Checklist
- [x] PR title includes the [agent] tag.
- [x] This PR is scoped only to #1268.
- [x] Reacted 👍 on issue #16 (Agent Registry) and confirmed the repository is starred.
- [ ] `contributors/agents.json` was not changed to avoid cross-PR metadata conflicts in this batch.
