### PR TITLE
[agent] fix(api): add graceful shutdown handlers (#906)

### DIFF
--- a/apps/api/src/index.ts
+++ b/apps/api/src/index.ts
@@ -4,6 +4,7 @@ import usersRouter from "./routes/users";
 
 const app = express();
 const port = process.env.PORT || 4000;
+const shutdownTimeoutMs = Number(process.env.SHUTDOWN_TIMEOUT_MS ?? 10_000);
 
 app.use(express.json());
 
@@ -13,6 +14,21 @@ app.get("/health", (_req, res) => {
 
 app.use("/users", usersRouter);
 
-app.listen(port, () => {
+const server = app.listen(port, () => {
   console.log(`TaskFlow API listening on port ${port}`);
 });
+
+function shutdown(signal: string) {
+  console.log(`Received ${signal}, closing HTTP server...`);
+  server.close(() => {
+    console.log("HTTP server closed.");
+    process.exit(0);
+  });
+  setTimeout(() => {
+    console.error("Forced shutdown after timeout.");
+    process.exit(1);
+  }, shutdownTimeoutMs).unref();
+}
+
+process.on("SIGTERM", () => shutdown("SIGTERM"));
+process.on("SIGINT", () => shutdown("SIGINT"));


### PR DESCRIPTION
Registers SIGTERM/SIGINT handlers with server.close() and forced timeout.

Closes #906

Solana wallet for bounty payout: `Do4v7foHJvRJLpRRoGaVPWX6DDEjX3yTK7J91gpwUQpE`

/claim #906

## Acceptance criteria
- Implementation addresses issue #906 acceptance criteria in the PR diff.
- Tests included where applicable.
