### PR TITLE
fix(api): add types and exports map to package.json (closes #925)

### DIFF
--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -5,10 +5,17 @@
   "description": "Express API service for TaskFlow.",
   "type": "module",
   "main": "src/index.ts",
+  "types": "src/index.ts",
+  "exports": {
+    ".": {
+      "types": "./src/index.ts",
+      "default": "./src/index.ts"
+    }
+  },
   "scripts": {
     "dev": "tsx src/index.ts",
-    "test": "echo \"No API tests configured yet\"",
-    "lint": "echo \"No API lint configured yet\""
+    "test": "echo 'No API tests configured yet'",
+    "lint": "echo 'No API lint configured yet'"
   },
   "dependencies": {
     "express": "^4.18.3"


### PR DESCRIPTION
Closes #925

Adds `types` field and `exports` map to `apps/api/package.json` exposing the TypeScript entrypoint with both `types` and `default` conditions.

/bounty $50