### PR TITLE
[agent] feat(web): add homepage SEO metadata (#2396)

### DIFF
--- a/apps/web/src/app/page.tsx
+++ b/apps/web/src/app/page.tsx
@@ -1,3 +1,10 @@
+import type { Metadata } from "next";
+
+export const metadata: Metadata = {
+  title: "TaskFlow — Task and proposal workspace",
+  description: "Plan tasks, coordinate jobs, and manage proposals from one workspace.",
+};
+
 export default function HomePage() {
   return (
     <main>


### PR DESCRIPTION
## Summary

Exports Next.js metadata with a meaningful title and description while leaving visible content unchanged.

Verification: `apps/web/src/app/page.tsx` exports `metadata`.

Fixes #2396

Wallet: `Do4v7foHJvRJLpRRoGaVPWX6DDEjX3yTK7J91gpwUQpE`
