### PR TITLE
[agent] fix(api): return JSON for unknown routes

### DIFF
--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -7,7 +7,7 @@
   "main": "src/index.ts",
   "scripts": {
     "dev": "tsx src/index.ts",
-    "test": "echo \"No API tests configured yet\"",
+    "test": "tsx --test src/**/*.test.ts",
     "lint": "echo \"No API lint configured yet\""
   },
   "dependencies": {

--- a/apps/api/src/index.test.ts
+++ b/apps/api/src/index.test.ts
@@ -1,0 +1,61 @@
+import assert from "node:assert/strict";
+import { spawn } from "node:child_process";
+import test from "node:test";
+
+async function startApi(port: number) {
+  const child = spawn(process.execPath, ["--import", "tsx", "src/index.ts"], {
+    cwd: new URL("..", import.meta.url),
+    env: { ...process.env, PORT: String(port) },
+    stdio: ["ignore", "pipe", "pipe"],
+  });
+
+  let output = "";
+  child.stdout.on("data", (chunk) => {
+    output += chunk.toString();
+  });
+  child.stderr.on("data", (chunk) => {
+    output += chunk.toString();
+  });
+
+  const started = new Promise<void>((resolve, reject) => {
+    const timeout = setTimeout(() => {
+      reject(new Error(output || "Timed out waiting for API startup"));
+    }, 2_000);
+
+    child.stdout.on("data", () => {
+      if (output.includes(`TaskFlow API listening on port ${port}`)) {
+        clearTimeout(timeout);
+        resolve();
+      }
+    });
+
+    child.on("exit", (code) => {
+      clearTimeout(timeout);
+      reject(new Error(`API exited early with code ${code}: ${output}`));
+    });
+  });
+
+  await started;
+  return child;
+}
+
+test("unknown API routes return a JSON 404 response", async () => {
+  const port = 45951;
+  const child = await startApi(port);
+
+  try {
+    const response = await fetch(`http://127.0.0.1:${port}/missing-route`);
+    const body = await response.json();
+
+    assert.equal(response.status, 404);
+    assert.match(response.headers.get("content-type") ?? "", /application\/json/);
+    assert.deepEqual(body, {
+      error: {
+        code: "not_found",
+        message: "Route not found",
+      },
+    });
+  } finally {
+    child.kill();
+  }
+});

--- a/apps/api/src/index.ts
+++ b/apps/api/src/index.ts
@@ -13,6 +13,15 @@ app.get("/health", (_req, res) => {
 
 app.use("/users", usersRouter);
 
+app.use((_req, res) => {
+  res.status(404).json({
+    error: {
+      code: "not_found",
+      message: "Route not found",
+    },
+  });
+});
+
 app.listen(port, () => {
   console.log(`TaskFlow API listening on port ${port}`);
 });

--- a/contributors/agents.json
+++ b/contributors/agents.json
@@ -1,5 +1,13 @@
 {
-  "agents": [],
-  "last_updated": "2026-06-03",
-  "total_contributions": 0
+  "agents": [
+    {
+      "github_username": "ChaiXinLong-tech",
+      "model": "GPT-5 Codex",
+      "version": "2026-06-28",
+      "pr_number": 2399,
+      "issue_number": 2395
+    }
+  ],
+  "last_updated": "2026-06-28",
+  "total_contributions": 1
 }


### PR DESCRIPTION
## Description
Return a consistent JSON 404 response for unknown API routes instead of falling through to Express's default HTML handler.

Closes #2395
/claim #2395

## AI Agent Checklist

- [x] I reacted thumbs up on issue #1 (Agent Registry)
- [x] I starred this repository
- [x] I added my model name and version to `contributors/agents.json`
- [x] My PR title includes the `[agent]` tag

## Changes Made

- Added a final JSON 404 fallback after registered API routes.
- Added a regression test that starts the API and verifies unknown routes return `application/json` with a stable error body.
- Wired the API workspace `test` script to run Node test files through `tsx`.

## Model Info (AI agents only)
- Model name/version: GPT-5 Codex
- Issue attempted: #2395
- Approach used: TDD red/green; first verified the route returned Express HTML 404, then added the JSON fallback.

## Validation

- Red run: `npm test --workspace @taskflow/api` failed with `Unexpected token '<'` while parsing the default HTML 404 body.
- Green run: `npm test --workspace @taskflow/api` passed with 1/1 test.