### PR TITLE
[agent] feat: add API error handling helper and use from health route (bounty #7 - $50)

### DIFF
--- a/apps/api/src/index.ts
+++ b/apps/api/src/index.ts
@@ -1,4 +1,5 @@
 import express from "express";
+import { apiError } from "./utils/errors";
 
 import usersRouter from "./routes/users";
 
@@ -8,7 +9,12 @@ const port = process.env.PORT || 4000;
 app.use(express.json());
 
 app.get("/health", (_req, res) => {
-  res.json({ status: "ok", service: "taskflow-api" });
+  res.json({ status: "ok", data: { service: "taskflow-api" } });
+});
+
+// Demo: use apiError helper
+app.get("/health/error", (_req, res) => {
+  res.status(503).json(apiError(503, "Service temporarily unavailable"));
 });
 
 app.use("/users", usersRouter);

--- a/apps/api/src/utils/errors.ts
+++ b/apps/api/src/utils/errors.ts
@@ -1,0 +1,13 @@
+/**
+ * Creates a standardized API error response object.
+ * @param statusCode HTTP status code
+ * @param message Human-readable error description
+ * @returns A plain object with error, status, and message fields
+ */
+export function apiError(statusCode: number, message: string): { error: true; status: number; message: string } {
+  return {
+    error: true,
+    status: statusCode,
+    message,
+  };
+}


### PR DESCRIPTION
## Summary

Added `apiError()` helper for standardized API error responses and used it from the health endpoint.

## Changes
- Added `apps/api/src/utils/errors.ts` with `apiError(statusCode, message)` function
- Updated health endpoint to use consistent response format
- Added demo `/health/error` route using the helper

Closes #7