### PR TITLE
[agent] fix(api): disable X-Powered-By response header (#1072)

### DIFF
--- a/apps/api/src/index.ts
+++ b/apps/api/src/index.ts
@@ -3,6 +3,8 @@ import express from "express";
 import usersRouter from "./routes/users";
 
 const app = express();
+app.disable("x-powered-by");
+
 const port = process.env.PORT || 4000;
 
 app.use(express.json());


### PR DESCRIPTION
Calls app.disable('x-powered-by') during API setup.

Closes #1072

/claim #1072

Solana wallet for bounty payout: `Do4v7foHJvRJLpRRoGaVPWX6DDEjX3yTK7J91gpwUQpE`


## Acceptance criteria
- Implementation addresses issue #1072 acceptance criteria in the PR diff.
- Tests included where applicable.
