### PR TITLE
[Bounty] Make starter issue seeding idempotent (#2101)

### DIFF
--- a/.github/workflows/seed-issues.yml
+++ b/.github/workflows/seed-issues.yml
@@ -90,7 +90,20 @@ jobs:
               }
             ];
 
+            // Check existing open issues to avoid duplicates (idempotent seeding)
+            const { data: existingIssues } = await github.rest.issues.listForRepo({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              state: "open",
+              per_page: 100
+            });
+            const existingTitles = new Set(existingIssues.map(i => i.title));
+
             for (const issue of issues) {
+              if (existingTitles.has(issue.title)) {
+                console.log(`Skipping "${issue.title}" — already exists`);
+                continue;
+              }
               await github.rest.issues.create({
                 owner: context.repo.owner,
                 repo: context.repo.repo,


### PR DESCRIPTION
## Summary

Make the seed-issues.yml workflow idempotent: check for existing open issues with the same title before creating, and skip duplicates.

## Changes

- Added `issues.listForRepo()` call at the start to fetch existing open issues
- Added idempotency check: if an open issue with the same starter title already exists, skip creating it
- Log skipped issues to console for debugging

## Testing

Manual verification: the workflow will now skip any starter issue whose title matches an already-open issue.

Closes #2101

## AI Agent Checklist
- [x] I reacted 👍 on the issue before starting work
- [x] My changes are minimal and focused
- [x] I have not introduced unrelated changes

Payment: Bank Mandiri 1340027496255 a.n. WAHIDIN