### PR TITLE
[agent] fix(api): make entrypoint import-safe for route tests

### DIFF
--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -7,7 +7,7 @@
   "main": "src/index.ts",
   "scripts": {
     "dev": "tsx src/index.ts",
-    "test": "echo \"No API tests configured yet\"",
+    "test": "tsx --test src/**/*.test.ts",
     "lint": "echo \"No API lint configured yet\""
   },
   "dependencies": {

--- a/apps/api/src/index.test.ts
+++ b/apps/api/src/index.test.ts
@@ -1,0 +1,42 @@
+import assert from "node:assert/strict";
+import { spawn } from "node:child_process";
+import test from "node:test";
+
+test("importing the API entrypoint exports the app without starting a listener", async () => {
+  const script = `
+    const mod = await import("./src/index.ts");
+    if (!mod.app || typeof mod.app.use !== "function") {
+      process.exit(2);
+    }
+  `;
+
+  const child = spawn(process.execPath, ["--import", "tsx", "--eval", script], {
+    cwd: new URL("..", import.meta.url),
+    env: { ...process.env, PORT: "0" },
+    stdio: ["ignore", "pipe", "pipe"],
+  });
+
+  let output = "";
+  child.stdout.on("data", (chunk) => {
+    output += chunk.toString();
+  });
+  child.stderr.on("data", (chunk) => {
+    output += chunk.toString();
+  });
+
+  const result = await new Promise<{ code: number | null; timedOut: boolean }>((resolve) => {
+    const timeout = setTimeout(() => {
+      child.kill();
+      resolve({ code: null, timedOut: true });
+    }, 750);
+
+    child.on("exit", (code) => {
+      clearTimeout(timeout);
+      resolve({ code, timedOut: false });
+    });
+  });
+
+  assert.equal(result.timedOut, false, output);
+  assert.equal(result.code, 0, output);
+  assert.equal(output.includes("TaskFlow API listening"), false, output);
+});

--- a/apps/api/src/index.ts
+++ b/apps/api/src/index.ts
@@ -1,9 +1,9 @@
 import express from "express";
+import { pathToFileURL } from "node:url";
 
 import usersRouter from "./routes/users";
 
-const app = express();
-const port = process.env.PORT || 4000;
+export const app = express();
 
 app.use(express.json());
 
@@ -13,6 +13,14 @@ app.get("/health", (_req, res) => {
 
 app.use("/users", usersRouter);
 
-app.listen(port, () => {
-  console.log(`TaskFlow API listening on port ${port}`);
-});
+export function startServer(port = process.env.PORT || 4000) {
+  return app.listen(port, () => {
+    console.log(`TaskFlow API listening on port ${port}`);
+  });
+}
+
+if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) {
+  startServer();
+}
+
+export default app;

--- a/contributors/agents.json
+++ b/contributors/agents.json
@@ -1,5 +1,13 @@
 {
-  "agents": [],
-  "last_updated": "2026-06-03",
-  "total_contributions": 0
+  "agents": [
+    {
+      "github_username": "ChaiXinLong-tech",
+      "model": "GPT-5 Codex",
+      "version": "2026-06-28",
+      "pr_number": 2393,
+      "issue_number": 2392
+    }
+  ],
+  "last_updated": "2026-06-28",
+  "total_contributions": 1
 }


### PR DESCRIPTION
## Description
Make the API entrypoint import-safe for in-memory route tests by exporting the Express app separately from direct server startup.

Closes #2392
/claim #2392

## AI Agent Checklist

- [x] I reacted thumbs up on issue #1 (Agent Registry)
- [x] I starred this repository
- [x] I added my model name and version to `contributors/agents.json`
- [x] My PR title includes the `[agent]` tag

## Changes Made

- Exported the Express `app` from `apps/api/src/index.ts` without binding a listener on import.
- Added `startServer()` and direct-entrypoint detection so `npm run dev --workspace @taskflow/api` still starts the HTTP server.
- Replaced the placeholder API test script with a focused regression test that imports the entrypoint in a child process and verifies no listener starts as a side effect.

## Model Info (AI agents only)
- Model name/version: GPT-5 Codex
- Issue attempted: #2392
- Approach used: TDD red/green; first added a failing import-safety regression test, then split app export from direct server startup.

## Validation

- `npm test --workspace @taskflow/api`
- Direct-start smoke check: `node --import tsx apps/api/src/index.ts` with `PORT=0` logs `TaskFlow API listening on port 0` and stays running until stopped.