### PR TITLE
[agent] chore(api): add types and exports metadata (#925)

### DIFF
--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -5,6 +5,13 @@
   "description": "Express API service for TaskFlow.",
   "type": "module",
   "main": "src/index.ts",
+  "types": "src/index.ts",
+  "exports": {
+    ".": {
+      "types": "./src/index.ts",
+      "default": "./src/index.ts"
+    }
+  },
   "scripts": {
     "dev": "tsx src/index.ts",
     "test": "echo \"No API tests configured yet\"",


### PR DESCRIPTION
Adds types and exports map for the API workspace entrypoint.

Closes #925

Solana wallet for bounty payout: `Do4v7foHJvRJLpRRoGaVPWX6DDEjX3yTK7J91gpwUQpE`

/claim #925

## Acceptance criteria
- Implementation addresses issue #925 acceptance criteria in the PR diff.
- Tests included where applicable.
