### PR TITLE
feat: add registerShutdownHandlers for SIGTERM/SIGINT drain

### DIFF
--- a/apps/api/src/lib/shutdown.ts
+++ b/apps/api/src/lib/shutdown.ts
@@ -1,0 +1,11 @@
+import { Server } from "http";
+export function registerShutdownHandlers(server:Server,timeoutMs=10000):void{
+  const g=(sig:string)=>{
+    console.log(`[${sig}] closing server`);
+    server.close(()=>process.exit(0));
+    setTimeout(()=>process.exit(1),timeoutMs).unref();
+  };
+  process.once("SIGTERM",()=>g("SIGTERM"));
+  process.once("SIGINT",()=>g("SIGINT"));
+}
+export default registerShutdownHandlers;


### PR DESCRIPTION
Closes #1130

Adds lib/shutdown.ts with registerShutdownHandlers(server, timeoutMs). Calls server.close(), forces exit after timeout.

/bounty 00