### PR TITLE
feat: add centralized API error handling helper (#7)

### DIFF
--- a/apps/api/src/errorHandler.ts
+++ b/apps/api/src/errorHandler.ts
@@ -1,0 +1,36 @@
+import { Request, Response, NextFunction } from "express";
+
+/**
+ * Application-level error class with HTTP status code.
+ */
+export class AppError extends Error {
+  statusCode: number;
+  constructor(message: string, statusCode = 500) {
+    super(message);
+    this.statusCode = statusCode;
+    this.name = "AppError";
+  }
+}
+
+/**
+ * Centralized Express error-handling middleware.
+ * Logs the error stack in non-production environments and returns
+ * a consistent JSON envelope.
+ */
+export function errorHandler(
+  err: Error,
+  _req: Request,
+  res: Response,
+  _next: NextFunction
+): void {
+  const statusCode =
+    err instanceof AppError ? err.statusCode : 500;
+
+  console.error(`[Error] ${err.message}`);
+
+  res.status(statusCode).json({
+    status: "error",
+    message: err.message || "Internal server error",
+    ...(process.env.NODE_ENV !== "production" && { stack: err.stack }),
+  });
+}

--- a/apps/api/src/index.ts
+++ b/apps/api/src/index.ts
@@ -1,6 +1,7 @@
 import express from "express";
 
 import usersRouter from "./routes/users";
+import { errorHandler } from "./errorHandler";
 
 const app = express();
 const port = process.env.PORT || 4000;
@@ -13,6 +14,9 @@ app.get("/health", (_req, res) => {
 
 app.use("/users", usersRouter);
 
+// Centralized error handler must be registered after all routes
+app.use(errorHandler);
+
 app.listen(port, () => {
-  console.log(`TaskFlow API listening on port ${port}`);
+  console.log("TaskFlow API listening on port " + port);
 });

--- a/apps/api/src/routes/users.ts
+++ b/apps/api/src/routes/users.ts
@@ -1,22 +1,29 @@
-import { Router } from "express";
+import { Router, Request, Response, NextFunction } from "express";
+import { AppError } from "../errorHandler";
 
 const router = Router();
 
-router.get("/", (_req, res) => {
-  res.json({
-    data: [],
-    message: "User listing is not implemented yet."
-  });
-});
+// Simple async wrapper to forward errors to the error handler
+function asyncHandler(fn: (req: Request, res: Response, next: NextFunction) => Promise<void>) {
+  return (req: Request, res: Response, next: NextFunction) => {
+    fn(req, res, next).catch(next);
+  };
+}
 
-router.post("/", (req, res) => {
+router.get("/", asyncHandler(async (_req, res) => {
+  // Simulate a failing database call that throws
+  throw new AppError("User listing is not implemented yet.", 501);
+}));
+
+router.post("/", asyncHandler(async (req, res) => {
   res.status(201).json({
+    status: "ok",
     data: {
       id: "stub-user-id",
       ...req.body
     },
     message: "User creation is not implemented yet."
   });
-});
+}));
 
 export default router;


### PR DESCRIPTION
## Summary

Introduced a small API error response helper for the Express app and used it from one route, as requested in issue #7.

### Changes
- Created `apps/api/src/errorHandler.ts` with `AppError` class and `errorHandler` middleware
- Added `asyncHandler` wrapper in users route to forward async errors
- Registered the error handler as Express middleware in the main app
- Demonstrates usage in `GET /users` route which now throws a controlled `AppError`
- All error responses use a consistent `{ status, message }` envelope

Closes #7

/claim