### PR TITLE
[agent] fix(ui): add types and exports map (#923)

### DIFF
--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -4,6 +4,13 @@
   "private": true,
   "description": "Shared UI components for TaskFlow.",
   "main": "src/index.ts",
+  "types": "src/index.ts",
+  "exports": {
+    ".": {
+      "types": "./src/index.ts",
+      "default": "./src/index.ts"
+    }
+  },
   "scripts": {
     "test": "echo \"No UI tests configured yet\"",
     "lint": "echo \"No UI lint configured yet\""


### PR DESCRIPTION
## Summary

Adds `types` and `exports['.']` pointing at `src/index.ts` without changing component behavior.

Verification: inspect `packages/ui/package.json` contract fields.

Fixes #923

Wallet: `Do4v7foHJvRJLpRRoGaVPWX6DDEjX3yTK7J91gpwUQpE`
