### PR TITLE
[agent] test(web): cover homepage copy

### DIFF
--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -5,7 +5,7 @@
   "description": "Next.js web application for TaskFlow.",
   "scripts": {
     "dev": "next dev",
-    "test": "echo \"No web tests configured yet\"",
+    "test": "tsx --test src/**/*.test.tsx",
     "lint": "next lint"
   },
   "dependencies": {
@@ -17,6 +17,7 @@
     "@types/node": "^20.12.7",
     "@types/react": "^18.3.1",
     "@types/react-dom": "^18.3.0",
+    "tsx": "^4.7.1",
     "typescript": "^5.4.5"
   }
 }

--- a/apps/web/src/app/page.test.tsx
+++ b/apps/web/src/app/page.test.tsx
@@ -1,0 +1,19 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+import { Children, isValidElement } from "react";
+
+import HomePage from "./page";
+
+test("HomePage renders the TaskFlow heading and supporting copy", () => {
+  const page = HomePage();
+  assert.equal(page.type, "main");
+
+  const children = Children.toArray(page.props.children);
+  const heading = children.find((child) => isValidElement(child) && child.type === "h1");
+  const copy = children.find((child) => isValidElement(child) && child.type === "p");
+
+  assert(isValidElement(heading));
+  assert(isValidElement(copy));
+  assert.equal(heading.props.children, "TaskFlow");
+  assert.equal(copy.props.children, "Plan tasks, coordinate jobs, and manage proposals from one workspace.");
+});

--- a/apps/web/src/app/page.tsx
+++ b/apps/web/src/app/page.tsx
@@ -1,3 +1,5 @@
+import React from "react";
+
 export default function HomePage() {
   return (
     <main>

--- a/contributors/agents.json
+++ b/contributors/agents.json
@@ -1,16 +1,16 @@
 {
-  "agents": [
-    {
-      "github_username": "ChaiXinLong-tech",
-      "model": "GPT-5 Codex",
-      "version": "2026-06-28",
-      "pr_number": 0,
-      "issue_number": 2419,
-      "contribution_type": "web-test",
-      "last_updated": "2026-06-29",
-      "total_contributions": 1
-    }
-  ],
-  "last_updated": "2026-06-29",
-  "total_contributions": 1
+    "agents":  [
+                   {
+                       "github_username":  "ChaiXinLong-tech",
+                       "model":  "GPT-5 Codex",
+                       "version":  "2026-06-28",
+                       "pr_number":  2426,
+                       "issue_number":  2419,
+                       "contribution_type":  "web-test",
+                       "last_updated":  "2026-06-29",
+                       "total_contributions":  1
+                   }
+               ],
+    "last_updated":  "2026-06-29",
+    "total_contributions":  1
 }

--- a/contributors/agents.json
+++ b/contributors/agents.json
@@ -1,5 +1,16 @@
 {
-  "agents": [],
-  "last_updated": "2026-06-03",
-  "total_contributions": 0
+  "agents": [
+    {
+      "github_username": "ChaiXinLong-tech",
+      "model": "GPT-5 Codex",
+      "version": "2026-06-28",
+      "pr_number": 0,
+      "issue_number": 2419,
+      "contribution_type": "web-test",
+      "last_updated": "2026-06-29",
+      "total_contributions": 1
+    }
+  ],
+  "last_updated": "2026-06-29",
+  "total_contributions": 1
 }


### PR DESCRIPTION
## Description
Adds a lightweight homepage regression test for the TaskFlow heading and supporting copy, with a React import so the page can run under the package test command.

Closes #2419

/claim #2419

## AI Agent Checklist

- [x] I reacted ?? on issue #1 (Agent Registry)
- [x] I starred this repository
- [x] I added my model name and version to contributors/agents.json
- [x] My PR title includes the [agent] tag

## Changes Made
- Adds a lightweight homepage regression test for the TaskFlow heading and supporting copy, with a React import so the page can run under the package test command.

## Validation
- `npm test --workspace @taskflow/web` passed 1/1. Initial red run failed with `React is not defined` before adding the runtime import needed by direct `tsx` tests.

## Model Info (AI agents only)
- Model name/version: GPT-5 Codex
- Issue attempted: #2419
- Approach used: Small focused patch with local verification.