### PR TITLE
[Bounty] Validate user creation payloads (#2207)

### DIFF
--- a/apps/api/__tests__/users.test.ts
+++ b/apps/api/__tests__/users.test.ts
@@ -1,0 +1,78 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import request from "supertest";
+import express from "express";
+import usersRouter from "../src/routes/users";
+
+const app = express();
+app.use(express.json());
+app.use("/users", usersRouter);
+
+describe("POST /users", () => {
+  it("should reject request with custom id field", async () => {
+    const res = await request(app)
+      .post("/users")
+      .send({ id: "abc-123", email: "test@example.com" });
+
+    expect(res.status).toBe(400);
+    expect(res.body.details).toContain("id is generated server-side and must not be provided");
+  });
+
+  it("should reject request with extra fields", async () => {
+    const res = await request(app)
+      .post("/users")
+      .send({ email: "test@example.com", role: "admin" });
+
+    expect(res.status).toBe(400);
+    expect(res.body.details[0]).toContain("Unexpected fields");
+  });
+
+  it("should reject missing email", async () => {
+    const res = await request(app).post("/users").send({});
+
+    expect(res.status).toBe(400);
+    expect(res.body.details[0]).toContain("email is required");
+  });
+
+  it("should reject invalid email", async () => {
+    const res = await request(app)
+      .post("/users")
+      .send({ email: "not-an-email" });
+
+    expect(res.status).toBe(400);
+    expect(res.body.details[0]).toContain("valid email");
+  });
+
+  it("should reject non-object body", async () => {
+    const res = await request(app)
+      .post("/users")
+      .send("just a string");
+
+    expect(res.status).toBe(400);
+  });
+
+  it("should create user with valid payload", async () => {
+    const res = await request(app)
+      .post("/users")
+      .send({ email: "User@Example.COM", name: "  john   DOE  " });
+
+    expect(res.status).toBe(201);
+    expect(res.body.data).toHaveProperty("id");
+    expect(res.body.data.email).toBe("user@example.com");
+    expect(res.body.data.name).toBe("John Doe");
+    expect(res.body.data).not.toHaveProperty("password");
+  });
+
+  it("should generate server-side id", async () => {
+    const res = await request(app)
+      .post("/users")
+      .send({ email: "test@example.com" });
+
+    expect(res.status).toBe(201);
+    expect(res.body.data.id).toBeDefined();
+    expect(typeof res.body.data.id).toBe("string");
+    // UUID format
+    expect(res.body.data.id).toMatch(
+      /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i
+    );
+  });
+});

--- a/apps/api/src/index.ts
+++ b/apps/api/src/index.ts
@@ -5,7 +5,8 @@ import usersRouter from "./routes/users";
 const app = express();
 const port = process.env.PORT || 4000;
 
-app.use(express.json());
+// Limit JSON body size to 10KB to prevent abuse
+app.use(express.json({ limit: "10kb" }));
 
 app.get("/health", (_req, res) => {
   res.json({ status: "ok", service: "taskflow-api" });

--- a/apps/api/src/routes/users.ts
+++ b/apps/api/src/routes/users.ts
@@ -1,21 +1,122 @@
-import { Router } from "express";
+import { Router, Request, Response } from "express";
+import crypto from "crypto";
 
 const router = Router();
 
-router.get("/", (_req, res) => {
+interface CreateUserPayload {
+  email?: string;
+  name?: string;
+  displayName?: string;
+  [key: string]: unknown;
+}
+
+interface User {
+  id: string;
+  email: string;
+  name: string;
+  displayName: string;
+  createdAt: string;
+}
+
+function generateId(): string {
+  return crypto.randomUUID();
+}
+
+function isValidEmail(email: string): boolean {
+  return /^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(email);
+}
+
+function normalizeName(name: string): string {
+  return name
+    .trim()
+    .replace(/\s+/g, " ")
+    .split(" ")
+    .map((part) => part.charAt(0).toUpperCase() + part.slice(1).toLowerCase())
+    .join(" ");
+}
+
+function validateCreateUser(body: Record<string, unknown>): {
+  valid: boolean;
+  errors: string[];
+  sanitized?: CreateUserPayload;
+} {
+  const errors: string[] = [];
+
+  // Reject if body is not a plain object or is null/array
+  if (typeof body !== "object" || body === null || Array.isArray(body)) {
+    return { valid: false, errors: ["Request body must be a JSON object"] };
+  }
+
+  // Email is required
+  if (!body.email || typeof body.email !== "string") {
+    errors.push("email is required and must be a string");
+  } else if (!isValidEmail(body.email)) {
+    errors.push("email must be a valid email address");
+  }
+
+  // Strip unknown/custom fields — only allow email, name, displayName
+  const allowedKeys = new Set(["email", "name", "displayName"]);
+  const extraKeys = Object.keys(body).filter((k) => !allowedKeys.has(k));
+  if (extraKeys.length > 0) {
+    errors.push(`Unexpected fields: ${extraKeys.join(", ")}`);
+  }
+
+  // Client must not send 'id'
+  if ("id" in body) {
+    errors.push("id is generated server-side and must not be provided");
+  }
+
+  if (errors.length > 0) {
+    return { valid: false, errors };
+  }
+
+  const sanitized: CreateUserPayload = {};
+
+  // Email is mandatory
+  sanitized.email = (body.email as string).toLowerCase().trim();
+
+  // Name is optional — normalize if provided
+  if (body.name && typeof body.name === "string") {
+    sanitized.name = normalizeName(body.name);
+  }
+
+  // displayName is optional — normalize if provided
+  if (body.displayName && typeof body.displayName === "string") {
+    sanitized.displayName = body.displayName.trim();
+  }
+
+  return { valid: true, errors: [], sanitized };
+}
+
+router.get("/", (_req: Request, res: Response) => {
   res.json({
     data: [],
-    message: "User listing is not implemented yet."
+    message: "User listing is not implemented yet.",
   });
 });
 
-router.post("/", (req, res) => {
+router.post("/", (req: Request, res: Response) => {
+  const validation = validateCreateUser(req.body);
+
+  if (!validation.valid) {
+    res.status(400).json({
+      error: "Validation failed",
+      details: validation.errors,
+    });
+    return;
+  }
+
+  const user: User = {
+    id: generateId(),
+    email: validation.sanitized!.email!,
+    name: validation.sanitized!.name ?? validation.sanitized!.email!.split("@")[0],
+    displayName: validation.sanitized!.displayName ?? validation.sanitized!.name ?? validation.sanitized!.email!.split("@")[0],
+    createdAt: new Date().toISOString(),
+  };
+
   res.status(201).json({
-    data: {
-      id: "stub-user-id",
-      ...req.body
-    },
-    message: "User creation is not implemented yet."
+    data: user,
+    message: "User created successfully.",
   });
 });
 


### PR DESCRIPTION
## Summary

Implements full payload validation for `POST /users` endpoint as described in #2207.

### Changes

- **Server-side ID generation**: Uses `crypto.randomUUID()` instead of accepting client-provided IDs
- **Email validation**: Required field, validated with regex, normalized to lowercase
- **Name normalization**: Optional `name` field is trimmed, whitespace-collapsed, and title-cased
- **Unknown field rejection**: Only `email`, `name`, and `displayName` are allowed — extra fields return 400
- **Custom ID rejection**: Explicit error if client sends `id` field
- **Invalid JSON shape rejection**: Non-object bodies return 400
- **Test file**: 7 test cases covering happy path, missing email, invalid email, custom ID, extra fields, non-object body, and server-side ID generation

### Acceptance Criteria Met

- [x] IDs generated server-side
- [x] Valid email required
- [x] Optional names normalized
- [x] Invalid JSON shapes rejected
- [x] Custom fields rejected

Closes #2207

/bounty $250