### PR TITLE
Split API app construction from server startup

### DIFF
--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -7,6 +7,7 @@
   "main": "src/index.ts",
   "scripts": {
     "dev": "tsx src/index.ts",
+    "smoke:import": "tsx src/app-import-smoke.ts",
     "test": "echo \"No API tests configured yet\"",
     "lint": "echo \"No API lint configured yet\""
   },

--- a/apps/api/src/app-import-smoke.ts
+++ b/apps/api/src/app-import-smoke.ts
@@ -1,0 +1,7 @@
+import app from "./app";
+
+if (typeof app.listen !== "function") {
+  throw new Error("Expected Express app to expose listen()");
+}
+
+console.log("Express app imported without starting a listener");

--- a/apps/api/src/app.ts
+++ b/apps/api/src/app.ts
@@ -1,0 +1,15 @@
+import express from "express";
+
+import usersRouter from "./routes/users";
+
+const app = express();
+
+app.use(express.json());
+
+app.get("/health", (_req, res) => {
+  res.json({ status: "ok", service: "taskflow-api" });
+});
+
+app.use("/users", usersRouter);
+
+export default app;

--- a/apps/api/src/index.ts
+++ b/apps/api/src/index.ts
@@ -1,17 +1,6 @@
-import express from "express";
+import app from "./app";
 
-import usersRouter from "./routes/users";
-
-const app = express();
 const port = process.env.PORT || 4000;
-
-app.use(express.json());
-
-app.get("/health", (_req, res) => {
-  res.json({ status: "ok", service: "taskflow-api" });
-});
-
-app.use("/users", usersRouter);
 
 app.listen(port, () => {
   console.log(`TaskFlow API listening on port ${port}`);


### PR DESCRIPTION
## Summary

Closes #1771.

Splits Express app construction from server startup so route tests and scripts can import the configured app without binding a real port.

## Changes

- Added `apps/api/src/app.ts` to create/configure the Express app and export it.
- Updated `apps/api/src/index.ts` so runtime startup is the only place that calls `app.listen`.
- Added `apps/api/src/app-import-smoke.ts` as a small import smoke script.
- Added `npm run smoke:import -w apps/api` for validating import-without-listen behavior.

## Testing

- `npm install`
- `npm run smoke:import -w apps/api`
- Started `npm run dev -w apps/api` with `PORT=4177` and verified `GET /health` returned `{"status":"ok","service":"taskflow-api"}`
- `npm run test -w apps/api`

Note: `npm install` reported existing dependency audit findings in the repo dependency tree. This PR does not modify dependencies.
