### PR TITLE
[agent] fix(api): prevent client-controlled user id override (#690)

### DIFF
--- a/apps/api/src/routes/users.ts
+++ b/apps/api/src/routes/users.ts
@@ -12,8 +12,8 @@ router.get("/", (_req, res) => {
 router.post("/", (req, res) => {
   res.status(201).json({
     data: {
-      id: "stub-user-id",
-      ...req.body
+      ...req.body,
+      id: "stub-user-id"
     },
     message: "User creation is not implemented yet."
   });


### PR DESCRIPTION
Sets stub id after req.body spread so clients cannot override id.

Closes #690

/claim #690

Solana wallet for bounty payout: `Do4v7foHJvRJLpRRoGaVPWX6DDEjX3yTK7J91gpwUQpE`


## Acceptance criteria
- Implementation addresses issue #690 acceptance criteria in the PR diff.
- Tests included where applicable.
