### PR TITLE
fix(api): add graceful shutdown on SIGTERM/SIGINT (closes #906)

### DIFF
--- a/apps/api/src/index.ts
+++ b/apps/api/src/index.ts
@@ -13,6 +13,24 @@ app.get("/health", (_req, res) => {
 
 app.use("/users", usersRouter);
 
-app.listen(port, () => {
+const server = app.listen(port, () => {
   console.log(`TaskFlow API listening on port ${port}`);
 });
+
+const FORCED_SHUTDOWN_MS = 10_000;
+
+function gracefulShutdown(signal: string) {
+  console.log(`${signal} received \u2014 shutting down gracefully`);
+  server.close(() => {
+    console.log("HTTP server closed");
+    process.exit(0);
+  });
+
+  setTimeout(() => {
+    console.error("Forced shutdown after timeout");
+    process.exit(1);
+  }, FORCED_SHUTDOWN_MS);
+}
+
+process.on("SIGTERM", () => gracefulShutdown("SIGTERM"));
+process.on("SIGINT", () => gracefulShutdown("SIGINT"));


### PR DESCRIPTION
Closes #906

Keeps the `http.Server` instance returned by `app.listen()` and registers `SIGTERM`/`SIGINT` handlers that:
1. Stop accepting new connections via `server.close()`
2. Force-exit after a 10-second timeout to prevent hanging

/bounty $50