### PR TITLE
Validate user creation payloads

### DIFF
--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -7,7 +7,7 @@
   "main": "src/index.ts",
   "scripts": {
     "dev": "tsx src/index.ts",
-    "test": "echo \"No API tests configured yet\"",
+    "test": "tsx --test \"src/**/*.test.ts\"",
     "lint": "echo \"No API lint configured yet\""
   },
   "dependencies": {

--- a/apps/api/src/routes/users.test.ts
+++ b/apps/api/src/routes/users.test.ts
@@ -1,0 +1,116 @@
+import assert from "node:assert/strict";
+import { after, before, describe, it } from "node:test";
+import express from "express";
+import type { Server } from "node:http";
+
+import usersRouter from "./users";
+
+type JsonBody = Record<string, unknown> | unknown[];
+
+let server: Server;
+let baseUrl: string;
+
+async function requestUsers(body: JsonBody) {
+  const response = await fetch(`${baseUrl}/users`, {
+    body: JSON.stringify(body),
+    headers: {
+      "content-type": "application/json"
+    },
+    method: "POST"
+  });
+
+  return {
+    body: await response.json(),
+    status: response.status
+  };
+}
+
+before(async () => {
+  const app = express();
+  app.use(express.json());
+  app.use("/users", usersRouter);
+
+  server = app.listen(0);
+  await new Promise<void>((resolve) => server.once("listening", resolve));
+
+  const address = server.address();
+  assert(address && typeof address === "object");
+  baseUrl = `http://127.0.0.1:${address.port}`;
+});
+
+after(async () => {
+  await new Promise<void>((resolve, reject) => {
+    server.close((error) => {
+      if (error) {
+        reject(error);
+        return;
+      }
+
+      resolve();
+    });
+  });
+});
+
+describe("POST /users", () => {
+  it("creates a user with a server-generated id and normalized email", async () => {
+    const { body, status } = await requestUsers({
+      email: "  Ada.Lovelace@EXAMPLE.COM  "
+    });
+
+    assert.equal(status, 201);
+    assert.match(body.data.id, /^[0-9a-f-]{36}$/i);
+    assert.equal(body.data.email, "ada.lovelace@example.com");
+  });
+
+  it("normalizes optional names", async () => {
+    const { body, status } = await requestUsers({
+      email: "grace@example.com",
+      name: "  Grace   Hopper  "
+    });
+
+    assert.equal(status, 201);
+    assert.equal(body.data.name, "Grace Hopper");
+  });
+
+  it("ignores client-controlled ids and unrelated fields", async () => {
+    const { body, status } = await requestUsers({
+      admin: true,
+      email: "user@example.com",
+      id: "client-id",
+      name: "User Name",
+      role: "owner"
+    });
+
+    assert.equal(status, 201);
+    assert.notEqual(body.data.id, "client-id");
+    assert.deepEqual(Object.keys(body.data).sort(), ["email", "id", "name"]);
+    assert.equal(body.data.email, "user@example.com");
+  });
+
+  it("rejects non-object JSON arrays", async () => {
+    const { body, status } = await requestUsers([{ email: "array@example.com" }]);
+
+    assert.equal(status, 422);
+    assert.deepEqual(body.details, ["Request body must be a JSON object."]);
+  });
+
+  it("requires a valid email address", async () => {
+    const { body, status } = await requestUsers({
+      email: "not-an-email",
+      name: "Bad Email"
+    });
+
+    assert.equal(status, 422);
+    assert.deepEqual(body.details, ["A valid email is required."]);
+  });
+
+  it("rejects non-string optional names", async () => {
+    const { body, status } = await requestUsers({
+      email: "name-type@example.com",
+      name: 42
+    });
+
+    assert.equal(status, 422);
+    assert.deepEqual(body.details, ["Name must be a string when provided."]);
+  });
+});

--- a/apps/api/src/routes/users.ts
+++ b/apps/api/src/routes/users.ts
@@ -1,6 +1,67 @@
 import { Router } from "express";
+import { randomUUID } from "node:crypto";
 
 const router = Router();
+
+type CreateUserInput = {
+  email: string;
+  name?: string;
+};
+
+type ValidationResult =
+  | { ok: true; value: CreateUserInput }
+  | { ok: false; errors: string[] };
+
+const EMAIL_PATTERN = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function normalizeOptionalName(value: unknown): string | undefined {
+  if (value === undefined || value === null) {
+    return undefined;
+  }
+
+  if (typeof value !== "string") {
+    return undefined;
+  }
+
+  const normalized = value.trim().replace(/\s+/g, " ");
+  return normalized.length > 0 ? normalized : undefined;
+}
+
+export function validateCreateUserPayload(body: unknown): ValidationResult {
+  if (!isRecord(body)) {
+    return { ok: false, errors: ["Request body must be a JSON object."] };
+  }
+
+  const errors: string[] = [];
+  const email =
+    typeof body.email === "string" ? body.email.trim().toLowerCase() : "";
+
+  if (!EMAIL_PATTERN.test(email)) {
+    errors.push("A valid email is required.");
+  }
+
+  if (body.name !== undefined && typeof body.name !== "string") {
+    errors.push("Name must be a string when provided.");
+  }
+
+  if (errors.length > 0) {
+    return { ok: false, errors };
+  }
+
+  const name = normalizeOptionalName(body.name);
+
+  return {
+    ok: true,
+    value: {
+      email,
+      ...(name ? { name } : {})
+    }
+  };
+}
 
 router.get("/", (_req, res) => {
   res.json({
@@ -10,10 +71,20 @@ router.get("/", (_req, res) => {
 });
 
 router.post("/", (req, res) => {
+  const result = validateCreateUserPayload(req.body);
+
+  if (!result.ok) {
+    res.status(422).json({
+      error: "Invalid user payload.",
+      details: result.errors
+    });
+    return;
+  }
+
   res.status(201).json({
     data: {
-      id: "stub-user-id",
-      ...req.body
+      id: randomUUID(),
+      ...result.value
     },
     message: "User creation is not implemented yet."
   });


### PR DESCRIPTION
Fixes #2207.

/claim #2207

## Summary
- Hardened `POST /users` so it rejects non-object JSON bodies.
- Requires a valid email, normalizes email and optional names, and ignores client-controlled ids or unrelated fields.
- Added regression coverage for the validation, normalization, and field-whitelisting cases.

## Verification
- `npm test --workspace @taskflow/api`
- `npm test`
- `git diff --check HEAD~1..HEAD`
