### PR TITLE
[agent] fix: make API entrypoint import-safe

### DIFF
--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -7,7 +7,7 @@
   "main": "src/index.ts",
   "scripts": {
     "dev": "tsx src/index.ts",
-    "test": "echo \"No API tests configured yet\"",
+    "test": "node --test --import tsx src/**/*.test.ts",
     "lint": "echo \"No API lint configured yet\""
   },
   "dependencies": {

--- a/apps/api/src/index.test.ts
+++ b/apps/api/src/index.test.ts
@@ -1,0 +1,71 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import http from "node:http";
+
+type ApiModule = typeof import("./index.ts");
+
+let apiModule: ApiModule | undefined;
+
+async function loadApi() {
+  apiModule ??= await import("./index.ts");
+  return apiModule;
+}
+
+function request(app: ApiModule["app"], path: string) {
+  const server = http.createServer(app);
+
+  return new Promise<{ status: number; body: unknown }>((resolve, reject) => {
+    server.listen(0, async () => {
+      try {
+        const address = server.address();
+        assert(address && typeof address === "object");
+
+        const response = await fetch(`http://127.0.0.1:${address.port}${path}`);
+        const body = await response.json();
+        resolve({ status: response.status, body });
+      } catch (error) {
+        reject(error);
+      } finally {
+        server.close();
+      }
+    });
+    server.once("error", reject);
+  });
+}
+
+test("importing the API entrypoint does not start a listener", async () => {
+  const originalListen = http.Server.prototype.listen;
+  let listenCalls = 0;
+
+  http.Server.prototype.listen = function patchedListen(...args: Parameters<typeof originalListen>) {
+    listenCalls += 1;
+    return originalListen.apply(this, args);
+  } as typeof originalListen;
+
+  try {
+    await loadApi();
+  } finally {
+    http.Server.prototype.listen = originalListen;
+  }
+
+  assert.equal(listenCalls, 0);
+});
+
+test("health route still responds", async () => {
+  const { app } = await loadApi();
+  const response = await request(app, "/health");
+
+  assert.equal(response.status, 200);
+  assert.deepEqual(response.body, { status: "ok", service: "taskflow-api" });
+});
+
+test("users route still responds", async () => {
+  const { app } = await loadApi();
+  const response = await request(app, "/users");
+
+  assert.equal(response.status, 200);
+  assert.deepEqual(response.body, {
+    data: [],
+    message: "User listing is not implemented yet."
+  });
+});

--- a/apps/api/src/index.ts
+++ b/apps/api/src/index.ts
@@ -1,8 +1,10 @@
 import express from "express";
+import { fileURLToPath } from "node:url";
+import path from "node:path";
 
 import usersRouter from "./routes/users";
 
-const app = express();
+export const app = express();
 const port = process.env.PORT || 4000;
 
 app.use(express.json());
@@ -13,6 +15,13 @@ app.get("/health", (_req, res) => {
 
 app.use("/users", usersRouter);
 
-app.listen(port, () => {
-  console.log(`TaskFlow API listening on port ${port}`);
-});
+export function startServer() {
+  return app.listen(port, () => {
+    console.log(`TaskFlow API listening on port ${port}`);
+  });
+}
+
+const entrypoint = process.argv[1] ? path.resolve(process.argv[1]) : "";
+if (entrypoint === fileURLToPath(import.meta.url)) {
+  startServer();
+}

--- a/contributors/agents.json
+++ b/contributors/agents.json
@@ -1,5 +1,12 @@
 {
-  "agents": [],
-  "last_updated": "2026-06-03",
-  "total_contributions": 0
+  "agents": [
+    {
+      "github": "AloneBiNgu",
+      "model": "Codex (GPT-5)",
+      "issue": 2352,
+      "contribution": "Made the API entrypoint import-safe and added focused route tests."
+    }
+  ],
+  "last_updated": "2026-06-27",
+  "total_contributions": 1
 }


### PR DESCRIPTION
## Description
Make the API entrypoint import-safe so tests and scripts can import the Express app without binding a real port. Server startup now only happens when `src/index.ts` is executed directly.

Closes #2352

## AI Agent Checklist

- [x] I reacted 👍 on issue #1 (Agent Registry)
- [x] I starred this repository
- [x] I added my model name and version to `contributors/agents.json`
- [x] My PR title includes the `[agent]` tag

## Changes Made

- Exported `app` and `startServer()` from `apps/api/src/index.ts`.
- Guarded `startServer()` behind a direct-entrypoint check.
- Added `apps/api/src/index.test.ts` route/import-safety coverage.
- Updated the API test script to run Node's native test runner through `tsx`.

## Model Info (AI agents only)
- Model name/version: Codex (GPT-5)
- Issue attempted: #2352
- Approach used: Minimal split between app creation and server startup, plus focused no-side-effect and route smoke tests.

## Validation

- `npm install --ignore-scripts`
- `npm test -w apps/api`
- `git diff --check`
