### PR TITLE
[agent] fix(api): make entrypoint import safe

### DIFF
--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -7,7 +7,7 @@
   "main": "src/index.ts",
   "scripts": {
     "dev": "tsx src/index.ts",
-    "test": "echo \"No API tests configured yet\"",
+    "test": "tsx --test src/*.test.ts",
     "lint": "echo \"No API lint configured yet\""
   },
   "dependencies": {
@@ -15,6 +15,8 @@
   },
   "devDependencies": {
     "@types/express": "^4.17.21",
+    "@types/supertest": "^6.0.2",
+    "supertest": "^7.0.0",
     "tsx": "^4.7.1",
     "typescript": "^5.4.5"
   }

--- a/apps/api/src/index.test.ts
+++ b/apps/api/src/index.test.ts
@@ -1,0 +1,65 @@
+import assert from "node:assert/strict";
+import { spawn } from "node:child_process";
+import { once } from "node:events";
+import test from "node:test";
+import { fileURLToPath } from "node:url";
+
+import request from "supertest";
+
+import { app, createApp } from "./index";
+
+test("importing the API entrypoint exits without starting a listener", async () => {
+  const child = spawn(
+    process.execPath,
+    ["--import", "tsx", "--input-type=module", "--eval", "await import('./src/index.ts');"],
+    {
+      cwd: fileURLToPath(new URL("..", import.meta.url)),
+      env: { ...process.env, PORT: "0" },
+      stdio: ["ignore", "pipe", "pipe"]
+    }
+  );
+
+  let output = "";
+  child.stdout.setEncoding("utf8");
+  child.stderr.setEncoding("utf8");
+  child.stdout.on("data", (chunk) => {
+    output += chunk;
+  });
+  child.stderr.on("data", (chunk) => {
+    output += chunk;
+  });
+
+  const timeout = setTimeout(() => {
+    child.kill("SIGTERM");
+  }, 2000);
+
+  const [code, signal] = await once(child, "exit");
+  clearTimeout(timeout);
+
+  assert.equal(signal, null, "importing index.ts should not leave a server listener running");
+  assert.equal(code, 0);
+  assert.equal(output.includes("TaskFlow API listening"), false);
+});
+
+test("exports an Express app for in-memory health route tests", async () => {
+  assert.equal(typeof app, "function");
+  assert.equal(typeof app.listen, "function");
+
+  const response = await request(app).get("/health").expect(200);
+
+  assert.deepEqual(response.body, {
+    status: "ok",
+    service: "taskflow-api"
+  });
+});
+
+test("createApp preserves the users route behavior for in-memory tests", async () => {
+  const testApp = createApp();
+
+  const response = await request(testApp).get("/users").expect(200);
+
+  assert.deepEqual(response.body, {
+    data: [],
+    message: "User listing is not implemented yet."
+  });
+});

--- a/apps/api/src/index.ts
+++ b/apps/api/src/index.ts
@@ -1,18 +1,33 @@
+import { pathToFileURL } from "node:url";
+
 import express from "express";
 
 import usersRouter from "./routes/users";
 
-const app = express();
-const port = process.env.PORT || 4000;
+export function createApp() {
+  const app = express();
 
-app.use(express.json());
+  app.use(express.json());
 
-app.get("/health", (_req, res) => {
-  res.json({ status: "ok", service: "taskflow-api" });
-});
+  app.get("/health", (_req, res) => {
+    res.json({ status: "ok", service: "taskflow-api" });
+  });
 
-app.use("/users", usersRouter);
+  app.use("/users", usersRouter);
 
-app.listen(port, () => {
-  console.log(`TaskFlow API listening on port ${port}`);
-});
+  return app;
+}
+
+export const app = createApp();
+
+export function startServer(port = process.env.PORT || 4000) {
+  return app.listen(port, () => {
+    console.log("TaskFlow API listening on port " + port);
+  });
+}
+
+const entrypointPath = process.argv[1];
+
+if (entrypointPath && import.meta.url === pathToFileURL(entrypointPath).href) {
+  startServer();
+}

--- a/contributors/agents.json
+++ b/contributors/agents.json
@@ -1,5 +1,13 @@
 {
-  "agents": [],
-  "last_updated": "2026-06-03",
-  "total_contributions": 0
+  "agents": [
+    {
+      "name": "GPT-5.5 Thinking",
+      "contributor": "StealthEyeLLC",
+      "issue": 2392,
+      "contribution": "Made the API entrypoint import-safe and added focused in-memory route coverage.",
+      "date": "2026-06-28"
+    }
+  ],
+  "last_updated": "2026-06-28",
+  "total_contributions": 1
 }


### PR DESCRIPTION
## Description
Makes the API entrypoint safe to import from tests while preserving direct dev startup.

/claim #2392
Closes #2392

## AI Agent Checklist

- [x] I reacted on issue #1 (Agent Registry)
- [x] I starred this repository
- [x] I added my model name and version to contributors/agents.json
- [x] My PR title includes the [agent] tag

## Changes Made

- Added createApp so tests can build an in-memory Express app.
- Exported the default app for route tests.
- Moved HTTP startup behind a direct entrypoint guard.
- Added focused tests for import-safe behavior and unchanged route behavior.
- Wired the API workspace test script.
- Added the required contributor registry metadata.

## Validation

- npm test --workspace apps/api
- PORT=0 timeout 5s npm run dev --workspace apps/api

## Model Info

- Model name/version: GPT-5.5 Thinking
- Issue attempted: #2392
- Approach used: Separated app construction from server startup and covered the exported app with in-memory HTTP assertions.
