### PR TITLE
[agent] fix(ci): pass current_name when updating existing labels (#845)

### DIFF
--- a/.github/workflows/create-labels.yml
+++ b/.github/workflows/create-labels.yml
@@ -80,6 +80,7 @@ jobs:
                 await github.rest.issues.updateLabel({
                   owner: context.repo.owner,
                   repo: context.repo.repo,
+                  current_name: label.name,
                   name: label.name,
                   color,
                   description: label.description || ""


### PR DESCRIPTION
Fixes updateLabel call so reruns refresh label color and description.

Closes #845

/claim #845

Solana wallet for bounty payout: `Do4v7foHJvRJLpRRoGaVPWX6DDEjX3yTK7J91gpwUQpE`


## Acceptance criteria
- Implementation addresses issue #845 acceptance criteria in the PR diff.
- Tests included where applicable.
