### PR TITLE
[agent] fix(api): validate user creation payloads (#2207)

### DIFF
--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -7,7 +7,7 @@
   "main": "src/index.ts",
   "scripts": {
     "dev": "tsx src/index.ts",
-    "test": "echo \"No API tests configured yet\"",
+    "test": "node --import tsx --test src/**/*.test.ts",
     "lint": "echo \"No API lint configured yet\""
   },
   "dependencies": {
@@ -15,6 +15,8 @@
   },
   "devDependencies": {
     "@types/express": "^4.17.21",
+    "@types/supertest": "^6.0.2",
+    "supertest": "^7.0.0",
     "tsx": "^4.7.1",
     "typescript": "^5.4.5"
   }

--- a/apps/api/src/routes/users.ts
+++ b/apps/api/src/routes/users.ts
@@ -1,21 +1,56 @@
+import { randomUUID } from "node:crypto";
 import { Router } from "express";
 
 const router = Router();
 
+const EMAIL_PATTERN = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
+
+function isPlainObject(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
 router.get("/", (_req, res) => {
   res.json({
     data: [],
-    message: "User listing is not implemented yet."
+    message: "User listing is not implemented yet.",
   });
 });
 
 router.post("/", (req, res) => {
-  res.status(201).json({
-    data: {
-      id: "stub-user-id",
-      ...req.body
-    },
-    message: "User creation is not implemented yet."
+  if (!isPlainObject(req.body)) {
+    return res.status(400).json({ error: "Request body must be a JSON object." });
+  }
+
+  const emailRaw = req.body.email;
+  if (typeof emailRaw !== "string") {
+    return res.status(400).json({ error: "A valid email is required." });
+  }
+
+  const email = emailRaw.trim().toLowerCase();
+  if (!email || !EMAIL_PATTERN.test(email)) {
+    return res.status(400).json({ error: "A valid email is required." });
+  }
+
+  let name: string | undefined;
+  if (req.body.name !== undefined && req.body.name !== null) {
+    if (typeof req.body.name !== "string") {
+      return res.status(400).json({ error: "Name must be a string when provided." });
+    }
+    const trimmed = req.body.name.trim().replace(/\s+/g, " ");
+    if (trimmed.length > 0) {
+      name = trimmed;
+    }
+  }
+
+  const user = {
+    id: randomUUID(),
+    email,
+    ...(name ? { name } : {}),
+  };
+
+  return res.status(201).json({
+    data: user,
+    message: "User created.",
   });
 });
 

--- a/apps/api/src/users.test.ts
+++ b/apps/api/src/users.test.ts
@@ -1,0 +1,39 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import request from "supertest";
+import express from "express";
+
+import usersRouter from "./routes/users.js";
+
+test("POST /users rejects client-controlled id and extra fields", async () => {
+  const app = express();
+  app.use(express.json());
+  app.use("/users", usersRouter);
+
+  const response = await request(app)
+    .post("/users")
+    .send({
+      id: "client-id",
+      email: "User@Example.com",
+      name: "  Ada  Lovelace ",
+      role: "admin",
+    });
+
+  assert.equal(response.status, 201);
+  assert.notEqual(response.body.data.id, "client-id");
+  assert.equal(response.body.data.email, "user@example.com");
+  assert.equal(response.body.data.name, "Ada Lovelace");
+  assert.equal(response.body.data.role, undefined);
+});
+
+test("POST /users rejects non-object bodies", async () => {
+  const app = express();
+  app.use(express.json());
+  app.use("/users", usersRouter);
+
+  const response = await request(app)
+    .post("/users")
+    .send(["not-an-object"]);
+
+  assert.equal(response.status, 400);
+});


### PR DESCRIPTION
Server-side ids, email normalization, and regression tests.

Closes #2207

/claim #2207

Solana wallet for bounty payout: `Do4v7foHJvRJLpRRoGaVPWX6DDEjX3yTK7J91gpwUQpE`


## Acceptance criteria
- Implementation addresses issue #2207 acceptance criteria in the PR diff.
- Tests included where applicable.
