### PR TITLE
fix(template): remove duplicate PI bounty amount (#775)

### DIFF
--- a/.github/ISSUE_TEMPLATE/pi_challenge.md
+++ b/.github/ISSUE_TEMPLATE/pi_challenge.md
@@ -19,6 +19,4 @@ Implement or document a small PI calculation challenge for TaskFlow's internal e
 
 ## Bounty Amount
 
-$50
-
 /bounty $50


### PR DESCRIPTION
Keeps a single `/bounty $50` marker in the PI challenge template.

Closes #775

Solana wallet for bounty payout: `Do4v7foHJvRJLpRRoGaVPWX6DDEjX3yTK7J91gpwUQpE`

/claim #775

## Acceptance criteria
- Implementation addresses issue #775 acceptance criteria in the PR diff.
- Tests included where applicable.
