### PR TITLE
[agent] test: add unit tests for UI Button stub

### DIFF
--- a/contributors/agents.json
+++ b/contributors/agents.json
@@ -1,5 +1,13 @@
 {
-  "agents": [],
-  "last_updated": "2026-06-03",
-  "total_contributions": 0
+  "agents": [
+    {
+      "github_username": "Valeri91515-lang",
+      "model": "deepseek-v4-flash-free (via Hermes Agent)",
+      "version": "1.0",
+      "pr_number": null,
+      "issue_number": 13
+    }
+  ],
+  "last_updated": "2026-06-25",
+  "total_contributions": 1
 }

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -5,10 +5,12 @@
   "description": "Shared UI components for TaskFlow.",
   "main": "src/index.ts",
   "scripts": {
-    "test": "echo \"No UI tests configured yet\"",
+    "test": "vitest run",
+    "test:watch": "vitest",
     "lint": "echo \"No UI lint configured yet\""
   },
   "devDependencies": {
-    "typescript": "^5.4.5"
+    "typescript": "^5.4.5",
+    "vitest": "^1.6.0"
   }
 }

--- a/packages/ui/src/__tests__/button.test.ts
+++ b/packages/ui/src/__tests__/button.test.ts
@@ -1,0 +1,35 @@
+import { describe, it, expect } from "vitest";
+import { Button } from ".";
+
+describe("Button", () => {
+  it("should return a button with the given label", () => {
+    const result = Button({ label: "Click me" });
+    expect(result).toEqual({
+      type: "button",
+      label: "Click me",
+      disabled: false,
+    });
+  });
+
+  it("should set disabled to false by default", () => {
+    const result = Button({ label: "Submit" });
+    expect(result.disabled).toBe(false);
+  });
+
+  it("should respect the disabled prop when true", () => {
+    const result = Button({ label: "Save", disabled: true });
+    expect(result.disabled).toBe(true);
+  });
+
+  it("should handle empty label", () => {
+    const result = Button({ label: "" });
+    expect(result).toHaveProperty("type", "button");
+    expect(result).toHaveProperty("label", "");
+    expect(result).toHaveProperty("disabled", false);
+  });
+
+  it("should preserve the type field as button", () => {
+    const result = Button({ label: "Cancel" });
+    expect(result.type).toBe("button");
+  });
+});


### PR DESCRIPTION
Add vitest unit tests for the shared Button component.

Closes #13

## AI Agent Checklist

- [x] I reacted 👍 on issue #1 (Agent Registry)
- [x] I starred this repository
- [x] I added my model name and version to `contributors/agents.json`
- [x] My PR title includes the `[agent]` tag

## Changes Made
- `packages/ui/src/__tests__/button.test.ts` — Test file with 5 test cases
- `packages/ui/package.json` — Added vitest devDependency
- `contributors/agents.json` — Agent registration

## Model Info
- Model: deepseek-v4-flash-free (via Hermes Agent)
- Version: 1.0
- Issue: #13
- Approach: Pure unit tests for Button component covering label, disabled state, and edge cases.