### PR TITLE
Fix starter issue seeding idempotency

### DIFF
--- a/.github/workflows/seed-issues.yml
+++ b/.github/workflows/seed-issues.yml
@@ -90,7 +90,31 @@ jobs:
               }
             ];
 
+            const quoteSearchTerm = (value) => `"${value.replace(/\\/g, "\\\\").replace(/"/g, '\\"')}"`;
+
+            const findOpenIssueByTitle = async (title) => {
+              const { data } = await github.rest.search.issuesAndPullRequests({
+                q: [
+                  `repo:${context.repo.owner}/${context.repo.repo}`,
+                  "is:issue",
+                  "is:open",
+                  "in:title",
+                  quoteSearchTerm(title)
+                ].join(" "),
+                per_page: 20
+              });
+
+              return data.items.find((item) => item.title === title);
+            };
+
             for (const issue of issues) {
+              const existingIssue = await findOpenIssueByTitle(issue.title);
+
+              if (existingIssue) {
+                core.info(`Skipping existing starter issue #${existingIssue.number}: ${issue.title}`);
+                continue;
+              }
+
               await github.rest.issues.create({
                 owner: context.repo.owner,
                 repo: context.repo.repo,


### PR DESCRIPTION
Closes #2101
/claim #2101

## Summary
- add an exact-title lookup before each starter issue creation
- skip already-open starter issues instead of duplicating them
- keep generated issue bodies and labels unchanged for newly-created starter issues

## Validation
- Parsed the embedded `actions/github-script` block locally by wrapping it in an async function.
- Duplicate-check path: each starter title is searched as an open issue in the current repo; exact title matches log a skip and continue, while misses use the existing create call.