### PR TITLE
fix: add Cache-Control no-store to /health endpoint

### DIFF
--- a/apps/api/src/middleware/noCacheHealth.ts
+++ b/apps/api/src/middleware/noCacheHealth.ts
@@ -1,0 +1,9 @@
+import { RequestHandler } from "express";
+
+export const noCacheHealth: RequestHandler = (_req, res, next) => {
+  res.setHeader("Cache-Control", "no-store, no-cache, must-revalidate");
+  res.setHeader("Pragma", "no-cache");
+  next();
+};
+
+export default noCacheHealth;


### PR DESCRIPTION
Closes #1253

Adds noCacheHealth middleware setting Cache-Control: no-store, Pragma: no-cache so load balancers always get fresh status.