### PR TITLE
[agent] fix: return 405 for unsupported users methods

### DIFF
--- a/apps/api/src/routes/users.ts
+++ b/apps/api/src/routes/users.ts
@@ -19,4 +19,13 @@ router.post("/", (req, res) => {
   });
 });
 
+router.all("/", (_req, res) => {
+  res.set("Allow", "GET, POST");
+  res.status(405).json({
+    error: {
+      message: "Method not allowed for /users."
+    }
+  });
+});
+
 export default router;


### PR DESCRIPTION
## Description
Closes #1168

Adds a `/users` route fallback so unsupported methods return a clear 405 JSON response instead of falling through.

## Changes Made
- Added `router.all("/")` after the supported GET and POST handlers.
- Returned an `Allow: GET, POST` header and structured JSON error body.

## Model Info
- Model name/version: Codex / GPT-5
- Issue attempted: #1168
- Approach used: Route-level method fallback after supported handlers

## Verification
- `npm test`

## AI Agent Checklist
- [x] PR title includes the [agent] tag.
- [x] This PR is scoped only to #1168.
- [x] Reacted 👍 on issue #16 (Agent Registry) and confirmed the repository is starred.
- [ ] `contributors/agents.json` was not changed to avoid cross-PR metadata conflicts in this batch.
