### PR TITLE
test: add unit tests for shared Button stub covering label and disabled values (#13)

### DIFF
--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -5,10 +5,11 @@
   "description": "Shared UI components for TaskFlow.",
   "main": "src/index.ts",
   "scripts": {
-    "test": "echo \"No UI tests configured yet\"",
+    "test": "vitest run",
     "lint": "echo \"No UI lint configured yet\""
   },
   "devDependencies": {
-    "typescript": "^5.4.5"
+    "typescript": "^5.4.5",
+    "vitest": "^1.6.0"
   }
 }

--- a/packages/ui/src/__tests__/Button.test.ts
+++ b/packages/ui/src/__tests__/Button.test.ts
@@ -1,0 +1,34 @@
+import { describe, it, expect } from "vitest";
+import { Button } from "../index.js";
+
+describe("Button", () => {
+  it("returns an object with type 'button'", () => {
+    const btn = Button({ label: "Click me" });
+    expect(btn.type).toBe("button");
+  });
+
+  it("sets the label correctly", () => {
+    const btn = Button({ label: "Submit" });
+    expect(btn.label).toBe("Submit");
+  });
+
+  it("defaults disabled to false when not provided", () => {
+    const btn = Button({ label: "Save" });
+    expect(btn.disabled).toBe(false);
+  });
+
+  it("respects disabled=true", () => {
+    const btn = Button({ label: "Delete", disabled: true });
+    expect(btn.disabled).toBe(true);
+  });
+
+  it("respects disabled=false explicitly", () => {
+    const btn = Button({ label: "Cancel", disabled: false });
+    expect(btn.disabled).toBe(false);
+  });
+
+  it("reflects a different label value", () => {
+    const btn = Button({ label: "Open" });
+    expect(btn.label).toBe("Open");
+  });
+});


### PR DESCRIPTION
## Summary

Closes #13

Adds a Vitest test suite for the shared `Button` component in `packages/ui`.

## Tests added (6 cases)

- Returns an object with `type: 'button'`
- Sets the `label` field correctly
- Defaults `disabled` to `false` when omitted
- Respects `disabled: true`
- Respects `disabled: false` explicitly
- Reflects different label values correctly

## Dependencies added
- `vitest` — test runner (devDependency)