### PR TITLE
refactor: split Express app construction from server startup

### DIFF
--- a/apps/api/src/app.ts
+++ b/apps/api/src/app.ts
@@ -1,0 +1,13 @@
+import express from "express";
+import usersRouter from "./routes/users";
+export function createApp(): express.Application {
+  const app = express();
+  app.disable("x-powered-by");
+  app.set("etag",false);
+  app.use(express.json({limit:process.env.BODY_LIMIT??"100kb"}));
+  app.get("/health",(_req,res)=>{ res.setHeader("Cache-Control","no-store"); res.json({status:"ok",data:{service:"taskflow-api"}}); });
+  app.use("/users",usersRouter);
+  app.use((_req,res)=>res.status(404).json({error:{code:"NOT_FOUND",message:"endpoint not found"}}));
+  return app;
+}
+export default createApp;


### PR DESCRIPTION
Closes #1771

Extracts createApp() into app.ts. index.ts calls createApp() then app.listen(). Tests can import createApp() without binding a port.