### PR TITLE
fix(template): add /bounty marker to bounty issue template (#687)

### DIFF
--- a/.github/ISSUE_TEMPLATE/bounty_task.md
+++ b/.github/ISSUE_TEMPLATE/bounty_task.md
@@ -18,4 +18,4 @@ Describe the task, expected context, and files likely involved.
 
 ## Bounty Amount
 
-$50
+/bounty $50


### PR DESCRIPTION
Updates `.github/ISSUE_TEMPLATE/bounty_task.md` to use the machine-readable `/bounty $50` marker required by the bounty program.

Closes #687


Solana wallet for bounty payout: `Do4v7foHJvRJLpRRoGaVPWX6DDEjX3yTK7J91gpwUQpE`

/claim #687

## Acceptance criteria
- Implementation addresses issue #687 acceptance criteria in the PR diff.
- Tests included where applicable.
