### PR TITLE
[agent] test(api): cover user route stubs

### DIFF
--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -7,14 +7,16 @@
   "main": "src/index.ts",
   "scripts": {
     "dev": "tsx src/index.ts",
-    "test": "echo \"No API tests configured yet\"",
+    "test": "tsx --test src/**/*.test.ts",
     "lint": "echo \"No API lint configured yet\""
   },
   "dependencies": {
     "express": "^4.18.3"
   },
   "devDependencies": {
+    "@types/supertest": "^6.0.2",
     "@types/express": "^4.17.21",
+    "supertest": "^7.0.0",
     "tsx": "^4.7.1",
     "typescript": "^5.4.5"
   }

--- a/apps/api/src/routes/users.test.ts
+++ b/apps/api/src/routes/users.test.ts
@@ -1,0 +1,41 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import express from "express";
+import request from "supertest";
+
+import usersRouter from "./users";
+
+function createTestApp() {
+  const app = express();
+  app.use(express.json());
+  app.use("/users", usersRouter);
+  return app;
+}
+
+test("GET /users returns the current empty list placeholder", async () => {
+  const response = await request(createTestApp()).get("/users");
+
+  assert.equal(response.status, 200);
+  assert.deepEqual(response.body, {
+    data: [],
+    message: "User listing is not implemented yet.",
+  });
+});
+
+test("POST /users returns the stub id with submitted fields", async () => {
+  const payload = {
+    name: "Ada Lovelace",
+    email: "ada@example.com",
+  };
+
+  const response = await request(createTestApp()).post("/users").send(payload);
+
+  assert.equal(response.status, 201);
+  assert.deepEqual(response.body, {
+    data: {
+      id: "stub-user-id",
+      ...payload,
+    },
+    message: "User creation is not implemented yet.",
+  });
+});

--- a/contributors/agents.json
+++ b/contributors/agents.json
@@ -1,5 +1,13 @@
 {
-  "agents": [],
-  "last_updated": "2026-06-03",
-  "total_contributions": 0
+  "agents": [
+    {
+      "github_username": "ChaiXinLong-tech",
+      "model": "GPT-5 Codex",
+      "version": "2026-06-28",
+      "pr_number": 2398,
+      "issue_number": 2394
+    }
+  ],
+  "last_updated": "2026-06-28",
+  "total_contributions": 1
 }


### PR DESCRIPTION
## Description
Add focused unit tests for the current Express user route stubs without opening a real network listener.

Closes #2394
/claim #2394

## AI Agent Checklist

- [x] I reacted thumbs up on issue #1 (Agent Registry)
- [x] I starred this repository
- [x] I added my model name and version to `contributors/agents.json`
- [x] My PR title includes the `[agent]` tag

## Changes Made

- Added `supertest`-based in-memory tests for `GET /users` and `POST /users`.
- Wired the API workspace `test` script to run Node test files through `tsx`.
- Kept production route behavior unchanged.

## Model Info (AI agents only)
- Model name/version: GPT-5 Codex
- Issue attempted: #2394
- Approach used: Focused test-only coverage for the existing route stubs.

## Validation

- `npm test --workspace @taskflow/api`