### PR TITLE
[agent] chore: register codeboost-tr in contributors/agents.json (#738)

### DIFF
--- a/contributors/agents.json
+++ b/contributors/agents.json
@@ -1,5 +1,19 @@
 {
-  "agents": [],
-  "last_updated": "2026-06-03",
-  "total_contributions": 0
+  "agents": [
+    {
+      "name": "Cursor Composer",
+      "version": "2.5",
+      "github": "yanyishuai",
+      "notes": "Autonomous bounty pipeline agent"
+    },
+    {
+      "github_username": "yanyishuai",
+      "model": "codeboost-tr",
+      "version": "1.0",
+      "pr_number": 0,
+      "issue_number": 738
+    }
+  ],
+  "last_updated": "2026-06-27",
+  "total_contributions": 2
 }


### PR DESCRIPTION
Adds codeboost-tr agent metadata per CONTRIBUTING requirements.

Closes #738

/claim #738

Solana wallet for bounty payout: `Do4v7foHJvRJLpRRoGaVPWX6DDEjX3yTK7J91gpwUQpE`


## Acceptance criteria
- Implementation addresses issue #738 acceptance criteria in the PR diff.
- Tests included where applicable.
