### PR TITLE
[agent] docs: add Prisma model comments

### DIFF
--- a/contributors/agents.json
+++ b/contributors/agents.json
@@ -4,7 +4,7 @@
       "github_username": "christianarriaga1234-coder",
       "model": "Codex",
       "version": "GPT-5",
-      "pr_number": 0,
+      "pr_number": 2486,
       "issue_number": 2405
     }
   ],

--- a/contributors/agents.json
+++ b/contributors/agents.json
@@ -1,5 +1,13 @@
 {
-  "agents": [],
-  "last_updated": "2026-06-03",
-  "total_contributions": 0
+  "agents": [
+    {
+      "github_username": "christianarriaga1234-coder",
+      "model": "Codex",
+      "version": "GPT-5",
+      "pr_number": 0,
+      "issue_number": 2405
+    }
+  ],
+  "last_updated": "2026-06-29",
+  "total_contributions": 1
 }

--- a/packages/db/prisma/schema.prisma
+++ b/packages/db/prisma/schema.prisma
@@ -7,6 +7,7 @@ datasource db {
   url      = env("DATABASE_URL")
 }
 
+/// TaskFlow account that owns jobs and submits proposals.
 model User {
   id        String     @id @default(cuid())
   email     String     @unique
@@ -17,6 +18,7 @@ model User {
   updatedAt DateTime   @updatedAt
 }
 
+/// Client-owned work listing that receives freelancer proposals.
 model Job {
   id          String     @id @default(cuid())
   title       String
@@ -29,6 +31,7 @@ model Job {
   updatedAt   DateTime   @updatedAt
 }
 
+/// Freelancer offer submitted by a user for a specific job.
 model Proposal {
   id        String   @id @default(cuid())
   summary   String


### PR DESCRIPTION
## Summary
- add concise domain comments for the User, Job, and Proposal Prisma models
- leave all model fields, defaults, and relations unchanged
- register this AI agent contribution

## Verification
- git diff --check
- pnpm dlx prisma@5.13.0 validate --schema packages/db/prisma/schema.prisma with DATABASE_URL=postgresql://user:pass@localhost:5432/taskflow

Agent: Codex GPT-5
Wallet: 0xE268d18FcaC8D8EDAbf12cb311bd5e115C064132

Closes #2405