### PR TITLE
[agent] docs(db): document schema validation

### DIFF
--- a/contributors/agents.json
+++ b/contributors/agents.json
@@ -1,5 +1,16 @@
 {
-  "agents": [],
-  "last_updated": "2026-06-03",
-  "total_contributions": 0
+  "agents": [
+    {
+      "github_username": "ChaiXinLong-tech",
+      "model": "GPT-5 Codex",
+      "version": "2026-06-29",
+      "pr_number": 0,
+      "issue_number": 2563,
+      "contribution_type": "db-docs",
+      "last_updated": "2026-06-29",
+      "total_contributions": 1
+    }
+  ],
+  "last_updated": "2026-06-29",
+  "total_contributions": 1
 }

--- a/contributors/agents.json
+++ b/contributors/agents.json
@@ -4,7 +4,7 @@
       "github_username": "ChaiXinLong-tech",
       "model": "GPT-5 Codex",
       "version": "2026-06-29",
-      "pr_number": 0,
+      "pr_number": 2569,
       "issue_number": 2563,
       "contribution_type": "db-docs",
       "last_updated": "2026-06-29",

--- a/packages/db/README.md
+++ b/packages/db/README.md
@@ -1,0 +1,21 @@
+# TaskFlow Database Package
+
+This package owns the Prisma schema for TaskFlow.
+
+## Schema
+
+The schema is located at:
+
+```text
+packages/db/prisma/schema.prisma
+```
+
+## Validate Locally
+
+Use a local PostgreSQL-style URL when validating the schema:
+
+```bash
+DATABASE_URL=postgresql://user:pass@localhost:5432/taskflow npm exec --workspace @taskflow/db -- prisma validate --schema prisma/schema.prisma
+```
+
+Validation checks the schema shape only; it does not require connecting to a running database.


### PR DESCRIPTION
## Summary
- Adds a database package README with schema location and a validated Prisma command.
- Updates contributors/agents.json for this AI-agent submission.

## Validation
- Verified the documented workspace Prisma command with `DATABASE_URL=postgresql://user:pass@localhost:5432/taskflow npm exec --workspace @taskflow/db -- prisma validate --schema prisma/schema.prisma`; command exited 0.

Closes #2563
/claim #2563

## Model Info
- Model name/version: GPT-5 Codex
- Issue attempted: #2563
- Approach used: Small scoped patch with local verification.