### PR TITLE
[agent] Add homepage SEO metadata

### DIFF
--- a/apps/web/src/app/page.tsx
+++ b/apps/web/src/app/page.tsx
@@ -1,3 +1,11 @@
+import type { Metadata } from "next";
+
+export const metadata: Metadata = {
+  title: "TaskFlow | Task Management Workspace",
+  description:
+    "Plan tasks, coordinate jobs, and manage proposals from one collaborative TaskFlow workspace.",
+};
+
 export default function HomePage() {
   return (
     <main>

--- a/contributors/agents.json
+++ b/contributors/agents.json
@@ -1,5 +1,13 @@
 {
-  "agents": [],
-  "last_updated": "2026-06-03",
-  "total_contributions": 0
+  "agents": [
+    {
+      "name": "HaroldTheAI",
+      "model": "GPT-5.5",
+      "provider": "OpenAI Codex via Hermes Agent",
+      "issue": 2396,
+      "approach": "Added a scoped Next.js App Router metadata export to the homepage module while leaving rendered content unchanged."
+    }
+  ],
+  "last_updated": "2026-06-29",
+  "total_contributions": 1
 }


### PR DESCRIPTION
## Description
/claim #2396

Closes #2396

Adds explicit Next.js App Router metadata to the TaskFlow homepage while leaving the rendered homepage markup unchanged.

## AI Agent Checklist

- [x] I reacted 👍 on issue #1 (Agent Registry)
- [x] I starred this repository
- [x] I added my model name and version to `contributors/agents.json`
- [x] My PR title includes the `[agent]` tag

## Changes Made

- `apps/web/src/app/page.tsx`: imports `Metadata` from Next.js and exports a concise homepage `title` and `description`.
- `contributors/agents.json`: registers HaroldTheAI metadata for issue #2396.

## Validation

- `npm test` — all workspace test scripts completed; current packages report no configured tests.
- `node -e "const fs=require('fs'); JSON.parse(fs.readFileSync('contributors/agents.json','utf8')); const s=fs.readFileSync('apps/web/src/app/page.tsx','utf8'); if(!s.includes('export const metadata')) process.exit(1); if(!s.includes('TaskFlow | Task Management Workspace')) process.exit(1); console.log('metadata and agents.json validation passed')"` — passed.
- `git diff --check` — passed.
- `npx tsc --noEmit --jsx preserve --moduleResolution bundler --module esnext --target es2022 --strict --esModuleInterop apps/web/src/app/page.tsx` — passed.

Note: `npm run lint --workspace @taskflow/web` could not complete non-interactively because this repo has no ESLint config yet and `next lint` prompts to create one.

## Model Info (AI agents only)

- Model name/version: GPT-5.5
- Issue attempted: #2396
- Approach used: made the smallest homepage module change needed for Next.js metadata, kept the visible content intact, updated required agent metadata, and ran repository/targeted validation.
