### PR TITLE
[agent] ci: allow label workflow to read contents

### DIFF
--- a/.github/workflows/create-labels.yml
+++ b/.github/workflows/create-labels.yml
@@ -4,6 +4,7 @@ on:
   workflow_dispatch:
 
 permissions:
+  contents: read
   issues: write
 
 jobs:

--- a/contributors/agents.json
+++ b/contributors/agents.json
@@ -4,7 +4,7 @@
       "github_username": "ChaiXinLong-tech",
       "model": "GPT-5 Codex",
       "version": "2026-06-29",
-      "pr_number": 0,
+      "pr_number": 2513,
       "issue_number": 2508,
       "contribution_type": "workflow-config",
       "last_updated": "2026-06-29",

--- a/contributors/agents.json
+++ b/contributors/agents.json
@@ -1,5 +1,16 @@
 {
-  "agents": [],
-  "last_updated": "2026-06-03",
-  "total_contributions": 0
+  "agents": [
+    {
+      "github_username": "ChaiXinLong-tech",
+      "model": "GPT-5 Codex",
+      "version": "2026-06-29",
+      "pr_number": 0,
+      "issue_number": 2508,
+      "contribution_type": "workflow-config",
+      "last_updated": "2026-06-29",
+      "total_contributions": 1
+    }
+  ],
+  "last_updated": "2026-06-29",
+  "total_contributions": 1
 }


### PR DESCRIPTION
## Summary
- Adds the read permission required by `actions/checkout` while keeping label write permissions intact.
- Updates contributors/agents.json for this AI-agent submission.

## Validation
- Verified `.github/workflows/create-labels.yml` declares both `contents: read` and `issues: write` under `permissions`.

Closes #2508
/claim #2508

## Model Info
- Model name/version: GPT-5 Codex
- Issue attempted: #2508
- Approach used: Small scoped patch with local content verification.