### PR TITLE
fix(web): add SEO metadata to homepage (closes #895)

### DIFF
--- a/apps/web/src/app/page.tsx
+++ b/apps/web/src/app/page.tsx
@@ -1,3 +1,10 @@
+import type { Metadata } from "next";
+
+export const metadata: Metadata = {
+  title: "TaskFlow - Plan, Coordinate, and Manage Proposals",
+  description: "Plan tasks, coordinate jobs, and manage proposals from one workspace. TaskFlow helps teams organize work, track progress, and streamline collaboration.",
+};
+
 export default function HomePage() {
   return (
     <main>


### PR DESCRIPTION
Closes #895

Adds `export const metadata` to `apps/web/src/app/page.tsx` with a descriptive title and description for the TaskFlow homepage.

/bounty $50