### PR TITLE
fix(workflows): make seed-issues.yml idempotent (closes #2101)

### DIFF
--- a/.github/workflows/seed-issues.yml
+++ b/.github/workflows/seed-issues.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - name: Create starter issues
+      - name: Create starter issues (idempotent)
         uses: actions/github-script@v7
         with:
           script: |
@@ -90,7 +90,23 @@ jobs:
               }
             ];
 
+            // Check existing open issues before creating
+            const existingTitles = new Set();
+            const existingIssues = await github.rest.issues.listForRepo({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              state: "open",
+              per_page: 100,
+            });
+            for (const issue of existingIssues.data) {
+              existingTitles.add(issue.title);
+            }
+
             for (const issue of issues) {
+              if (existingTitles.has(issue.title)) {
+                console.log(`Skipping duplicate: ${issue.title}`);
+                continue;
+              }
               await github.rest.issues.create({
                 owner: context.repo.owner,
                 repo: context.repo.repo,
@@ -98,4 +114,5 @@ jobs:
                 body: issue.body,
                 labels: ["good first issue", "bounty", "AI agent friendly"]
               });
+              console.log(`Created: ${issue.title}`);
             }


### PR DESCRIPTION
Closes #2101

Makes the seed-issues workflow idempotent by:
1. Fetching all existing open issues before creating new ones
2. Checking if an issue with the same title already exists
3. Skipping creation if a duplicate title is found

This prevents duplicate starter bounty issues on repeated workflow runs.

/bounty $50