### PR TITLE
fix: prevent mass assignment in POST /users — allowlist name and email only

### DIFF
--- a/apps/api/src/routes/users.ts
+++ b/apps/api/src/routes/users.ts
@@ -3,19 +3,25 @@ import { Router } from "express";
 const router = Router();
 
 router.get("/", (_req, res) => {
-  res.json({
-    data: [],
-    message: "User listing is not implemented yet."
-  });
+  res.json({ data: [], message: "User listing is not implemented yet." });
 });
 
 router.post("/", (req, res) => {
+  // Allowlist only safe fields to prevent mass assignment.
+  const { name, email } = req.body as { name?: unknown; email?: unknown };
+
+  if (typeof name !== "string" || name.trim().length === 0) {
+    res.status(400).json({ error: { code: "VALIDATION_ERROR", message: "name is required" } });
+    return;
+  }
+  if (typeof email !== "string" || !/^[^\s@]+@[^\s@]+\.[^\s@]{2,}$/.test(email)) {
+    res.status(400).json({ error: { code: "VALIDATION_ERROR", message: "valid email required" } });
+    return;
+  }
+
   res.status(201).json({
-    data: {
-      id: "stub-user-id",
-      ...req.body
-    },
-    message: "User creation is not implemented yet."
+    data: { id: "stub-user-id", name: name.trim(), email: email.toLowerCase() },
+    message: "User creation is not implemented yet.",
   });
 });
 


### PR DESCRIPTION
Closes #223

Destructures only {name, email} from req.body. Validates both fields before use. Strips all other properties from the response.