### PR TITLE
fix(ci): make issue seeding idempotent with existing-title check

### DIFF
--- a/.github/workflows/seed-idempotent.yml
+++ b/.github/workflows/seed-idempotent.yml
@@ -1,0 +1,19 @@
+name: Seed Issues Idempotent
+on:
+  workflow_dispatch:
+jobs:
+  seed:
+    runs-on: ubuntu-latest
+    permissions:
+      issues: write
+    steps:
+      - uses: actions/github-script@v7
+        with:
+          script: |
+            const want=[{title:"[Starter] Example",body:"/bounty $50\nExample."}];
+            const have=await github.paginate(github.rest.issues.listForRepo,{owner:context.repo.owner,repo:context.repo.repo,state:"open",per_page:100});
+            const titles=new Set(have.map(i=>i.title));
+            for(const i of want){
+              if(titles.has(i.title)){console.log("skip:"+i.title);continue;}
+              await github.rest.issues.create({owner:context.repo.owner,repo:context.repo.repo,title:i.title,body:i.body,labels:["bounty"]});
+            }


### PR DESCRIPTION
Closes #2101

New seed-idempotent.yml checks existing open issues before creating. Skips any issue whose title already exists.