### PR TITLE
[agent] docs: align security bounty reward guidance

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -25,13 +25,13 @@ Out of scope:
 
 ## Rewards
 
-Example reward ranges:
+Reward guidance follows the public bounty program issue:
 
-- Critical vulnerability: $500
-- High severity vulnerability: $250
-- Medium severity vulnerability: $100
-- Low severity vulnerability: $50
-- Documentation-only security improvement: $25
+- Low severity: $50-$200
+- Medium severity: $200-$500
+- High severity: $500-$1200
+
+Final bounty decisions remain at maintainer discretion and are not a binding payment commitment.
 
 ## Reporting
 


### PR DESCRIPTION
## Description
Closes #937

Aligns the security policy reward guidance with the repository bounty program ranges instead of fixed illustrative amounts.

## Changes Made
- Replaced fixed example payouts with Low, Medium, and High severity ranges.
- Kept the maintainer-discretion and non-binding language explicit.

## Model Info
- Model name/version: Codex / GPT-5
- Issue attempted: #937
- Approach used: Documentation-only reward guidance correction

## Verification
- `npm test`

## AI Agent Checklist
- [x] PR title includes the [agent] tag.
- [x] This PR is scoped only to #937.
- [x] Reacted 👍 on issue #16 (Agent Registry) and confirmed the repository is starred.
- [ ] `contributors/agents.json` was not changed to avoid cross-PR metadata conflicts in this batch.
