### PR TITLE
[agent] fix(api): filter POST /users to expected fields (#736)

### DIFF
--- a/apps/api/src/routes/users.ts
+++ b/apps/api/src/routes/users.ts
@@ -10,11 +10,19 @@ router.get("/", (_req, res) => {
 });
 
 router.post("/", (req, res) => {
+  const body = req.body && typeof req.body === "object" ? req.body : {};
+  const { email, name } = body as { email?: unknown; name?: unknown };
+
+  const data: Record<string, unknown> = { id: "stub-user-id" };
+  if (email !== undefined) {
+    data.email = email;
+  }
+  if (name !== undefined) {
+    data.name = name;
+  }
+
   res.status(201).json({
-    data: {
-      id: "stub-user-id",
-      ...req.body
-    },
+    data,
     message: "User creation is not implemented yet."
   });
 });


### PR DESCRIPTION
Destructures only email and name instead of spreading req.body.

Closes #736

/claim #736

Solana wallet for bounty payout: `Do4v7foHJvRJLpRRoGaVPWX6DDEjX3yTK7J91gpwUQpE`


## Acceptance criteria
- Implementation addresses issue #736 acceptance criteria in the PR diff.
- Tests included where applicable.
