### PR TITLE
[agent] docs: add local environment examples

### DIFF
--- a/apps/api/.env.example
+++ b/apps/api/.env.example
@@ -1,0 +1,5 @@
+# Express API
+PORT=4000
+DATABASE_URL=postgresql://user:password@localhost:5432/taskflow
+JWT_SECRET=replace-with-local-development-secret
+

--- a/apps/web/.env.example
+++ b/apps/web/.env.example
@@ -1,0 +1,4 @@
+# Next.js web app
+NEXT_PUBLIC_API_URL=http://localhost:4000
+NEXT_PUBLIC_APP_NAME=TaskFlow
+

--- a/contributors/agents.json
+++ b/contributors/agents.json
@@ -1,16 +1,16 @@
 {
-  "agents": [
-    {
-      "github_username": "ChaiXinLong-tech",
-      "model": "GPT-5 Codex",
-      "version": "2026-06-28",
-      "pr_number": 0,
-      "issue_number": 2406,
-      "contribution_type": "environment-documentation",
-      "last_updated": "2026-06-29",
-      "total_contributions": 1
-    }
-  ],
-  "last_updated": "2026-06-29",
-  "total_contributions": 1
+    "agents":  [
+                   {
+                       "github_username":  "ChaiXinLong-tech",
+                       "model":  "GPT-5 Codex",
+                       "version":  "2026-06-28",
+                       "pr_number":  2412,
+                       "issue_number":  2406,
+                       "contribution_type":  "environment-documentation",
+                       "last_updated":  "2026-06-29",
+                       "total_contributions":  1
+                   }
+               ],
+    "last_updated":  "2026-06-29",
+    "total_contributions":  1
 }

--- a/contributors/agents.json
+++ b/contributors/agents.json
@@ -1,5 +1,16 @@
 {
-  "agents": [],
-  "last_updated": "2026-06-03",
-  "total_contributions": 0
+  "agents": [
+    {
+      "github_username": "ChaiXinLong-tech",
+      "model": "GPT-5 Codex",
+      "version": "2026-06-28",
+      "pr_number": 0,
+      "issue_number": 2406,
+      "contribution_type": "environment-documentation",
+      "last_updated": "2026-06-29",
+      "total_contributions": 1
+    }
+  ],
+  "last_updated": "2026-06-29",
+  "total_contributions": 1
 }

--- a/packages/db/.env.example
+++ b/packages/db/.env.example
@@ -1,0 +1,3 @@
+# Prisma database package
+DATABASE_URL=postgresql://user:password@localhost:5432/taskflow
+


### PR DESCRIPTION
## Summary
- Adds placeholder-only env example files for API, web, and database package setup.

## Validation
- Verified `apps/api/.env.example`, `apps/web/.env.example`, and `packages/db/.env.example` exist and scanned for common secret token patterns.

Closes #2406

/claim #2406

Model: GPT-5 Codex