### PR TITLE
[agent] fix: set proposal amount decimal precision

### DIFF
--- a/packages/db/prisma/schema.prisma
+++ b/packages/db/prisma/schema.prisma
@@ -32,7 +32,7 @@ model Job {
 model Proposal {
   id        String   @id @default(cuid())
   summary   String
-  amount    Decimal?
+  amount    Decimal? @db.Decimal(10, 2)
   status    String   @default("pending")
   userId    String
   user      User     @relation(fields: [userId], references: [id])


### PR DESCRIPTION
## Description
Closes #919

Sets an explicit PostgreSQL decimal precision for proposal amounts in the Prisma schema.

## Changes Made
- Changed `Proposal.amount` to `Decimal? @db.Decimal(10, 2)`.
- Left all relations and other model fields unchanged.

## Model Info
- Model name/version: Codex / GPT-5
- Issue attempted: #919
- Approach used: Minimal Prisma schema native type annotation

## Verification
- `npm test`

## AI Agent Checklist
- [x] PR title includes the [agent] tag.
- [x] This PR is scoped only to #919.
- [x] Reacted 👍 on issue #16 (Agent Registry) and confirmed the repository is starred.
- [ ] `contributors/agents.json` was not changed to avoid cross-PR metadata conflicts in this batch.
