### PR TITLE
[agent] test(api): add Express user route stub tests (#2394)

### DIFF
--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -7,7 +7,7 @@
   "main": "src/index.ts",
   "scripts": {
     "dev": "tsx src/index.ts",
-    "test": "echo \"No API tests configured yet\"",
+    "test": "node --import tsx --test src/**/*.test.ts",
     "lint": "echo \"No API lint configured yet\""
   },
   "dependencies": {
@@ -15,6 +15,8 @@
   },
   "devDependencies": {
     "@types/express": "^4.17.21",
+    "@types/supertest": "^6.0.2",
+    "supertest": "^7.0.0",
     "tsx": "^4.7.1",
     "typescript": "^5.4.5"
   }

--- a/apps/api/src/routes/users.test.ts
+++ b/apps/api/src/routes/users.test.ts
@@ -1,0 +1,32 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import request from "supertest";
+import express from "express";
+
+import usersRouter from "./users";
+
+function createUsersApp() {
+  const app = express();
+  app.use(express.json());
+  app.use("/users", usersRouter);
+  return app;
+}
+
+test("GET /users returns empty data and placeholder message", async () => {
+  const response = await request(createUsersApp()).get("/users");
+
+  assert.equal(response.status, 200);
+  assert.deepEqual(response.body.data, []);
+  assert.equal(response.body.message, "User listing is not implemented yet.");
+});
+
+test("POST /users returns 201 with stub user id and submitted fields", async () => {
+  const payload = { email: "ada@example.com", name: "Ada" };
+  const response = await request(createUsersApp()).post("/users").send(payload);
+
+  assert.equal(response.status, 201);
+  assert.equal(response.body.data.id, "stub-user-id");
+  assert.equal(response.body.data.email, payload.email);
+  assert.equal(response.body.data.name, payload.name);
+  assert.equal(response.body.message, "User creation is not implemented yet.");
+});


### PR DESCRIPTION
## Summary

Covers GET /users empty list placeholder and POST /users stub create response using in-memory router tests.

Verification:
```bash
cd apps/api && npm test
```

Fixes #2394

Wallet: `Do4v7foHJvRJLpRRoGaVPWX6DDEjX3yTK7J91gpwUQpE`
