### PR TITLE
fix: add .npmrc enforcing lockfile for reproducible installs

### DIFF
--- a/apps/api/.npmrc
+++ b/apps/api/.npmrc
@@ -1,0 +1,3 @@
+save-exact=true
+package-lock=true
+engine-strict=true


### PR DESCRIPTION
Closes #1722

Adds apps/api/.npmrc with save-exact=true, package-lock=true, engine-strict=true to prevent non-reproducible installs.