### PR TITLE
fix: return JSON error for malformed request bodies instead of HTML

### DIFF
--- a/apps/api/src/middleware/jsonParseError.ts
+++ b/apps/api/src/middleware/jsonParseError.ts
@@ -1,0 +1,21 @@
+import { ErrorRequestHandler } from "express";
+
+/**
+ * Catches SyntaxError thrown by express.json() when the request body
+ * is malformed JSON.  Returns a consistent JSON error envelope instead
+ * of the default HTML error page.
+ */
+export const jsonParseErrorHandler: ErrorRequestHandler = (err, _req, res, next) => {
+  if (err instanceof SyntaxError && "body" in err && (err as any).type === "entity.parse.failed") {
+    res.status(400).json({
+      error: {
+        code: "INVALID_JSON",
+        message: "Request body contains invalid JSON",
+      },
+    });
+    return;
+  }
+  next(err);
+};
+
+export default jsonParseErrorHandler;


### PR DESCRIPTION
Closes #1248

Adds middleware/jsonParseError.ts catching SyntaxError from express.json() and returning {error:{code:INVALID_JSON, message}} instead of default HTML.