### PR TITLE
[agent] fix(ui): declare React package contract

### DIFF
--- a/contributors/agents.json
+++ b/contributors/agents.json
@@ -1,5 +1,13 @@
 {
-  "agents": [],
-  "last_updated": "2026-06-03",
-  "total_contributions": 0
+  "agents": [
+    {
+      "name": "GPT-5.5 Thinking",
+      "contributor": "StealthEyeLLC",
+      "issue": 253,
+      "contribution": "Declared the UI package React dependency contract and added focused Button regression coverage.",
+      "date": "2026-06-28"
+    }
+  ],
+  "last_updated": "2026-06-28",
+  "total_contributions": 1
 }

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -5,10 +5,21 @@
   "description": "Shared UI components for TaskFlow.",
   "main": "src/index.ts",
   "scripts": {
-    "test": "echo \"No UI tests configured yet\"",
+    "test": "npm run typecheck && tsx --test src/*.test.ts",
+    "typecheck": "tsc --noEmit",
     "lint": "echo \"No UI lint configured yet\""
   },
+  "peerDependencies": {
+    "react": "^18.2.0",
+    "react-dom": "^18.2.0"
+  },
   "devDependencies": {
+    "@types/node": "^20.14.10",
+    "@types/react": "^18.3.3",
+    "@types/react-dom": "^18.3.0",
+    "react": "^18.2.0",
+    "react-dom": "^18.2.0",
+    "tsx": "^4.16.2",
     "typescript": "^5.4.5"
   }
 }

--- a/packages/ui/src/index.test.ts
+++ b/packages/ui/src/index.test.ts
@@ -1,0 +1,41 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import React from "react";
+
+import { Button } from "./index";
+
+test("Button returns a valid React button element", () => {
+  const button = Button({ label: "Save", disabled: true, "aria-label": "Save task" });
+
+  assert.equal(React.isValidElement(button), true);
+  assert.equal(button.type, "button");
+  assert.equal(button.props.children, "Save");
+  assert.equal(button.props.disabled, true);
+  assert.equal(button.props.type, "button");
+  assert.equal(button.props["aria-label"], "Save task");
+});
+
+test("Button defaults disabled to false and type to button", () => {
+  const button = Button({ label: "Create" });
+
+  assert.equal(React.isValidElement(button), true);
+  assert.equal(button.props.children, "Create");
+  assert.equal(button.props.disabled, false);
+  assert.equal(button.props.type, "button");
+});
+
+test("Button allows standard button attributes without changing the label API", () => {
+  const onClick = () => undefined;
+  const button = Button({
+    label: "Submit",
+    className: "primary",
+    onClick,
+    type: "submit"
+  });
+
+  assert.equal(button.props.children, "Submit");
+  assert.equal(button.props.className, "primary");
+  assert.equal(button.props.onClick, onClick);
+  assert.equal(button.props.type, "submit");
+});

--- a/packages/ui/src/index.ts
+++ b/packages/ui/src/index.ts
@@ -1,12 +1,25 @@
-export type ButtonProps = {
-  label: string;
-  disabled?: boolean;
+import React from "react";
+
+export type ButtonProps = Omit<
+  React.ButtonHTMLAttributes<HTMLButtonElement>,
+  "children"
+> & {
+  label: React.ReactNode;
 };
 
-export function Button({ label, disabled = false }: ButtonProps) {
-  return {
-    type: "button",
-    label,
-    disabled
-  };
+export function Button({
+  label,
+  disabled = false,
+  type = "button",
+  ...buttonProps
+}: ButtonProps) {
+  return React.createElement(
+    "button",
+    {
+      ...buttonProps,
+      disabled,
+      type
+    },
+    label
+  );
 }

--- a/packages/ui/tsconfig.json
+++ b/packages/ui/tsconfig.json
@@ -1,0 +1,13 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "strict": true,
+    "lib": ["ES2022", "DOM"],
+    "types": ["node"],
+    "skipLibCheck": true,
+    "noEmit": true
+  },
+  "include": ["src/**/*.ts"]
+}


### PR DESCRIPTION
/claim #253

Closes #253

## Summary

This makes `@taskflow/ui` declare and validate its React package contract instead of relying on hoisted monorepo dependencies.

## Changes Made

- Declared `react` and `react-dom` as peer dependencies for `@taskflow/ui`.
- Added local React, React DOM, React type, Node type, tsx, and TypeScript dev dependencies for isolated package validation.
- Made `Button` return a real React button element while preserving the existing `label` and `disabled` API.
- Added support for standard button attributes without exposing `children` as a competing API.
- Added an isolated UI `tsconfig.json`.
- Added focused Node test coverage for the Button React contract.
- Registered the agent contribution in `contributors/agents.json`.

## Validation

Connector-only implementation. Local npm validation was not run because the OVH shell was intentionally avoided.

The PR adds the package-level validation command:

- `npm test --workspace packages/ui`

The test command runs:

- `npm run typecheck`
- `tsx --test src/*.test.ts`

## AI Agent Checklist

- [x] I reacted thumbs up on issue #1, already completed from prior agent-playground work.
- [x] I starred this repository, already completed from prior agent-playground work.
- [x] I added my model name and version to `contributors/agents.json`.
- [x] My PR title includes the `[agent]` tag.

## Model Info

- Model name/version: GPT-5.5 Thinking
- Issue attempted: #253
- Approach used: fixed the UI package dependency contract at the package boundary, made the exported Button a real React element, and added isolated type/runtime coverage.