### PR TITLE
Validate user creation payloads

### DIFF
--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -7,7 +7,7 @@
   "main": "src/index.ts",
   "scripts": {
     "dev": "tsx src/index.ts",
-    "test": "echo \"No API tests configured yet\"",
+    "test": "node --import tsx --test \"src/**/*.test.ts\"",
     "lint": "echo \"No API lint configured yet\""
   },
   "dependencies": {

--- a/apps/api/src/routes/users.test.ts
+++ b/apps/api/src/routes/users.test.ts
@@ -1,0 +1,177 @@
+import assert from "node:assert/strict";
+import { createServer, type Server } from "node:http";
+import type { AddressInfo } from "node:net";
+import { describe, it } from "node:test";
+import express from "express";
+
+import usersRouter, { createUserFromPayload } from "./users";
+
+async function withServer(run: (baseUrl: string) => Promise<void>): Promise<void> {
+  const app = express();
+  app.use(express.json());
+  app.use("/users", usersRouter);
+
+  const server = createServer(app);
+
+  await new Promise<void>((resolve) => {
+    server.listen(0, "127.0.0.1", resolve);
+  });
+
+  const address = server.address() as AddressInfo;
+  const baseUrl = `http://127.0.0.1:${address.port}`;
+
+  try {
+    await run(baseUrl);
+  } finally {
+    await closeServer(server);
+  }
+}
+
+async function closeServer(server: Server): Promise<void> {
+  await new Promise<void>((resolve, reject) => {
+    server.close((error) => {
+      if (error) {
+        reject(error);
+        return;
+      }
+
+      resolve();
+    });
+  });
+}
+
+async function postUser(baseUrl: string, payload: unknown) {
+  const response = await fetch(`${baseUrl}/users`, {
+    method: "POST",
+    headers: {
+      "content-type": "application/json"
+    },
+    body: JSON.stringify(payload)
+  });
+
+  const body = response.headers.get("content-type")?.includes("application/json")
+    ? await response.json()
+    : await response.text();
+
+  return {
+    status: response.status,
+    body
+  };
+}
+
+describe("createUserFromPayload", () => {
+  it("rejects non-object JSON bodies", () => {
+    for (const payload of [null, [], "user@example.com", 42, true]) {
+      const result = createUserFromPayload(payload);
+
+      assert.equal(result.ok, false);
+      if (!result.ok) {
+        assert.match(result.error, /JSON object/);
+      }
+    }
+  });
+
+  it("requires a valid normalized email", () => {
+    for (const payload of [
+      {},
+      { email: "" },
+      { email: "not-an-email" },
+      { email: "missing-domain@" },
+      { email: 123 }
+    ]) {
+      const result = createUserFromPayload(payload);
+
+      assert.equal(result.ok, false);
+      if (!result.ok) {
+        assert.equal(result.error, "A valid email is required.");
+      }
+    }
+  });
+
+  it("normalizes trusted fields and ignores client-controlled fields", () => {
+    const result = createUserFromPayload(
+      {
+        id: "client-id",
+        email: "  ADA@Example.COM  ",
+        name: " Ada   Lovelace ",
+        role: "admin",
+        metadata: { elevated: true }
+      },
+      () => "server-id"
+    );
+
+    assert.deepEqual(result, {
+      ok: true,
+      user: {
+        id: "server-id",
+        email: "ada@example.com",
+        name: "Ada Lovelace"
+      }
+    });
+  });
+
+  it("omits blank optional names and rejects invalid name shapes", () => {
+    assert.deepEqual(
+      createUserFromPayload({ email: "person@example.com", name: "   " }, () => "id-1"),
+      {
+        ok: true,
+        user: {
+          id: "id-1",
+          email: "person@example.com"
+        }
+      }
+    );
+
+    for (const name of [null, 123, ["Ada"]]) {
+      const result = createUserFromPayload({ email: "person@example.com", name });
+
+      assert.equal(result.ok, false);
+      if (!result.ok) {
+        assert.equal(result.error, "Name must be a string when provided.");
+      }
+    }
+  });
+});
+
+describe("POST /users", () => {
+  it("rejects array request bodies at the route boundary", async () => {
+    await withServer(async (baseUrl) => {
+      const response = await postUser(baseUrl, [{ email: "person@example.com" }]);
+
+      assert.equal(response.status, 400);
+      assert.deepEqual(response.body, {
+        error: "Request body must be a JSON object."
+      });
+    });
+  });
+
+  it("creates users from normalized trusted fields only", async () => {
+    await withServer(async (baseUrl) => {
+      const response = await postUser(baseUrl, {
+        id: "client-id",
+        email: "  USER@Example.COM  ",
+        name: " User   Name ",
+        isAdmin: true
+      });
+
+      assert.equal(response.status, 201);
+      assert.equal(response.body.message, "User creation is not implemented yet.");
+      assert.match(
+        response.body.data.id,
+        /^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/
+      );
+      assert.notEqual(response.body.data.id, "client-id");
+      assert.deepEqual(
+        {
+          ...response.body.data,
+          id: "server-id"
+        },
+        {
+          id: "server-id",
+          email: "user@example.com",
+          name: "User Name"
+        }
+      );
+    });
+  });
+});

--- a/apps/api/src/routes/users.ts
+++ b/apps/api/src/routes/users.ts
@@ -1,6 +1,80 @@
+import { randomUUID } from "node:crypto";
 import { Router } from "express";
 
 const router = Router();
+
+type CreatedUser = {
+  id: string;
+  email: string;
+  name?: string;
+};
+
+type UserCreationResult =
+  | { ok: true; user: CreatedUser }
+  | { ok: false; error: string };
+
+const emailPattern = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
+
+function isPlainObject(value: unknown): value is Record<string, unknown> {
+  return (
+    typeof value === "object" &&
+    value !== null &&
+    !Array.isArray(value) &&
+    Object.prototype.toString.call(value) === "[object Object]"
+  );
+}
+
+function normalizeText(value: string): string {
+  return value.trim().replace(/\s+/g, " ");
+}
+
+export function createUserFromPayload(
+  body: unknown,
+  generateId: () => string = randomUUID
+): UserCreationResult {
+  if (!isPlainObject(body)) {
+    return {
+      ok: false,
+      error: "Request body must be a JSON object."
+    };
+  }
+
+  if (typeof body.email !== "string") {
+    return {
+      ok: false,
+      error: "A valid email is required."
+    };
+  }
+
+  const email = normalizeText(body.email).toLowerCase();
+  if (!emailPattern.test(email)) {
+    return {
+      ok: false,
+      error: "A valid email is required."
+    };
+  }
+
+  const user: CreatedUser = {
+    id: generateId(),
+    email
+  };
+
+  if (body.name !== undefined) {
+    if (typeof body.name !== "string") {
+      return {
+        ok: false,
+        error: "Name must be a string when provided."
+      };
+    }
+
+    const name = normalizeText(body.name);
+    if (name.length > 0) {
+      user.name = name;
+    }
+  }
+
+  return { ok: true, user };
+}
 
 router.get("/", (_req, res) => {
   res.json({
@@ -10,11 +84,16 @@ router.get("/", (_req, res) => {
 });
 
 router.post("/", (req, res) => {
+  const result = createUserFromPayload(req.body);
+
+  if (!result.ok) {
+    return res.status(400).json({
+      error: result.error
+    });
+  }
+
   res.status(201).json({
-    data: {
-      id: "stub-user-id",
-      ...req.body
-    },
+    data: result.user,
     message: "User creation is not implemented yet."
   });
 });


### PR DESCRIPTION
﻿/claim #2207

## Summary
- Validate POST /users payloads before creating the response object.
- Generate the user id server-side with `randomUUID()` and return only trusted fields (`id`, normalized `email`, optional normalized `name`).
- Add focused unit and HTTP route regression tests for issue #2207.

## Why this PR is intentionally small
This keeps the bounty fix limited to the API route and tests. It does not rewrite app structure and does not modify leaderboard or contributor metadata, so the review surface stays focused on the acceptance criteria.

## Validation
- `npm test --workspace @taskflow/api`
- `npm test`
- `git diff --check`

Closes #2207

## Payout
USDC on Base: `0xa3d7745af6E77ce825f0AF6DB94bA8073355E022`
