### PR TITLE
[agent] chore(ui): add TypeScript config

### DIFF
--- a/contributors/agents.json
+++ b/contributors/agents.json
@@ -1,5 +1,16 @@
 {
-  "agents": [],
-  "last_updated": "2026-06-03",
-  "total_contributions": 0
+  "agents": [
+    {
+      "github_username": "ChaiXinLong-tech",
+      "model": "GPT-5 Codex",
+      "version": "2026-06-29",
+      "pr_number": 0,
+      "issue_number": 2561,
+      "contribution_type": "ui-config",
+      "last_updated": "2026-06-29",
+      "total_contributions": 1
+    }
+  ],
+  "last_updated": "2026-06-29",
+  "total_contributions": 1
 }

--- a/contributors/agents.json
+++ b/contributors/agents.json
@@ -4,7 +4,7 @@
       "github_username": "ChaiXinLong-tech",
       "model": "GPT-5 Codex",
       "version": "2026-06-29",
-      "pr_number": 0,
+      "pr_number": 2567,
       "issue_number": 2561,
       "contribution_type": "ui-config",
       "last_updated": "2026-06-29",

--- a/packages/ui/tsconfig.json
+++ b/packages/ui/tsconfig.json
@@ -1,0 +1,12 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "ESNext",
+    "moduleResolution": "Bundler",
+    "strict": true,
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true,
+    "noEmit": true
+  },
+  "include": ["src/**/*.ts"]
+}


### PR DESCRIPTION
## Summary
- Adds a no-emit TypeScript config for focused UI package type checking.
- Updates contributors/agents.json for this AI-agent submission.

## Validation
- Verified with repository-local `tsc --noEmit -p packages/ui/tsconfig.json`; command exited 0.

Closes #2561
/claim #2561

## Model Info
- Model name/version: GPT-5 Codex
- Issue attempted: #2561
- Approach used: Small scoped patch with local verification.