### PR TITLE
Fix user creation payload validation

### DIFF
--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -7,7 +7,7 @@
   "main": "src/index.ts",
   "scripts": {
     "dev": "tsx src/index.ts",
-    "test": "echo \"No API tests configured yet\"",
+    "test": "tsx --test src/**/*.test.ts",
     "lint": "echo \"No API lint configured yet\""
   },
   "dependencies": {

--- a/apps/api/src/index.ts
+++ b/apps/api/src/index.ts
@@ -1,4 +1,5 @@
 import express from "express";
+import { pathToFileURL } from "node:url";
 
 import usersRouter from "./routes/users";
 
@@ -13,6 +14,10 @@ app.get("/health", (_req, res) => {
 
 app.use("/users", usersRouter);
 
-app.listen(port, () => {
-  console.log(`TaskFlow API listening on port ${port}`);
-});
+if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) {
+  app.listen(port, () => {
+    console.log(`TaskFlow API listening on port ${port}`);
+  });
+}
+
+export default app;

--- a/apps/api/src/routes/users.test.ts
+++ b/apps/api/src/routes/users.test.ts
@@ -1,0 +1,77 @@
+import assert from "node:assert/strict";
+import { after, before, describe, it } from "node:test";
+import type { Server } from "node:http";
+
+import app from "../index";
+
+let server: Server;
+let baseUrl: string;
+
+const postUser = async (body: unknown) =>
+  fetch(`${baseUrl}/users`, {
+    method: "POST",
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify(body)
+  });
+
+describe("POST /users", () => {
+  before(async () => {
+    await new Promise<void>((resolve) => {
+      server = app.listen(0, () => {
+        const address = server.address();
+        assert.notEqual(address, null);
+        assert.notEqual(typeof address, "string");
+        baseUrl = `http://127.0.0.1:${address.port}`;
+        resolve();
+      });
+    });
+  });
+
+  after(async () => {
+    await new Promise<void>((resolve, reject) => {
+      server.close((error) => (error ? reject(error) : resolve()));
+    });
+  });
+
+  it("rejects non-object JSON bodies", async () => {
+    const response = await postUser(["not", "an", "object"]);
+    const payload = await response.json();
+
+    assert.equal(response.status, 400);
+    assert.equal(payload.error, "Request body must be a JSON object.");
+  });
+
+  it("requires a valid email", async () => {
+    const response = await postUser({ email: "not-an-email" });
+    const payload = await response.json();
+
+    assert.equal(response.status, 400);
+    assert.equal(payload.error, "A valid email is required.");
+  });
+
+  it("normalizes email and name values", async () => {
+    const response = await postUser({
+      email: "  User@Example.COM  ",
+      name: "  Luis   Gonzalez  "
+    });
+    const payload = await response.json();
+
+    assert.equal(response.status, 201);
+    assert.equal(payload.data.email, "user@example.com");
+    assert.equal(payload.data.name, "Luis Gonzalez");
+  });
+
+  it("ignores client-controlled id and unrelated fields", async () => {
+    const response = await postUser({
+      id: "attacker-id",
+      email: "owner@example.com",
+      role: "admin"
+    });
+    const payload = await response.json();
+
+    assert.equal(response.status, 201);
+    assert.notEqual(payload.data.id, "attacker-id");
+    assert.equal(payload.data.role, undefined);
+    assert.match(payload.data.id, /^[0-9a-f-]{36}$/);
+  });
+});

--- a/apps/api/src/routes/users.ts
+++ b/apps/api/src/routes/users.ts
@@ -1,6 +1,26 @@
 import { Router } from "express";
+import crypto from "node:crypto";
 
 const router = Router();
+
+type CreateUserPayload = {
+  email?: unknown;
+  name?: unknown;
+};
+
+const emailPattern = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
+
+const isPlainObject = (value: unknown): value is CreateUserPayload =>
+  typeof value === "object" && value !== null && !Array.isArray(value);
+
+const normalizeText = (value: unknown): string | undefined => {
+  if (typeof value !== "string") {
+    return undefined;
+  }
+
+  const normalized = value.trim().replace(/\s+/g, " ");
+  return normalized.length > 0 ? normalized : undefined;
+};
 
 router.get("/", (_req, res) => {
   res.json({
@@ -10,12 +30,31 @@ router.get("/", (_req, res) => {
 });
 
 router.post("/", (req, res) => {
+  if (!isPlainObject(req.body)) {
+    res.status(400).json({
+      error: "Request body must be a JSON object."
+    });
+    return;
+  }
+
+  const email = normalizeText(req.body.email)?.toLowerCase();
+
+  if (!email || !emailPattern.test(email)) {
+    res.status(400).json({
+      error: "A valid email is required."
+    });
+    return;
+  }
+
+  const name = normalizeText(req.body.name);
+
   res.status(201).json({
     data: {
-      id: "stub-user-id",
-      ...req.body
+      id: crypto.randomUUID(),
+      email,
+      ...(name ? { name } : {})
     },
-    message: "User creation is not implemented yet."
+    message: "User created."
   });
 });
 


### PR DESCRIPTION
Closes #2207

/claim #2207

## Summary
- Validate `POST /users` request bodies before creating a user response.
- Require a valid email and normalize email/name text.
- Generate user ids server-side and ignore client-controlled `id` plus unrelated fields.
- Export the Express app so route tests can exercise it without starting the production listener.

## Tests
- `npm test --workspace @taskflow/api`