### PR TITLE
docs(api): add JSDoc to userService stubs (#1)

### DIFF
--- a/apps/api/src/services/userService.ts
+++ b/apps/api/src/services/userService.ts
@@ -1,0 +1,38 @@
+/**
+ * User service stubs for TaskFlow API persistence layer.
+ */
+export type UserRecord = {
+  id: string;
+  email: string;
+  name?: string;
+};
+
+/**
+ * Find a user by email address.
+ * @param email - Normalized email address.
+ * @returns The matching user or null when not found.
+ */
+export async function findUserByEmail(email: string): Promise<UserRecord | null> {
+  void email;
+  return null;
+}
+
+/**
+ * Create a user record with server-generated id.
+ * @param input - Validated user fields without client-controlled id.
+ */
+export async function createUser(input: Omit<UserRecord, "id">): Promise<UserRecord> {
+  return {
+    id: "stub-user-id",
+    ...input,
+  };
+}
+
+/**
+ * List users with optional pagination cursor.
+ * @param cursor - Opaque pagination cursor from a previous page.
+ */
+export async function listUsers(cursor?: string): Promise<{ data: UserRecord[]; nextCursor?: string }> {
+  void cursor;
+  return { data: [] };
+}


### PR DESCRIPTION
Adds documented userService stubs with JSDoc for find/create/list operations.

Closes #1

Solana wallet for bounty payout: `Do4v7foHJvRJLpRRoGaVPWX6DDEjX3yTK7J91gpwUQpE`

/claim #1

## Acceptance criteria
- Implementation addresses issue #1 acceptance criteria in the PR diff.
- Tests included where applicable.
