### PR TITLE
fix(db): add explicit Decimal precision to Proposal.amount (closes #919)

### DIFF
--- a/packages/db/prisma/schema.prisma
+++ b/packages/db/prisma/schema.prisma
@@ -32,7 +32,7 @@ model Job {
 model Proposal {
   id        String   @id @default(cuid())
   summary   String
-  amount    Decimal?
+  amount    Decimal? @db.Decimal(12, 2)
   status    String   @default("pending")
   userId    String
   user      User     @relation(fields: [userId], references: [id])


### PR DESCRIPTION
Closes #919

Adds `@db.Decimal(12, 2)` to `Proposal.amount` for money-safe precision and scale. The field remains optional (`Decimal?`).

/bounty $50