### PR TITLE
[agent] docs(db): add environment example (#2607)

### DIFF
--- a/packages/db/.env.example
+++ b/packages/db/.env.example
@@ -1,0 +1,2 @@
+# Database workspace environment (copy to packages/db/.env)
+DATABASE_URL=postgresql://postgres:postgres@localhost:5432/taskflow


### PR DESCRIPTION
## Summary

Adds `packages/db/.env.example` with PostgreSQL `DATABASE_URL` placeholder for Prisma.

Fixes #2607

Wallet: `Do4v7foHJvRJLpRRoGaVPWX6DDEjX3yTK7J91gpwUQpE`

/claim #2607
