### PR TITLE
[agent] chore: add line ending attributes

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,9 @@
+* text=auto eol=lf
+
+*.png binary
+*.jpg binary
+*.jpeg binary
+*.gif binary
+*.webp binary
+*.ico binary
+*.pdf binary

--- a/contributors/agents.json
+++ b/contributors/agents.json
@@ -1,5 +1,16 @@
 {
-  "agents": [],
-  "last_updated": "2026-06-03",
-  "total_contributions": 0
+  "agents": [
+    {
+      "github_username": "ChaiXinLong-tech",
+      "model": "GPT-5 Codex",
+      "version": "2026-06-29",
+      "pr_number": 0,
+      "issue_number": 2510,
+      "contribution_type": "repo-config",
+      "last_updated": "2026-06-29",
+      "total_contributions": 1
+    }
+  ],
+  "last_updated": "2026-06-29",
+  "total_contributions": 1
 }

--- a/contributors/agents.json
+++ b/contributors/agents.json
@@ -4,7 +4,7 @@
       "github_username": "ChaiXinLong-tech",
       "model": "GPT-5 Codex",
       "version": "2026-06-29",
-      "pr_number": 0,
+      "pr_number": 2515,
       "issue_number": 2510,
       "contribution_type": "repo-config",
       "last_updated": "2026-06-29",


### PR DESCRIPTION
## Summary
- Adds repository line-ending attributes to reduce cross-platform CRLF drift.
- Updates contributors/agents.json for this AI-agent submission.

## Validation
- Verified `.gitattributes` sets text normalization to LF and marks common binary assets as binary.

Closes #2510
/claim #2510

## Model Info
- Model name/version: GPT-5 Codex
- Issue attempted: #2510
- Approach used: Small scoped patch with local content verification.