### PR TITLE
fix(ci): make seed-meta-issue workflow idempotent with title check

### DIFF
--- a/.github/workflows/seed-meta-idempotent.yml
+++ b/.github/workflows/seed-meta-idempotent.yml
@@ -1,0 +1,16 @@
+name: Seed Meta Issue Idempotent
+on:
+  workflow_dispatch:
+jobs:
+  seed:
+    runs-on: ubuntu-latest
+    permissions:
+      issues: write
+    steps:
+      - uses: actions/github-script@v7
+        with:
+          script: |
+            const TITLE="Bug Bounty Program";
+            const list=await github.paginate(github.rest.issues.listForRepo,{owner:context.repo.owner,repo:context.repo.repo,state:"open",per_page:100});
+            if(list.some(i=>i.title===TITLE)){console.log("exists, skip");return;}
+            await github.rest.issues.create({owner:context.repo.owner,repo:context.repo.repo,title:TITLE,body:"/bounty program meta issue",labels:["bounty"]});


### PR DESCRIPTION
Closes #805

New seed-meta-idempotent.yml checks if meta issue already exists before creating. Prevents duplicate issues on re-run.