### PR TITLE
Add web app root layout

### DIFF
--- a/apps/web/src/app/layout.tsx
+++ b/apps/web/src/app/layout.tsx
@@ -1,0 +1,19 @@
+import type { Metadata } from "next";
+import type { ReactNode } from "react";
+
+export const metadata: Metadata = {
+  title: "TaskFlow",
+  description: "Plan tasks, coordinate jobs, and manage proposals from one workspace.",
+};
+
+interface RootLayoutProps {
+  children: ReactNode;
+}
+
+export default function RootLayout({ children }: RootLayoutProps) {
+  return (
+    <html lang="en">
+      <body>{children}</body>
+    </html>
+  );
+}


### PR DESCRIPTION
## Summary

Closes #447.

Adds the missing App Router root layout so the web app can produce a production build.

## Changes

- Added `apps/web/src/app/layout.tsx`.
- Added required `html` and `body` wrappers for App Router.
- Added focused TaskFlow metadata through the Next.js `metadata` export.

## Testing

- `npm install`
- `npm exec -w apps/web -- next build`

The build no longer fails on the missing root layout error and completed successfully.

Note: `npm install` reported existing dependency audit findings in the repo dependency tree. This PR does not modify dependencies.
