### PR TITLE
[agent] feat(api): validate POST /users payloads

### DIFF
--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -7,7 +7,7 @@
   "main": "src/index.ts",
   "scripts": {
     "dev": "tsx src/index.ts",
-    "test": "echo \"No API tests configured yet\"",
+    "test": "node --import tsx --test src/routes/users.test.ts",
     "lint": "echo \"No API lint configured yet\""
   },
   "dependencies": {

--- a/apps/api/src/routes/users.test.ts
+++ b/apps/api/src/routes/users.test.ts
@@ -1,0 +1,139 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import express from "express";
+import type { AddressInfo } from "node:net";
+
+import usersRouter from "./users.js";
+
+function createApp() {
+  const app = express();
+  app.use(express.json());
+  app.use("/users", usersRouter);
+  return app;
+}
+
+async function startServer() {
+  const app = createApp();
+  const server = app.listen(0);
+  await new Promise<void>((resolve) => server.on("listening", () => resolve()));
+  const { port } = server.address() as AddressInfo;
+  return {
+    url: `http://127.0.0.1:${port}`,
+    close: () =>
+      new Promise<void>((resolve, reject) =>
+        server.close((err) => (err ? reject(err) : resolve()))
+      )
+  };
+}
+
+async function postUsers(url: string, body: string, contentType = "application/json") {
+  return fetch(`${url}/users`, {
+    method: "POST",
+    headers: { "Content-Type": contentType },
+    body
+  });
+}
+
+test("POST /users rejects non-object JSON bodies (array)", async () => {
+  const srv = await startServer();
+  try {
+    const res = await postUsers(srv.url, JSON.stringify([{ email: "a@b.co" }]));
+    assert.equal(res.status, 400);
+    const data = (await res.json()) as { error: string };
+    assert.match(data.error, /JSON object/);
+  } finally {
+    await srv.close();
+  }
+});
+
+test("POST /users rejects non-object JSON bodies (string)", async () => {
+  const srv = await startServer();
+  try {
+    const res = await postUsers(srv.url, JSON.stringify("hello"));
+    assert.equal(res.status, 400);
+  } finally {
+    await srv.close();
+  }
+});
+
+test("POST /users rejects null body", async () => {
+  const srv = await startServer();
+  try {
+    const res = await postUsers(srv.url, JSON.stringify(null));
+    assert.equal(res.status, 400);
+  } finally {
+    await srv.close();
+  }
+});
+
+test("POST /users requires a valid email", async () => {
+  const srv = await startServer();
+  try {
+    const res = await postUsers(srv.url, JSON.stringify({ name: "Alice" }));
+    assert.equal(res.status, 400);
+    const bad = await postUsers(srv.url, JSON.stringify({ email: "not-an-email" }));
+    assert.equal(bad.status, 400);
+    const empty = await postUsers(srv.url, JSON.stringify({ email: "   " }));
+    assert.equal(empty.status, 400);
+  } finally {
+    await srv.close();
+  }
+});
+
+test("POST /users normalizes email (trim + lowercase) and name (collapse whitespace)", async () => {
+  const srv = await startServer();
+  try {
+    const res = await postUsers(
+      srv.url,
+      JSON.stringify({ email: "  Alice@Example.COM  ", name: "  Alice   Smith  " })
+    );
+    assert.equal(res.status, 201);
+    const data = (await res.json()) as { data: { email: string; name: string; id: string } };
+    assert.equal(data.data.email, "alice@example.com");
+    assert.equal(data.data.name, "Alice Smith");
+    assert.ok(data.data.id && typeof data.data.id === "string");
+  } finally {
+    await srv.close();
+  }
+});
+
+test("POST /users ignores client-controlled id and unrelated fields", async () => {
+  const srv = await startServer();
+  try {
+    const res = await postUsers(
+      srv.url,
+      JSON.stringify({
+        id: "client-supplied-id",
+        email: "bob@example.com",
+        isAdmin: true,
+        role: "superuser",
+        extra: { nested: 1 }
+      })
+    );
+    assert.equal(res.status, 201);
+    const data = (await res.json()) as { data: Record<string, unknown> };
+    assert.notEqual(data.data.id, "client-supplied-id");
+    assert.equal(data.data.email, "bob@example.com");
+    assert.equal(data.data.isAdmin, undefined);
+    assert.equal(data.data.role, undefined);
+    assert.equal(data.data.extra, undefined);
+    assert.deepEqual(Object.keys(data.data).sort(), ["email", "id"].sort());
+  } finally {
+    await srv.close();
+  }
+});
+
+test("POST /users omits name when not a non-empty string", async () => {
+  const srv = await startServer();
+  try {
+    const res = await postUsers(
+      srv.url,
+      JSON.stringify({ email: "c@example.com", name: 123 })
+    );
+    assert.equal(res.status, 201);
+    const data = (await res.json()) as { data: Record<string, unknown> };
+    assert.equal(data.data.name, undefined);
+  } finally {
+    await srv.close();
+  }
+});

--- a/apps/api/src/routes/users.ts
+++ b/apps/api/src/routes/users.ts
@@ -1,6 +1,27 @@
 import { Router } from "express";
+import { randomUUID } from "node:crypto";
 
 const router = Router();
+
+// Reasonably strict email regex (RFC 5322 simplified).
+const EMAIL_REGEX = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
+const MAX_EMAIL_LENGTH = 254;
+const MAX_NAME_LENGTH = 100;
+
+function isPlainObject(value: unknown): value is Record<string, unknown> {
+  return (
+    typeof value === "object" &&
+    value !== null &&
+    !Array.isArray(value)
+  );
+}
+
+function normalizeName(value: unknown): string | undefined {
+  if (typeof value !== "string") return undefined;
+  const trimmed = value.trim().replace(/\s+/g, " ");
+  if (trimmed.length === 0) return undefined;
+  return trimmed.slice(0, MAX_NAME_LENGTH);
+}
 
 router.get("/", (_req, res) => {
   res.json({
@@ -10,12 +31,43 @@ router.get("/", (_req, res) => {
 });
 
 router.post("/", (req, res) => {
-  res.status(201).json({
-    data: {
-      id: "stub-user-id",
-      ...req.body
-    },
-    message: "User creation is not implemented yet."
+  const body: unknown = req.body;
+
+  if (!isPlainObject(body)) {
+    return res.status(400).json({
+      error: "Invalid request body. Expected a JSON object."
+    });
+  }
+
+  const rawEmail = body.email;
+  if (typeof rawEmail !== "string") {
+    return res.status(400).json({
+      error: "A valid 'email' string is required."
+    });
+  }
+
+  const email = rawEmail.trim().toLowerCase();
+  if (email.length === 0 || email.length > MAX_EMAIL_LENGTH || !EMAIL_REGEX.test(email)) {
+    return res.status(400).json({
+      error: "A valid 'email' string is required."
+    });
+  }
+
+  const name = normalizeName(body.name);
+
+  // Server generates the id; client-controlled `id` and any other
+  // extra fields on the request body are intentionally ignored.
+  const user: { id: string; email: string; name?: string } = {
+    id: randomUUID(),
+    email
+  };
+  if (name !== undefined) {
+    user.name = name;
+  }
+
+  return res.status(201).json({
+    data: user,
+    message: "User created."
   });
 });
 

--- a/contributors/agents.json
+++ b/contributors/agents.json
@@ -1,5 +1,13 @@
 {
-  "agents": [],
-  "last_updated": "2026-06-03",
-  "total_contributions": 0
+  "agents": [
+    {
+      "github_username": "danielalanbates",
+      "model": "claude-sonnet-4.5",
+      "version": "claude-sonnet-4-5",
+      "pr_number": null,
+      "issue_number": 2207
+    }
+  ],
+  "last_updated": "2026-06-25",
+  "total_contributions": 1
 }


### PR DESCRIPTION
Closes #2207

## Summary
Hardens `POST /users` against malformed and abusive payloads.

- Reject non-object JSON bodies (arrays, scalars, null) with `400`.
- Require a valid email (regex + length cap); normalize via trim + lowercase.
- Normalize optional `name`: trim, collapse internal whitespace, drop if empty/non-string, cap length.
- Generate user `id` server-side with `crypto.randomUUID()`; client-supplied `id` and any other extra fields are ignored.
- Response shape is the whitelisted `{ id, email, name? }`.

## Tests
Adds `apps/api/src/routes/users.test.ts` using Node's built-in test runner (no new deps). 7 regression tests cover each acceptance criterion. `npm test --workspace @taskflow/api` passes locally.

## Agent disclosure
- Registered in `contributors/agents.json`
- 👍 on Issue #16
- Repo starred
- `[agent]` tag in PR title

*This PR was created with the assistance of claude-sonnet-4.5 by Anthropic. Happy to make any adjustments!*