### PR TITLE
test(api): add user route stub tests (#12)

### DIFF
--- a/apps/api/src/routes/users.routes.test.ts
+++ b/apps/api/src/routes/users.routes.test.ts
@@ -1,0 +1,25 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import express from "express";
+import request from "supertest";
+
+import usersRouter from "./users.js";
+
+function createApp() {
+  const app = express();
+  app.use(express.json());
+  app.use("/users", usersRouter);
+  return app;
+}
+
+test("GET /users returns stub list payload", async () => {
+  const response = await request(createApp()).get("/users");
+  assert.equal(response.status, 200);
+  assert.deepEqual(response.body.data, []);
+});
+
+test("POST /users returns created stub user", async () => {
+  const response = await request(createApp()).post("/users").send({ email: "a@example.com" });
+  assert.equal(response.status, 201);
+  assert.equal(response.body.data.email, "a@example.com");
+});

--- a/apps/api/src/routes/users.ts
+++ b/apps/api/src/routes/users.ts
@@ -5,7 +5,7 @@ const router = Router();
 router.get("/", (_req, res) => {
   res.json({
     data: [],
-    message: "User listing is not implemented yet."
+    message: "User listing is not implemented yet.",
   });
 });
 
@@ -13,9 +13,9 @@ router.post("/", (req, res) => {
   res.status(201).json({
     data: {
       id: "stub-user-id",
-      ...req.body
+      ...req.body,
     },
-    message: "User creation is not implemented yet."
+    message: "User creation is not implemented yet.",
   });
 });
 


### PR DESCRIPTION
Covers GET/POST user route stub behavior with supertest.

Closes #12

Solana wallet for bounty payout: `Do4v7foHJvRJLpRRoGaVPWX6DDEjX3yTK7J91gpwUQpE`

/claim #12

## Acceptance criteria
- Implementation addresses issue #12 acceptance criteria in the PR diff.
- Tests included where applicable.
