### PR TITLE
[agent] fix(#5): add Prisma schema model comments

### DIFF
--- a/packages/db/prisma/schema.prisma
+++ b/packages/db/prisma/schema.prisma
@@ -7,16 +7,20 @@ datasource db {
   url      = env("DATABASE_URL")
 }
 
+/// Core user entity for the TaskFlow platform.
+/// Represents both clients and freelancers; role is determined by associated Jobs/Proposals.
 model User {
   id        String     @id @default(cuid())
   email     String     @unique
   name      String?
-  jobs      Job[]
-  proposals Proposal[]
+  jobs      Job[]            /// Jobs posted by this user (client-side)
+  proposals Proposal[]       /// Proposals submitted by this user (freelancer-side)
   createdAt DateTime   @default(now())
   updatedAt DateTime   @updatedAt
 }
 
+/// A task or project posted by a client.
+/// Freelancers submit Proposals to win the Job.
 model Job {
   id          String     @id @default(cuid())
   title       String
@@ -24,11 +28,13 @@ model Job {
   status      String     @default("draft")
   ownerId     String
   owner       User       @relation(fields: [ownerId], references: [id])
-  proposals   Proposal[]
+  proposals   Proposal[]       /// Bids submitted by freelancers for this job
   createdAt   DateTime   @default(now())
   updatedAt   DateTime   @updatedAt
 }
 
+/// A freelancer's bid on a Job.
+/// Accepted proposal converts the Job to "active" status.
 model Proposal {
   id        String   @id @default(cuid())
   summary   String


### PR DESCRIPTION
## Summary

Added brief comments to Prisma schema models explaining their role in the TaskFlow domain.

## Changes

- **packages/db/prisma/schema.prisma**: Added doc comments to User, Job, and Proposal models

## Verification

- User: core entity representing both clients and freelancers
- Job: task/project posted by clients
- Proposal: freelancer's bid on a job

## Wallet (for payout)

- **USDC (Base/Polygon):** `0x683d2759cb626f536c842e8a3d943776198b8b8a`
- **PayPal:** `ahmadyusrizal89@gmail.com`

Closes #5
