### PR TITLE
[agent] fix(ci): use ASCII dash in seeded meta issue title (#2437)

### DIFF
--- a/.github/workflows/seed-meta-issue.yml
+++ b/.github/workflows/seed-meta-issue.yml
@@ -38,7 +38,7 @@ jobs:
             const createdIssue = await github.rest.issues.create({
               owner: context.repo.owner,
               repo: context.repo.repo,
-              title: "Bug Bounty Program — How to Participate",
+              title: "Bug Bounty Program - How to Participate",
               body: bodyForIssue("[NUMBER]"),
               labels: ["bounty", "good first issue", "AI agent friendly"]
             });


### PR DESCRIPTION
## Summary

Replaces the Unicode em dash in the seeded meta issue title with a hyphen.

Verification: title is `Bug Bounty Program - How to Participate`.

Fixes #2437

Wallet: `Do4v7foHJvRJLpRRoGaVPWX6DDEjX3yTK7J91gpwUQpE`
