### PR TITLE
docs: add JSDoc comments to userService route handlers

### DIFF
--- a/apps/api/src/routes/users.ts
+++ b/apps/api/src/routes/users.ts
@@ -2,6 +2,10 @@ import { Router } from "express";
 
 const router = Router();
 
+/**
+ * GET /users
+ * Returns a list of users. Currently returns an empty stub response.
+ */
 router.get("/", (_req, res) => {
   res.json({
     data: [],
@@ -9,6 +13,10 @@ router.get("/", (_req, res) => {
   });
 });
 
+/**
+ * POST /users
+ * Creates a new user. Currently returns a stub response with the request body.
+ */
 router.post("/", (req, res) => {
   res.status(201).json({
     data: {


### PR DESCRIPTION
Closes #1

Adds concise JSDoc comments to the GET and POST user route handlers in the userService so future contributors can understand the intended behavior.

**Changes:**
- Added JSDoc to `GET /users` — describes it as returning a list of users (currently a stub)
- Added JSDoc to `POST /users` — describes it as creating a new user (currently a stub)

The PR is focused and minimal, only touching the user service file.