### PR TITLE
chore: limit API JSON body size

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,6 +66,10 @@ npm run dev -w apps/web
 
 npm run dev -w apps/api
 
+The API accepts JSON request bodies up to `100kb` by default. Keep local
+payloads below that limit unless the API configuration is intentionally
+updated.
+
 ## Database
 
 Prisma schema is available in packages/db/prisma/schema.prisma 

--- a/apps/api/src/index.ts
+++ b/apps/api/src/index.ts
@@ -5,7 +5,7 @@ import usersRouter from "./routes/users";
 const app = express();
 const port = process.env.PORT || 4000;
 
-app.use(express.json());
+app.use(express.json({ limit: "100kb" }));
 
 app.get("/health", (_req, res) => {
   res.json({ status: "ok", service: "taskflow-api" });


### PR DESCRIPTION
Fixes #9

## Summary
- Configured Express JSON parsing with a conservative 100kb request body limit.
- Documented the default API payload limit in the README backend instructions.

## Verification
- `npm test --workspace apps/api`

/claim #9