### PR TITLE
[agent] feat: validate user creation payloads - reject invalid input, generate server-side id (bounty #2207 - $250)

### DIFF
--- a/apps/api/src/routes/users.ts
+++ b/apps/api/src/routes/users.ts
@@ -1,21 +1,97 @@
-import { Router } from "express";
+import { Router, Request, Response } from "express";
+import { randomUUID } from "crypto";
 
 const router = Router();
 
-router.get("/", (_req, res) => {
+interface CreateUserPayload {
+  email?: unknown;
+  name?: unknown;
+  [key: string]: unknown;
+}
+
+function isValidEmail(email: string): boolean {
+  return /^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(email);
+}
+
+function normalizeEmail(email: string): string {
+  return email.trim().toLowerCase();
+}
+
+function normalizeName(name: string): string {
+  return name.trim().replace(/\s+/g, " ");
+}
+
+// GET /users - list users (stub)
+router.get("/", (_req: Request, res: Response) => {
   res.json({
     data: [],
-    message: "User listing is not implemented yet."
+    message: "User listing is not implemented yet.",
   });
 });
 
-router.post("/", (req, res) => {
+// POST /users - create user with validation
+router.post("/", (req: Request, res: Response) => {
+  const body = req.body;
+
+  // Reject non-object JSON bodies
+  if (body === null || body === undefined || typeof body !== "object" || Array.isArray(body)) {
+    res.status(400).json({
+      error: "Request body must be a JSON object",
+    });
+    return;
+  }
+
+  const payload = body as Record<string, unknown>;
+
+  // Require a valid email
+  if (payload.email === undefined || payload.email === null) {
+    res.status(400).json({
+      error: "email is required",
+    });
+    return;
+  }
+
+  if (typeof payload.email !== "string") {
+    res.status(400).json({
+      error: "email must be a string",
+    });
+    return;
+  }
+
+  const normalizedEmail = normalizeEmail(payload.email);
+
+  if (!isValidEmail(normalizedEmail)) {
+    res.status(400).json({
+      error: "email must be a valid email address",
+    });
+    return;
+  }
+
+  // Normalize name if provided
+  let normalizedName: string | undefined;
+  if (payload.name !== undefined && payload.name !== null) {
+    if (typeof payload.name !== "string") {
+      res.status(400).json({
+        error: "name must be a string",
+      });
+      return;
+    }
+    normalizedName = normalizeName(payload.name);
+  }
+
+  // Build user object - ignore client-controlled id and unrelated fields
+  const user = {
+    id: randomUUID(),
+    email: normalizedEmail,
+  };
+
+  if (normalizedName !== undefined) {
+    (user as Record<string, unknown>).name = normalizedName;
+  }
+
   res.status(201).json({
-    data: {
-      id: "stub-user-id",
-      ...req.body
-    },
-    message: "User creation is not implemented yet."
+    data: user,
+    message: "User created successfully.",
   });
 });
 


### PR DESCRIPTION
## Summary

Implements proper validation for POST /users endpoint as specified in issue #2207.

## Changes
- Reject non-object JSON bodies with 400 error
- Require a valid email field with proper validation
- Normalize email (trim, lowercase) and name (trim, collapse whitespace)
- Ignore client-controlled id field and unrelated fields
- Generate server-side UUID for each new user
- Add proper TypeScript types

Closes #2207