### PR TITLE
[agent] fix: remove duplicate PI template bounty amount (#775)

### DIFF
--- a/.github/ISSUE_TEMPLATE/pi_challenge.md
+++ b/.github/ISSUE_TEMPLATE/pi_challenge.md
@@ -17,8 +17,4 @@ Implement or document a small PI calculation challenge for TaskFlow's internal e
 - [ ] Keep the implementation deterministic and lightweight.
 - [ ] Reference this issue in the pull request.
 
-## Bounty Amount
-
-$50
-
 /bounty $50


### PR DESCRIPTION
Keeps single /bounty $50 marker in PI challenge template.

Closes #775

/claim #775

Solana wallet for bounty payout: `Do4v7foHJvRJLpRRoGaVPWX6DDEjX3yTK7J91gpwUQpE`


## Acceptance criteria
- Implementation addresses issue #775 acceptance criteria in the PR diff.
- Tests included where applicable.
