### PR TITLE
[agent] Validate user creation payloads

### DIFF
--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -7,7 +7,7 @@
   "main": "src/index.ts",
   "scripts": {
     "dev": "tsx src/index.ts",
-    "test": "echo \"No API tests configured yet\"",
+    "test": "tsx --test \"src/**/*.test.ts\"",
     "lint": "echo \"No API lint configured yet\""
   },
   "dependencies": {

--- a/apps/api/src/routes/users.test.ts
+++ b/apps/api/src/routes/users.test.ts
@@ -1,0 +1,65 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { buildUserFromPayload } from "./users";
+
+test("rejects non-object user payloads", () => {
+  for (const payload of [null, [], "user", 42, true]) {
+    const result = buildUserFromPayload(payload);
+
+    assert.equal(result.ok, false);
+  }
+});
+
+test("requires a valid email", () => {
+  for (const payload of [{}, { email: "" }, { email: "not-an-email" }]) {
+    const result = buildUserFromPayload(payload);
+
+    assert.equal(result.ok, false);
+  }
+});
+
+test("normalizes email and name values", () => {
+  const result = buildUserFromPayload({
+    email: "  USER@Example.COM ",
+    name: "  Ada Lovelace  "
+  });
+
+  assert.equal(result.ok, true);
+  assert.equal(result.user.email, "user@example.com");
+  assert.equal(result.user.name, "Ada Lovelace");
+});
+
+test("omits blank optional names", () => {
+  const result = buildUserFromPayload({
+    email: "user@example.com",
+    name: "   "
+  });
+
+  assert.equal(result.ok, true);
+  assert.equal("name" in result.user, false);
+});
+
+test("ignores client-controlled ids and unrelated fields", () => {
+  const result = buildUserFromPayload({
+    id: "client-id",
+    email: "user@example.com",
+    role: "admin"
+  });
+
+  assert.equal(result.ok, true);
+  assert.notEqual(result.user.id, "client-id");
+  assert.match(result.user.id, /^user_/);
+  assert.deepEqual(Object.keys(result.user).sort(), ["email", "id"]);
+});
+
+test("rejects non-string names", () => {
+  for (const name of [123, null, undefined]) {
+    const result = buildUserFromPayload({
+      email: "user@example.com",
+      name
+    });
+
+    assert.equal(result.ok, false);
+  }
+});

--- a/apps/api/src/routes/users.ts
+++ b/apps/api/src/routes/users.ts
@@ -1,6 +1,85 @@
 import { Router } from "express";
+import { randomUUID } from "node:crypto";
 
 const router = Router();
+
+type UserCreateResult =
+  | {
+      ok: true;
+      user: {
+        id: string;
+        email: string;
+        name?: string;
+      };
+    }
+  | {
+      ok: false;
+      message: string;
+    };
+
+const EMAIL_PATTERN = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
+
+function isPlainObject(value: unknown): value is Record<string, unknown> {
+  return (
+    typeof value === "object" &&
+    value !== null &&
+    !Array.isArray(value) &&
+    Object.prototype.toString.call(value) === "[object Object]"
+  );
+}
+
+function createUserId() {
+  return `user_${randomUUID()}`;
+}
+
+export function buildUserFromPayload(body: unknown): UserCreateResult {
+  if (!isPlainObject(body)) {
+    return {
+      ok: false,
+      message: "User payload must be a JSON object."
+    };
+  }
+
+  if (typeof body.email !== "string") {
+    return {
+      ok: false,
+      message: "A valid email is required."
+    };
+  }
+
+  const email = body.email.trim().toLowerCase();
+
+  if (!EMAIL_PATTERN.test(email)) {
+    return {
+      ok: false,
+      message: "A valid email is required."
+    };
+  }
+
+  const user: Extract<UserCreateResult, { ok: true }>["user"] = {
+    id: createUserId(),
+    email
+  };
+
+  if ("name" in body) {
+    if (typeof body.name !== "string") {
+      return {
+        ok: false,
+        message: "Name must be a string when provided."
+      };
+    }
+
+    const name = body.name.trim();
+    if (name) {
+      user.name = name;
+    }
+  }
+
+  return {
+    ok: true,
+    user
+  };
+}
 
 router.get("/", (_req, res) => {
   res.json({
@@ -10,11 +89,17 @@ router.get("/", (_req, res) => {
 });
 
 router.post("/", (req, res) => {
+  const result = buildUserFromPayload(req.body);
+
+  if (!result.ok) {
+    res.status(400).json({
+      error: result.message
+    });
+    return;
+  }
+
   res.status(201).json({
-    data: {
-      id: "stub-user-id",
-      ...req.body
-    },
+    data: result.user,
     message: "User creation is not implemented yet."
   });
 });

--- a/contributors/agents.json
+++ b/contributors/agents.json
@@ -4,7 +4,7 @@
       "github_username": "binglang001",
       "model": "GPT-5 Codex",
       "version": "2026-06-26",
-      "pr_number": 0,
+      "pr_number": 2218,
       "issue_number": 2207
     }
   ],

--- a/contributors/agents.json
+++ b/contributors/agents.json
@@ -1,5 +1,13 @@
 {
-  "agents": [],
-  "last_updated": "2026-06-03",
-  "total_contributions": 0
+  "agents": [
+    {
+      "github_username": "binglang001",
+      "model": "GPT-5 Codex",
+      "version": "2026-06-26",
+      "pr_number": 0,
+      "issue_number": 2207
+    }
+  ],
+  "last_updated": "2026-06-26",
+  "total_contributions": 1
 }


### PR DESCRIPTION
## Summary
- Validate POST /users request bodies before creating stub users
- Require and normalize email values, normalize optional names, and ignore client-controlled ids/extra fields
- Add regression tests for invalid shapes, email validation, normalization, and field allowlisting

/claim #2207

Closes #2207

## Tests
- npm test --workspace @taskflow/api
- npm test