### PR TITLE
[agent] chore(api): add TypeScript config

### DIFF
--- a/apps/api/tsconfig.json
+++ b/apps/api/tsconfig.json
@@ -1,0 +1,13 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "ESNext",
+    "moduleResolution": "Bundler",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true,
+    "noEmit": true
+  },
+  "include": ["src/**/*.ts"]
+}

--- a/contributors/agents.json
+++ b/contributors/agents.json
@@ -1,5 +1,16 @@
 {
-  "agents": [],
-  "last_updated": "2026-06-03",
-  "total_contributions": 0
+  "agents": [
+    {
+      "github_username": "ChaiXinLong-tech",
+      "model": "GPT-5 Codex",
+      "version": "2026-06-29",
+      "pr_number": 0,
+      "issue_number": 2559,
+      "contribution_type": "api-config",
+      "last_updated": "2026-06-29",
+      "total_contributions": 1
+    }
+  ],
+  "last_updated": "2026-06-29",
+  "total_contributions": 1
 }

--- a/contributors/agents.json
+++ b/contributors/agents.json
@@ -4,7 +4,7 @@
       "github_username": "ChaiXinLong-tech",
       "model": "GPT-5 Codex",
       "version": "2026-06-29",
-      "pr_number": 0,
+      "pr_number": 2565,
       "issue_number": 2559,
       "contribution_type": "api-config",
       "last_updated": "2026-06-29",


### PR DESCRIPTION
## Summary
- Adds a no-emit TypeScript config for focused API package type checking.
- Updates contributors/agents.json for this AI-agent submission.

## Validation
- Verified with repository-local `tsc --noEmit -p apps/api/tsconfig.json`; command exited 0.

Closes #2559
/claim #2559

## Model Info
- Model name/version: GPT-5 Codex
- Issue attempted: #2559
- Approach used: Small scoped patch with local verification.