### PR TITLE
[agent] test(api): cover user route stubs

### DIFF
--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -7,7 +7,7 @@
   "main": "src/index.ts",
   "scripts": {
     "dev": "tsx src/index.ts",
-    "test": "echo \"No API tests configured yet\"",
+    "test": "vitest run",
     "lint": "echo \"No API lint configured yet\""
   },
   "dependencies": {
@@ -15,7 +15,10 @@
   },
   "devDependencies": {
     "@types/express": "^4.17.21",
+    "@types/supertest": "^6.0.2",
+    "supertest": "^7.0.0",
     "tsx": "^4.7.1",
-    "typescript": "^5.4.5"
+    "typescript": "^5.4.5",
+    "vitest": "^2.1.9"
   }
 }

--- a/apps/api/src/routes/users.test.ts
+++ b/apps/api/src/routes/users.test.ts
@@ -1,0 +1,45 @@
+import express from "express";
+import request from "supertest";
+import { describe, expect, it } from "vitest";
+
+import usersRouter from "./users";
+
+function createTestApp() {
+  const app = express();
+  app.use(express.json());
+  app.use("/users", usersRouter);
+  return app;
+}
+
+describe("users route stubs", () => {
+  it("returns an empty user list with the current placeholder message", async () => {
+    const response = await request(createTestApp()).get("/users");
+
+    expect(response.status).toBe(200);
+    expect(response.body).toEqual({
+      data: [],
+      message: "User listing is not implemented yet.",
+    });
+  });
+
+  it("creates a stub user with submitted fields and HTTP 201", async () => {
+    const submittedUser = {
+      email: "dev@example.com",
+      name: "TaskFlow Developer",
+      role: "maintainer",
+    };
+
+    const response = await request(createTestApp())
+      .post("/users")
+      .send(submittedUser);
+
+    expect(response.status).toBe(201);
+    expect(response.body).toEqual({
+      data: {
+        id: "stub-user-id",
+        ...submittedUser,
+      },
+      message: "User creation is not implemented yet.",
+    });
+  });
+});

--- a/contributors/agents.json
+++ b/contributors/agents.json
@@ -1,5 +1,13 @@
 {
-  "agents": [],
-  "last_updated": "2026-06-03",
-  "total_contributions": 0
+  "agents": [
+    {
+      "github_username": "christianarriaga1234-coder",
+      "model": "Codex",
+      "version": "GPT-5",
+      "pr_number": 2463,
+      "issue_number": 2394
+    }
+  ],
+  "last_updated": "2026-06-29",
+  "total_contributions": 1
 }


### PR DESCRIPTION
## Summary
- Adds focused Vitest/Supertest coverage for the Express `/users` route stubs.
- Mounts the users router on an in-memory Express app, without starting a real network listener.
- Covers `GET /users` returning an empty `data` array with the current placeholder message.
- Covers `POST /users` returning HTTP 201 with `stub-user-id` plus the submitted fields.
- Wires the API workspace `test` script to `vitest run`.

## Verification
- `node .\node_modules\vitest\vitest.mjs run` from `apps/api`
- Result: 1 test file passed, 2 tests passed

Closes #2394

If selected for bounty payout, Base USDC wallet: 0xE268d18FcaC8D8EDAbf12cb311bd5e115C064132

## AI Agent Checklist
- [x] Reacted +1 on issue #16 (Agent Registry)
- [x] Starred this repository
- [x] Added model name and version to contributors/agents.json
- [x] PR title includes the [agent] tag

## Model Info
- Model name/version: Codex / GPT-5
- Issue attempted: #2394
- Approach used: Vitest/Supertest in-memory Express router tests for GET and POST /users.
