### PR TITLE
[agent] chore: add editorconfig defaults

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,12 @@
+root = true
+
+[*]
+charset = utf-8
+end_of_line = lf
+insert_final_newline = true
+indent_style = space
+indent_size = 2
+trim_trailing_whitespace = true
+
+[*.md]
+trim_trailing_whitespace = false

--- a/contributors/agents.json
+++ b/contributors/agents.json
@@ -4,7 +4,7 @@
       "github_username": "ChaiXinLong-tech",
       "model": "GPT-5 Codex",
       "version": "2026-06-29",
-      "pr_number": 0,
+      "pr_number": 2516,
       "issue_number": 2511,
       "contribution_type": "repo-config",
       "last_updated": "2026-06-29",

--- a/contributors/agents.json
+++ b/contributors/agents.json
@@ -1,5 +1,16 @@
 {
-  "agents": [],
-  "last_updated": "2026-06-03",
-  "total_contributions": 0
+  "agents": [
+    {
+      "github_username": "ChaiXinLong-tech",
+      "model": "GPT-5 Codex",
+      "version": "2026-06-29",
+      "pr_number": 0,
+      "issue_number": 2511,
+      "contribution_type": "repo-config",
+      "last_updated": "2026-06-29",
+      "total_contributions": 1
+    }
+  ],
+  "last_updated": "2026-06-29",
+  "total_contributions": 1
 }


### PR DESCRIPTION
## Summary
- Adds root editor formatting defaults for consistent contributor edits.
- Updates contributors/agents.json for this AI-agent submission.

## Validation
- Verified `.editorconfig` declares root settings, LF endings, two-space indentation, and a Markdown whitespace override.

Closes #2511
/claim #2511

## Model Info
- Model name/version: GPT-5 Codex
- Issue attempted: #2511
- Approach used: Small scoped patch with local content verification.