### PR TITLE
[agent] fix(api): add input validation to user creation endpoint (#1699)

### DIFF
--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -11,7 +11,8 @@
     "lint": "echo \"No API lint configured yet\""
   },
   "dependencies": {
-    "express": "^4.18.3"
+    "express": "^4.18.3",
+    "zod": "^3.23.8"
   },
   "devDependencies": {
     "@types/express": "^4.17.21",

--- a/apps/api/src/routes/users.ts
+++ b/apps/api/src/routes/users.ts
@@ -1,21 +1,35 @@
 import { Router } from "express";
+import { z } from "zod";
 
 const router = Router();
+
+const createUserSchema = z.object({
+  email: z.string().email(),
+  name: z.string().min(1).optional(),
+});
 
 router.get("/", (_req, res) => {
   res.json({
     data: [],
-    message: "User listing is not implemented yet."
+    message: "User listing is not implemented yet.",
   });
 });
 
 router.post("/", (req, res) => {
+  const parsed = createUserSchema.safeParse(req.body);
+  if (!parsed.success) {
+    return res.status(400).json({ error: parsed.error.flatten() });
+  }
+
+  const { email, name } = parsed.data;
+
   res.status(201).json({
     data: {
       id: "stub-user-id",
-      ...req.body
+      email,
+      ...(name ? { name } : {}),
     },
-    message: "User creation is not implemented yet."
+    message: "User creation is not implemented yet.",
   });
 });
 


### PR DESCRIPTION
Uses Zod schema validation to reject unvalidated POST /users payloads.

Closes #1699

/claim #1699

Solana wallet for bounty payout: `Do4v7foHJvRJLpRRoGaVPWX6DDEjX3yTK7J91gpwUQpE`


## Acceptance criteria
- Implementation addresses issue #1699 acceptance criteria in the PR diff.
- Tests included where applicable.
