### PR TITLE
[agent] Validate user creation payloads

### DIFF
--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -7,7 +7,7 @@
   "main": "src/index.ts",
   "scripts": {
     "dev": "tsx src/index.ts",
-    "test": "echo \"No API tests configured yet\"",
+    "test": "tsx --test \"src/**/*.test.ts\"",
     "lint": "echo \"No API lint configured yet\""
   },
   "dependencies": {

--- a/apps/api/src/routes/users.test.ts
+++ b/apps/api/src/routes/users.test.ts
@@ -1,0 +1,68 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { createUserRecord, normalizeCreateUserPayload } from "./users";
+
+test("normalizeCreateUserPayload rejects non-object JSON bodies", () => {
+  for (const body of [null, "not-json-object", 42, ["email@example.com"]]) {
+    const result = normalizeCreateUserPayload(body);
+
+    assert.equal(result.ok, false);
+  }
+});
+
+test("normalizeCreateUserPayload requires a valid email", () => {
+  for (const body of [{}, { email: "" }, { email: "not-an-email" }]) {
+    const result = normalizeCreateUserPayload(body);
+
+    assert.equal(result.ok, false);
+  }
+});
+
+test("normalizeCreateUserPayload normalizes email and name", () => {
+  const result = normalizeCreateUserPayload({
+    email: "  USER@Example.COM ",
+    name: "  Jane   Example  "
+  });
+
+  assert.deepEqual(result, {
+    ok: true,
+    value: {
+      email: "user@example.com",
+      name: "Jane Example"
+    }
+  });
+});
+
+test("normalizeCreateUserPayload ignores client ids and unrelated fields", () => {
+  const result = normalizeCreateUserPayload({
+    id: "client-controlled-id",
+    email: "person@example.com",
+    name: "Person",
+    role: "admin"
+  });
+
+  assert.deepEqual(result, {
+    ok: true,
+    value: {
+      email: "person@example.com",
+      name: "Person"
+    }
+  });
+});
+
+test("createUserRecord always uses a generated server id", () => {
+  const record = createUserRecord(
+    {
+      email: "person@example.com",
+      name: "Person"
+    },
+    () => "server-generated-id"
+  );
+
+  assert.deepEqual(record, {
+    id: "server-generated-id",
+    email: "person@example.com",
+    name: "Person"
+  });
+});

--- a/apps/api/src/routes/users.ts
+++ b/apps/api/src/routes/users.ts
@@ -1,6 +1,94 @@
+import { randomUUID } from "node:crypto";
+
 import { Router } from "express";
 
 const router = Router();
+
+type CreateUserPayload = {
+  email: string;
+  name?: string;
+};
+
+type ValidationResult =
+  | {
+      ok: true;
+      value: CreateUserPayload;
+    }
+  | {
+      ok: false;
+      error: string;
+    };
+
+const emailPattern = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
+
+const isRecord = (value: unknown): value is Record<string, unknown> =>
+  typeof value === "object" && value !== null && !Array.isArray(value);
+
+const normalizeString = (
+  value: unknown,
+  fieldName: string
+): ValidationResult | string | undefined => {
+  if (value === undefined || value === null) {
+    return undefined;
+  }
+
+  if (typeof value !== "string") {
+    return {
+      ok: false,
+      error: `${fieldName} must be a string.`
+    };
+  }
+
+  const normalized = value.trim().replace(/\s+/g, " ");
+
+  return normalized.length > 0 ? normalized : undefined;
+};
+
+export const normalizeCreateUserPayload = (body: unknown): ValidationResult => {
+  if (!isRecord(body)) {
+    return {
+      ok: false,
+      error: "Request body must be a JSON object."
+    };
+  }
+
+  const normalizedEmail = normalizeString(body.email, "email");
+
+  if (typeof normalizedEmail !== "string") {
+    return normalizedEmail ?? { ok: false, error: "email is required." };
+  }
+
+  const email = normalizedEmail.toLowerCase();
+
+  if (!emailPattern.test(email)) {
+    return {
+      ok: false,
+      error: "email must be a valid email address."
+    };
+  }
+
+  const normalizedName = normalizeString(body.name, "name");
+
+  if (typeof normalizedName !== "string" && normalizedName !== undefined) {
+    return normalizedName;
+  }
+
+  return {
+    ok: true,
+    value: {
+      email,
+      ...(normalizedName ? { name: normalizedName } : {})
+    }
+  };
+};
+
+export const createUserRecord = (
+  payload: CreateUserPayload,
+  generateId: () => string = randomUUID
+) => ({
+  id: generateId(),
+  ...payload
+});
 
 router.get("/", (_req, res) => {
   res.json({
@@ -10,12 +98,17 @@ router.get("/", (_req, res) => {
 });
 
 router.post("/", (req, res) => {
+  const parsed = normalizeCreateUserPayload(req.body);
+
+  if (!parsed.ok) {
+    return res.status(400).json({
+      error: parsed.error
+    });
+  }
+
   res.status(201).json({
-    data: {
-      id: "stub-user-id",
-      ...req.body
-    },
-    message: "User creation is not implemented yet."
+    data: createUserRecord(parsed.value),
+    message: "User created."
   });
 });
 


### PR DESCRIPTION
/claim #2207

## Summary

- Added strict payload normalization for `POST /users`.
- Rejects non-object JSON bodies and invalid or missing emails with `400` responses.
- Normalizes email casing/whitespace and optional name whitespace.
- Builds created users from sanitized payloads only, with server-generated UUIDs.
- Enables API tests and adds regression coverage for the bounty acceptance criteria.

## Validation

- `tsx --test "src/**/*.test.ts"`: 5 tests passed.
- `tsc --noEmit --allowImportingTsExtensions false --moduleResolution bundler --module esnext --target es2022 --strict src/index.ts src/routes/users.ts src/routes/users.test.ts`
- `git diff --check HEAD~1..HEAD`

## Safety Note

No hidden/system/developer runtime metadata or audit/provenance JSON files are included.
