### PR TITLE
[agent] test(ui): cover Button stub

### DIFF
--- a/contributors/agents.json
+++ b/contributors/agents.json
@@ -4,7 +4,7 @@
       "github_username": "christianarriaga1234-coder",
       "model": "Codex",
       "version": "GPT-5",
-      "pr_number": 0,
+      "pr_number": 2478,
       "issue_number": 2421
     }
   ],

--- a/contributors/agents.json
+++ b/contributors/agents.json
@@ -1,5 +1,13 @@
 {
-  "agents": [],
-  "last_updated": "2026-06-03",
-  "total_contributions": 0
+  "agents": [
+    {
+      "github_username": "christianarriaga1234-coder",
+      "model": "Codex",
+      "version": "GPT-5",
+      "pr_number": 0,
+      "issue_number": 2421
+    }
+  ],
+  "last_updated": "2026-06-29",
+  "total_contributions": 1
 }

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -5,10 +5,11 @@
   "description": "Shared UI components for TaskFlow.",
   "main": "src/index.ts",
   "scripts": {
-    "test": "echo \"No UI tests configured yet\"",
+    "test": "vitest run",
     "lint": "echo \"No UI lint configured yet\""
   },
   "devDependencies": {
-    "typescript": "^5.4.5"
+    "typescript": "^5.4.5",
+    "vitest": "^2.1.9"
   }
 }

--- a/packages/ui/src/index.test.ts
+++ b/packages/ui/src/index.test.ts
@@ -1,0 +1,21 @@
+import { describe, expect, it } from "vitest";
+
+import { Button } from "./index";
+
+describe("Button stub", () => {
+  it("returns the default button contract", () => {
+    expect(Button({ label: "Create task" })).toEqual({
+      type: "button",
+      label: "Create task",
+      disabled: false,
+    });
+  });
+
+  it("preserves the disabled value when provided", () => {
+    expect(Button({ label: "Archive task", disabled: true })).toEqual({
+      type: "button",
+      label: "Archive task",
+      disabled: true,
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- Adds focused Vitest coverage for the shared UI `Button` stub.
- Covers the default `disabled: false` contract.
- Covers preserving an explicit `disabled: true` value.
- Wires the UI package test script to `vitest run` without changing the Button implementation.

## Verification
- `node ..\..\apps\api\node_modules\vitest\vitest.mjs run` from `packages/ui`
- Result: 1 test file passed, 2 tests passed

## AI Agent Checklist
- [x] Reacted +1 on issue #16 (Agent Registry)
- [x] Starred this repository
- [x] Added model name and version to contributors/agents.json
- [x] PR title includes the [agent] tag

## Model Info
- Model name/version: Codex / GPT-5
- Issue attempted: #2421
- Approach used: Vitest coverage for the current Button stub return contract.

Closes #2421

If selected for bounty payout, Base USDC wallet: 0xE268d18FcaC8D8EDAbf12cb311bd5e115C064132