### PR TITLE
[agent] docs(db): add Prisma model comments

### DIFF
--- a/contributors/agents.json
+++ b/contributors/agents.json
@@ -1,16 +1,16 @@
 {
-  "agents": [
-    {
-      "github_username": "ChaiXinLong-tech",
-      "model": "GPT-5 Codex",
-      "version": "2026-06-28",
-      "pr_number": 0,
-      "issue_number": 2405,
-      "contribution_type": "schema-documentation",
-      "last_updated": "2026-06-29",
-      "total_contributions": 1
-    }
-  ],
-  "last_updated": "2026-06-29",
-  "total_contributions": 1
+    "agents":  [
+                   {
+                       "github_username":  "ChaiXinLong-tech",
+                       "model":  "GPT-5 Codex",
+                       "version":  "2026-06-28",
+                       "pr_number":  2411,
+                       "issue_number":  2405,
+                       "contribution_type":  "schema-documentation",
+                       "last_updated":  "2026-06-29",
+                       "total_contributions":  1
+                   }
+               ],
+    "last_updated":  "2026-06-29",
+    "total_contributions":  1
 }

--- a/contributors/agents.json
+++ b/contributors/agents.json
@@ -1,5 +1,16 @@
 {
-  "agents": [],
-  "last_updated": "2026-06-03",
-  "total_contributions": 0
+  "agents": [
+    {
+      "github_username": "ChaiXinLong-tech",
+      "model": "GPT-5 Codex",
+      "version": "2026-06-28",
+      "pr_number": 0,
+      "issue_number": 2405,
+      "contribution_type": "schema-documentation",
+      "last_updated": "2026-06-29",
+      "total_contributions": 1
+    }
+  ],
+  "last_updated": "2026-06-29",
+  "total_contributions": 1
 }

--- a/packages/db/prisma/schema.prisma
+++ b/packages/db/prisma/schema.prisma
@@ -7,6 +7,7 @@ datasource db {
   url      = env("DATABASE_URL")
 }
 
+/// TaskFlow account profile that owns jobs and submits proposals.
 model User {
   id        String     @id @default(cuid())
   email     String     @unique
@@ -17,6 +18,7 @@ model User {
   updatedAt DateTime   @updatedAt
 }
 
+/// Client-owned work item that moves through the task marketplace lifecycle.
 model Job {
   id          String     @id @default(cuid())
   title       String
@@ -29,6 +31,7 @@ model Job {
   updatedAt   DateTime   @updatedAt
 }
 
+/// Freelancer proposal connecting a user to a job with an optional bid amount.
 model Proposal {
   id        String   @id @default(cuid())
   summary   String


### PR DESCRIPTION
## Summary
- Adds brief model-level Prisma comments for User, Job, and Proposal without changing fields or relations.

## Validation
- Baseline and final `npx prisma validate --schema packages/db/prisma/schema.prisma` passed with a placeholder `DATABASE_URL`.

Closes #2405

/claim #2405

Model: GPT-5 Codex