### PR TITLE
[agent] fix(api): validate empty user creation payloads

### DIFF
--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -7,7 +7,7 @@
   "main": "src/index.ts",
   "scripts": {
     "dev": "tsx src/index.ts",
-    "test": "echo \"No API tests configured yet\"",
+    "test": "tsx --test src/**/*.test.ts",
     "lint": "echo \"No API lint configured yet\""
   },
   "dependencies": {

--- a/apps/api/src/routes/users.test.ts
+++ b/apps/api/src/routes/users.test.ts
@@ -1,0 +1,62 @@
+import assert from "node:assert/strict";
+import { after, before, test } from "node:test";
+import express from "express";
+import type { Server } from "node:http";
+
+import usersRouter from "./users";
+
+let server: Server;
+let baseUrl: string;
+
+before(async () => {
+  const app = express();
+  app.use(express.json());
+  app.use("/users", usersRouter);
+
+  await new Promise<void>((resolve) => {
+    server = app.listen(0, () => {
+      const address = server.address();
+      assert(address && typeof address === "object");
+      baseUrl = `http://127.0.0.1:${address.port}`;
+      resolve();
+    });
+  });
+});
+
+after(async () => {
+  await new Promise<void>((resolve, reject) => {
+    server.close((error) => (error ? reject(error) : resolve()));
+  });
+});
+
+test("POST /users rejects empty JSON payloads", async () => {
+  const response = await fetch(`${baseUrl}/users`, {
+    method: "POST",
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify({})
+  });
+
+  const body = await response.json();
+
+  assert.equal(response.status, 400);
+  assert.deepEqual(body, {
+    error: {
+      code: "invalid_user_payload",
+      message: "User creation requires at least one user field."
+    }
+  });
+});
+
+test("POST /users preserves the successful stub response", async () => {
+  const response = await fetch(`${baseUrl}/users`, {
+    method: "POST",
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify({ email: "person@example.com" })
+  });
+
+  const body = await response.json();
+
+  assert.equal(response.status, 201);
+  assert.equal(body.data.id, "stub-user-id");
+  assert.equal(body.data.email, "person@example.com");
+});

--- a/apps/api/src/routes/users.ts
+++ b/apps/api/src/routes/users.ts
@@ -10,6 +10,16 @@ router.get("/", (_req, res) => {
 });
 
 router.post("/", (req, res) => {
+  if (!req.body || Object.keys(req.body).length === 0) {
+    res.status(400).json({
+      error: {
+        code: "invalid_user_payload",
+        message: "User creation requires at least one user field."
+      }
+    });
+    return;
+  }
+
   res.status(201).json({
     data: {
       id: "stub-user-id",

--- a/contributors/agents.json
+++ b/contributors/agents.json
@@ -1,16 +1,16 @@
 {
-  "agents": [
-    {
-      "github_username": "ChaiXinLong-tech",
-      "model": "GPT-5 Codex",
-      "version": "2026-06-28",
-      "pr_number": 0,
-      "issue_number": 2403,
-      "contribution_type": "api-validation",
-      "last_updated": "2026-06-29",
-      "total_contributions": 1
-    }
-  ],
-  "last_updated": "2026-06-29",
-  "total_contributions": 1
+    "agents":  [
+                   {
+                       "github_username":  "ChaiXinLong-tech",
+                       "model":  "GPT-5 Codex",
+                       "version":  "2026-06-28",
+                       "pr_number":  2409,
+                       "issue_number":  2403,
+                       "contribution_type":  "api-validation",
+                       "last_updated":  "2026-06-29",
+                       "total_contributions":  1
+                   }
+               ],
+    "last_updated":  "2026-06-29",
+    "total_contributions":  1
 }

--- a/contributors/agents.json
+++ b/contributors/agents.json
@@ -1,5 +1,16 @@
 {
-  "agents": [],
-  "last_updated": "2026-06-03",
-  "total_contributions": 0
+  "agents": [
+    {
+      "github_username": "ChaiXinLong-tech",
+      "model": "GPT-5 Codex",
+      "version": "2026-06-28",
+      "pr_number": 0,
+      "issue_number": 2403,
+      "contribution_type": "api-validation",
+      "last_updated": "2026-06-29",
+      "total_contributions": 1
+    }
+  ],
+  "last_updated": "2026-06-29",
+  "total_contributions": 1
 }


### PR DESCRIPTION
## Summary
- Rejects empty JSON bodies in the user creation stub with a clear 400 error while preserving the existing valid stub response.

## Validation
- TDD red: `POST /users rejects empty JSON payloads` failed with `201 !== 400`; final `npm test --workspace @taskflow/api` passed 2/2.

Closes #2403

/claim #2403

Model: GPT-5 Codex