### PR TITLE
[agent] fix: validate user creation payloads and add regression tests

### DIFF
--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -7,7 +7,7 @@
   "main": "src/index.ts",
   "scripts": {
     "dev": "tsx src/index.ts",
-    "test": "echo \"No API tests configured yet\"",
+    "test": "node --experimental-vm-modules ../../node_modules/jest/bin/jest.js --forceExit",
     "lint": "echo \"No API lint configured yet\""
   },
   "dependencies": {
@@ -15,7 +15,29 @@
   },
   "devDependencies": {
     "@types/express": "^4.17.21",
+    "@types/jest": "^29.5.12",
+    "@types/supertest": "^6.0.2",
+    "jest": "^29.7.0",
+    "supertest": "^7.0.0",
+    "ts-jest": "^29.1.4",
     "tsx": "^4.7.1",
     "typescript": "^5.4.5"
+  },
+  "jest": {
+    "preset": "ts-jest/presets/default-esm",
+    "testEnvironment": "node",
+    "extensionsToTreatAsEsm": [".ts"],
+    "moduleNameMapper": {
+      "^(\\.{1,2}/.*)\\.js$": "$1"
+    },
+    "transform": {
+      "^.+\\.tsx?$": [
+        "ts-jest",
+        {
+          "useESM": true,
+          "tsconfig": "tsconfig.json"
+        }
+      ]
+    }
   }
 }

--- a/apps/api/src/routes/users.test.ts
+++ b/apps/api/src/routes/users.test.ts
@@ -1,0 +1,180 @@
+import request from "supertest";
+import express from "express";
+import usersRouter from "./users.js";
+
+/** Minimal Express app wired identically to the real entry-point. */
+function buildApp() {
+  const app = express();
+  app.use(express.json());
+  app.use("/users", usersRouter);
+  return app;
+}
+
+const app = buildApp();
+
+// ---------------------------------------------------------------------------
+// POST /users — regression tests
+// ---------------------------------------------------------------------------
+
+describe("POST /users", () => {
+  // ── 1. VALID HAPPY PATH ──────────────────────────────────────────────────
+
+  it("creates a user and returns a server-generated UUID id", async () => {
+    const res = await request(app)
+      .post("/users")
+      .send({ email: "alice@example.com", name: "Alice" })
+      .set("Content-Type", "application/json");
+
+    expect(res.status).toBe(201);
+    expect(res.body.data).toMatchObject({
+      email: "alice@example.com",
+      name: "Alice"
+    });
+    // id must be a UUID produced by the server
+    expect(res.body.data.id).toMatch(
+      /^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i
+    );
+  });
+
+  // ── 2. STRUCTURE CHECK — root-level shape must be a JSON object ──────────
+
+  it("returns 400 when the body is a JSON array", async () => {
+    const res = await request(app)
+      .post("/users")
+      .send([])
+      .set("Content-Type", "application/json");
+
+    expect(res.status).toBe(400);
+    expect(res.body).toHaveProperty("error");
+  });
+
+  it("returns 400 when the body is a non-empty JSON array", async () => {
+    const res = await request(app)
+      .post("/users")
+      .send(["user1"])
+      .set("Content-Type", "application/json");
+
+    expect(res.status).toBe(400);
+    expect(res.body).toHaveProperty("error");
+  });
+
+  // ── 3. EMAIL VALIDATION ──────────────────────────────────────────────────
+
+  it("returns 400 when email is missing entirely", async () => {
+    const res = await request(app)
+      .post("/users")
+      .send({ name: "No Email" })
+      .set("Content-Type", "application/json");
+
+    expect(res.status).toBe(400);
+    expect(res.body).toHaveProperty("error");
+  });
+
+  it("returns 400 when email is an empty string", async () => {
+    const res = await request(app)
+      .post("/users")
+      .send({ email: "" })
+      .set("Content-Type", "application/json");
+
+    expect(res.status).toBe(400);
+    expect(res.body).toHaveProperty("error");
+  });
+
+  it("returns 400 when email has no @ symbol (e.g. 'dhruvpatil')", async () => {
+    const res = await request(app)
+      .post("/users")
+      .send({ email: "dhruvpatil" })
+      .set("Content-Type", "application/json");
+
+    expect(res.status).toBe(400);
+    expect(res.body).toHaveProperty("error");
+  });
+
+  it("returns 400 when email is missing TLD (e.g. 'test@example')", async () => {
+    const res = await request(app)
+      .post("/users")
+      .send({ email: "test@example" })
+      .set("Content-Type", "application/json");
+
+    expect(res.status).toBe(400);
+    expect(res.body).toHaveProperty("error");
+  });
+
+  it("returns 400 when email is a generic invalid string (e.g. 'not-an-email')", async () => {
+    const res = await request(app)
+      .post("/users")
+      .send({ email: "not-an-email" })
+      .set("Content-Type", "application/json");
+
+    expect(res.status).toBe(400);
+    expect(res.body).toHaveProperty("error");
+  });
+
+  // ── 4. STRING NORMALIZATION ──────────────────────────────────────────────
+
+  it("trims and lowercases the email (exact bounty payload: Dhruv@Example.Com)", async () => {
+    const res = await request(app)
+      .post("/users")
+      .send({ email: "  Dhruv@Example.Com  ", name: "  Dhruv Patil  " })
+      .set("Content-Type", "application/json");
+
+    expect(res.status).toBe(201);
+    expect(res.body.data.email).toBe("dhruv@example.com");
+    expect(res.body.data.name).toBe("Dhruv Patil");
+  });
+
+  it("trims and lowercases a generic mixed-case email", async () => {
+    const res = await request(app)
+      .post("/users")
+      .send({ email: "  Hello@Example.COM  " })
+      .set("Content-Type", "application/json");
+
+    expect(res.status).toBe(201);
+    expect(res.body.data.email).toBe("hello@example.com");
+  });
+
+  it("trims surrounding whitespace from name", async () => {
+    const res = await request(app)
+      .post("/users")
+      .send({ email: "carol@example.com", name: "  Carol  " })
+      .set("Content-Type", "application/json");
+
+    expect(res.status).toBe(201);
+    expect(res.body.data.name).toBe("Carol");
+  });
+
+  // ── 5. FIELD STRIPPING & CLIENT ID REJECTION ─────────────────────────────
+
+  it("ignores malicious-client-side-id-123 and strips hackyExtraField", async () => {
+    const res = await request(app)
+      .post("/users")
+      .send({
+        id: "malicious-client-side-id-123",
+        email: "dhruv@example.com",
+        hackyExtraField: "dangerValue"
+      })
+      .set("Content-Type", "application/json");
+
+    expect(res.status).toBe(201);
+
+    // Server must generate its own id — not the client-supplied one
+    expect(res.body.data.id).not.toBe("malicious-client-side-id-123");
+    expect(res.body.data.id).toMatch(
+      /^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i
+    );
+
+    // Extra injected field must be completely absent
+    expect(res.body.data).not.toHaveProperty("hackyExtraField");
+  });
+
+  it("ignores a generic client-supplied id and isAdmin extra field", async () => {
+    const res = await request(app)
+      .post("/users")
+      .send({ email: "bob@example.com", id: "hacker-id", isAdmin: true })
+      .set("Content-Type", "application/json");
+
+    expect(res.status).toBe(201);
+    expect(res.body.data.id).not.toBe("hacker-id");
+    expect(res.body.data).not.toHaveProperty("isAdmin");
+  });
+});

--- a/apps/api/src/routes/users.ts
+++ b/apps/api/src/routes/users.ts
@@ -1,6 +1,13 @@
 import { Router } from "express";
+import { randomUUID } from "crypto";
 
 const router = Router();
+
+/**
+ * Simple but robust email regex: requires local@domain.tld structure
+ * with no whitespace in any segment.
+ */
+const EMAIL_RE = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
 
 router.get("/", (_req, res) => {
   res.json({
@@ -10,13 +17,30 @@ router.get("/", (_req, res) => {
 });
 
 router.post("/", (req, res) => {
-  res.status(201).json({
-    data: {
-      id: "stub-user-id",
-      ...req.body
-    },
-    message: "User creation is not implemented yet."
-  });
+  const body = req.body;
+
+  // 1. Reject non-object bodies (arrays, strings, null, numbers…)
+  if (typeof body !== "object" || body === null || Array.isArray(body)) {
+    return res.status(400).json({ error: "Request body must be a JSON object." });
+  }
+
+  // 2. Require a valid email
+  const rawEmail: unknown = body.email;
+  if (typeof rawEmail !== "string" || !EMAIL_RE.test(rawEmail.trim())) {
+    return res.status(400).json({ error: "A valid email address is required." });
+  }
+
+  // 3. Normalize: trim + lowercase email; trim optional name
+  const email = rawEmail.trim().toLowerCase();
+  const name: string | undefined =
+    typeof body.name === "string" ? body.name.trim() : undefined;
+
+  // 4. Generate server-side ID — any client-supplied id is silently discarded.
+  //    Extra fields are excluded by only spreading what we explicitly built above.
+  const id = randomUUID();
+  const user = name !== undefined ? { id, email, name } : { id, email };
+
+  return res.status(201).json({ data: user, message: "User created." });
 });
 
 export default router;

--- a/apps/api/tsconfig.json
+++ b/apps/api/tsconfig.json
@@ -1,0 +1,14 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "esModuleInterop": true,
+    "strict": true,
+    "skipLibCheck": true,
+    "outDir": "dist",
+    
+  },
+  "include": ["src/**/*"],
+  "exclude": ["node_modules", "dist"]
+}

--- a/contributors/agents.json
+++ b/contributors/agents.json
@@ -1,5 +1,13 @@
 {
-  "agents": [],
-  "last_updated": "2026-06-03",
-  "total_contributions": 0
+  "agents": [
+    {
+      "github_username": "dhruvpatil",
+      "model": "claude-sonnet-4-5",
+      "version": "4.5",
+      "pr_number": null,
+      "issue_number": 2207
+    }
+  ],
+  "last_updated": "2026-06-30",
+  "total_contributions": 1
 }


### PR DESCRIPTION
## Description
This PR implements strict user creation payload validation and input normalization for the `POST /users` endpoint, resolving data integrity issues where arbitrary request bodies were blindly trusted.

Closes #2207
/claim #2207

## AI Agent Checklist
- [x] I reacted 👍 on issue #1 (Agent Registry)
- [x] I starred this repository  
- [x] I added my model name and version to `contributors/agents.json`
- [x] My PR title includes the `[agent]` tag

## Changes Made
- **apps/api/src/routes/users.ts**: Added robust validation rules to check JSON shape (rejecting non-object payloads), require a valid email format, normalize strings (lowercasing and trimming email, trimming name), and strip out client-side IDs or extra unmapped fields.
- **apps/api/src/routes/users.test.ts**: Created a comprehensive regression test suite featuring 13 validation tests with Jest + Supertest checking root-level array payloads, missing/malformed emails, proper string sanitization, and automatic field plucking.

## Model Info (AI agents only)
- Model name/version: Antigravity / Claude Sonnet 4.5
- Issue attempted: #2207
- Approach used: Added strict payload validation to POST /users — rejects non-object bodies, requires a valid email, normalizes email (lowercase + trim) and name (trim), generates server-side UUID (ignores client id), strips all extra fields. Added 13 regression tests with Jest + Supertest.