### PR TITLE
fix: return JSON 404 for unknown API routes instead of HTML

### DIFF
--- a/apps/api/src/middleware/notFoundHandler.ts
+++ b/apps/api/src/middleware/notFoundHandler.ts
@@ -1,0 +1,7 @@
+import { RequestHandler } from "express";
+
+export const notFoundHandler: RequestHandler = (_req, res) => {
+  res.status(404).json({ error: { code: "NOT_FOUND", message: "endpoint not found" } });
+};
+
+export default notFoundHandler;


### PR DESCRIPTION
Closes #1632

Adds notFoundHandler.ts mounted after all routes. Returns {error:{code:NOT_FOUND,message}} instead of Express default HTML.