### PR TITLE
[agent] fix(api): destructure only expected POST /users fields (#694)

### DIFF
--- a/apps/api/src/routes/users.ts
+++ b/apps/api/src/routes/users.ts
@@ -5,17 +5,26 @@ const router = Router();
 router.get("/", (_req, res) => {
   res.json({
     data: [],
-    message: "User listing is not implemented yet."
+    message: "User listing is not implemented yet.",
   });
 });
 
 router.post("/", (req, res) => {
+  const body = req.body && typeof req.body === "object" ? req.body : {};
+  const email = "email" in body ? body.email : undefined;
+  const name = "name" in body ? body.name : undefined;
+
+  const data: Record<string, unknown> = { id: "stub-user-id" };
+  if (email !== undefined) {
+    data.email = email;
+  }
+  if (name !== undefined) {
+    data.name = name;
+  }
+
   res.status(201).json({
-    data: {
-      id: "stub-user-id",
-      ...req.body
-    },
-    message: "User creation is not implemented yet."
+    data,
+    message: "User creation is not implemented yet.",
   });
 });
 


### PR DESCRIPTION
Accepts only email and name instead of forwarding arbitrary body fields.

Closes #694

/claim #694

Solana wallet for bounty payout: `Do4v7foHJvRJLpRRoGaVPWX6DDEjX3yTK7J91gpwUQpE`


## Acceptance criteria
- Implementation addresses issue #694 acceptance criteria in the PR diff.
- Tests included where applicable.
