### PR TITLE
[agent] fix(api): return 405 for unsupported /users methods (#1168)

### DIFF
--- a/apps/api/src/routes/users.ts
+++ b/apps/api/src/routes/users.ts
@@ -19,4 +19,9 @@ router.post("/", (req, res) => {
   });
 });
 
+router.all("/", (req, res) => {
+  res.set("Allow", "GET, POST");
+  res.status(405).json({ error: `Method ${req.method} not allowed for /users` });
+});
+
 export default router;


### PR DESCRIPTION
Adds Allow header and JSON 405 for PATCH/DELETE on /users.

Closes #1168

/claim #1168

Solana wallet for bounty payout: `Do4v7foHJvRJLpRRoGaVPWX6DDEjX3yTK7J91gpwUQpE`


## Acceptance criteria
- Implementation addresses issue #1168 acceptance criteria in the PR diff.
- Tests included where applicable.
