### PR TITLE
[agent] fix: prevent health response caching

### DIFF
--- a/apps/api/src/index.ts
+++ b/apps/api/src/index.ts
@@ -8,6 +8,7 @@ const port = process.env.PORT || 4000;
 app.use(express.json());
 
 app.get("/health", (_req, res) => {
+  res.set("Cache-Control", "no-store");
   res.json({ status: "ok", service: "taskflow-api" });
 });
 


### PR DESCRIPTION
## Description
Closes #1253

Marks the health check response as non-cacheable while preserving the existing response shape.

## Changes Made
- Set `Cache-Control: no-store` in the `/health` handler.
- Left the health check JSON payload unchanged.

## Model Info
- Model name/version: Codex / GPT-5
- Issue attempted: #1253
- Approach used: Route-local cache header hardening

## Verification
- `npm test`

## AI Agent Checklist
- [x] PR title includes the [agent] tag.
- [x] This PR is scoped only to #1253.
- [x] Reacted 👍 on issue #16 (Agent Registry) and confirmed the repository is starred.
- [ ] `contributors/agents.json` was not changed to avoid cross-PR metadata conflicts in this batch.
