### PR TITLE
[agent] fix(api): split app construction from server startup (#1771)

### DIFF
--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -7,7 +7,7 @@
   "main": "src/index.ts",
   "scripts": {
     "dev": "tsx src/index.ts",
-    "test": "echo \"No API tests configured yet\"",
+    "test": "node --import tsx --test src/**/*.test.ts",
     "lint": "echo \"No API lint configured yet\""
   },
   "dependencies": {
@@ -15,6 +15,8 @@
   },
   "devDependencies": {
     "@types/express": "^4.17.21",
+    "@types/supertest": "^6.0.2",
+    "supertest": "^7.0.0",
     "tsx": "^4.7.1",
     "typescript": "^5.4.5"
   }

--- a/apps/api/src/app.test.ts
+++ b/apps/api/src/app.test.ts
@@ -1,0 +1,17 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import request from "supertest";
+
+import createApp from "./app.js";
+
+test("createApp can be imported without binding a port", () => {
+  const app = createApp();
+  assert.ok(app);
+});
+
+test("unknown routes return JSON 404", async () => {
+  const response = await request(createApp()).get("/missing-route");
+  assert.equal(response.status, 404);
+  assert.equal(response.headers["content-type"]?.includes("json"), true);
+  assert.equal(response.body.error, "Route not found");
+});

--- a/apps/api/src/app.ts
+++ b/apps/api/src/app.ts
@@ -1,0 +1,27 @@
+import express from "express";
+
+import usersRouter from "./routes/users.js";
+
+export function createApp() {
+  const app = express();
+
+  app.use(express.json());
+
+  app.get("/health", (_req, res) => {
+    res.json({ status: "ok", service: "taskflow-api" });
+  });
+
+  app.use("/users", usersRouter);
+
+  app.use((_req, res) => {
+    res.status(404).json({
+      status: "error",
+      error: "Route not found",
+      data: null,
+    });
+  });
+
+  return app;
+}
+
+export default createApp();

--- a/apps/api/src/index.ts
+++ b/apps/api/src/index.ts
@@ -1,17 +1,7 @@
-import express from "express";
+import createApp from "./app.js";
 
-import usersRouter from "./routes/users";
-
-const app = express();
+const app = createApp();
 const port = process.env.PORT || 4000;
-
-app.use(express.json());
-
-app.get("/health", (_req, res) => {
-  res.json({ status: "ok", service: "taskflow-api" });
-});
-
-app.use("/users", usersRouter);
 
 app.listen(port, () => {
   console.log(`TaskFlow API listening on port ${port}`);


### PR DESCRIPTION
Exports createApp from app.ts and keeps listen in index.ts with import smoke test.

Closes #1771

/claim #1771

Solana wallet for bounty payout: `Do4v7foHJvRJLpRRoGaVPWX6DDEjX3yTK7J91gpwUQpE`


## Acceptance criteria
- Implementation addresses issue #1771 acceptance criteria in the PR diff.
- Tests included where applicable.
