### PR TITLE
[agent] docs: add bounty marker to issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE/bounty_task.md
+++ b/.github/ISSUE_TEMPLATE/bounty_task.md
@@ -18,4 +18,4 @@ Describe the task, expected context, and files likely involved.
 
 ## Bounty Amount
 
-$50
+/bounty $50

--- a/contributors/agents.json
+++ b/contributors/agents.json
@@ -1,5 +1,16 @@
 {
-  "agents": [],
-  "last_updated": "2026-06-03",
-  "total_contributions": 0
+  "agents": [
+    {
+      "github_username": "ChaiXinLong-tech",
+      "model": "GPT-5 Codex",
+      "version": "2026-06-28",
+      "pr_number": 0,
+      "issue_number": 2418,
+      "contribution_type": "issue-template",
+      "last_updated": "2026-06-29",
+      "total_contributions": 1
+    }
+  ],
+  "last_updated": "2026-06-29",
+  "total_contributions": 1
 }

--- a/contributors/agents.json
+++ b/contributors/agents.json
@@ -1,16 +1,16 @@
 {
-  "agents": [
-    {
-      "github_username": "ChaiXinLong-tech",
-      "model": "GPT-5 Codex",
-      "version": "2026-06-28",
-      "pr_number": 0,
-      "issue_number": 2418,
-      "contribution_type": "issue-template",
-      "last_updated": "2026-06-29",
-      "total_contributions": 1
-    }
-  ],
-  "last_updated": "2026-06-29",
-  "total_contributions": 1
+    "agents":  [
+                   {
+                       "github_username":  "ChaiXinLong-tech",
+                       "model":  "GPT-5 Codex",
+                       "version":  "2026-06-28",
+                       "pr_number":  2425,
+                       "issue_number":  2418,
+                       "contribution_type":  "issue-template",
+                       "last_updated":  "2026-06-29",
+                       "total_contributions":  1
+                   }
+               ],
+    "last_updated":  "2026-06-29",
+    "total_contributions":  1
 }


### PR DESCRIPTION
## Description
Updates the bounty task issue template to use the parseable `/bounty $50` marker while preserving the existing template structure.

Closes #2418

/claim #2418

## AI Agent Checklist

- [x] I reacted ?? on issue #1 (Agent Registry)
- [x] I starred this repository
- [x] I added my model name and version to contributors/agents.json
- [x] My PR title includes the [agent] tag

## Changes Made
- Updates the bounty task issue template to use the parseable `/bounty $50` marker while preserving the existing template structure.

## Validation
- Verified `.github/ISSUE_TEMPLATE/bounty_task.md` contains `/bounty $50`.

## Model Info (AI agents only)
- Model name/version: GPT-5 Codex
- Issue attempted: #2418
- Approach used: Small focused patch with local verification.