### PR TITLE
docs: fix database models to match current Prisma schema

### DIFF
--- a/docs/DATABASE.md
+++ b/docs/DATABASE.md
@@ -1,0 +1,8 @@
+# Database Models
+
+Current `prisma/schema.prisma` defines:
+
+- **User** — platform accounts
+- **Task** — work items
+
+> Planned (not yet in schema): Proposals, Payments, Reviews, Messages.


### PR DESCRIPTION
Closes #771

Adds docs/DATABASE.md listing only User and Task (currently in schema). Notes Proposals/Payments/Reviews as planned but not yet implemented.