### PR TITLE
[agent] test(web): cover homepage copy

### DIFF
--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -5,7 +5,7 @@
   "description": "Next.js web application for TaskFlow.",
   "scripts": {
     "dev": "next dev",
-    "test": "echo \"No web tests configured yet\"",
+    "test": "vitest run",
     "lint": "next lint"
   },
   "dependencies": {
@@ -17,6 +17,7 @@
     "@types/node": "^20.12.7",
     "@types/react": "^18.3.1",
     "@types/react-dom": "^18.3.0",
-    "typescript": "^5.4.5"
+    "typescript": "^5.4.5",
+    "vitest": "^1.5.0"
   }
 }

--- a/apps/web/src/app/page.test.tsx
+++ b/apps/web/src/app/page.test.tsx
@@ -1,0 +1,15 @@
+import { renderToStaticMarkup } from "react-dom/server";
+import { describe, expect, it } from "vitest";
+
+import HomePage from "./page";
+
+describe("HomePage", () => {
+  it("renders the TaskFlow heading and supporting copy", () => {
+    const html = renderToStaticMarkup(<HomePage />);
+
+    expect(html).toContain("<h1>TaskFlow</h1>");
+    expect(html).toContain(
+      "Plan tasks, coordinate jobs, and manage proposals from one workspace.",
+    );
+  });
+});

--- a/apps/web/vitest.config.ts
+++ b/apps/web/vitest.config.ts
@@ -1,0 +1,10 @@
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+  esbuild: {
+    jsx: "automatic",
+  },
+  test: {
+    include: ["src/**/*.test.{ts,tsx}"],
+  },
+});

--- a/contributors/agents.json
+++ b/contributors/agents.json
@@ -1,5 +1,13 @@
 {
-  "agents": [],
-  "last_updated": "2026-06-03",
-  "total_contributions": 0
+  "agents": [
+    {
+      "github_username": "christianarriaga1234-coder",
+      "model": "Codex",
+      "version": "GPT-5",
+      "pr_number": 0,
+      "issue_number": 2419
+    }
+  ],
+  "last_updated": "2026-06-29",
+  "total_contributions": 1
 }

--- a/contributors/agents.json
+++ b/contributors/agents.json
@@ -4,7 +4,7 @@
       "github_username": "christianarriaga1234-coder",
       "model": "Codex",
       "version": "GPT-5",
-      "pr_number": 0,
+      "pr_number": 2506,
       "issue_number": 2419
     }
   ],


### PR DESCRIPTION
## Summary
- add a focused Vitest regression test for the homepage heading and supporting copy
- configure Vitest for React automatic JSX in the web package
- keep homepage content and layout unchanged
- register this AI agent contribution

## Verification
- git diff --check
- apps/web/node_modules/.bin/vitest.cmd run

Note: `pnpm --dir apps/web test` was attempted locally, but this environment blocks pnpm dependency build scripts with `ERR_PNPM_IGNORED_BUILDS` for esbuild. The underlying Vitest command passed after dependencies were installed.

Agent: Codex GPT-5
Wallet: 0xE268d18FcaC8D8EDAbf12cb311bd5e115C064132

Closes #2419