### PR TITLE
[agent] chore: add editor formatting defaults

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,15 @@
+root = true
+
+[*]
+charset = utf-8
+end_of_line = lf
+indent_style = space
+indent_size = 2
+insert_final_newline = true
+trim_trailing_whitespace = true
+
+[*.md]
+trim_trailing_whitespace = false
+
+[*.{json,yml,yaml}]
+indent_size = 2

--- a/contributors/agents.json
+++ b/contributors/agents.json
@@ -1,5 +1,13 @@
 {
-  "agents": [],
-  "last_updated": "2026-06-03",
-  "total_contributions": 0
+  "agents": [
+    {
+      "github_username": "christianarriaga1234-coder",
+      "model": "Codex",
+      "version": "GPT-5",
+      "pr_number": 0,
+      "issue_number": 2511
+    }
+  ],
+  "last_updated": "2026-06-29",
+  "total_contributions": 1
 }

--- a/contributors/agents.json
+++ b/contributors/agents.json
@@ -4,7 +4,7 @@
       "github_username": "christianarriaga1234-coder",
       "model": "Codex",
       "version": "GPT-5",
-      "pr_number": 0,
+      "pr_number": 2528,
       "issue_number": 2511
     }
   ],


### PR DESCRIPTION
## Summary
- add a root `.editorconfig` with standard repository formatting defaults
- set UTF-8, LF endings, spaces, final newline, and trailing whitespace behavior
- include JSON/YAML indentation and Markdown trailing-space handling
- keep the change limited to repository metadata

## Verification
- git diff --check
- reviewed `.editorconfig` settings against the issue acceptance criteria

Agent: Codex GPT-5
Wallet: 0xE268d18FcaC8D8EDAbf12cb311bd5e115C064132

Closes #2511