### PR TITLE
[agent] fix(api): export import-safe Express app for route tests (#2392)

### DIFF
--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -7,7 +7,7 @@
   "main": "src/index.ts",
   "scripts": {
     "dev": "tsx src/index.ts",
-    "test": "echo \"No API tests configured yet\"",
+    "test": "node --import tsx --test src/**/*.test.ts",
     "lint": "echo \"No API lint configured yet\""
   },
   "dependencies": {

--- a/apps/api/src/app.test.ts
+++ b/apps/api/src/app.test.ts
@@ -1,0 +1,10 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { createApp } from "./app";
+
+test("createApp can be imported without binding a port", () => {
+  const app = createApp();
+  assert.ok(app);
+  assert.equal(typeof app.listen, "function");
+});

--- a/apps/api/src/app.ts
+++ b/apps/api/src/app.ts
@@ -1,0 +1,17 @@
+import express from "express";
+
+import usersRouter from "./routes/users";
+
+export function createApp() {
+  const app = express();
+
+  app.use(express.json());
+
+  app.get("/health", (_req, res) => {
+    res.json({ status: "ok", service: "taskflow-api" });
+  });
+
+  app.use("/users", usersRouter);
+
+  return app;
+}

--- a/apps/api/src/index.ts
+++ b/apps/api/src/index.ts
@@ -1,17 +1,7 @@
-import express from "express";
+import { createApp } from "./app";
 
-import usersRouter from "./routes/users";
-
-const app = express();
+const app = createApp();
 const port = process.env.PORT || 4000;
-
-app.use(express.json());
-
-app.get("/health", (_req, res) => {
-  res.json({ status: "ok", service: "taskflow-api" });
-});
-
-app.use("/users", usersRouter);
 
 app.listen(port, () => {
   console.log(`TaskFlow API listening on port ${port}`);


### PR DESCRIPTION
## Summary

Splits app construction from server startup so tests can import the app without binding a port.

Verification:
```bash
cd apps/api && npm test
```

Fixes #2392

Wallet: `Do4v7foHJvRJLpRRoGaVPWX6DDEjX3yTK7J91gpwUQpE`
