### PR TITLE
fix: add JSON 404 fallback for unknown API routes (Closes #2395)

### DIFF
--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -7,7 +7,7 @@
   "main": "src/index.ts",
   "scripts": {
     "dev": "tsx src/index.ts",
-    "test": "echo \"No API tests configured yet\"",
+    "test": "node --import tsx --test src/__tests__/*.test.ts",
     "lint": "echo \"No API lint configured yet\""
   },
   "dependencies": {

--- a/apps/api/src/__tests__/api.test.ts
+++ b/apps/api/src/__tests__/api.test.ts
@@ -1,0 +1,72 @@
+import { describe, it, before, after } from "node:test";
+import assert from "node:assert";
+import http from "node:http";
+import { app } from "../index.js";
+
+let server: http.Server;
+let baseUrl: string;
+
+before(() => {
+  return new Promise<void>((resolve) => {
+    server = app.listen(0, () => {
+      const addr = server.address();
+      if (addr && typeof addr === "object") {
+        baseUrl = `http://127.0.0.1:${addr.port}`;
+      }
+      resolve();
+    });
+  });
+});
+
+after(() => {
+  server?.close();
+});
+
+function fetchJson(path: string) {
+  return new Promise<{ status: number; body: unknown }>((resolve, reject) => {
+    http.get(`${baseUrl}${path}`, (res) => {
+      let data = "";
+      res.on("data", (chunk) => (data += chunk));
+      res.on("end", () => {
+        try {
+          resolve({ status: res.statusCode ?? 0, body: JSON.parse(data) });
+        } catch {
+          resolve({ status: res.statusCode ?? 0, body: data });
+        }
+      });
+    }).on("error", reject);
+  });
+}
+
+describe("API unknown route JSON 404 fallback", () => {
+  it("returns JSON 404 for an unknown API route", async () => {
+    const res = await fetchJson("/nonexistent-route");
+    assert.strictEqual(res.status, 404);
+    const obj = res.body as Record<string, unknown>;
+    assert.strictEqual(obj.error, "Not Found");
+    assert.ok(typeof obj.message === "string");
+  });
+
+  it("returns JSON 404 for another unknown path", async () => {
+    const res = await fetchJson("/api/ghost-endpoint");
+    assert.strictEqual(res.status, 404);
+    const obj = res.body as Record<string, unknown>;
+    assert.strictEqual(obj.error, "Not Found");
+  });
+
+  it("/health endpoint still returns 200", async () => {
+    const res = await fetchJson("/health");
+    assert.strictEqual(res.status, 200);
+    const obj = res.body as Record<string, unknown>;
+    assert.strictEqual(obj.status, "ok");
+    assert.strictEqual(obj.service, "taskflow-api");
+  });
+
+  it("/users endpoint still returns 200", async () => {
+    const res = await fetchJson("/users");
+    assert.strictEqual(res.status, 200);
+    const obj = res.body as Record<string, unknown>;
+    assert.strictEqual(obj.message, "User listing is not implemented yet.");
+    assert.deepStrictEqual(obj.data, []);
+  });
+});

--- a/apps/api/src/index.ts
+++ b/apps/api/src/index.ts
@@ -2,7 +2,7 @@ import express from "express";
 
 import usersRouter from "./routes/users";
 
-const app = express();
+export const app = express();
 const port = process.env.PORT || 4000;
 
 app.use(express.json());
@@ -13,6 +13,20 @@ app.get("/health", (_req, res) => {
 
 app.use("/users", usersRouter);
 
-app.listen(port, () => {
-  console.log(`TaskFlow API listening on port ${port}`);
+// JSON 404 fallback for unknown API routes
+app.use((_req, res) => {
+  res.status(404).json({
+    error: "Not Found",
+    message: "The requested API route does not exist."
+  });
 });
+
+// Only start the server when run directly (not imported for tests)
+const isDirectRun = process.argv[1] && (
+  process.argv[1].endsWith("index.ts") || process.argv[1].endsWith("index.js")
+);
+if (isDirectRun || process.env.START_SERVER === "1") {
+  app.listen(port, () => {
+    console.log(`TaskFlow API listening on port ${port}`);
+  });
+}


### PR DESCRIPTION
## Summary

Express now returns `application/json` 404 responses for unmatched API routes instead of falling through to the default HTML handler.

## Changes

- **`apps/api/src/index.ts`**: Added JSON 404 middleware after all route handlers. Refactored to export the Express `app` and conditionally start the server (only when run directly, not when imported for tests).
- **`apps/api/src/__tests__/api.test.ts`**: New regression tests using `node:test` covering:
  - Unknown route returns 404 JSON with error message
  - `/health` endpoint still returns 200
  - `/users` endpoint still returns 200
- **`apps/api/package.json`**: Updated test script to `node --import tsx --test`

## Acceptance Criteria

- [x] Unknown API routes return HTTP 404 with `application/json` response
- [x] Existing `/health` and `/users` behavior remains unchanged
- [x] Focused regression test for unknown routes added
- [x] Change scoped to API app and tests

Closes #2395