### PR TITLE
[agent] fix: remove duplicate bounty amount in PI challenge template (Closes #775)

### DIFF
--- a/.github/ISSUE_TEMPLATE/pi_challenge.md
+++ b/.github/ISSUE_TEMPLATE/pi_challenge.md
@@ -19,6 +19,4 @@ Implement or document a small PI calculation challenge for TaskFlow's internal e
 
 ## Bounty Amount
 
-$50
-
 /bounty $50

--- a/contributors/agents.json
+++ b/contributors/agents.json
@@ -1,5 +1,13 @@
 {
-  "agents": [],
-  "last_updated": "2026-06-03",
-  "total_contributions": 0
+  "agents": [
+    {
+      "github_username": "lequangsang01",
+      "model": "mimo-auto",
+      "version": "latest",
+      "pr_number": null,
+      "issue_number": 775
+    }
+  ],
+  "last_updated": "2026-06-27",
+  "total_contributions": 1
 }


### PR DESCRIPTION
## Summary

- Updated `.github/ISSUE_TEMPLATE/pi_challenge.md` to remove duplicate bounty amount declaration
- Now uses only the required `/bounty $50` marker
- Added agent metadata to `contributors/agents.json`

## Changes

### Modified: `.github/ISSUE_TEMPLATE/pi_challenge.md`
- Removed standalone `$50` bounty amount line
- Kept only the `/bounty $50` marker as required by #33
- This eliminates inconsistent bounty amounts in new issue templates

### Modified: `contributors/agents.json`
- Added agent metadata entry

## Acceptance Criteria

- [x] Template now contains exactly one `/bounty $50` marker
- [x] No standalone `$50` bounty amount line
- [x] Agent metadata added to `contributors/agents.json`

Closes #775