### PR TITLE
feat(math): add deterministic PI estimation challenge (#14)

### DIFF
--- a/packages/math/README.md
+++ b/packages/math/README.md
@@ -1,0 +1,18 @@
+# PI Calculation Challenge
+
+Deterministic PI estimate using the Leibniz series:
+
+```
+PI ≈ 4 * (1 - 1/3 + 1/5 - 1/7 + ...)
+```
+
+## Run
+
+```bash
+npm test -w packages/math
+```
+
+## Notes
+
+- `estimatePi(iterations)` throws on non-positive iteration counts.
+- `estimatePiDefault()` uses 10,000 iterations (~0.01 absolute error).

--- a/packages/math/package.json
+++ b/packages/math/package.json
@@ -1,0 +1,13 @@
+{
+  "name": "@taskflow/math",
+  "version": "0.1.0",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "test": "node --import tsx --test src/**/*.test.ts"
+  },
+  "devDependencies": {
+    "tsx": "^4.7.1",
+    "typescript": "^5.4.5"
+  }
+}

--- a/packages/math/src/pi.test.ts
+++ b/packages/math/src/pi.test.ts
@@ -1,0 +1,20 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { estimatePi, estimatePiDefault } from "./pi.ts";
+
+test("estimatePi approaches PI with more iterations", () => {
+  const rough = estimatePi(100);
+  const better = estimatePi(10_000);
+  assert.ok(Math.abs(rough - Math.PI) > Math.abs(better - Math.PI));
+});
+
+test("estimatePiDefault returns a finite value", () => {
+  const value = estimatePiDefault();
+  assert.ok(Number.isFinite(value));
+  assert.ok(Math.abs(value - Math.PI) < 0.01);
+});
+
+test("estimatePi rejects invalid iteration counts", () => {
+  assert.throws(() => estimatePi(0));
+});

--- a/packages/math/src/pi.ts
+++ b/packages/math/src/pi.ts
@@ -1,0 +1,23 @@
+/**
+ * Estimate PI using the Leibniz series.
+ * Converges slowly but is deterministic and easy to audit.
+ */
+export function estimatePi(iterations: number): number {
+  if (!Number.isInteger(iterations) || iterations <= 0) {
+    throw new Error("iterations must be a positive integer");
+  }
+
+  let sum = 0;
+  for (let i = 0; i < iterations; i += 1) {
+    const term = 1 / (2 * i + 1);
+    sum += i % 2 === 0 ? term : -term;
+  }
+  return sum * 4;
+}
+
+/** Default iteration count for a quick local demo. */
+export const DEFAULT_PI_ITERATIONS = 10_000;
+
+export function estimatePiDefault(): number {
+  return estimatePi(DEFAULT_PI_ITERATIONS);
+}


### PR DESCRIPTION
Leibniz series PI estimator with tests and README.

Closes #14

Solana wallet for bounty payout: `Do4v7foHJvRJLpRRoGaVPWX6DDEjX3yTK7J91gpwUQpE`

/claim #14

## Acceptance criteria
- Implementation addresses issue #14 acceptance criteria in the PR diff.
- Tests included where applicable.
