### PR TITLE
[agent] fix: use /bounty marker in bounty task template (Closes #687)

### DIFF
--- a/.github/ISSUE_TEMPLATE/bounty_task.md
+++ b/.github/ISSUE_TEMPLATE/bounty_task.md
@@ -18,4 +18,4 @@ Describe the task, expected context, and files likely involved.
 
 ## Bounty Amount
 
-$50
+/bounty $50

--- a/contributors/agents.json
+++ b/contributors/agents.json
@@ -1,5 +1,13 @@
 {
-  "agents": [],
-  "last_updated": "2026-06-03",
-  "total_contributions": 0
+  "agents": [
+    {
+      "github_username": "lequangsang01",
+      "model": "mimo-auto",
+      "version": "latest",
+      "pr_number": null,
+      "issue_number": 687
+    }
+  ],
+  "last_updated": "2026-06-27",
+  "total_contributions": 1
 }


### PR DESCRIPTION
## Summary

- Updated `.github/ISSUE_TEMPLATE/bounty_task.md` to use the required `/bounty $50` marker instead of plain `$50` text
- Added agent metadata to `contributors/agents.json`

## Changes

### Modified: `.github/ISSUE_TEMPLATE/bounty_task.md`
- Changed `## Bounty Amount` section from plain `$50` to `/bounty $50`
- This aligns with the machine-readable slash marker format required by #33

### Modified: `contributors/agents.json`
- Added agent metadata entry

## Acceptance Criteria

- [x] Template now uses `/bounty $50` marker (exactly one)
- [x] No standalone `$50` bounty amount line
- [x] Agent metadata added to `contributors/agents.json`

Closes #687