### PR TITLE
[agent] test(ui): add Button stub unit tests (#13)

### DIFF
--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -5,10 +5,11 @@
   "description": "Shared UI components for TaskFlow.",
   "main": "src/index.ts",
   "scripts": {
-    "test": "echo \"No UI tests configured yet\"",
+    "test": "node --import tsx --test src/**/*.test.ts",
     "lint": "echo \"No UI lint configured yet\""
   },
   "devDependencies": {
+    "tsx": "^4.7.1",
     "typescript": "^5.4.5"
   }
 }

--- a/packages/ui/src/button.test.ts
+++ b/packages/ui/src/button.test.ts
@@ -1,0 +1,16 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { Button } from "./index.ts";
+
+test("Button returns label and disabled flag", () => {
+  const result = Button({ label: "Save", disabled: true });
+  assert.equal(result.type, "button");
+  assert.equal(result.label, "Save");
+  assert.equal(result.disabled, true);
+});
+
+test("Button defaults disabled to false", () => {
+  const result = Button({ label: "Go" });
+  assert.equal(result.disabled, false);
+});


### PR DESCRIPTION
Covers label and disabled defaults for the shared Button stub.

Closes #13

/claim #13

Solana wallet for bounty payout: `Do4v7foHJvRJLpRRoGaVPWX6DDEjX3yTK7J91gpwUQpE`


## Acceptance criteria
- Implementation addresses issue #13 acceptance criteria in the PR diff.
- Tests included where applicable.
