### PR TITLE
[agent] fix(db): set explicit Proposal.amount decimal precision (#919)

### DIFF
--- a/packages/db/prisma/schema.prisma
+++ b/packages/db/prisma/schema.prisma
@@ -32,7 +32,7 @@ model Job {
 model Proposal {
   id        String   @id @default(cuid())
   summary   String
-  amount    Decimal?
+  amount    Decimal? @db.Decimal(12, 2)
   status    String   @default("pending")
   userId    String
   user      User     @relation(fields: [userId], references: [id])


### PR DESCRIPTION
Uses @db.Decimal(12, 2) for money-safe proposal amounts.

Closes #919

/claim #919

Solana wallet for bounty payout: `Do4v7foHJvRJLpRRoGaVPWX6DDEjX3yTK7J91gpwUQpE`


## Acceptance criteria
- Implementation addresses issue #919 acceptance criteria in the PR diff.
- Tests included where applicable.
