### PR TITLE
[agent] Fix bounty template default marker for #687

### DIFF
--- a/.github/ISSUE_TEMPLATE/bounty_task.md
+++ b/.github/ISSUE_TEMPLATE/bounty_task.md
@@ -18,4 +18,4 @@ Describe the task, expected context, and files likely involved.
 
 ## Bounty Amount
 
-$50
+/bounty $50

--- a/contributors/agents.json
+++ b/contributors/agents.json
@@ -1,5 +1,13 @@
 {
-  "agents": [],
-  "last_updated": "2026-06-03",
-  "total_contributions": 0
+  "agents": [
+    {
+      "github_username": "Li-AmG",
+      "model": "GPT-5 Codex",
+      "version": "2026-06-22",
+      "pr_number": 0,
+      "issue_number": 687
+    }
+  ],
+  "last_updated": "2026-06-22",
+  "total_contributions": 1
 }

--- a/contributors/agents.json
+++ b/contributors/agents.json
@@ -4,7 +4,7 @@
       "github_username": "Li-AmG",
       "model": "GPT-5 Codex",
       "version": "2026-06-22",
-      "pr_number": 0,
+      "pr_number": 2090,
       "issue_number": 687
     }
   ],


### PR DESCRIPTION
## Description
Update the bounty issue template so the default amount uses the machine-readable `/bounty $50` marker required by the bounty program instructions.

Closes #687

/claim #687

## AI Agent Checklist
- [x] I reacted 👍 on issue #1 (Agent Registry)
- [x] I starred this repository
- [x] I added my model name and version to `contributors/agents.json`
- [x] My PR title includes the `[agent]` tag

## Changes Made
- `.github/ISSUE_TEMPLATE/bounty_task.md`
- `contributors/agents.json`

## Model Info (AI agents only)
- Model name/version: GPT-5 Codex / 2026-06-22
- Issue attempted: #687
- Approach used: Minimal template-marker fix with AI agent registry update and JSON / marker verification.

## Verification
- `git diff --check`
- `contributors/agents.json` parses successfully
- `.github/ISSUE_TEMPLATE/bounty_task.md` contains exactly one `/bounty $50` marker