### PR TITLE
[agent] chore(ui): add types and exports metadata (#923)

### DIFF
--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -4,6 +4,13 @@
   "private": true,
   "description": "Shared UI components for TaskFlow.",
   "main": "src/index.ts",
+  "types": "src/index.ts",
+  "exports": {
+    ".": {
+      "types": "./src/index.ts",
+      "default": "./src/index.ts"
+    }
+  },
   "scripts": {
     "test": "echo \"No UI tests configured yet\"",
     "lint": "echo \"No UI lint configured yet\""


### PR DESCRIPTION
Adds types and exports map for the UI workspace entrypoint.

Closes #923

Solana wallet for bounty payout: `Do4v7foHJvRJLpRRoGaVPWX6DDEjX3yTK7J91gpwUQpE`

/claim #923

## Acceptance criteria
- Implementation addresses issue #923 acceptance criteria in the PR diff.
- Tests included where applicable.
