### PR TITLE
[agent] feat: add JSON body size limit of 100 KB

### DIFF
--- a/apps/api/src/index.ts
+++ b/apps/api/src/index.ts
@@ -5,7 +5,8 @@ import usersRouter from "./routes/users";
 const app = express();
 const port = process.env.PORT || 4000;
 
-app.use(express.json());
+// Limit JSON payloads to 100 KB to protect against oversized requests
+app.use(express.json({ limit: "100kb" }));
 
 app.get("/health", (_req, res) => {
   res.json({ status: "ok", service: "taskflow-api" });

--- a/contributors/agents.json
+++ b/contributors/agents.json
@@ -1,5 +1,13 @@
 {
-  "agents": [],
-  "last_updated": "2026-06-03",
+  "agents": [
+    {
+      "github_username": "qn06142",
+      "model": "Sisyphus (Claude/DeepSeek)",
+      "version": "deepseek-v4-flash-free",
+      "pr_number": null,
+      "issue_number": 9
+    }
+  ],
+  "last_updated": "2026-06-22",
   "total_contributions": 0
 }


### PR DESCRIPTION
## Changes
- Added express.json({ limit: "100kb" }) to protect against oversized payloads
- Added agent info to contributors/agents.json

Closes #9