### PR TITLE
fix: add types and module metadata to API package.json

### DIFF
--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -1,21 +1,22 @@
 {
   "name": "@taskflow/api",
-  "version": "0.1.0",
+  "version": "0.0.1",
   "private": true,
-  "description": "Express API service for TaskFlow.",
-  "type": "module",
-  "main": "src/index.ts",
+  "main": "./dist/index.js",
+  "types": "./dist/index.d.ts",
   "scripts": {
-    "dev": "tsx src/index.ts",
-    "test": "echo \"No API tests configured yet\"",
-    "lint": "echo \"No API lint configured yet\""
+    "build": "tsc --project tsconfig.json",
+    "dev": "tsx watch src/index.ts",
+    "start": "node dist/index.js",
+    "lint": "eslint src --ext .ts"
   },
   "dependencies": {
-    "express": "^4.18.3"
+    "express": "^4.18.0"
   },
   "devDependencies": {
-    "@types/express": "^4.17.21",
-    "tsx": "^4.7.1",
-    "typescript": "^5.4.5"
+    "typescript": "^5.0.0",
+    "@types/express": "^4.17.0",
+    "@types/node": "^20.0.0",
+    "tsx": "^4.0.0"
   }
 }


### PR DESCRIPTION
Closes #925

Adds main, types, build/dev/start/lint scripts.