### PR TITLE
feat(ui): improve Button prop annotations (#3)

### DIFF
--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -5,7 +5,7 @@
   "description": "Shared UI components for TaskFlow.",
   "main": "src/index.ts",
   "scripts": {
-    "test": "echo \"No UI tests configured yet\"",
+    "test": "node --import tsx --test src/**/*.test.ts",
     "lint": "echo \"No UI lint configured yet\""
   },
   "devDependencies": {

--- a/packages/ui/src/button.test.ts
+++ b/packages/ui/src/button.test.ts
@@ -1,0 +1,16 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { Button } from "../src/index.ts";
+
+test("Button returns label and disabled flag", () => {
+  const result = Button({ label: "Save", disabled: true });
+  assert.equal(result.type, "button");
+  assert.equal(result.label, "Save");
+  assert.equal(result.disabled, true);
+});
+
+test("Button defaults disabled to false", () => {
+  const result = Button({ label: "Go" });
+  assert.equal(result.disabled, false);
+});

--- a/packages/ui/src/index.ts
+++ b/packages/ui/src/index.ts
@@ -1,12 +1,19 @@
 export type ButtonProps = {
-  label: string;
-  disabled?: boolean;
+  readonly label: string;
+  readonly disabled?: boolean;
 };
 
-export function Button({ label, disabled = false }: ButtonProps) {
+export type ButtonStub = {
+  readonly type: "button";
+  readonly label: string;
+  readonly disabled: boolean;
+};
+
+/** Shared Button stub used by the web app until real UI primitives land. */
+export function Button({ label, disabled = false }: ButtonProps): ButtonStub {
   return {
     type: "button",
     label,
-    disabled
+    disabled,
   };
 }


### PR DESCRIPTION
Adds readonly props, explicit ButtonStub return type, and unit tests.

Closes #3

Solana wallet for bounty payout: `Do4v7foHJvRJLpRRoGaVPWX6DDEjX3yTK7J91gpwUQpE`

/claim #3

## Acceptance criteria
- Implementation addresses issue #3 acceptance criteria in the PR diff.
- Tests included where applicable.
