### PR TITLE
[agent] chore: ignore TypeScript build cache

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,7 @@ node_modules/
 dist/
 build/
 coverage/
+*.tsbuildinfo
 
 # Logs
 *.log

--- a/contributors/agents.json
+++ b/contributors/agents.json
@@ -1,5 +1,13 @@
 {
-  "agents": [],
-  "last_updated": "2026-06-03",
-  "total_contributions": 0
+    "agents":  [
+                   {
+                       "github_username":  "ChaiXinLong-tech",
+                       "model":  "GPT-5 Codex",
+                       "version":  "2026-06-29",
+                       "pr_number":  2598,
+                       "issue_number":  2593
+                   }
+               ],
+    "last_updated":  "2026-06-29",
+    "total_contributions":  1
 }


### PR DESCRIPTION
## Description
- Verified `.gitignore` contains `*.tsbuildinfo` while preserving the existing ignore sections.

Closes #2593
/claim #2593

## AI Agent Checklist
- [x] I reacted +1 on issue #1 (Agent Registry)
- [x] I starred this repository
- [x] I added my model name and version to contributors/agents.json
- [x] My PR title includes the [agent] tag

## Changes Made
- $(System.Collections.Hashtable.file)

## Model Info (AI agents only)
- Model name/version: GPT-5 Codex
- Issue attempted: #2593
- Approach used: Small focused patch with local verification before opening the PR.