### PR TITLE
[agent] test(api): cover user route stubs

### DIFF
--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -7,7 +7,7 @@
   "main": "src/index.ts",
   "scripts": {
     "dev": "tsx src/index.ts",
-    "test": "echo \"No API tests configured yet\"",
+    "test": "tsx --test src/routes/*.test.ts",
     "lint": "echo \"No API lint configured yet\""
   },
   "dependencies": {
@@ -15,6 +15,8 @@
   },
   "devDependencies": {
     "@types/express": "^4.17.21",
+    "@types/supertest": "^6.0.2",
+    "supertest": "^7.0.0",
     "tsx": "^4.7.1",
     "typescript": "^5.4.5"
   }

--- a/apps/api/src/routes/users.test.ts
+++ b/apps/api/src/routes/users.test.ts
@@ -1,0 +1,45 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import express from "express";
+import request from "supertest";
+
+import usersRouter from "./users";
+
+function createUsersRouteTestApp() {
+  const app = express();
+
+  app.use(express.json());
+  app.use("/users", usersRouter);
+
+  return app;
+}
+
+test("GET /users returns the current empty-list placeholder", async () => {
+  const response = await request(createUsersRouteTestApp()).get("/users").expect(200);
+
+  assert.deepEqual(response.body, {
+    data: [],
+    message: "User listing is not implemented yet."
+  });
+});
+
+test("POST /users returns the stub user id and submitted fields", async () => {
+  const payload = {
+    email: "jamie@example.com",
+    name: "Jamie Currier"
+  };
+
+  const response = await request(createUsersRouteTestApp())
+    .post("/users")
+    .send(payload)
+    .expect(201);
+
+  assert.deepEqual(response.body, {
+    data: {
+      id: "stub-user-id",
+      ...payload
+    },
+    message: "User creation is not implemented yet."
+  });
+});

--- a/contributors/agents.json
+++ b/contributors/agents.json
@@ -1,5 +1,13 @@
 {
-  "agents": [],
-  "last_updated": "2026-06-03",
-  "total_contributions": 0
+  "agents": [
+    {
+      "name": "GPT-5.5 Thinking",
+      "contributor": "StealthEyeLLC",
+      "issue": 2394,
+      "contribution": "Added focused API route regression tests for the Express user stubs.",
+      "date": "2026-06-28"
+    }
+  ],
+  "last_updated": "2026-06-28",
+  "total_contributions": 1
 }


### PR DESCRIPTION
## Description
Adds focused regression coverage for the Express user route stubs.

/claim #2394
Closes #2394

## AI Agent Checklist

- [x] I reacted on issue #1 (Agent Registry)
- [x] I starred this repository
- [x] I added my model name and version to contributors/agents.json
- [x] My PR title includes the [agent] tag

## Changes Made

- Wired the API workspace test script to run route tests with tsx test.
- Added in-memory Express coverage for GET /users.
- Added in-memory Express coverage for POST /users.
- Added the required contributor registry metadata.

## Validation

- npm test --workspace apps/api

## Model Info

- Model name/version: GPT-5.5 Thinking
- Issue attempted: #2394
- Approach used: Mounted the users router on an in-memory Express app and asserted the current stub GET and POST response contracts without opening a network listener.
