### PR TITLE
test: add unit tests for Express user route stubs (Closes #2394)

### DIFF
--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -7,7 +7,7 @@
   "main": "src/index.ts",
   "scripts": {
     "dev": "tsx src/index.ts",
-    "test": "echo \"No API tests configured yet\"",
+    "test": "node --import tsx --test src/routes/users.test.ts",
     "lint": "echo \"No API lint configured yet\""
   },
   "dependencies": {
@@ -15,6 +15,8 @@
   },
   "devDependencies": {
     "@types/express": "^4.17.21",
+    "@types/supertest": "^6.0.2",
+    "supertest": "^7.1.0",
     "tsx": "^4.7.1",
     "typescript": "^5.4.5"
   }

--- a/apps/api/src/routes/users.test.ts
+++ b/apps/api/src/routes/users.test.ts
@@ -1,0 +1,38 @@
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+import express from "express";
+import request from "supertest";
+import usersRouter from "./users";
+
+describe("Users API Routes", () => {
+  const app = express();
+  app.use(express.json());
+  app.use("/users", usersRouter);
+
+  it("GET /users returns empty data array and placeholder message", async () => {
+    const res = await request(app).get("/users").expect(200);
+
+    assert.deepStrictEqual(res.body.data, []);
+    assert.strictEqual(
+      res.body.message,
+      "User listing is not implemented yet."
+    );
+  });
+
+  it("POST /users returns 201 with stub user id and submitted fields", async () => {
+    const payload = { name: "Test User", email: "test@example.com" };
+
+    const res = await request(app)
+      .post("/users")
+      .send(payload)
+      .expect(201);
+
+    assert.strictEqual(res.body.data.id, "stub-user-id");
+    assert.strictEqual(res.body.data.name, "Test User");
+    assert.strictEqual(res.body.data.email, "test@example.com");
+    assert.strictEqual(
+      res.body.message,
+      "User creation is not implemented yet."
+    );
+  });
+});


### PR DESCRIPTION
## Summary

Adds unit tests for the Express user route stubs as specified in #2394.

## Changes

- **New**: `apps/api/src/routes/users.test.ts`
  - Tests `GET /users` returns 200 with empty data array and placeholder message
  - Tests `POST /users` returns 201 with stub user id and submitted fields
  - Uses `node:test` runner + `supertest` for in-memory testing (no real network listener)

- **Modified**: `apps/api/package.json`
  - Added `supertest` + `@types/supertest` devDependencies
  - Updated `test` script to run `node --import tsx --test`

## Acceptance Criteria

- [x] Cover `GET /users` returning an empty data array and the current placeholder message
- [x] Cover `POST /users` returning HTTP 201 with the stub user id and submitted fields
- [x] Tests mount the router in-memory and do not require opening a real network listener
- [x] Keep the change scoped to API route tests and test script wiring

Closes #2394