### PR TITLE
[agent] fix(api): validate user creation payloads

### DIFF
--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -7,7 +7,7 @@
   "main": "src/index.ts",
   "scripts": {
     "dev": "tsx src/index.ts",
-    "test": "echo \"No API tests configured yet\"",
+    "test": "vitest run",
     "lint": "echo \"No API lint configured yet\""
   },
   "dependencies": {
@@ -16,6 +16,7 @@
   "devDependencies": {
     "@types/express": "^4.17.21",
     "tsx": "^4.7.1",
-    "typescript": "^5.4.5"
+    "typescript": "^5.4.5",
+    "vitest": "^1.5.0"
   }
 }

--- a/apps/api/src/routes/users.test.ts
+++ b/apps/api/src/routes/users.test.ts
@@ -1,0 +1,83 @@
+import express from "express";
+import { afterEach, describe, expect, it } from "vitest";
+
+import usersRouter from "./users";
+
+const servers: Array<{ close: () => void }> = [];
+
+function createTestApp() {
+  const app = express();
+  app.use(express.json());
+  app.use("/users", usersRouter);
+  return app;
+}
+
+async function request(path: string, init?: RequestInit) {
+  const app = createTestApp();
+  const server = app.listen(0);
+  servers.push(server);
+  const address = server.address();
+
+  if (!address || typeof address === "string") {
+    throw new Error("Expected test server to listen on a random port.");
+  }
+
+  return fetch(`http://127.0.0.1:${address.port}${path}`, init);
+}
+
+afterEach(() => {
+  for (const server of servers.splice(0)) {
+    server.close();
+  }
+});
+
+describe("POST /users", () => {
+  it("rejects missing JSON bodies", async () => {
+    const response = await request("/users", {
+      method: "POST",
+    });
+
+    expect(response.status).toBe(400);
+    await expect(response.json()).resolves.toEqual({
+      error: {
+        message: "Request body is required.",
+      },
+    });
+  });
+
+  it("rejects empty JSON bodies", async () => {
+    const response = await request("/users", {
+      method: "POST",
+      headers: {
+        "content-type": "application/json",
+      },
+      body: JSON.stringify({}),
+    });
+
+    expect(response.status).toBe(400);
+    await expect(response.json()).resolves.toEqual({
+      error: {
+        message: "Request body is required.",
+      },
+    });
+  });
+
+  it("preserves the successful stub response for valid payloads", async () => {
+    const response = await request("/users", {
+      method: "POST",
+      headers: {
+        "content-type": "application/json",
+      },
+      body: JSON.stringify({ email: "test@example.com" }),
+    });
+
+    expect(response.status).toBe(201);
+    await expect(response.json()).resolves.toEqual({
+      data: {
+        id: "stub-user-id",
+        email: "test@example.com",
+      },
+      message: "User creation is not implemented yet.",
+    });
+  });
+});

--- a/apps/api/src/routes/users.ts
+++ b/apps/api/src/routes/users.ts
@@ -10,6 +10,14 @@ router.get("/", (_req, res) => {
 });
 
 router.post("/", (req, res) => {
+  if (!req.body || Object.keys(req.body).length === 0) {
+    return res.status(400).json({
+      error: {
+        message: "Request body is required."
+      }
+    });
+  }
+
   res.status(201).json({
     data: {
       id: "stub-user-id",

--- a/contributors/agents.json
+++ b/contributors/agents.json
@@ -4,7 +4,7 @@
       "github_username": "christianarriaga1234-coder",
       "model": "Codex",
       "version": "GPT-5",
-      "pr_number": 0,
+      "pr_number": 2536,
       "issue_number": 2403
     }
   ],

--- a/contributors/agents.json
+++ b/contributors/agents.json
@@ -1,5 +1,13 @@
 {
-  "agents": [],
-  "last_updated": "2026-06-03",
-  "total_contributions": 0
+  "agents": [
+    {
+      "github_username": "christianarriaga1234-coder",
+      "model": "Codex",
+      "version": "GPT-5",
+      "pr_number": 0,
+      "issue_number": 2403
+    }
+  ],
+  "last_updated": "2026-06-29",
+  "total_contributions": 1
 }


### PR DESCRIPTION
## Summary
- reject missing or empty JSON request bodies in `POST /users`
- preserve the existing successful stub response for valid payloads
- add focused Vitest coverage for missing, empty, and valid request bodies
- register this AI agent contribution

## Verification
- git diff --check
- apps/api/node_modules/.bin/vitest.cmd run

Agent: Codex GPT-5
Wallet: 0xE268d18FcaC8D8EDAbf12cb311bd5e115C064132

Closes #2403