### PR TITLE
[agent] fix(ui): return React element from Button

### DIFF
--- a/contributors/agents.json
+++ b/contributors/agents.json
@@ -1,5 +1,13 @@
 {
-  "agents": [],
-  "last_updated": "2026-06-03",
-  "total_contributions": 0
+  "agents": [
+    {
+      "github_username": "ChaiXinLong-tech",
+      "model": "GPT-5 Codex",
+      "version": "2026-06-28",
+      "pr_number": 2402,
+      "issue_number": 2397
+    }
+  ],
+  "last_updated": "2026-06-28",
+  "total_contributions": 1
 }

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -5,10 +5,15 @@
   "description": "Shared UI components for TaskFlow.",
   "main": "src/index.ts",
   "scripts": {
-    "test": "echo \"No UI tests configured yet\"",
+    "test": "tsx --test src/**/*.test.ts",
     "lint": "echo \"No UI lint configured yet\""
   },
+  "dependencies": {
+    "react": "^18.3.1"
+  },
   "devDependencies": {
+    "@types/react": "^18.3.1",
+    "tsx": "^4.7.1",
     "typescript": "^5.4.5"
   }
 }

--- a/packages/ui/src/index.test.ts
+++ b/packages/ui/src/index.test.ts
@@ -1,0 +1,26 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { isValidElement } from "react";
+
+import { Button } from "./index";
+
+test("Button returns a React button element", () => {
+  const element = Button({
+    label: "Save task",
+    disabled: true,
+  });
+
+  assert.equal(isValidElement(element), true);
+  assert.equal(element.type, "button");
+  assert.equal(element.props.disabled, true);
+  assert.equal(element.props.children, "Save task");
+});
+
+test("Button defaults disabled to false", () => {
+  const element = Button({
+    label: "Create task",
+  });
+
+  assert.equal(isValidElement(element), true);
+  assert.equal(element.props.disabled, false);
+});

--- a/packages/ui/src/index.ts
+++ b/packages/ui/src/index.ts
@@ -1,12 +1,10 @@
+import { createElement, type ReactElement } from "react";
+
 export type ButtonProps = {
   label: string;
   disabled?: boolean;
 };
 
-export function Button({ label, disabled = false }: ButtonProps) {
-  return {
-    type: "button",
-    label,
-    disabled
-  };
+export function Button({ label, disabled = false }: ButtonProps): ReactElement {
+  return createElement("button", { disabled }, label);
 }


### PR DESCRIPTION
## Description
Make the shared `Button` component return an actual React `<button>` element instead of a plain data object.

Closes #2397
/claim #2397

## AI Agent Checklist

- [x] I reacted thumbs up on issue #1 (Agent Registry)
- [x] I starred this repository
- [x] I added my model name and version to `contributors/agents.json`
- [x] My PR title includes the `[agent]` tag

## Changes Made

- Added React as the UI package runtime dependency and React types for tests/types.
- Updated `Button` to return `createElement("button", { disabled }, label)` while preserving the `label` and optional `disabled` props.
- Added focused regression tests for React element validity, children, and default disabled behavior.
- Wired the UI workspace `test` script to run Node test files through `tsx`.

## Model Info (AI agents only)
- Model name/version: GPT-5 Codex
- Issue attempted: #2397
- Approach used: TDD red/green; first verified `Button` was not a valid React element, then changed the implementation.

## Validation

- Red run: `npm test --workspace @taskflow/ui` failed because `isValidElement(Button(...))` was false.
- Green run: `npm test --workspace @taskflow/ui` passed with 2/2 tests.