### PR TITLE
[agent] fix(ui): return React element from Button component (#220)

### DIFF
--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -5,10 +5,19 @@
   "description": "Shared UI components for TaskFlow.",
   "main": "src/index.ts",
   "scripts": {
-    "test": "echo \"No UI tests configured yet\"",
+    "test": "node --import tsx --test src/**/*.test.ts",
     "lint": "echo \"No UI lint configured yet\""
   },
+  "peerDependencies": {
+    "react": "^18.0.0 || ^19.0.0",
+    "react-dom": "^18.0.0 || ^19.0.0"
+  },
   "devDependencies": {
+    "@types/react": "^18.3.1",
+    "@types/react-dom": "^18.3.0",
+    "react": "^18.3.1",
+    "react-dom": "^18.3.1",
+    "tsx": "^4.7.1",
     "typescript": "^5.4.5"
   }
 }

--- a/packages/ui/src/button.test.ts
+++ b/packages/ui/src/button.test.ts
@@ -1,0 +1,16 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { renderToStaticMarkup } from "react-dom/server";
+
+import { Button } from "./index.ts";
+
+test("Button renders a JSX button element", () => {
+  const html = renderToStaticMarkup(Button({ label: "Save", disabled: true }));
+  assert.match(html, /<button[^>]*disabled[^>]*>Save<\/button>/);
+});
+
+test("Button renders enabled state by default", () => {
+  const html = renderToStaticMarkup(Button({ label: "Go" }));
+  assert.match(html, /<button[^>]*>Go<\/button>/);
+  assert.doesNotMatch(html, /disabled/);
+});

--- a/packages/ui/src/index.ts
+++ b/packages/ui/src/index.ts
@@ -1,12 +1,15 @@
+import { createElement, type ReactElement } from "react";
+
 export type ButtonProps = {
   label: string;
   disabled?: boolean;
 };
 
-export function Button({ label, disabled = false }: ButtonProps) {
-  return {
-    type: "button",
+/** Shared Button stub used by the web app until real UI primitives land. */
+export function Button({ label, disabled = false }: ButtonProps): ReactElement {
+  return createElement(
+    "button",
+    { type: "button", disabled },
     label,
-    disabled
-  };
+  );
 }


### PR DESCRIPTION
Uses React createElement so Button renders a real button element.

Closes #220

/claim #220

Solana wallet for bounty payout: `Do4v7foHJvRJLpRRoGaVPWX6DDEjX3yTK7J91gpwUQpE`


## Acceptance criteria
- Implementation addresses issue #220 acceptance criteria in the PR diff.
- Tests included where applicable.
