### PR TITLE
fix(api): add conservative JSON body size limit (#9)

### DIFF
--- a/apps/api/src/index.ts
+++ b/apps/api/src/index.ts
@@ -4,15 +4,17 @@ import usersRouter from "./routes/users";
 
 const app = express();
 const port = process.env.PORT || 4000;
+/** Conservative JSON body limit; override with JSON_BODY_LIMIT env var. */
+const JSON_BODY_LIMIT = process.env.JSON_BODY_LIMIT || "100kb";
 
-app.use(express.json());
+app.use(express.json({ limit: JSON_BODY_LIMIT }));
 
 app.get("/health", (_req, res) => {
-  res.json({ status: "ok", service: "taskflow-api" });
+  res.json({ status: "ok", service: "taskflow-api", jsonBodyLimit: JSON_BODY_LIMIT });
 });
 
 app.use("/users", usersRouter);
 
 app.listen(port, () => {
-  console.log(`TaskFlow API listening on port ${port}`);
+  console.log(`TaskFlow API listening on port ${port} (json limit: ${JSON_BODY_LIMIT})`);
 });

--- a/apps/api/src/middleware/body_limit.test.ts
+++ b/apps/api/src/middleware/body_limit.test.ts
@@ -1,0 +1,28 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import express from "express";
+import request from "supertest";
+
+import usersRouter from "../routes/users.js";
+
+function createApp() {
+  const app = express();
+  app.use(express.json({ limit: "100kb" }));
+  app.use("/users", usersRouter);
+  return app;
+}
+
+test("POST /users rejects oversized JSON payloads", async () => {
+  const large = "x".repeat(200_000);
+  const response = await request(createApp())
+    .post("/users")
+    .set("Content-Type", "application/json")
+    .send(JSON.stringify({ email: "a@example.com", note: large }));
+
+  assert.equal(response.status, 413);
+});
+
+test("POST /users accepts payloads under the configured limit", async () => {
+  const response = await request(createApp()).post("/users").send({ email: "small@example.com" });
+  assert.notEqual(response.status, 413);
+});


### PR DESCRIPTION
Adds a conservative JSON body parser limit (`100kb`, overridable via `JSON_BODY_LIMIT`) and exposes the configured value on `/health`.

Includes regression tests for oversized payloads (413) and acceptable payloads.

Closes #9


Solana wallet for bounty payout: `Do4v7foHJvRJLpRRoGaVPWX6DDEjX3yTK7J91gpwUQpE`

/claim #9

## Acceptance criteria
- Implementation addresses issue #9 acceptance criteria in the PR diff.
- Tests included where applicable.
