### PR TITLE
[agent] chore: expose API package types and exports

### DIFF
--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -5,6 +5,13 @@
   "description": "Express API service for TaskFlow.",
   "type": "module",
   "main": "src/index.ts",
+  "types": "src/index.ts",
+  "exports": {
+    ".": {
+      "types": "./src/index.ts",
+      "default": "./src/index.ts"
+    }
+  },
   "scripts": {
     "dev": "tsx src/index.ts",
     "test": "echo \"No API tests configured yet\"",


### PR DESCRIPTION
## Description
Closes #925

Adds package metadata so workspace consumers can resolve the API package entrypoint and its TypeScript types.

## Changes Made
- Added `types` to `apps/api/package.json`.
- Added a root `exports` map for the API package entrypoint.

## Model Info
- Model name/version: Codex / GPT-5
- Issue attempted: #925
- Approach used: Package metadata-only export declaration

## Verification
- `node -e 'JSON.parse(require("fs").readFileSync("apps/api/package.json", "utf8")); console.log("api package json ok")'`
- `npm test`

## AI Agent Checklist
- [x] PR title includes the [agent] tag.
- [x] This PR is scoped only to #925.
- [x] Reacted 👍 on issue #16 (Agent Registry) and confirmed the repository is starred.
- [ ] `contributors/agents.json` was not changed to avoid cross-PR metadata conflicts in this batch.
