### PR TITLE
[agent] docs(api): add environment example (#2606)

### DIFF
--- a/apps/api/.env.example
+++ b/apps/api/.env.example
@@ -1,0 +1,2 @@
+# API workspace environment (copy to apps/api/.env)
+PORT=4000


### PR DESCRIPTION
## Summary

Adds `apps/api/.env.example` with `PORT=4000` consumed by `src/index.ts`.

Fixes #2606

Wallet: `Do4v7foHJvRJLpRRoGaVPWX6DDEjX3yTK7J91gpwUQpE`

/claim #2606
