### PR TITLE
[agent] fix(ci): align seeded JSDoc task with user route stubs (#2438)

### DIFF
--- a/.github/workflows/seed-issues.yml
+++ b/.github/workflows/seed-issues.yml
@@ -29,8 +29,8 @@ jobs:
 
             const issues = [
               {
-                title: "Add JSDoc to userService",
-                body: bountyBody("Add concise JSDoc comments to the user service functions so future contributors can understand the intended behavior.")
+                title: "Add JSDoc to user route stubs",
+                body: bountyBody("Add concise JSDoc comments to the Express user route stubs in apps/api/src/routes/users.ts so future contributors can understand the intended behavior.")
               },
               {
                 title: "Fix typo in README",


### PR DESCRIPTION
## Summary

Updates the first seeded issue to reference the existing Express user route stubs instead of a missing `userService` module.

Verification: seeded title is `Add JSDoc to user route stubs`.

Fixes #2438

Wallet: `Do4v7foHJvRJLpRRoGaVPWX6DDEjX3yTK7J91gpwUQpE`
