### PR TITLE
[agent] fix(api): validate PORT before server startup (#1126)

### DIFF
--- a/apps/api/src/index.ts
+++ b/apps/api/src/index.ts
@@ -2,8 +2,21 @@ import express from "express";
 
 import usersRouter from "./routes/users";
 
+function parsePort(value: string | undefined): number {
+  if (value === undefined || value.trim() === "") {
+    return 4000;
+  }
+
+  const port = Number.parseInt(value, 10);
+  if (!Number.isInteger(port) || port < 0 || port > 65535) {
+    throw new Error(`Invalid PORT value: ${value}`);
+  }
+
+  return port;
+}
+
 const app = express();
-const port = process.env.PORT || 4000;
+const port = parsePort(process.env.PORT);
 
 app.use(express.json());
 


### PR DESCRIPTION
Parses PORT as integer 0-65535 with clear startup errors.

Closes #1126

/claim #1126

Solana wallet for bounty payout: `Do4v7foHJvRJLpRRoGaVPWX6DDEjX3yTK7J91gpwUQpE`


## Acceptance criteria
- Implementation addresses issue #1126 acceptance criteria in the PR diff.
- Tests included where applicable.
