### PR TITLE
[agent] fix: add /bounty marker to bounty issue template (#687)

### DIFF
--- a/.github/ISSUE_TEMPLATE/bounty_task.md
+++ b/.github/ISSUE_TEMPLATE/bounty_task.md
@@ -16,6 +16,4 @@ Describe the task, expected context, and files likely involved.
 - [ ] Documentation or tests are updated when relevant.
 - [ ] The pull request links this issue.
 
-## Bounty Amount
-
-$50
+/bounty $50


### PR DESCRIPTION
Replaces plain $50 text with required /bounty $50 marker.

Closes #687

/claim #687

Solana wallet for bounty payout: `Do4v7foHJvRJLpRRoGaVPWX6DDEjX3yTK7J91gpwUQpE`


## Acceptance criteria
- Implementation addresses issue #687 acceptance criteria in the PR diff.
- Tests included where applicable.
