### PR TITLE
feat: validate user creation body

### DIFF
--- a/apps/api/src/routes/users.ts
+++ b/apps/api/src/routes/users.ts
@@ -10,6 +10,20 @@ router.get("/", (_req, res) => {
 });
 
 router.post("/", (req, res) => {
+  if (!req.body || typeof req.body !== "object" || Array.isArray(req.body)) {
+    return res.status(400).json({
+      error: "Invalid request body.",
+      message: "Expected a JSON object for user creation."
+    });
+  }
+
+  if (typeof req.body.email !== "string" || req.body.email.trim() === "") {
+    return res.status(400).json({
+      error: "Invalid email.",
+      message: "A non-empty email is required to create a user."
+    });
+  }
+
   res.status(201).json({
     data: {
       id: "stub-user-id",


### PR DESCRIPTION
Fixes #6

## Summary
- Added lightweight validation for the user creation route.
- Returns clear 400 responses for non-object bodies and missing or blank email values.
- Leaves the successful response shape unchanged for valid requests.

## Verification
- `npm test --workspace apps/api`

/claim #6