### PR TITLE
[agent] fix(api): enable CORS middleware (#692)

### DIFF
--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -11,9 +11,11 @@
     "lint": "echo \"No API lint configured yet\""
   },
   "dependencies": {
+    "cors": "^2.8.5",
     "express": "^4.18.3"
   },
   "devDependencies": {
+    "@types/cors": "^2.8.17",
     "@types/express": "^4.17.21",
     "tsx": "^4.7.1",
     "typescript": "^5.4.5"

--- a/apps/api/src/index.ts
+++ b/apps/api/src/index.ts
@@ -1,10 +1,12 @@
 import express from "express";
+import cors from "cors";
 
 import usersRouter from "./routes/users";
 
 const app = express();
 const port = process.env.PORT || 4000;
 
+app.use(cors());
 app.use(express.json());
 
 app.get("/health", (_req, res) => {


### PR DESCRIPTION
Adds cors package and app.use(cors()) for cross-origin frontend requests.

Closes #692

Solana wallet for bounty payout: `Do4v7foHJvRJLpRRoGaVPWX6DDEjX3yTK7J91gpwUQpE`

/claim #692

## Acceptance criteria
- Implementation addresses issue #692 acceptance criteria in the PR diff.
- Tests included where applicable.
