### PR TITLE
fix: return 405 Method Not Allowed for unsupported methods on /users

### DIFF
--- a/apps/api/src/middleware/methodNotAllowed.ts
+++ b/apps/api/src/middleware/methodNotAllowed.ts
@@ -1,0 +1,22 @@
+import { RequestHandler, Router } from "express";
+
+/**
+ * Returns 405 Method Not Allowed with an Allow header listing
+ * the supported methods for a given route.
+ *
+ * Usage:
+ *   router.all("/", methodNotAllowed(["GET", "POST"]));
+ */
+export function methodNotAllowed(allowed: string[]): RequestHandler {
+  return (_req, res) => {
+    res.setHeader("Allow", allowed.join(", "));
+    res.status(405).json({
+      error: {
+        code: "METHOD_NOT_ALLOWED",
+        message: 
+      }
+    });
+  };
+}
+
+export default methodNotAllowed;


### PR DESCRIPTION
Closes #1168

Adds middleware/methodNotAllowed.ts returning 405 with Allow header listing supported methods. Uses standard JSON error envelope.