### PR TITLE
docs: add accurate API routes reference matching current implementation

### DIFF
--- a/docs/ROUTES.md
+++ b/docs/ROUTES.md
@@ -1,0 +1,9 @@
+# API Routes
+
+| Method | Path    | Description          |
+|--------|---------|----------------------|
+| GET    | /health | Liveness probe       |
+| GET    | /users  | List users (stub)    |
+| POST   | /users  | Create user (stub)   |
+
+> Planned routes not yet implemented: tasks, auth, proposals.


### PR DESCRIPTION
Closes #773

Adds docs/ROUTES.md with only the 3 currently-implemented routes. Clearly marks planned routes as not yet implemented.