### PR TITLE
[agent] fix(api): validate POST /users request payloads (#2403)

### DIFF
--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -7,7 +7,7 @@
   "main": "src/index.ts",
   "scripts": {
     "dev": "tsx src/index.ts",
-    "test": "echo \"No API tests configured yet\"",
+    "test": "node --import tsx --test src/**/*.test.ts",
     "lint": "echo \"No API lint configured yet\""
   },
   "dependencies": {
@@ -15,6 +15,8 @@
   },
   "devDependencies": {
     "@types/express": "^4.17.21",
+    "@types/supertest": "^6.0.2",
+    "supertest": "^7.0.0",
     "tsx": "^4.7.1",
     "typescript": "^5.4.5"
   }

--- a/apps/api/src/routes/users.test.ts
+++ b/apps/api/src/routes/users.test.ts
@@ -1,0 +1,37 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import request from "supertest";
+import express from "express";
+
+import usersRouter from "./users";
+
+function createUsersApp() {
+  const app = express();
+  app.use(express.json());
+  app.use("/users", usersRouter);
+  return app;
+}
+
+test("POST /users rejects missing or empty JSON bodies", async () => {
+  const app = createUsersApp();
+
+  const emptyObject = await request(app).post("/users").send({});
+  assert.equal(emptyObject.status, 400);
+  assert.equal(emptyObject.body.error, "Request body must be a non-empty JSON object.");
+
+  const arrayBody = await request(app).post("/users").send(["not-an-object"]);
+  assert.equal(arrayBody.status, 400);
+
+  const stringBody = await request(app).post("/users").send("not-json-object");
+  assert.equal(stringBody.status, 400);
+});
+
+test("POST /users preserves stub response for valid payloads", async () => {
+  const response = await request(createUsersApp())
+    .post("/users")
+    .send({ email: "ada@example.com", name: "Ada" });
+
+  assert.equal(response.status, 201);
+  assert.equal(response.body.data.id, "stub-user-id");
+  assert.equal(response.body.data.email, "ada@example.com");
+});

--- a/apps/api/src/routes/users.ts
+++ b/apps/api/src/routes/users.ts
@@ -2,6 +2,10 @@ import { Router } from "express";
 
 const router = Router();
 
+function isPlainObject(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
 router.get("/", (_req, res) => {
   res.json({
     data: [],
@@ -10,6 +14,12 @@ router.get("/", (_req, res) => {
 });
 
 router.post("/", (req, res) => {
+  if (!isPlainObject(req.body) || Object.keys(req.body).length === 0) {
+    return res.status(400).json({
+      error: "Request body must be a non-empty JSON object."
+    });
+  }
+
   res.status(201).json({
     data: {
       id: "stub-user-id",


### PR DESCRIPTION
## Summary

Rejects missing or empty JSON bodies with a clear 400 response while preserving the stub success shape.

Verification:
```bash
cd apps/api && npm test
```

Fixes #2403

Wallet: `Do4v7foHJvRJLpRRoGaVPWX6DDEjX3yTK7J91gpwUQpE`
