### PR TITLE
[agent] fix(ci): add contents read permission to label sync workflow (#2508)

### DIFF
--- a/.github/workflows/create-labels.yml
+++ b/.github/workflows/create-labels.yml
@@ -4,6 +4,7 @@ on:
   workflow_dispatch:
 
 permissions:
+  contents: read
   issues: write
 
 jobs:


### PR DESCRIPTION
## Summary

Adds `contents: read` so checkout works with explicit workflow permissions.

Fixes #2508

Wallet: `Do4v7foHJvRJLpRRoGaVPWX6DDEjX3yTK7J91gpwUQpE`
