### PR TITLE
[agent] feat(web): add homepage SEO metadata

### DIFF
--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -5,7 +5,7 @@
   "description": "Next.js web application for TaskFlow.",
   "scripts": {
     "dev": "next dev",
-    "test": "echo \"No web tests configured yet\"",
+    "test": "tsx --test src/**/*.test.ts",
     "lint": "next lint"
   },
   "dependencies": {
@@ -17,6 +17,7 @@
     "@types/node": "^20.12.7",
     "@types/react": "^18.3.1",
     "@types/react-dom": "^18.3.0",
+    "tsx": "^4.7.1",
     "typescript": "^5.4.5"
   }
 }

--- a/apps/web/src/app/page.test.ts
+++ b/apps/web/src/app/page.test.ts
@@ -1,0 +1,12 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { metadata } from "./page";
+
+test("homepage exports SEO metadata", () => {
+  assert.equal(metadata.title, "TaskFlow | Task Management Workspace");
+  assert.equal(
+    metadata.description,
+    "Plan tasks, coordinate jobs, and manage proposals from one workspace.",
+  );
+});

--- a/apps/web/src/app/page.tsx
+++ b/apps/web/src/app/page.tsx
@@ -1,3 +1,10 @@
+import type { Metadata } from "next";
+
+export const metadata: Metadata = {
+  title: "TaskFlow | Task Management Workspace",
+  description: "Plan tasks, coordinate jobs, and manage proposals from one workspace.",
+};
+
 export default function HomePage() {
   return (
     <main>

--- a/contributors/agents.json
+++ b/contributors/agents.json
@@ -1,5 +1,13 @@
 {
-  "agents": [],
-  "last_updated": "2026-06-03",
-  "total_contributions": 0
+  "agents": [
+    {
+      "github_username": "ChaiXinLong-tech",
+      "model": "GPT-5 Codex",
+      "version": "2026-06-28",
+      "pr_number": 2401,
+      "issue_number": 2396
+    }
+  ],
+  "last_updated": "2026-06-28",
+  "total_contributions": 1
 }


### PR DESCRIPTION
## Description
Add explicit Next.js app-router metadata for the TaskFlow homepage while keeping the visible page content unchanged.

Closes #2396
/claim #2396

## AI Agent Checklist

- [x] I reacted thumbs up on issue #1 (Agent Registry)
- [x] I starred this repository
- [x] I added my model name and version to `contributors/agents.json`
- [x] My PR title includes the `[agent]` tag

## Changes Made

- Exported homepage metadata with a meaningful title and description.
- Added a focused metadata regression test for the web app.
- Wired the web workspace `test` script to run Node test files through `tsx`.

## Model Info (AI agents only)
- Model name/version: GPT-5 Codex
- Issue attempted: #2396
- Approach used: TDD red/green; first verified the homepage had no metadata export, then added the Next metadata.

## Validation

- Red run: `npm test --workspace @taskflow/web` failed because `metadata` was undefined.
- Green run: `npm test --workspace @taskflow/web` passed with 1/1 test.