### PR TITLE
fix(api): whitelist fields and validate POST /users payload (closes #134)

### DIFF
--- a/apps/api/src/routes/users.ts
+++ b/apps/api/src/routes/users.ts
@@ -2,6 +2,11 @@ import { Router } from "express";
 
 const router = Router();
 
+interface CreateUserPayload {
+  name?: string;
+  email?: string;
+}
+
 router.get("/", (_req, res) => {
   res.json({
     data: [],
@@ -10,10 +15,25 @@ router.get("/", (_req, res) => {
 });
 
 router.post("/", (req, res) => {
+  const { name, email } = req.body as CreateUserPayload;
+
+  if (!name || typeof name !== "string") {
+    return res.status(400).json({
+      error: "Invalid or missing 'name' field. Must be a non-empty string.",
+    });
+  }
+
+  if (!email || typeof email !== "string") {
+    return res.status(400).json({
+      error: "Invalid or missing 'email' field. Must be a non-empty string.",
+    });
+  }
+
   res.status(201).json({
     data: {
       id: "stub-user-id",
-      ...req.body
+      name,
+      email,
     },
     message: "User creation is not implemented yet."
   });


### PR DESCRIPTION
Closes #134

Fixes mass assignment / prototype pollution in `POST /users` by:
1. Whitelisting only `name` and `email` from `req.body` instead of spreading all fields
2. Adding input validation for both fields (non-empty string check)
3. Returning 400 with a clear error message on invalid input

This prevents arbitrary key injection and ensures only expected fields are included in the response.

/bounty $50