### PR TITLE
feat: add graceful shutdown on SIGTERM/SIGINT with connection drain

### DIFF
--- a/apps/api/src/lib/gracefulShutdown.ts
+++ b/apps/api/src/lib/gracefulShutdown.ts
@@ -1,0 +1,13 @@
+import { Server } from "http";
+
+export function gracefulShutdown(server: Server, timeoutMs = 10000): void {
+  const shutdown = (sig: string) => {
+    console.log(sig + ": shutting down gracefully");
+    server.close(() => process.exit(0));
+    setTimeout(() => process.exit(1), timeoutMs).unref();
+  };
+  process.on("SIGTERM", () => shutdown("SIGTERM"));
+  process.on("SIGINT", () => shutdown("SIGINT"));
+}
+
+export default gracefulShutdown;


### PR DESCRIPTION
Closes #1437

Adds gracefulShutdown.ts: registers signal handlers, calls server.close() to drain, forces exit after 10s timeout.

/bounty 00