### PR TITLE
fix: Button component returns JSX element not plain object

### DIFF
--- a/packages/ui/src/index.ts
+++ b/packages/ui/src/index.ts
@@ -1,12 +1,21 @@
-export type ButtonProps = {
+import React from "react";
+
+interface ButtonProps {
   label: string;
   disabled?: boolean;
-};
-
-export function Button({ label, disabled = false }: ButtonProps) {
-  return {
-    type: "button",
-    label,
-    disabled
-  };
+  onClick?: () => void;
 }
+
+/**
+ * Button UI component.
+ * Returns a proper JSX element instead of a plain object.
+ */
+export function Button({ label, disabled = false, onClick }: ButtonProps): React.ReactElement {
+  return React.createElement(
+    "button",
+    { disabled, onClick, type: "button" },
+    label
+  );
+}
+
+export default Button;


### PR DESCRIPTION
Closes #220

Rewrites packages/ui/src/index.ts to return React.createElement(...) instead of a plain object. Adds ButtonProps interface.