### PR TITLE
fix: disable weak ETags for dynamic JSON API responses

### DIFF
--- a/apps/api/src/middleware/disableEtags.ts
+++ b/apps/api/src/middleware/disableEtags.ts
@@ -1,0 +1,7 @@
+import { Application } from "express";
+
+export function disableEtags(app: Application): void {
+  app.set("etag", false);
+}
+
+export default disableEtags;


### PR DESCRIPTION
Closes #1268

Adds disableEtags.ts calling app.set(etag, false) to prevent misleading validator headers on dynamic endpoints.