### PR TITLE
[agent] fix(web): add Next.js metadata for homepage SEO (#895)

### DIFF
--- a/apps/web/src/app/page.tsx
+++ b/apps/web/src/app/page.tsx
@@ -1,3 +1,10 @@
+import type { Metadata } from "next";
+
+export const metadata: Metadata = {
+  title: "TaskFlow — Task and proposal workspace",
+  description: "Plan tasks, coordinate jobs, and manage proposals from one workspace.",
+};
+
 export default function HomePage() {
   return (
     <main>


### PR DESCRIPTION
Adds title and description metadata export on the homepage.

Closes #895

/claim #895

Solana wallet for bounty payout: `Do4v7foHJvRJLpRRoGaVPWX6DDEjX3yTK7J91gpwUQpE`


## Acceptance criteria
- Implementation addresses issue #895 acceptance criteria in the PR diff.
- Tests included where applicable.
