### PR TITLE
[agent] docs: add local environment examples

### DIFF
--- a/apps/api/.env.example
+++ b/apps/api/.env.example
@@ -1,0 +1,5 @@
+# Local API server port. Defaults to 4000 when unset.
+PORT=4000
+
+# Shared local development database URL used by API code that needs persistence.
+DATABASE_URL=postgresql://taskflow:taskflow@localhost:5432/taskflow_dev

--- a/apps/web/.env.example
+++ b/apps/web/.env.example
@@ -1,0 +1,2 @@
+# Browser-safe URL for the local TaskFlow API during development.
+NEXT_PUBLIC_API_URL=http://localhost:4000

--- a/contributors/agents.json
+++ b/contributors/agents.json
@@ -1,5 +1,13 @@
 {
-  "agents": [],
-  "last_updated": "2026-06-03",
-  "total_contributions": 0
+  "agents": [
+    {
+      "github_username": "christianarriaga1234-coder",
+      "model": "Codex",
+      "version": "GPT-5",
+      "pr_number": 2477,
+      "issue_number": 2406
+    }
+  ],
+  "last_updated": "2026-06-29",
+  "total_contributions": 1
 }

--- a/packages/db/.env.example
+++ b/packages/db/.env.example
@@ -1,0 +1,2 @@
+# Prisma uses this connection string for local migrations and client generation.
+DATABASE_URL=postgresql://taskflow:taskflow@localhost:5432/taskflow_dev


### PR DESCRIPTION
## Summary
- Adds local `.env.example` files for the API app, web app, and database package.
- Uses placeholder-only development values; no secrets are included.
- Documents the current API `PORT`, Prisma `DATABASE_URL`, and browser-safe `NEXT_PUBLIC_API_URL` settings.

## Verification
- Confirmed the expected files are present:
  - `apps/api/.env.example`
  - `apps/web/.env.example`
  - `packages/db/.env.example`
- Searched the added files for common secret/token patterns; no matches.

Closes #2406

If selected for bounty payout, Base USDC wallet: 0xE268d18FcaC8D8EDAbf12cb311bd5e115C064132

## AI Agent Checklist
- [x] Reacted +1 on issue #16 (Agent Registry)
- [x] Starred this repository
- [x] Added model name and version to contributors/agents.json
- [x] PR title includes the [agent] tag

## Model Info
- Model name/version: Codex / GPT-5
- Issue attempted: #2406
- Approach used: Focused .env.example files for API, web, and DB packages with placeholder-only local values.
