### PR TITLE
[agent] fix(web): upgrade Next.js to patched 15.x release (#445)

### DIFF
--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -9,14 +9,14 @@
     "lint": "next lint"
   },
   "dependencies": {
-    "next": "^14.2.3",
-    "react": "^18.3.1",
-    "react-dom": "^18.3.1"
+    "next": "^15.1.6",
+    "react": "^19.0.0",
+    "react-dom": "^19.0.0"
   },
   "devDependencies": {
     "@types/node": "^20.12.7",
-    "@types/react": "^18.3.1",
-    "@types/react-dom": "^18.3.0",
+    "@types/react": "^19.0.0",
+    "@types/react-dom": "^19.0.0",
     "typescript": "^5.4.5"
   }
 }


### PR DESCRIPTION
Bumps next/react to versions without known high-severity advisories.

Closes #445

/claim #445

Solana wallet for bounty payout: `Do4v7foHJvRJLpRRoGaVPWX6DDEjX3yTK7J91gpwUQpE`


## Acceptance criteria
- Implementation addresses issue #445 acceptance criteria in the PR diff.
- Tests included where applicable.
