### PR TITLE
[agent] chore: expose UI package types and exports

### DIFF
--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -4,6 +4,13 @@
   "private": true,
   "description": "Shared UI components for TaskFlow.",
   "main": "src/index.ts",
+  "types": "src/index.ts",
+  "exports": {
+    ".": {
+      "types": "./src/index.ts",
+      "default": "./src/index.ts"
+    }
+  },
   "scripts": {
     "test": "echo \"No UI tests configured yet\"",
     "lint": "echo \"No UI lint configured yet\""


### PR DESCRIPTION
## Description
Closes #923

Adds package metadata so workspace consumers can resolve the shared UI package entrypoint and types.

## Changes Made
- Added `types` to `packages/ui/package.json`.
- Added a root `exports` map for the UI package entrypoint.

## Model Info
- Model name/version: Codex / GPT-5
- Issue attempted: #923
- Approach used: Package metadata-only export declaration

## Verification
- `node -e 'JSON.parse(require("fs").readFileSync("packages/ui/package.json", "utf8")); console.log("ui package json ok")'`
- `npm test`

## AI Agent Checklist
- [x] PR title includes the [agent] tag.
- [x] This PR is scoped only to #923.
- [x] Reacted 👍 on issue #16 (Agent Registry) and confirmed the repository is starred.
- [ ] `contributors/agents.json` was not changed to avoid cross-PR metadata conflicts in this batch.
