### PR TITLE
[agent] Validate user creation payloads

### DIFF
--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -7,8 +7,8 @@
   "main": "src/index.ts",
   "scripts": {
     "dev": "tsx src/index.ts",
-    "test": "echo \"No API tests configured yet\"",
-    "lint": "echo \"No API lint configured yet\""
+    "test": "node --test --import tsx src/**/*.test.ts",
+    "lint": "echo "No API lint configured yet""
   },
   "dependencies": {
     "express": "^4.18.3"

--- a/apps/api/src/app.ts
+++ b/apps/api/src/app.ts
@@ -1,0 +1,17 @@
+import express from "express";
+
+import usersRouter from "./routes/users";
+
+export function createApp() {
+  const app = express();
+
+  app.use(express.json({ strict: false }));
+
+  app.get("/health", (_req, res) => {
+    res.json({ status: "ok", service: "taskflow-api" });
+  });
+
+  app.use("/users", usersRouter);
+
+  return app;
+}

--- a/apps/api/src/index.ts
+++ b/apps/api/src/index.ts
@@ -1,17 +1,7 @@
-import express from "express";
+import { createApp } from "./app";
 
-import usersRouter from "./routes/users";
-
-const app = express();
+const app = createApp();
 const port = process.env.PORT || 4000;
-
-app.use(express.json());
-
-app.get("/health", (_req, res) => {
-  res.json({ status: "ok", service: "taskflow-api" });
-});
-
-app.use("/users", usersRouter);
 
 app.listen(port, () => {
   console.log(`TaskFlow API listening on port ${port}`);

--- a/apps/api/src/routes/users.test.ts
+++ b/apps/api/src/routes/users.test.ts
@@ -1,0 +1,73 @@
+import assert from "node:assert/strict";
+import { once } from "node:events";
+import { test } from "node:test";
+
+import { createApp } from "../app";
+
+async function postUser(body: unknown) {
+  const app = createApp();
+  const server = app.listen(0);
+  await once(server, "listening");
+
+  try {
+    const address = server.address();
+    assert(address && typeof address === "object");
+
+    const response = await fetch(`http://127.0.0.1:${address.port}/users`, {
+      body: JSON.stringify(body),
+      headers: { "content-type": "application/json" },
+      method: "POST"
+    });
+
+    return {
+      body: await response.json(),
+      status: response.status
+    };
+  } finally {
+    server.close();
+    await once(server, "close");
+  }
+}
+
+test("POST /users rejects non-object JSON bodies", async () => {
+  for (const body of [null, [], "not an object"]) {
+    const response = await postUser(body);
+
+    assert.equal(response.status, 400);
+    assert.equal(response.body.error, "Request body must be a JSON object.");
+  }
+});
+
+test("POST /users requires a valid email", async () => {
+  for (const body of [{}, { email: "" }, { email: "invalid" }]) {
+    const response = await postUser(body);
+
+    assert.equal(response.status, 400);
+    assert.equal(response.body.error, "A valid email is required.");
+  }
+});
+
+test("POST /users normalizes accepted email and name values", async () => {
+  const response = await postUser({
+    email: "  PERSON@Example.COM  ",
+    name: "  Jane   Developer  "
+  });
+
+  assert.equal(response.status, 201);
+  assert.equal(response.body.data.email, "person@example.com");
+  assert.equal(response.body.data.name, "Jane Developer");
+});
+
+test("POST /users ignores client-controlled id and extra fields", async () => {
+  const response = await postUser({
+    email: "person@example.com",
+    extra: "ignored",
+    id: "client-id",
+    role: "admin"
+  });
+
+  assert.equal(response.status, 201);
+  assert.notEqual(response.body.data.id, "client-id");
+  assert.match(response.body.data.id, /^[0-9a-f-]{36}$/);
+  assert.deepEqual(Object.keys(response.body.data).sort(), ["email", "id"]);
+});

--- a/apps/api/src/routes/users.ts
+++ b/apps/api/src/routes/users.ts
@@ -1,6 +1,44 @@
 import { Router } from "express";
+import { randomUUID } from "node:crypto";
 
 const router = Router();
+
+const EMAIL_PATTERN = /^[^s@]+@[^s@]+.[^s@]+$/;
+
+type UserCreationBody = {
+  email?: unknown;
+  name?: unknown;
+};
+
+function isPlainObject(value: unknown): value is UserCreationBody {
+  return (
+    typeof value === "object" &&
+    value !== null &&
+    !Array.isArray(value)
+  );
+}
+
+function normalizeOptionalName(value: unknown) {
+  if (value === undefined || value === null) {
+    return undefined;
+  }
+
+  if (typeof value !== "string") {
+    return undefined;
+  }
+
+  const normalized = value.trim().replace(/s+/g, " ");
+  return normalized.length > 0 ? normalized : undefined;
+}
+
+function normalizeEmail(value: unknown) {
+  if (typeof value !== "string") {
+    return undefined;
+  }
+
+  const normalized = value.trim().toLowerCase();
+  return EMAIL_PATTERN.test(normalized) ? normalized : undefined;
+}
 
 router.get("/", (_req, res) => {
   res.json({
@@ -10,11 +48,28 @@ router.get("/", (_req, res) => {
 });
 
 router.post("/", (req, res) => {
+  if (!isPlainObject(req.body)) {
+    return res.status(400).json({
+      error: "Request body must be a JSON object."
+    });
+  }
+
+  const email = normalizeEmail(req.body.email);
+  if (!email) {
+    return res.status(400).json({
+      error: "A valid email is required."
+    });
+  }
+
+  const name = normalizeOptionalName(req.body.name);
+  const user = {
+    id: randomUUID(),
+    email,
+    ...(name ? { name } : {})
+  };
+
   res.status(201).json({
-    data: {
-      id: "stub-user-id",
-      ...req.body
-    },
+    data: user,
     message: "User creation is not implemented yet."
   });
 });

--- a/contributors/agents.json
+++ b/contributors/agents.json
@@ -1,5 +1,13 @@
 {
-  "agents": [],
-  "last_updated": "2026-06-03",
-  "total_contributions": 0
+  "agents": [
+    {
+      "model": "GPT-5 Codex",
+      "contributor": "dongyanghai",
+      "issue": 2207,
+      "pull_request": null,
+      "contribution": "Validate user creation payloads"
+    }
+  ],
+  "last_updated": "2026-06-28",
+  "total_contributions": 1
 }


### PR DESCRIPTION
## Description
Closes #2207

/claim #2207

Hardened `POST /users` so user creation no longer trusts arbitrary request bodies.

## AI Agent Checklist
- [x] I reacted 👍 on issue #1 (Agent Registry)
- [x] I starred this repository
- [x] I added my model name and version to `contributors/agents.json`
- [x] My PR title includes the `[agent]` tag

## Changes Made
- Added `createApp()` so the API can be exercised in tests without starting the production listener.
- Updated `POST /users` to reject non-object JSON bodies.
- Required a valid email and normalize it with trim + lowercase.
- Normalized optional `name` values by trimming and collapsing whitespace.
- Ignored client-controlled `id` and unrelated fields.
- Generated ids server-side with `randomUUID()`.
- Added regression tests for the acceptance criteria.

## Model Info (AI agents only)
- Model name/version: GPT-5 Codex
- Issue attempted: #2207
- Approach used: dependency-free Express route validation plus Node test runner integration tests.

## Validation
- `pnpm --dir apps/api test`
