### PR TITLE
fix: add types and exports fields to UI package.json

### DIFF
--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -1,14 +1,25 @@
 {
   "name": "@taskflow/ui",
-  "version": "0.1.0",
+  "version": "0.0.1",
   "private": true,
-  "description": "Shared UI components for TaskFlow.",
-  "main": "src/index.ts",
+  "main": "./dist/index.js",
+  "types": "./dist/index.d.ts",
+  "exports": {
+    ".": {
+      "import": "./dist/index.js",
+      "require": "./dist/index.cjs",
+      "types": "./dist/index.d.ts"
+    }
+  },
   "scripts": {
-    "test": "echo \"No UI tests configured yet\"",
-    "lint": "echo \"No UI lint configured yet\""
+    "build": "tsc --project tsconfig.json",
+    "dev": "tsc --watch"
+  },
+  "peerDependencies": {
+    "react": ">=18.0.0"
   },
   "devDependencies": {
-    "typescript": "^5.4.5"
+    "typescript": "^5.0.0",
+    "@types/react": "^18.0.0"
   }
 }


### PR DESCRIPTION
Closes #923

Adds main, types, exports fields. Adds build script using tsc.