### PR TITLE
[agent] fix(ui): declare React peer dependencies (#253)

### DIFF
--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -5,10 +5,17 @@
   "description": "Shared UI components for TaskFlow.",
   "main": "src/index.ts",
   "scripts": {
-    "test": "echo \"No UI tests configured yet\"",
+    "test": "node --import tsx --test src/**/*.test.ts",
     "lint": "echo \"No UI lint configured yet\""
   },
+  "peerDependencies": {
+    "react": "^18.0.0 || ^19.0.0",
+    "react-dom": "^18.0.0 || ^19.0.0"
+  },
   "devDependencies": {
+    "@types/react": "^18.3.1",
+    "@types/react-dom": "^18.3.0",
+    "tsx": "^4.7.1",
     "typescript": "^5.4.5"
   }
 }


### PR DESCRIPTION
Adds react/react-dom peerDependencies and @types/react dev deps.

Closes #253

/claim #253

Solana wallet for bounty payout: `Do4v7foHJvRJLpRRoGaVPWX6DDEjX3yTK7J91gpwUQpE`


## Acceptance criteria
- Implementation addresses issue #253 acceptance criteria in the PR diff.
- Tests included where applicable.
