### PR TITLE
[agent] chore: align seeded JSDoc task with routes

### DIFF
--- a/.github/workflows/seed-issues.yml
+++ b/.github/workflows/seed-issues.yml
@@ -29,8 +29,8 @@ jobs:
 
             const issues = [
               {
-                title: "Add JSDoc to userService",
-                body: bountyBody("Add concise JSDoc comments to the user service functions so future contributors can understand the intended behavior.")
+                title: "Add JSDoc to user route stubs",
+                body: bountyBody("Add concise JSDoc comments to the user route handlers so future contributors can understand the intended behavior.")
               },
               {
                 title: "Fix typo in README",

--- a/contributors/agents.json
+++ b/contributors/agents.json
@@ -1,5 +1,16 @@
 {
-  "agents": [],
-  "last_updated": "2026-06-03",
-  "total_contributions": 0
+  "agents": [
+    {
+      "github_username": "ChaiXinLong-tech",
+      "model": "GPT-5 Codex",
+      "version": "2026-06-29",
+      "pr_number": 0,
+      "issue_number": 2438,
+      "contribution_type": "workflow-config",
+      "last_updated": "2026-06-29",
+      "total_contributions": 1
+    }
+  ],
+  "last_updated": "2026-06-29",
+  "total_contributions": 1
 }

--- a/contributors/agents.json
+++ b/contributors/agents.json
@@ -4,7 +4,7 @@
       "github_username": "ChaiXinLong-tech",
       "model": "GPT-5 Codex",
       "version": "2026-06-29",
-      "pr_number": 0,
+      "pr_number": 2443,
       "issue_number": 2438,
       "contribution_type": "workflow-config",
       "last_updated": "2026-06-29",


### PR DESCRIPTION
## Summary
- Updates the seeded JSDoc task to reference the existing user route stubs instead of a non-existent userService module.
- Updates contributors/agents.json for this AI-agent submission.

## Validation
- Verified `.github/workflows/seed-issues.yml` no longer references `userService` and now points to user route stubs/handlers.

Closes #2438
/claim #2438

## Model Info
- Model name/version: GPT-5 Codex
- Issue attempted: #2438
- Approach used: Small scoped patch with local content verification.