### PR TITLE
docs: document expected environment variables (#4)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,21 @@
+# TaskFlow Environment Variables
+# Copy this file to .env and fill in your values
+
+# === Database ===
+# PostgreSQL connection string (required)
+DATABASE_URL=postgresql://user:password@localhost:5432/taskflow
+
+# === API Server ===
+# Port the Express API server listens on (default: 4000)
+PORT=4000
+
+# Maximum JSON request body size (default: 100kb)
+MAX_BODY_SIZE=100kb
+
+# === Web App ===
+# URL where the Next.js web app is served (default: http://localhost:3000)
+NEXT_PUBLIC_API_URL=http://localhost:4000
+
+# === Authentication (optional) ===
+# JWT secret for signing tokens (required for production)
+# JWT_SECRET=your-secret-here


### PR DESCRIPTION
## Summary

Added a `.env.example` file documenting expected local environment variables for the web and API apps, as requested in issue #4.

### Changes
- Created `.env.example` with all expected environment variables
- Documented `DATABASE_URL`, `PORT`, `MAX_BODY_SIZE`, `NEXT_PUBLIC_API_URL`
- Added descriptions and default values for each variable
- Included setup instructions for copying to `.env`

Closes #4

/claim