### PR TITLE
[agent] test(web): add homepage copy regression test (#2419)

### DIFF
--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -5,7 +5,7 @@
   "description": "Next.js web application for TaskFlow.",
   "scripts": {
     "dev": "next dev",
-    "test": "echo \"No web tests configured yet\"",
+    "test": "node --import tsx --test src/**/*.test.tsx",
     "lint": "next lint"
   },
   "dependencies": {
@@ -17,6 +17,7 @@
     "@types/node": "^20.12.7",
     "@types/react": "^18.3.1",
     "@types/react-dom": "^18.3.0",
+    "tsx": "^4.7.1",
     "typescript": "^5.4.5"
   }
 }

--- a/apps/web/src/app/page.test.tsx
+++ b/apps/web/src/app/page.test.tsx
@@ -1,0 +1,16 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { createElement } from "react";
+import { renderToStaticMarkup } from "react-dom/server";
+
+import HomePage from "./page";
+
+test("homepage renders TaskFlow heading and supporting copy", () => {
+  const html = renderToStaticMarkup(createElement(HomePage));
+
+  assert.match(html, /<h1>TaskFlow<\/h1>/);
+  assert.match(
+    html,
+    /Plan tasks, coordinate jobs, and manage proposals from one workspace\./,
+  );
+});

--- a/apps/web/tsconfig.json
+++ b/apps/web/tsconfig.json
@@ -1,0 +1,5 @@
+{
+  "compilerOptions": {
+    "jsx": "react-jsx"
+  }
+}


### PR DESCRIPTION
## Summary

Adds a lightweight test for the TaskFlow heading and supporting copy.

Verification:
```bash
cd apps/web && npm test
```

Fixes #2419

Wallet: `Do4v7foHJvRJLpRRoGaVPWX6DDEjX3yTK7J91gpwUQpE`
