### PR TITLE
fix: validate name and email in POST /users body

### DIFF
--- a/apps/api/src/middleware/validateUser.ts
+++ b/apps/api/src/middleware/validateUser.ts
@@ -1,0 +1,9 @@
+import { RequestHandler } from "express";
+const EMAIL_RE=/^[^\\s@]+@[^\\s@]+\\.[^\\s@]{2,}$/;
+export const validateCreateUser: RequestHandler=(req,res,next)=>{
+  const {name,email}=req.body;
+  if(typeof name!=="string"||name.trim().length===0){res.status(400).json({error:{code:"VALIDATION_ERROR",message:"name required"}});return;}
+  if(typeof email!=="string"||!EMAIL_RE.test(email)){res.status(400).json({error:{code:"VALIDATION_ERROR",message:"valid email required"}});return;}
+  next();
+};
+export default validateCreateUser;


### PR DESCRIPTION
Closes #1699

Adds validateCreateUser middleware rejecting missing/empty name and invalid email with 400 JSON error envelope.