### PR TITLE
test: add unit tests for user route stubs covering list and create (#12)

### DIFF
--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -7,7 +7,7 @@
   "main": "src/index.ts",
   "scripts": {
     "dev": "tsx src/index.ts",
-    "test": "echo \"No API tests configured yet\"",
+    "test": "vitest run",
     "lint": "echo \"No API lint configured yet\""
   },
   "dependencies": {
@@ -16,6 +16,9 @@
   "devDependencies": {
     "@types/express": "^4.17.21",
     "tsx": "^4.7.1",
-    "typescript": "^5.4.5"
+    "typescript": "^5.4.5",
+    "vitest": "^1.6.0",
+    "supertest": "^7.0.0",
+    "@types/supertest": "^6.0.2"
   }
 }

--- a/apps/api/src/__tests__/users.test.ts
+++ b/apps/api/src/__tests__/users.test.ts
@@ -1,0 +1,64 @@
+import { describe, it, expect, beforeAll } from "vitest";
+import express from "express";
+import request from "supertest";
+import usersRouter from "../routes/users.js";
+
+function buildApp() {
+  const app = express();
+  app.use(express.json());
+  app.use("/users", usersRouter);
+  return app;
+}
+
+describe("GET /users", () => {
+  let app: ReturnType<typeof buildApp>;
+
+  beforeAll(() => {
+    app = buildApp();
+  });
+
+  it("returns 200 with an empty data array", async () => {
+    const res = await request(app).get("/users");
+    expect(res.status).toBe(200);
+    expect(res.body).toHaveProperty("data");
+    expect(Array.isArray(res.body.data)).toBe(true);
+  });
+
+  it("returns a message field", async () => {
+    const res = await request(app).get("/users");
+    expect(res.body).toHaveProperty("message");
+    expect(typeof res.body.message).toBe("string");
+  });
+});
+
+describe("POST /users", () => {
+  let app: ReturnType<typeof buildApp>;
+
+  beforeAll(() => {
+    app = buildApp();
+  });
+
+  it("returns 201 with a data object", async () => {
+    const res = await request(app)
+      .post("/users")
+      .send({ name: "Alice", email: "alice@example.com" });
+    expect(res.status).toBe(201);
+    expect(res.body).toHaveProperty("data");
+    expect(typeof res.body.data).toBe("object");
+  });
+
+  it("returns a message field", async () => {
+    const res = await request(app)
+      .post("/users")
+      .send({ name: "Bob" });
+    expect(res.body).toHaveProperty("message");
+  });
+
+  it("reflects body fields in the stub response", async () => {
+    const res = await request(app)
+      .post("/users")
+      .send({ name: "Carol", role: "user" });
+    expect(res.status).toBe(201);
+    expect(res.body.data).toMatchObject({ name: "Carol" });
+  });
+});


### PR DESCRIPTION
## Summary

Closes #12

Adds a Vitest + Supertest test suite for the Express user routes, covering both `GET /users` and `POST /users` stub behaviour.

## Tests added

**`GET /users`**
- Returns `200` with an empty `data` array
- Returns a `message` string field

**`POST /users`**
- Returns `201` with a `data` object
- Returns a `message` field
- Reflects body fields in the stub response

## Dependencies added
- `vitest` — test runner (dev)
- `supertest` + `@types/supertest` — HTTP assertion helper (dev)