### PR TITLE
feat: add API error response helper

### DIFF
--- a/apps/api/src/routes/users.ts
+++ b/apps/api/src/routes/users.ts
@@ -1,5 +1,7 @@
 import { Router } from "express";
 
+import { sendApiError } from "../utils/apiError";
+
 const router = Router();
 
 router.get("/", (_req, res) => {
@@ -10,6 +12,15 @@ router.get("/", (_req, res) => {
 });
 
 router.post("/", (req, res) => {
+  if (!req.body || typeof req.body !== "object" || Array.isArray(req.body)) {
+    return sendApiError(
+      res,
+      400,
+      "Invalid request body.",
+      "Expected a JSON object for user creation."
+    );
+  }
+
   res.status(201).json({
     data: {
       id: "stub-user-id",

--- a/apps/api/src/utils/apiError.ts
+++ b/apps/api/src/utils/apiError.ts
@@ -1,0 +1,13 @@
+import type { Response } from "express";
+
+export function sendApiError(
+  res: Response,
+  statusCode: number,
+  error: string,
+  message: string
+) {
+  return res.status(statusCode).json({
+    error,
+    message
+  });
+}


### PR DESCRIPTION
Fixes #7

## Summary
- Added a reusable sendApiError helper for consistent JSON error responses.
- Used the helper from the user creation route for invalid request bodies.

## Verification
- `npm test --workspace apps/api`

/claim #7