### PR TITLE
[agent] feat: return JSON 404 for unknown API routes (bounty #2395)

### DIFF
--- a/apps/api/src/index.ts
+++ b/apps/api/src/index.ts
@@ -13,6 +13,11 @@ app.get("/health", (_req, res) => {
 
 app.use("/users", usersRouter);
 
+// 404 handler for unknown routes
+app.use((_req, res) => {
+  res.status(404).json({ error: "Not found" });
+});
+
 app.listen(port, () => {
   console.log(`TaskFlow API listening on port ${port}`);
 });


### PR DESCRIPTION
## Summary

Unknown API routes now return a JSON 404 response instead of the default HTML.

## Changes
- Added catch-all middleware after all routes
- Returns `{ "error": "Not found" }` with 404 status

Closes #2395