### PR TITLE
[agent] fix(api): disable ETag generation for dynamic JSON (#1268)

### DIFF
--- a/apps/api/src/index.ts
+++ b/apps/api/src/index.ts
@@ -3,6 +3,8 @@ import express from "express";
 import usersRouter from "./routes/users";
 
 const app = express();
+app.set("etag", false);
+
 const port = process.env.PORT || 4000;
 
 app.use(express.json());


### PR DESCRIPTION
Sets app.set('etag', false) before registering routes.

Closes #1268

/claim #1268

Solana wallet for bounty payout: `Do4v7foHJvRJLpRRoGaVPWX6DDEjX3yTK7J91gpwUQpE`


## Acceptance criteria
- Implementation addresses issue #1268 acceptance criteria in the PR diff.
- Tests included where applicable.
