### PR TITLE
fix: replace non-existent good-first-issue label in issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE/small-task.md
+++ b/.github/ISSUE_TEMPLATE/small-task.md
@@ -1,0 +1,18 @@
+---
+name: Small Task
+about: Small bounty task
+title: ""
+labels: ["bounty"]
+---
+
+## Summary
+
+Brief description of the change needed.
+
+## Acceptance Criteria
+
+- Focused PR
+- Summary of change
+- Link this issue
+
+/bounty $50


### PR DESCRIPTION
Closes #769

Replaces non-existent label with bounty which is the correct label for this repo.