### PR TITLE
[agent] fix(ci): make manual seed workflows idempotent (#805)

### DIFF
--- a/.github/workflows/seed-issues.yml
+++ b/.github/workflows/seed-issues.yml
@@ -15,8 +15,50 @@ jobs:
         uses: actions/github-script@v7
         with:
           script: |
+            const requiredLabels = [
+              { name: "good first issue", color: "7057ff", description: "Good for new contributors." },
+              { name: "bounty", color: "e4e669", description: "Reward-backed contribution task." },
+              { name: "AI agent friendly", color: "0e8a16", description: "Suitable for autonomous AI agents." }
+            ];
+
+            for (const label of requiredLabels) {
+              try {
+                await github.rest.issues.createLabel({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  name: label.name,
+                  color: label.color,
+                  description: label.description
+                });
+              } catch (error) {
+                if (error.status !== 422) {
+                  throw error;
+                }
+
+                await github.rest.issues.updateLabel({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  name: label.name,
+                  color: label.color,
+                  description: label.description
+                });
+              }
+            }
+
+            const existing = await github.rest.issues.listForRepo({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              state: "open",
+              per_page: 100,
+            });
+            const parentIssue = existing.data.find((item) =>
+              item.title.includes("Bug Bounty Program")
+            );
+            const parentRef = parentIssue ? `Parent bounty: #${parentIssue.number}` : "";
+
             const bountyBody = (description) => [
               description,
+              parentRef,
               "",
               "## Acceptance Criteria",
               "",
@@ -25,7 +67,7 @@ jobs:
               "- Link this issue in the pull request description.",
               "",
               "/bounty $50"
-            ].join("\n");
+            ].filter(Boolean).join("\n");
 
             const issues = [
               {
@@ -90,7 +132,14 @@ jobs:
               }
             ];
 
+            const openTitles = new Set(existing.data.map((item) => item.title));
+
             for (const issue of issues) {
+              if (openTitles.has(issue.title)) {
+                core.info(`Skipping existing open issue: ${issue.title}`);
+                continue;
+              }
+
               await github.rest.issues.create({
                 owner: context.repo.owner,
                 repo: context.repo.repo,

--- a/.github/workflows/seed-meta-issue.yml
+++ b/.github/workflows/seed-meta-issue.yml
@@ -15,6 +15,8 @@ jobs:
         uses: actions/github-script@v7
         with:
           script: |
+            const canonicalTitle = "Bug Bounty Program — How to Participate";
+
             const bodyForIssue = (issueNumber) => [
               "This repository runs an open bug bounty program.",
               "",
@@ -35,20 +37,44 @@ jobs:
               "description, the better."
             ].join("\n");
 
-            const createdIssue = await github.rest.issues.create({
+            const existing = await github.rest.issues.listForRepo({
               owner: context.repo.owner,
               repo: context.repo.repo,
-              title: "Bug Bounty Program — How to Participate",
-              body: bodyForIssue("[NUMBER]"),
-              labels: ["bounty", "good first issue", "AI agent friendly"]
+              state: "all",
+              per_page: 100,
             });
 
-            await github.rest.issues.update({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              issue_number: createdIssue.data.number,
-              body: bodyForIssue(createdIssue.data.number)
-            });
+            let targetIssue = existing.data.find(
+              (item) => !item.pull_request && item.title === canonicalTitle
+            );
+
+            if (targetIssue) {
+              await github.rest.issues.update({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: targetIssue.number,
+                body: bodyForIssue(targetIssue.number)
+              });
+              core.info(`Updated existing meta issue #${targetIssue.number}`);
+            } else {
+              const createdIssue = await github.rest.issues.create({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                title: canonicalTitle,
+                body: bodyForIssue("[NUMBER]"),
+                labels: ["bounty", "good first issue", "AI agent friendly"]
+              });
+
+              await github.rest.issues.update({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: createdIssue.data.number,
+                body: bodyForIssue(createdIssue.data.number)
+              });
+
+              targetIssue = createdIssue.data;
+              core.info(`Created meta issue #${targetIssue.number}`);
+            }
 
             try {
               await github.graphql(
@@ -62,9 +88,9 @@ jobs:
                   }
                 `,
                 {
-                  issueId: createdIssue.data.node_id
+                  issueId: targetIssue.node_id
                 }
               );
             } catch (error) {
-              core.warning(`Created issue #${createdIssue.data.number}, but pinning failed: ${error.message}`);
+              core.warning(`Meta issue #${targetIssue.number} ready, but pinning failed: ${error.message}`);
             }


### PR DESCRIPTION
Skips duplicate starter issues and reuses Bug Bounty Program meta issue.

Closes #805

/claim #805

Solana wallet for bounty payout: `Do4v7foHJvRJLpRRoGaVPWX6DDEjX3yTK7J91gpwUQpE`


## Acceptance criteria
- Implementation addresses issue #805 acceptance criteria in the PR diff.
- Tests included where applicable.
