### PR TITLE
fix: restrict JSON body size to 100 kb (#9)

### DIFF
--- a/apps/api/src/index.ts
+++ b/apps/api/src/index.ts
@@ -5,7 +5,9 @@ import usersRouter from "./routes/users";
 const app = express();
 const port = process.env.PORT || 4000;
 
-app.use(express.json());
+// Restrict JSON body size to 100 kb to limit exposure to
+// request-body-based DoS and large-payload attacks.
+app.use(express.json({ limit: "100kb" }));
 
 app.get("/health", (_req, res) => {
   res.json({ status: "ok", service: "taskflow-api" });


### PR DESCRIPTION
## Summary

Closes #9

Adds an explicit `limit` option to `express.json()` to cap request body size at **100 kb**.

## Motivation

Without a body-size cap, a client can send arbitrarily large JSON payloads, exhausting server memory or CPU during parsing (ReDoS-style or simple allocation attacks). Express does not set a limit by default.

## Change

```ts
// before
app.use(express.json());

// after
app.use(express.json({ limit: '100kb' }));
```

100 kb is a conservative default that covers normal API use while blocking abnormal payloads.