### PR TITLE
fix: add SEO metadata title and description to web app homepage

### DIFF
--- a/apps/web/src/app/layout.tsx
+++ b/apps/web/src/app/layout.tsx
@@ -1,0 +1,19 @@
+import type { Metadata } from "next";
+
+export const metadata: Metadata = {
+  title: "TaskFlow | Distributed Task Marketplace",
+  description: "TaskFlow is an open-source distributed task marketplace connecting clients with skilled contributors.",
+  openGraph: {
+    title: "TaskFlow",
+    description: "Open-source distributed task marketplace",
+    type: "website",
+  },
+};
+
+export default function RootLayout({ children }: { children: React.ReactNode }) {
+  return (
+    <html lang="en">
+      <body>{children}</body>
+    </html>
+  );
+}


### PR DESCRIPTION
Closes #895

Adds Next.js Metadata export to layout.tsx with title, description, and OpenGraph fields.