### PR TITLE
[agent] chore: add monorepo production build scripts (#915)

### DIFF
--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -5,6 +5,7 @@
   "description": "Next.js web application for TaskFlow.",
   "scripts": {
     "dev": "next dev",
+    "build": "next build",
     "test": "echo \"No web tests configured yet\"",
     "lint": "next lint"
   },

--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
   ],
   "scripts": {
     "dev": "npm run dev --workspaces --if-present",
+    "build": "npm run build --workspaces --if-present",
     "test": "npm run test --workspaces --if-present",
     "lint": "npm run lint --workspaces --if-present",
     "format": "npm run format --workspaces --if-present"


### PR DESCRIPTION
Adds root build script and apps/web next build command.

Closes #915

Solana wallet for bounty payout: `Do4v7foHJvRJLpRRoGaVPWX6DDEjX3yTK7J91gpwUQpE`

/claim #915

## Acceptance criteria
- Implementation addresses issue #915 acceptance criteria in the PR diff.
- Tests included where applicable.
