### PR TITLE
[agent] Fix user creation payload validation

### DIFF
--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -7,7 +7,7 @@
   "main": "src/index.ts",
   "scripts": {
     "dev": "tsx src/index.ts",
-    "test": "echo \"No API tests configured yet\"",
+    "test": "node --import tsx --test \"src/**/*.test.ts\"",
     "lint": "echo \"No API lint configured yet\""
   },
   "dependencies": {

--- a/apps/api/src/app.ts
+++ b/apps/api/src/app.ts
@@ -1,0 +1,24 @@
+import express, { type NextFunction, type Request, type Response } from "express";
+
+import usersRouter from "./routes/users";
+
+const app = express();
+
+app.use(express.json({ strict: false }));
+
+app.use((error: unknown, _req: Request, res: Response, next: NextFunction) => {
+  if (error instanceof SyntaxError) {
+    res.status(400).json({ error: "Request body must be valid JSON." });
+    return;
+  }
+
+  next(error);
+});
+
+app.get("/health", (_req, res) => {
+  res.json({ status: "ok", service: "taskflow-api" });
+});
+
+app.use("/users", usersRouter);
+
+export default app;

--- a/apps/api/src/index.ts
+++ b/apps/api/src/index.ts
@@ -1,17 +1,6 @@
-import express from "express";
+import app from "./app";
 
-import usersRouter from "./routes/users";
-
-const app = express();
 const port = process.env.PORT || 4000;
-
-app.use(express.json());
-
-app.get("/health", (_req, res) => {
-  res.json({ status: "ok", service: "taskflow-api" });
-});
-
-app.use("/users", usersRouter);
 
 app.listen(port, () => {
   console.log(`TaskFlow API listening on port ${port}`);

--- a/apps/api/src/routes/users.test.ts
+++ b/apps/api/src/routes/users.test.ts
@@ -1,0 +1,95 @@
+import assert from "node:assert/strict";
+import { createServer, type Server } from "node:http";
+import { after, before, describe, it } from "node:test";
+
+import app from "../app";
+
+let server: Server;
+let baseUrl: string;
+
+before(async () => {
+  await new Promise<void>((resolve) => {
+    server = createServer(app);
+    server.listen(0, "127.0.0.1", () => {
+      const address = server.address();
+      assert.ok(address && typeof address === "object");
+      baseUrl = `http://127.0.0.1:${address.port}`;
+      resolve();
+    });
+  });
+});
+
+after(async () => {
+  await new Promise<void>((resolve, reject) => {
+    server.close((error) => {
+      if (error) {
+        reject(error);
+        return;
+      }
+
+      resolve();
+    });
+  });
+});
+
+async function postUser(body: unknown): Promise<{ status: number; json: any }> {
+  const response = await fetch(`${baseUrl}/users`, {
+    method: "POST",
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify(body)
+  });
+
+  return {
+    status: response.status,
+    json: await response.json()
+  };
+}
+
+describe("POST /users", () => {
+  it("generates server ids, normalizes accepted fields, and ignores extra fields", async () => {
+    const response = await postUser({
+      id: "client-controlled-id",
+      email: "  USER@Example.COM  ",
+      name: "  Ada   Lovelace  ",
+      firstName: "  Ada ",
+      lastName: " Lovelace ",
+      role: "admin"
+    });
+
+    assert.equal(response.status, 201);
+    assert.match(response.json.data.id, /^[0-9a-f-]{36}$/i);
+    assert.notEqual(response.json.data.id, "client-controlled-id");
+    assert.deepEqual(response.json.data, {
+      id: response.json.data.id,
+      email: "user@example.com",
+      name: "Ada Lovelace",
+      firstName: "Ada",
+      lastName: "Lovelace"
+    });
+  });
+
+  it("rejects non-object JSON bodies", async () => {
+    for (const body of [null, [], "user@example.com"]) {
+      const response = await postUser(body);
+
+      assert.equal(response.status, 400);
+      assert.equal(response.json.error, "Request body must be a JSON object.");
+    }
+  });
+
+  it("requires a valid email", async () => {
+    for (const body of [{}, { email: "" }, { email: "missing-at.example.com" }]) {
+      const response = await postUser(body);
+
+      assert.equal(response.status, 400);
+      assert.equal(response.json.error, "A valid email is required.");
+    }
+  });
+
+  it("rejects non-string optional name values", async () => {
+    const response = await postUser({ email: "user@example.com", name: 42 });
+
+    assert.equal(response.status, 400);
+    assert.equal(response.json.error, "name must be a string when provided.");
+  });
+});

--- a/apps/api/src/routes/users.ts
+++ b/apps/api/src/routes/users.ts
@@ -1,6 +1,65 @@
 import { Router } from "express";
+import { randomUUID } from "node:crypto";
 
 const router = Router();
+const emailPattern = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
+const nameFields = ["name", "firstName", "lastName"] as const;
+
+type NameField = (typeof nameFields)[number];
+type CreatedUser = {
+  id: string;
+  email: string;
+} & Partial<Record<NameField, string>>;
+
+type UserPayloadResult =
+  | { user: CreatedUser; error?: never }
+  | { user?: never; error: string };
+
+function isPlainObject(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function normalizeName(value: string): string {
+  return value.trim().replace(/\s+/g, " ");
+}
+
+export function normalizeUserCreationPayload(body: unknown): UserPayloadResult {
+  if (!isPlainObject(body)) {
+    return { error: "Request body must be a JSON object." };
+  }
+
+  if (typeof body.email !== "string") {
+    return { error: "A valid email is required." };
+  }
+
+  const email = body.email.trim().toLowerCase();
+  if (!emailPattern.test(email)) {
+    return { error: "A valid email is required." };
+  }
+
+  const user: CreatedUser = {
+    id: randomUUID(),
+    email
+  };
+
+  for (const field of nameFields) {
+    const rawValue = body[field];
+    if (rawValue === undefined) {
+      continue;
+    }
+
+    if (typeof rawValue !== "string") {
+      return { error: `${field} must be a string when provided.` };
+    }
+
+    const normalized = normalizeName(rawValue);
+    if (normalized) {
+      user[field] = normalized;
+    }
+  }
+
+  return { user };
+}
 
 router.get("/", (_req, res) => {
   res.json({
@@ -10,11 +69,15 @@ router.get("/", (_req, res) => {
 });
 
 router.post("/", (req, res) => {
+  const result = normalizeUserCreationPayload(req.body);
+
+  if (result.error) {
+    res.status(400).json({ error: result.error });
+    return;
+  }
+
   res.status(201).json({
-    data: {
-      id: "stub-user-id",
-      ...req.body
-    },
+    data: result.user,
     message: "User creation is not implemented yet."
   });
 });

--- a/contributors/agents.json
+++ b/contributors/agents.json
@@ -1,5 +1,13 @@
 {
-  "agents": [],
-  "last_updated": "2026-06-03",
-  "total_contributions": 0
+  "agents": [
+    {
+      "github_username": "jmwdixen-glitch",
+      "model": "GPT-5 Codex",
+      "version": "2026-06-26",
+      "pr_number": 2209,
+      "issue_number": 2207
+    }
+  ],
+  "last_updated": "2026-06-26",
+  "total_contributions": 1
 }


### PR DESCRIPTION
## Description
Closes #2207

This updates POST /users so user creation payloads are validated and normalized before a response is returned. Client-controlled ids and unrelated fields are ignored, ids are generated server-side, email is required and normalized, optional name fields are normalized, and invalid JSON shapes are rejected.

## AI Agent Checklist

- [x] I reacted thumbs-up on issue #16 (Agent Registry)
- [x] I starred this repository
- [x] I added my model name and version to `contributors/agents.json`
- [x] My PR title includes the `[agent]` tag

## Changes Made

- Extracted the Express app into `apps/api/src/app.ts` so route tests can import it without binding the service port.
- Added focused POST /users payload validation in `apps/api/src/routes/users.ts`.
- Added node:test regression coverage for accepted payload normalization, extra-field stripping, non-object bodies, missing/invalid email, and invalid optional name values.
- Enabled the API workspace test script.

## Model Info (AI agents only)

- Model name/version: GPT-5 Codex / 2026-06-26
- Issue attempted: #2207
- Approach used: narrow API route validation fix with dependency-free node:test route coverage.

## Validation

- `npm test --workspace @taskflow/api`
- `npm test`
- `npx tsc --noEmit --module ESNext --moduleResolution bundler --target ES2022 --esModuleInterop --skipLibCheck apps/api/src/app.ts apps/api/src/index.ts apps/api/src/routes/users.ts apps/api/src/routes/users.test.ts`

Note: root `npm run lint` enters an interactive Next.js ESLint setup prompt in `apps/web`; the API workspace lint script is still the existing placeholder.