### PR TITLE
[agent] fix(#14): add PI calculation using Leibniz series

### DIFF
--- a/packages/ui/src/utils/pi.ts
+++ b/packages/ui/src/utils/pi.ts
@@ -1,0 +1,31 @@
+/**
+ * PI Calculation Challenge (#14)
+ *
+ * Uses the Leibniz formula to approximate PI:
+ * PI/4 = 1 - 1/3 + 1/5 - 1/7 + 1/9 - ...
+ *
+ * The more iterations, the more accurate the result.
+ */
+
+/**
+ * Approximates PI using the Leibniz series.
+ * @param iterations - Number of terms to compute (default: 1,000,000)
+ * @returns Approximation of PI
+ */
+export function calculatePI(iterations: number = 1_000_000): number {
+  let sum = 0;
+  for (let i = 0; i < iterations; i++) {
+    const sign = i % 2 === 0 ? 1 : -1;
+    sum += sign / (2 * i + 1);
+  }
+  return sum * 4;
+}
+
+/**
+ * Returns PI with a specified number of decimal places using Leibniz.
+ * Note: Leibniz converges slowly; 10M iterations ≈ 7 decimal accuracy.
+ */
+export function piToDecimalPlaces(places: number): string {
+  const pi = calculatePI(10_000_000);
+  return pi.toFixed(places);
+}


### PR DESCRIPTION
## Summary

Added a PI calculation function using the Leibniz series with documentation of the chosen approach.

## Changes

- **packages/ui/src/utils/pi.ts**: `calculatePI()` using Leibniz formula, `piToDecimalPlaces()` helper

## Algorithm Notes

- Leibniz formula: PI/4 = 1 - 1/3 + 1/5 - 1/7 + ...
- Converges slowly: 1M iterations ≈ 4 decimal accuracy
- 10M iterations ≈ 7 decimal accuracy
- For production use, Math.PI is more appropriate

## Wallet (for payout)

- **USDC (Base/Polygon):** `0x683d2759cb626f536c842e8a3d943776198b8b8a`
- **PayPal:** `ahmadyusrizal89@gmail.com`

Closes #14
