### PR TITLE
Return React element from Button

### DIFF
--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -8,7 +8,11 @@
     "test": "echo \"No UI tests configured yet\"",
     "lint": "echo \"No UI lint configured yet\""
   },
+  "peerDependencies": {
+    "react": "^18.3.1"
+  },
   "devDependencies": {
+    "@types/react": "^18.3.1",
     "typescript": "^5.4.5"
   }
 }

--- a/packages/ui/src/index.ts
+++ b/packages/ui/src/index.ts
@@ -1,12 +1,17 @@
+import { createElement, type ReactElement } from "react";
+
 export type ButtonProps = {
   label: string;
   disabled?: boolean;
 };
 
-export function Button({ label, disabled = false }: ButtonProps) {
-  return {
-    type: "button",
+export function Button({ label, disabled = false }: ButtonProps): ReactElement {
+  return createElement(
+    "button",
+    {
+      type: "button",
+      disabled,
+    },
     label,
-    disabled
-  };
+  );
 }


### PR DESCRIPTION
## Summary

Closes #1173.

Updates the shared `Button` component so it returns a real React button element instead of a plain object.

## Changes

- Uses React `createElement` to return a button element from `Button`.
- Preserves the existing `label` and `disabled` props.
- Adds React as a peer dependency for the shared UI package.
- Adds `@types/react` for local package type support.

## Testing

- `npm install`
- `..\..\node_modules\.bin\tsc.cmd --module esnext --moduleResolution node --target es2020 --jsx react-jsx --noEmit src\index.ts` from `packages/ui`
- Runtime smoke check with `tsx` verifying:
  - `Button(...)` returns a valid React element
  - element type is `button`
  - `disabled` is forwarded
  - label is rendered as children

Note: `npm install` reported existing dependency audit findings in the repo dependency tree. This PR does not modify lockfiles.
