### PR TITLE
[agent] docs(db): document Prisma schema validation (#2563)

### DIFF
--- a/packages/db/README.md
+++ b/packages/db/README.md
@@ -1,0 +1,30 @@
+# TaskFlow Database (`@taskflow/db`)
+
+Prisma schema and database utilities for TaskFlow.
+
+## Schema
+
+The Prisma schema lives at `prisma/schema.prisma`. It defines `User`, `Job`, and
+`Proposal` models backed by PostgreSQL via `DATABASE_URL`.
+
+## Validate locally
+
+From this package directory:
+
+```bash
+npm install
+npx prisma validate --schema=prisma/schema.prisma
+```
+
+Or, when using npm scripts from a package that adds one:
+
+```bash
+npm run validate
+```
+
+## Notes
+
+- Validation checks schema syntax and relation wiring only — it does not require
+  a live database connection.
+- Use `DATABASE_URL` when generating a client or running migrations against a
+  real Postgres instance.


### PR DESCRIPTION
## Summary

Adds `packages/db/README.md` with schema path and `npx prisma validate` command.

Verification:
```bash
cd packages/db && npx prisma validate --schema=prisma/schema.prisma
```

Fixes #2563

Wallet: `Do4v7foHJvRJLpRRoGaVPWX6DDEjX3yTK7J91gpwUQpE`
