### PR TITLE
fix: add graceful shutdown on SIGTERM/SIGINT

### DIFF
--- a/apps/api/src/lib/shutdownV2.ts
+++ b/apps/api/src/lib/shutdownV2.ts
@@ -1,0 +1,11 @@
+import { Server } from "http";
+export function setupGracefulShutdown(server: Server, timeoutMs = 10000): void {
+  const shutdown = (sig: string): void => {
+    console.log(`[${sig}] graceful shutdown initiated`);
+    server.close(() => { console.log("server closed"); process.exit(0); });
+    setTimeout(() => { console.error("shutdown timeout"); process.exit(1); }, timeoutMs).unref();
+  };
+  process.once("SIGTERM", () => shutdown("SIGTERM"));
+  process.once("SIGINT",  () => shutdown("SIGINT"));
+}
+export default setupGracefulShutdown;


### PR DESCRIPTION
Closes #906

Adds lib/shutdownV2.ts with setupGracefulShutdown(server) handling SIGTERM and SIGINT with drain timeout.