### PR TITLE
[agent] fix(api): set Cache-Control no-store on /health (#1253)

### DIFF
--- a/apps/api/src/index.ts
+++ b/apps/api/src/index.ts
@@ -8,6 +8,7 @@ const port = process.env.PORT || 4000;
 app.use(express.json());
 
 app.get("/health", (_req, res) => {
+  res.set("Cache-Control", "no-store");
   res.json({ status: "ok", service: "taskflow-api" });
 });
 


### PR DESCRIPTION
Prevents stale health responses from intermediary caches.

Closes #1253

/claim #1253

Solana wallet for bounty payout: `Do4v7foHJvRJLpRRoGaVPWX6DDEjX3yTK7J91gpwUQpE`


## Acceptance criteria
- Implementation addresses issue #1253 acceptance criteria in the PR diff.
- Tests included where applicable.
