### PR TITLE
[agent] fix(api): add SIGTERM/SIGINT graceful shutdown (#1165)

### DIFF
--- a/apps/api/src/index.ts
+++ b/apps/api/src/index.ts
@@ -13,6 +13,23 @@ app.get("/health", (_req, res) => {
 
 app.use("/users", usersRouter);
 
-app.listen(port, () => {
+const server = app.listen(port, () => {
   console.log(`TaskFlow API listening on port ${port}`);
 });
+
+const SHUTDOWN_TIMEOUT_MS = 10_000;
+
+function shutdown(signal: string) {
+  console.log(`Received ${signal}, closing server...`);
+  server.close(() => {
+    console.log("Server closed");
+    process.exit(0);
+  });
+  setTimeout(() => {
+    console.error("Forced shutdown after timeout");
+    process.exit(1);
+  }, SHUTDOWN_TIMEOUT_MS).unref();
+}
+
+process.on("SIGTERM", () => shutdown("SIGTERM"));
+process.on("SIGINT", () => shutdown("SIGINT"));


### PR DESCRIPTION
Drains in-flight requests with server.close and forced timeout.

Closes #1165

/claim #1165

Solana wallet for bounty payout: `Do4v7foHJvRJLpRRoGaVPWX6DDEjX3yTK7J91gpwUQpE`


## Acceptance criteria
- Implementation addresses issue #1165 acceptance criteria in the PR diff.
- Tests included where applicable.
