### PR TITLE
[agent] fix(api): normalize health response envelope

### DIFF
--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -7,7 +7,7 @@
   "main": "src/index.ts",
   "scripts": {
     "dev": "tsx src/index.ts",
-    "test": "echo \"No API tests configured yet\"",
+    "test": "tsx --test src/**/*.test.ts",
     "lint": "echo \"No API lint configured yet\""
   },
   "dependencies": {

--- a/apps/api/src/index.test.ts
+++ b/apps/api/src/index.test.ts
@@ -1,0 +1,70 @@
+import assert from "node:assert/strict";
+import { execFile, spawn, type ChildProcess } from "node:child_process";
+import { once } from "node:events";
+import { test } from "node:test";
+
+async function startApi(port: number): Promise<ChildProcess> {
+  const command = process.platform === "win32" ? "npx tsx src/index.ts" : "npx tsx src/index.ts";
+  const child = process.platform === "win32"
+    ? spawn("cmd.exe", ["/d", "/s", "/c", command], {
+      cwd: process.cwd(),
+      env: { ...process.env, PORT: String(port) }
+    })
+    : spawn("npx", ["tsx", "src/index.ts"], {
+    cwd: process.cwd(),
+    env: { ...process.env, PORT: String(port) }
+  });
+
+  const stderr: string[] = [];
+  child.stderr.on("data", (chunk) => stderr.push(String(chunk)));
+
+  for (let attempt = 0; attempt < 30; attempt += 1) {
+    if (child.exitCode !== null) {
+      throw new Error(`API exited before startup: ${stderr.join("")}`);
+    }
+
+    try {
+      const response = await fetch(`http://127.0.0.1:${port}/health`);
+      if (response.ok) {
+        return child;
+      }
+    } catch {
+      await new Promise((resolve) => setTimeout(resolve, 100));
+    }
+  }
+
+  child.kill();
+  throw new Error(`API did not start: ${stderr.join("")}`);
+}
+
+async function stopApi(child: ChildProcess): Promise<void> {
+  if (process.platform === "win32" && child.pid) {
+    await new Promise<void>((resolve) => {
+      execFile("taskkill", ["/PID", String(child.pid), "/T", "/F"], () => resolve());
+    });
+    return;
+  }
+
+  child.kill();
+  await once(child, "close");
+}
+
+test("GET /health returns a status/data envelope", { timeout: 10_000 }, async () => {
+  const port = 48104;
+  const child = await startApi(port);
+
+  try {
+    const response = await fetch(`http://127.0.0.1:${port}/health`);
+    const body = await response.json();
+
+    assert.equal(response.status, 200);
+    assert.deepEqual(body, {
+      status: "ok",
+      data: {
+        service: "taskflow-api"
+      }
+    });
+  } finally {
+    await stopApi(child);
+  }
+});

--- a/apps/api/src/index.ts
+++ b/apps/api/src/index.ts
@@ -8,7 +8,12 @@ const port = process.env.PORT || 4000;
 app.use(express.json());
 
 app.get("/health", (_req, res) => {
-  res.json({ status: "ok", service: "taskflow-api" });
+  res.json({
+    status: "ok",
+    data: {
+      service: "taskflow-api"
+    }
+  });
 });
 
 app.use("/users", usersRouter);

--- a/contributors/agents.json
+++ b/contributors/agents.json
@@ -1,5 +1,16 @@
 {
-  "agents": [],
-  "last_updated": "2026-06-03",
-  "total_contributions": 0
+  "agents": [
+    {
+      "github_username": "ChaiXinLong-tech",
+      "model": "GPT-5 Codex",
+      "version": "2026-06-28",
+      "pr_number": 0,
+      "issue_number": 2404,
+      "contribution_type": "api-health-response",
+      "last_updated": "2026-06-29",
+      "total_contributions": 1
+    }
+  ],
+  "last_updated": "2026-06-29",
+  "total_contributions": 1
 }

--- a/contributors/agents.json
+++ b/contributors/agents.json
@@ -1,16 +1,16 @@
 {
-  "agents": [
-    {
-      "github_username": "ChaiXinLong-tech",
-      "model": "GPT-5 Codex",
-      "version": "2026-06-28",
-      "pr_number": 0,
-      "issue_number": 2404,
-      "contribution_type": "api-health-response",
-      "last_updated": "2026-06-29",
-      "total_contributions": 1
-    }
-  ],
-  "last_updated": "2026-06-29",
-  "total_contributions": 1
+    "agents":  [
+                   {
+                       "github_username":  "ChaiXinLong-tech",
+                       "model":  "GPT-5 Codex",
+                       "version":  "2026-06-28",
+                       "pr_number":  2410,
+                       "issue_number":  2404,
+                       "contribution_type":  "api-health-response",
+                       "last_updated":  "2026-06-29",
+                       "total_contributions":  1
+                   }
+               ],
+    "last_updated":  "2026-06-29",
+    "total_contributions":  1
 }


### PR DESCRIPTION
## Summary
- Changes `/health` to return a stable `{ status, data }` envelope while retaining the service identifier.

## Validation
- TDD red: health response assertion showed `service` at the top level instead of inside `data`; final `npm test --workspace @taskflow/api` passed 1/1.

Closes #2404

/claim #2404

Model: GPT-5 Codex