### PR TITLE
[Bounty] Add request body size limit (#9)

### DIFF
--- a/apps/api/src/index.ts
+++ b/apps/api/src/index.ts
@@ -5,8 +5,7 @@ import usersRouter from "./routes/users";
 const app = express();
 const port = process.env.PORT || 4000;
 
-app.use(express.json());
-
+app.use(express.json({ limit: "10kb" }));
 app.get("/health", (_req, res) => {
   res.json({ status: "ok", service: "taskflow-api" });
 });


### PR DESCRIPTION
## Summary

Adds a 10KB JSON body size limit to the Express API to prevent oversized payloads.

### Changes

- Replaced `express.json()` with `express.json({ limit: "10kb" })` (1 line change)

Closes #9

/bounty $50