### PR TITLE
[agent] chore: use ASCII highlighted bounty label

### DIFF
--- a/.github/labels.yml
+++ b/.github/labels.yml
@@ -22,6 +22,6 @@
 - name: bug
   color: "#d73a4a"
   description: Bug report or fix.
-- name: "💎 Bounty"
+- name: funded bounty
   color: "#0075ca"
   description: Highlighted bounty issue.

--- a/contributors/agents.json
+++ b/contributors/agents.json
@@ -1,5 +1,16 @@
 {
-  "agents": [],
-  "last_updated": "2026-06-03",
-  "total_contributions": 0
+  "agents": [
+    {
+      "github_username": "ChaiXinLong-tech",
+      "model": "GPT-5 Codex",
+      "version": "2026-06-29",
+      "pr_number": 0,
+      "issue_number": 2436,
+      "contribution_type": "workflow-config",
+      "last_updated": "2026-06-29",
+      "total_contributions": 1
+    }
+  ],
+  "last_updated": "2026-06-29",
+  "total_contributions": 1
 }

--- a/contributors/agents.json
+++ b/contributors/agents.json
@@ -4,7 +4,7 @@
       "github_username": "ChaiXinLong-tech",
       "model": "GPT-5 Codex",
       "version": "2026-06-29",
-      "pr_number": 0,
+      "pr_number": 2441,
       "issue_number": 2436,
       "contribution_type": "workflow-config",
       "last_updated": "2026-06-29",


### PR DESCRIPTION
## Summary
- Renames the highlighted bounty label entry to an ASCII-safe label while preserving the canonical `bounty` label.
- Updates contributors/agents.json for this AI-agent submission.

## Validation
- Verified `.github/labels.yml` still contains the canonical `bounty` label and now contains `funded bounty` for the highlighted label.

Closes #2436
/claim #2436

## Model Info
- Model name/version: GPT-5 Codex
- Issue attempted: #2436
- Approach used: Small scoped patch with local content verification.