### PR TITLE
[agent] fix(web): add committed ESLint config for non-interactive lint (#655)

### DIFF
--- a/apps/web/.eslintrc.json
+++ b/apps/web/.eslintrc.json
@@ -1,0 +1,3 @@
+{
+  "extends": "next/core-web-vitals"
+}

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -17,6 +17,8 @@
     "@types/node": "^20.12.7",
     "@types/react": "^18.3.1",
     "@types/react-dom": "^18.3.0",
+    "eslint": "^8.57.0",
+    "eslint-config-next": "^14.2.3",
     "typescript": "^5.4.5"
   }
 }


### PR DESCRIPTION
Adds eslint-config-next and .eslintrc.json so next lint does not prompt.

Closes #655

/claim #655

Solana wallet for bounty payout: `Do4v7foHJvRJLpRRoGaVPWX6DDEjX3yTK7J91gpwUQpE`


## Acceptance criteria
- Implementation addresses issue #655 acceptance criteria in the PR diff.
- Tests included where applicable.
