### PR TITLE
types: annotate Button stub return

### DIFF
--- a/packages/ui/src/index.ts
+++ b/packages/ui/src/index.ts
@@ -3,7 +3,13 @@ export type ButtonProps = {
   disabled?: boolean;
 };
 
-export function Button({ label, disabled = false }: ButtonProps) {
+export type ButtonStub = {
+  type: "button";
+  label: string;
+  disabled: boolean;
+};
+
+export function Button({ label, disabled = false }: ButtonProps): ButtonStub {
   return {
     type: "button",
     label,


### PR DESCRIPTION
Fixes #3

## Summary
- Added an explicit ButtonStub return type for the shared Button stub.
- Kept the existing ButtonProps input shape and runtime behavior unchanged.

## Verification
- `npm test --workspace packages/ui`

/claim #3