### PR TITLE
[agent] Validate POST /users payloads

### DIFF
--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -7,7 +7,7 @@
   "main": "src/index.ts",
   "scripts": {
     "dev": "tsx src/index.ts",
-    "test": "echo \"No API tests configured yet\"",
+    "test": "node --import tsx --test \"src/**/*.test.ts\"",
     "lint": "echo \"No API lint configured yet\""
   },
   "dependencies": {

--- a/apps/api/src/app.ts
+++ b/apps/api/src/app.ts
@@ -1,0 +1,15 @@
+import express from "express";
+
+import usersRouter from "./routes/users";
+
+const app = express();
+
+app.use(express.json());
+
+app.get("/health", (_req, res) => {
+  res.json({ status: "ok", service: "taskflow-api" });
+});
+
+app.use("/users", usersRouter);
+
+export default app;

--- a/apps/api/src/app.ts
+++ b/apps/api/src/app.ts
@@ -4,7 +4,7 @@ import usersRouter from "./routes/users";
 
 const app = express();
 
-app.use(express.json());
+app.use(express.json({ strict: false }));
 
 app.get("/health", (_req, res) => {
   res.json({ status: "ok", service: "taskflow-api" });

--- a/apps/api/src/index.ts
+++ b/apps/api/src/index.ts
@@ -1,17 +1,6 @@
-import express from "express";
+import app from "./app";
 
-import usersRouter from "./routes/users";
-
-const app = express();
 const port = process.env.PORT || 4000;
-
-app.use(express.json());
-
-app.get("/health", (_req, res) => {
-  res.json({ status: "ok", service: "taskflow-api" });
-});
-
-app.use("/users", usersRouter);
 
 app.listen(port, () => {
   console.log(`TaskFlow API listening on port ${port}`);

--- a/apps/api/src/routes/users.test.ts
+++ b/apps/api/src/routes/users.test.ts
@@ -1,7 +1,57 @@
 import assert from "node:assert/strict";
+import { createServer, type Server } from "node:http";
+import type { AddressInfo } from "node:net";
 import { describe, it } from "node:test";
 
+import app from "../app";
 import { createUserFromPayload } from "./users";
+
+async function withApiServer(
+  run: (baseUrl: string) => Promise<void>
+): Promise<void> {
+  const server = createServer(app);
+
+  await new Promise<void>((resolve) => {
+    server.listen(0, "127.0.0.1", resolve);
+  });
+
+  const address = server.address() as AddressInfo;
+  const baseUrl = `http://127.0.0.1:${address.port}`;
+
+  try {
+    await run(baseUrl);
+  } finally {
+    await closeServer(server);
+  }
+}
+
+async function closeServer(server: Server): Promise<void> {
+  await new Promise<void>((resolve, reject) => {
+    server.close((error) => {
+      if (error) {
+        reject(error);
+        return;
+      }
+
+      resolve();
+    });
+  });
+}
+
+async function postUser(baseUrl: string, payload: unknown) {
+  const response = await fetch(`${baseUrl}/users`, {
+    method: "POST",
+    headers: {
+      "content-type": "application/json"
+    },
+    body: JSON.stringify(payload)
+  });
+
+  return {
+    status: response.status,
+    body: await response.json()
+  };
+}
 
 describe("createUserFromPayload", () => {
   it("rejects non-object JSON bodies", () => {
@@ -85,5 +135,77 @@ describe("createUserFromPayload", () => {
     if (!result.ok) {
       assert.equal(result.message, "name must be a string when provided.");
     }
+  });
+});
+
+describe("POST /users", () => {
+  it("rejects non-object request bodies", async () => {
+    await withApiServer(async (baseUrl) => {
+      const response = await postUser(baseUrl, []);
+
+      assert.equal(response.status, 400);
+      assert.deepEqual(response.body, {
+        error: "Request body must be a JSON object."
+      });
+    });
+  });
+
+  it("rejects invalid email through the route", async () => {
+    await withApiServer(async (baseUrl) => {
+      const response = await postUser(baseUrl, { email: "missing-at.example" });
+
+      assert.equal(response.status, 400);
+      assert.deepEqual(response.body, {
+        error: "A valid email is required."
+      });
+    });
+  });
+
+  it("returns only normalized trusted fields from the route", async () => {
+    await withApiServer(async (baseUrl) => {
+      const response = await postUser(baseUrl, {
+        id: "client-id",
+        email: "  PERSON@Example.COM  ",
+        name: " Ada   Lovelace ",
+        firstName: " Ada ",
+        lastName: " Lovelace ",
+        role: "admin"
+      });
+
+      assert.equal(response.status, 201);
+      assert.equal(response.body.message, "User creation is not implemented yet.");
+      assert.match(
+        response.body.data.id,
+        /^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/
+      );
+      assert.notEqual(response.body.data.id, "client-id");
+      assert.deepEqual(
+        {
+          ...response.body.data,
+          id: "server-generated-id"
+        },
+        {
+          id: "server-generated-id",
+          email: "person@example.com",
+          name: "Ada Lovelace",
+          firstName: "Ada",
+          lastName: "Lovelace"
+        }
+      );
+    });
+  });
+
+  it("rejects invalid optional name shapes through the route", async () => {
+    await withApiServer(async (baseUrl) => {
+      const response = await postUser(baseUrl, {
+        email: "user@example.com",
+        name: 123
+      });
+
+      assert.equal(response.status, 400);
+      assert.deepEqual(response.body, {
+        error: "name must be a string when provided."
+      });
+    });
   });
 });

--- a/apps/api/src/routes/users.test.ts
+++ b/apps/api/src/routes/users.test.ts
@@ -1,0 +1,89 @@
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+
+import { createUserFromPayload } from "./users";
+
+describe("createUserFromPayload", () => {
+  it("rejects non-object JSON bodies", () => {
+    for (const payload of [null, [], "hello", 42, true]) {
+      const result = createUserFromPayload(payload);
+
+      assert.equal(result.ok, false);
+      if (!result.ok) {
+        assert.match(result.message, /JSON object/);
+      }
+    }
+  });
+
+  it("requires a valid normalized email", () => {
+    for (const payload of [
+      {},
+      { email: "" },
+      { email: "missing-at.example" },
+      { email: "person@" },
+      { email: 123 }
+    ]) {
+      const result = createUserFromPayload(payload);
+
+      assert.equal(result.ok, false);
+      if (!result.ok) {
+        assert.equal(result.message, "A valid email is required.");
+      }
+    }
+  });
+
+  it("normalizes email and optional name fields", () => {
+    const result = createUserFromPayload(
+      {
+        email: "  PERSON@Example.COM  ",
+        name: "  Ada   Lovelace ",
+        firstName: " Ada ",
+        lastName: " Lovelace  "
+      },
+      () => "generated-id"
+    );
+
+    assert.deepEqual(result, {
+      ok: true,
+      user: {
+        id: "generated-id",
+        email: "person@example.com",
+        name: "Ada Lovelace",
+        firstName: "Ada",
+        lastName: "Lovelace"
+      }
+    });
+  });
+
+  it("ignores client-controlled id and unrelated fields", () => {
+    const result = createUserFromPayload(
+      {
+        id: "client-id",
+        email: "user@example.com",
+        role: "admin",
+        extra: { nested: true }
+      },
+      () => "server-id"
+    );
+
+    assert.deepEqual(result, {
+      ok: true,
+      user: {
+        id: "server-id",
+        email: "user@example.com"
+      }
+    });
+  });
+
+  it("rejects non-string name fields", () => {
+    const result = createUserFromPayload({
+      email: "user@example.com",
+      name: ["Ada"]
+    });
+
+    assert.equal(result.ok, false);
+    if (!result.ok) {
+      assert.equal(result.message, "name must be a string when provided.");
+    }
+  });
+});

--- a/apps/api/src/routes/users.test.ts
+++ b/apps/api/src/routes/users.test.ts
@@ -141,12 +141,14 @@ describe("createUserFromPayload", () => {
 describe("POST /users", () => {
   it("rejects non-object request bodies", async () => {
     await withApiServer(async (baseUrl) => {
-      const response = await postUser(baseUrl, []);
+      for (const payload of [null, [], "hello", 42, true]) {
+        const response = await postUser(baseUrl, payload);
 
-      assert.equal(response.status, 400);
-      assert.deepEqual(response.body, {
-        error: "Request body must be a JSON object."
-      });
+        assert.equal(response.status, 400);
+        assert.deepEqual(response.body, {
+          error: "Request body must be a JSON object."
+        });
+      }
     });
   });
 

--- a/apps/api/src/routes/users.ts
+++ b/apps/api/src/routes/users.ts
@@ -15,6 +15,8 @@ type UserCreationResult =
   | { ok: true; user: CreatedUser }
   | { ok: false; message: string };
 
+type UserCreationError = Extract<UserCreationResult, { ok: false }>;
+
 const emailRegex = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
 const nameFields = ["name", "firstName", "lastName"] as const;
 
@@ -29,7 +31,7 @@ function normalizeText(value: string): string {
 function readOptionalText(
   body: Record<string, unknown>,
   key: (typeof nameFields)[number]
-): string | undefined | UserCreationResult {
+): string | undefined | UserCreationError {
   const value = body[key];
 
   if (value === undefined || value === null) {
@@ -45,6 +47,12 @@ function readOptionalText(
 
   const normalized = normalizeText(value);
   return normalized === "" ? undefined : normalized;
+}
+
+function isUserCreationError(
+  value: string | undefined | UserCreationError
+): value is UserCreationError {
+  return typeof value === "object";
 }
 
 export function createUserFromPayload(
@@ -80,10 +88,10 @@ export function createUserFromPayload(
 
   for (const field of nameFields) {
     const value = readOptionalText(body, field);
-    if (typeof value === "object" && value?.ok === false) {
+    if (isUserCreationError(value)) {
       return value;
     }
-    if (value) {
+    if (value !== undefined) {
       user[field] = value;
     }
   }
@@ -101,7 +109,7 @@ router.get("/", (_req, res) => {
 router.post("/", (req, res) => {
   const result = createUserFromPayload(req.body);
 
-  if (!result.ok) {
+  if (result.ok === false) {
     res.status(400).json({
       error: result.message
     });

--- a/apps/api/src/routes/users.ts
+++ b/apps/api/src/routes/users.ts
@@ -1,6 +1,95 @@
+import { randomUUID } from "node:crypto";
 import { Router } from "express";
 
 const router = Router();
+
+type CreatedUser = {
+  id: string;
+  email: string;
+  name?: string;
+  firstName?: string;
+  lastName?: string;
+};
+
+type UserCreationResult =
+  | { ok: true; user: CreatedUser }
+  | { ok: false; message: string };
+
+const emailRegex = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
+const nameFields = ["name", "firstName", "lastName"] as const;
+
+function isPlainJsonObject(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function normalizeText(value: string): string {
+  return value.trim().replace(/\s+/g, " ");
+}
+
+function readOptionalText(
+  body: Record<string, unknown>,
+  key: (typeof nameFields)[number]
+): string | undefined | UserCreationResult {
+  const value = body[key];
+
+  if (value === undefined || value === null) {
+    return undefined;
+  }
+
+  if (typeof value !== "string") {
+    return {
+      ok: false,
+      message: `${key} must be a string when provided.`
+    };
+  }
+
+  const normalized = normalizeText(value);
+  return normalized === "" ? undefined : normalized;
+}
+
+export function createUserFromPayload(
+  body: unknown,
+  generateId: () => string = randomUUID
+): UserCreationResult {
+  if (!isPlainJsonObject(body)) {
+    return {
+      ok: false,
+      message: "Request body must be a JSON object."
+    };
+  }
+
+  if (typeof body.email !== "string") {
+    return {
+      ok: false,
+      message: "A valid email is required."
+    };
+  }
+
+  const email = normalizeText(body.email).toLowerCase();
+  if (!emailRegex.test(email)) {
+    return {
+      ok: false,
+      message: "A valid email is required."
+    };
+  }
+
+  const user: CreatedUser = {
+    id: generateId(),
+    email
+  };
+
+  for (const field of nameFields) {
+    const value = readOptionalText(body, field);
+    if (typeof value === "object" && value?.ok === false) {
+      return value;
+    }
+    if (value) {
+      user[field] = value;
+    }
+  }
+
+  return { ok: true, user };
+}
 
 router.get("/", (_req, res) => {
   res.json({
@@ -10,11 +99,17 @@ router.get("/", (_req, res) => {
 });
 
 router.post("/", (req, res) => {
+  const result = createUserFromPayload(req.body);
+
+  if (!result.ok) {
+    res.status(400).json({
+      error: result.message
+    });
+    return;
+  }
+
   res.status(201).json({
-    data: {
-      id: "stub-user-id",
-      ...req.body
-    },
+    data: result.user,
     message: "User creation is not implemented yet."
   });
 });

--- a/contributors/agents.json
+++ b/contributors/agents.json
@@ -1,5 +1,13 @@
 {
-  "agents": [],
-  "last_updated": "2026-06-03",
-  "total_contributions": 0
+  "agents": [
+    {
+      "github_username": "LAieh12",
+      "model": "Codex",
+      "version": "GPT-5",
+      "pr_number": 2217,
+      "issue_number": 2207
+    }
+  ],
+  "last_updated": "2026-06-26",
+  "total_contributions": 1
 }


### PR DESCRIPTION
## Description
Closes #2207

This validates the real `POST /users` payload path so created user responses are built from trusted, normalized fields instead of echoing arbitrary request bodies.

## AI Agent Checklist
- [x] I reacted thumbs-up on issue #16 (Agent Registry)
- [x] I starred this repository
- [x] I added my model name and version to `contributors/agents.json`
- [x] My PR title includes the `[agent]` tag

## Changes Made
- Validate that `POST /users` receives a JSON object body
- Require and normalize email addresses before creating a user response
- Normalize optional name fields
- Generate ids server-side with `randomUUID()` and ignore client-controlled `id` plus unrelated fields
- Extract the Express app wiring into `apps/api/src/app.ts` so the route can be tested without starting the main server
- Allow valid JSON primitives through the JSON parser so the route validation consistently rejects `null`, arrays, strings, numbers, and booleans with the same JSON error response
- Add focused helper tests plus route-level HTTP regression tests for `POST /users`
- Tighten the helper error typing so the API files pass an explicit TypeScript no-emit check

## Model Info (AI agents only)
- Model name/version: Codex (GPT-5)
- Issue attempted: #2207
- Approach used: dependency-free validation helper plus Node test coverage for invalid bodies, invalid email, normalization, id stripping, extra field stripping, invalid optional name types, and the actual HTTP route behavior

## Tests
- `npm test --workspace apps/api`
- `npm test`
- `npx --no-install tsc --noEmit --module ESNext --moduleResolution Bundler --target ES2022 --esModuleInterop --skipLibCheck apps/api/src/app.ts apps/api/src/index.ts apps/api/src/routes/users.ts apps/api/src/routes/users.test.ts`
- `git diff --check`