### PR TITLE
fix(workflows): make starter issue seeding idempotent

### DIFF
--- a/.github/workflows/seed-issues.yml
+++ b/.github/workflows/seed-issues.yml
@@ -90,7 +90,31 @@ jobs:
               }
             ];
 
+            // Validation Note: Query open issues in the repository to build a Set of existing titles.
+            // For each starter issue, we skip creation if the title is already present in the Set.
+            const openTitles = new Set();
+            let page = 1;
+            while (true) {
+              const { data: batch } = await github.rest.issues.listForRepo({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                state: "open",
+                per_page: 100,
+                page: page
+              });
+              if (!batch || batch.length === 0) break;
+              for (const item of batch) {
+                openTitles.add(item.title);
+              }
+              if (batch.length < 100) break;
+              page++;
+            }
+
             for (const issue of issues) {
+              if (openTitles.has(issue.title)) {
+                console.log(`Skipping existing open issue: "${issue.title}"`);
+                continue;
+              }
               await github.rest.issues.create({
                 owner: context.repo.owner,
                 repo: context.repo.repo,


### PR DESCRIPTION
Closes #2101

### Summary
This PR implements idempotency logic in `.github/workflows/seed-issues.yml` to prevent duplicate starter issues from being created on repeated manual runs of the workflow.

### Changes
- Queries existing open issues from the repository using `github.rest.issues.listForRepo` with pagination.
- Compiles a Set of existing open issue titles.
- When iterating over the starter issues list, skips creation if the issue title already exists in the open issues Set.
- Preserves all issue body formatting, labels, and metadata for issues that do need to be created.

### Payment Info
PayPal: https://paypal.me/sureshc26
