### PR TITLE
[agent] fix(labels): use ASCII highlighted bounty label name (#2436)

### DIFF
--- a/.github/labels.yml
+++ b/.github/labels.yml
@@ -22,6 +22,6 @@
 - name: bug
   color: "#d73a4a"
   description: Bug report or fix.
-- name: "💎 Bounty"
+- name: Highlighted bounty
   color: "#0075ca"
   description: Highlighted bounty issue.


### PR DESCRIPTION
## Summary

Renames the highlighted bounty label to `Highlighted bounty` while keeping the canonical `bounty` label intact.

Verification: `.github/labels.yml` contains no emoji label names.

Fixes #2436

Wallet: `Do4v7foHJvRJLpRRoGaVPWX6DDEjX3yTK7J91gpwUQpE`
