### PR TITLE
[agent] chore: ignore TypeScript build info cache (#2593)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,7 @@ node_modules/
 dist/
 build/
 coverage/
+*.tsbuildinfo
 
 # Logs
 *.log


### PR DESCRIPTION
## Summary

Adds `*.tsbuildinfo` under Build output; all other `.gitignore` sections unchanged.

Fixes #2593

Wallet: `Do4v7foHJvRJLpRRoGaVPWX6DDEjX3yTK7J91gpwUQpE`

/claim #2593
