### PR TITLE
[agent] fix(db): generate Prisma client on install (#908)

### DIFF
--- a/packages/db/package.json
+++ b/packages/db/package.json
@@ -4,6 +4,8 @@
   "private": true,
   "description": "Prisma schema and database utilities for TaskFlow.",
   "scripts": {
+    "generate": "prisma generate --schema=prisma/schema.prisma",
+    "postinstall": "npm run generate",
     "test": "echo \"No database tests configured yet\"",
     "lint": "echo \"No database lint configured yet\""
   },


### PR DESCRIPTION
## Summary

Adds `generate` and `postinstall` scripts running `prisma generate --schema=prisma/schema.prisma`.

Verification:
```bash
cd packages/db && npm install
```

Fixes #908

Wallet: `Do4v7foHJvRJLpRRoGaVPWX6DDEjX3yTK7J91gpwUQpE`
