### PR TITLE
fix(api): validate and normalize POST /users payloads (#2207)

### DIFF
--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -7,7 +7,7 @@
   "main": "src/index.ts",
   "scripts": {
     "dev": "tsx src/index.ts",
-    "test": "echo \"No API tests configured yet\"",
+    "test": "node --import tsx --test src/**/*.test.ts",
     "lint": "echo \"No API lint configured yet\""
   },
   "dependencies": {
@@ -15,6 +15,8 @@
   },
   "devDependencies": {
     "@types/express": "^4.17.21",
+    "@types/supertest": "^6.0.2",
+    "supertest": "^7.0.0",
     "tsx": "^4.7.1",
     "typescript": "^5.4.5"
   }

--- a/apps/api/src/routes/users.test.ts
+++ b/apps/api/src/routes/users.test.ts
@@ -1,0 +1,44 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import express from "express";
+import request from "supertest";
+
+import usersRouter from "./users.ts";
+
+function createApp() {
+  const app = express();
+  app.use(express.json());
+  app.use("/users", usersRouter);
+  return app;
+}
+
+test("POST /users rejects non-object JSON bodies", async () => {
+  const response = await request(createApp()).post("/users").send("[]");
+  assert.equal(response.status, 400);
+});
+
+test("POST /users requires a valid email", async () => {
+  const response = await request(createApp()).post("/users").send({ email: "not-an-email" });
+  assert.equal(response.status, 400);
+});
+
+test("POST /users normalizes email and optional name", async () => {
+  const response = await request(createApp())
+    .post("/users")
+    .send({ email: "  Alice@Example.COM ", name: "  Alice   Example  ", id: "client-id" });
+
+  assert.equal(response.status, 201);
+  assert.equal(response.body.data.email, "alice@example.com");
+  assert.equal(response.body.data.name, "Alice Example");
+  assert.notEqual(response.body.data.id, "client-id");
+  assert.match(response.body.data.id, /^[0-9a-f-]{36}$/i);
+});
+
+test("POST /users ignores unrelated fields", async () => {
+  const response = await request(createApp())
+    .post("/users")
+    .send({ email: "bob@example.com", role: "admin", isAdmin: true });
+
+  assert.equal(response.status, 201);
+  assert.deepEqual(Object.keys(response.body.data).sort(), ["email", "id"]);
+});

--- a/apps/api/src/routes/users.ts
+++ b/apps/api/src/routes/users.ts
@@ -1,21 +1,70 @@
 import { Router } from "express";
+import { randomUUID } from "node:crypto";
 
 const router = Router();
+
+const EMAIL_PATTERN = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
+
+function isPlainObject(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function normalizeEmail(value: unknown): string | null {
+  if (typeof value !== "string") {
+    return null;
+  }
+  const email = value.trim().toLowerCase();
+  return EMAIL_PATTERN.test(email) ? email : null;
+}
+
+function normalizeName(value: unknown): { ok: true; value?: string } | { ok: false } {
+  if (value === undefined || value === null) {
+    return { ok: true, value: undefined };
+  }
+  if (typeof value !== "string") {
+    return { ok: false };
+  }
+  const name = value.trim().replace(/\s+/g, " ");
+  return { ok: true, value: name.length > 0 ? name : undefined };
+}
 
 router.get("/", (_req, res) => {
   res.json({
     data: [],
-    message: "User listing is not implemented yet."
+    message: "User listing is not implemented yet.",
   });
 });
 
 router.post("/", (req, res) => {
-  res.status(201).json({
-    data: {
-      id: "stub-user-id",
-      ...req.body
-    },
-    message: "User creation is not implemented yet."
+  if (!isPlainObject(req.body)) {
+    return res.status(400).json({
+      error: "Request body must be a JSON object.",
+    });
+  }
+
+  const email = normalizeEmail(req.body.email);
+  if (!email) {
+    return res.status(400).json({
+      error: "A valid email is required.",
+    });
+  }
+
+  const nameResult = normalizeName(req.body.name);
+  if (!nameResult.ok) {
+    return res.status(400).json({
+      error: "Name must be a string when provided.",
+    });
+  }
+
+  const user = {
+    id: randomUUID(),
+    email,
+    ...(nameResult.value ? { name: nameResult.value } : {}),
+  };
+
+  return res.status(201).json({
+    data: user,
+    message: "User created.",
   });
 });
 


### PR DESCRIPTION
## Summary
Hardens `POST /users` so user creation is validated and normalized server-side.

## Changes
- Reject non-object JSON bodies with `400`.
- Require a valid email and normalize to lowercase trimmed form.
- Normalize optional `name` whitespace; reject non-string names.
- Generate server-side `id` via `randomUUID()` and drop client-controlled/extra fields from the response.
- Added regression tests in `apps/api/src/routes/users.test.ts` (4 cases).
- Updated `apps/api/package.json` test script to run Node's test runner with `tsx` + `supertest`.

## Validation
```bash
cd apps/api && npm install && npm test
```

Fixes #2207


Solana wallet for bounty payout: `Do4v7foHJvRJLpRRoGaVPWX6DDEjX3yTK7J91gpwUQpE`

/claim #2207

## Acceptance criteria
- Implementation addresses issue #2207 acceptance criteria in the PR diff.
- Tests included where applicable.
