### PR TITLE
[agent] fix(ci): grant contents read for create-labels checkout (#910)

### DIFF
--- a/.github/workflows/create-labels.yml
+++ b/.github/workflows/create-labels.yml
@@ -5,6 +5,7 @@ on:
 
 permissions:
   issues: write
+  contents: read
 
 jobs:
   create-labels:


### PR DESCRIPTION
Adds contents: read permission required by actions/checkout.

Closes #910

/claim #910

Solana wallet for bounty payout: `Do4v7foHJvRJLpRRoGaVPWX6DDEjX3yTK7J91gpwUQpE`


## Acceptance criteria
- Implementation addresses issue #910 acceptance criteria in the PR diff.
- Tests included where applicable.
