### PR TITLE
test: add unit tests for leaderboard update helpers covering new and existing contributors (#11)

### DIFF
--- a/scripts/__tests__/update-leaderboard.test.js
+++ b/scripts/__tests__/update-leaderboard.test.js
@@ -1,0 +1,55 @@
+import { describe, it, expect } from "vitest";
+import { incrementUser, mergeLeaderboard } from "../update-leaderboard.js";
+
+describe("incrementUser", () => {
+  it("increments an existing contributor's count", () => {
+    const board = { alice: 3, bob: 1 };
+    const result = incrementUser(board, "alice");
+    expect(result.alice).toBe(4);
+  });
+
+  it("starts a new contributor at 1", () => {
+    const board = { alice: 3 };
+    const result = incrementUser(board, "carol");
+    expect(result.carol).toBe(1);
+  });
+
+  it("does not mutate the original leaderboard", () => {
+    const board = { alice: 2 };
+    incrementUser(board, "alice");
+    expect(board.alice).toBe(2);
+  });
+
+  it("preserves other contributors unchanged", () => {
+    const board = { alice: 5, bob: 2 };
+    const result = incrementUser(board, "alice");
+    expect(result.bob).toBe(2);
+  });
+
+  it("handles an empty leaderboard", () => {
+    const result = incrementUser({}, "dave");
+    expect(result.dave).toBe(1);
+  });
+});
+
+describe("mergeLeaderboard", () => {
+  it("merges counts for existing users", () => {
+    const existing = { alice: 3, bob: 2 };
+    const updates = { alice: 2 };
+    expect(mergeLeaderboard(existing, updates).alice).toBe(5);
+  });
+
+  it("adds new users from updates", () => {
+    const existing = { alice: 3 };
+    const updates = { carol: 4 };
+    const result = mergeLeaderboard(existing, updates);
+    expect(result.carol).toBe(4);
+    expect(result.alice).toBe(3);
+  });
+
+  it("does not mutate the existing leaderboard", () => {
+    const existing = { alice: 1 };
+    mergeLeaderboard(existing, { alice: 5 });
+    expect(existing.alice).toBe(1);
+  });
+});

--- a/scripts/package.json
+++ b/scripts/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "@taskflow/scripts",
+  "version": "0.1.0",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "test": "vitest run"
+  },
+  "devDependencies": {
+    "vitest": "^1.6.0"
+  }
+}

--- a/scripts/update-leaderboard.js
+++ b/scripts/update-leaderboard.js
@@ -1,0 +1,27 @@
+/**
+ * Leaderboard update helper.
+ * Increments the PR count for a given GitHub username in a leaderboard object.
+ *
+ * @param {Record<string, number>} leaderboard - Current leaderboard state
+ * @param {string} username - GitHub username to increment
+ * @returns {Record<string, number>} Updated leaderboard (new object, does not mutate input)
+ */
+export function incrementUser(leaderboard, username) {
+  const current = leaderboard[username] ?? 0;
+  return { ...leaderboard, [username]: current + 1 };
+}
+
+/**
+ * Merges a partial leaderboard update into the existing leaderboard.
+ *
+ * @param {Record<string, number>} existing - Current leaderboard
+ * @param {Record<string, number>} updates - Partial updates to apply
+ * @returns {Record<string, number>} Merged leaderboard
+ */
+export function mergeLeaderboard(existing, updates) {
+  const result = { ...existing };
+  for (const [user, count] of Object.entries(updates)) {
+    result[user] = (result[user] ?? 0) + count;
+  }
+  return result;
+}


### PR DESCRIPTION
## Summary

Closes #11

Introduces a `scripts/update-leaderboard.js` helper module with two pure functions extracted from the leaderboard shell workflow, and a Vitest suite covering both new and existing contributor scenarios.

## New files

### `scripts/update-leaderboard.js`
- `incrementUser(leaderboard, username)` — increments a user's PR count, returns a new object
- `mergeLeaderboard(existing, updates)` — merges a partial update into the existing board

### `scripts/__tests__/update-leaderboard.test.js` (8 test cases)

**`incrementUser`**
- Increments existing contributor's count
- Starts new contributor at 1
- Does not mutate the original object
- Preserves other contributors
- Handles an empty leaderboard

**`mergeLeaderboard`**
- Merges counts for existing users
- Adds new users from updates
- Does not mutate the existing leaderboard