### PR TITLE
[Feat] Add request body size limit

### DIFF
--- a/apps/api/src/index.ts
+++ b/apps/api/src/index.ts
@@ -5,7 +5,8 @@ import usersRouter from "./routes/users";
 const app = express();
 const port = process.env.PORT || 4000;
 
-app.use(express.json());
+// Limit JSON body size to 100KB to prevent abuse
+app.use(express.json({ limit: "100kb" }));
 
 app.get("/health", (_req, res) => {
   res.json({ status: "ok", service: "taskflow-api" });


### PR DESCRIPTION
Closes #9

Configured a conservative 100KB JSON body size limit in the Express app to prevent abuse.

Changes:
- Added `{ limit: "100kb" }` to `express.json()` middleware