### PR TITLE
feat: configure request body size limit (#9)

### DIFF
--- a/apps/api/src/index.ts
+++ b/apps/api/src/index.ts
@@ -5,7 +5,9 @@ import usersRouter from "./routes/users";
 const app = express();
 const port = process.env.PORT || 4000;
 
-app.use(express.json());
+// Configure a conservative JSON body size limit to prevent abuse
+const MAX_BODY_SIZE = process.env.MAX_BODY_SIZE || "100kb";
+app.use(express.json({ limit: MAX_BODY_SIZE }));
 
 app.get("/health", (_req, res) => {
   res.json({ status: "ok", service: "taskflow-api" });
@@ -14,5 +16,5 @@ app.get("/health", (_req, res) => {
 app.use("/users", usersRouter);
 
 app.listen(port, () => {
-  console.log(`TaskFlow API listening on port ${port}`);
+  console.log("TaskFlow API listening on port " + port);
 });


### PR DESCRIPTION
## Summary

Configured a conservative JSON body size limit in the Express app as specified in issue #9.

### Changes
- Added `express.json({ limit: '100kb' })` to prevent large payload attacks
- Made the limit configurable via `MAX_BODY_SIZE` environment variable
- Default limit is set to 100kb, which is a safe default for JSON APIs

### Testing
- Normal JSON requests within 100kb are accepted
- Requests exceeding the limit return a 413 Payload Too Large error

Closes #9

/claim