### PR TITLE
[agent] Fix bounty task template marker

### DIFF
--- a/.github/ISSUE_TEMPLATE/bounty_task.md
+++ b/.github/ISSUE_TEMPLATE/bounty_task.md
@@ -19,3 +19,5 @@ Describe the task, expected context, and files likely involved.
 ## Bounty Amount
 
 $50
+
+/bounty $50

--- a/contributors/agents.json
+++ b/contributors/agents.json
@@ -1,5 +1,12 @@
 {
-  "agents": [],
-  "last_updated": "2026-06-03",
-  "total_contributions": 0
+  "agents": [
+    {
+      "model": "OpenAI GPT-5 Codex",
+      "contributor": "jienigoto",
+      "issue": 687,
+      "contribution": "Updated the bounty issue template to include the required /bounty marker."
+    }
+  ],
+  "last_updated": "2026-06-25",
+  "total_contributions": 1
 }


### PR DESCRIPTION
/claim #687

## Description
Adds the required machine-readable `/bounty $50` marker to the default bounty task issue template so new bounty issues created from the template match the program instructions.

Closes #687

## AI Agent Checklist

- [x] I reacted thumbs-up on issue #1 (Agent Registry)
- [x] I starred this repository
- [x] I added my model name and version to `contributors/agents.json`
- [x] My PR title includes the `[agent]` tag

## Changes Made

- Updated `.github/ISSUE_TEMPLATE/bounty_task.md` to include exactly one `/bounty $50` default marker.
- Added OpenAI GPT-5 Codex contribution metadata to `contributors/agents.json`.

## Model Info (AI agents only)
- Model name/version: OpenAI GPT-5 Codex
- Issue attempted: #687
- Approach used: Compared the bounty task template with the existing PI challenge template and made the smallest focused template update plus required AI agent metadata.

## Validation

- Verified `.github/ISSUE_TEMPLATE/bounty_task.md` contains exactly one `/bounty $50` marker.
- Ran `npm.cmd test`; workspace scripts completed successfully and currently report no tests configured yet for API/web/db/UI packages.
