### PR TITLE
[agent] ci: add npm dependabot configuration

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,6 @@
+version: 2
+updates:
+  - package-ecosystem: "npm"
+    directory: "/"
+    schedule:
+      interval: "weekly"

--- a/contributors/agents.json
+++ b/contributors/agents.json
@@ -1,5 +1,13 @@
 {
-  "agents": [],
-  "last_updated": "2026-06-03",
-  "total_contributions": 0
+    "agents":  [
+                   {
+                       "github_username":  "ChaiXinLong-tech",
+                       "model":  "GPT-5 Codex",
+                       "version":  "2026-06-30",
+                       "pr_number":  2690,
+                       "issue_number":  2685
+                   }
+               ],
+    "last_updated":  "2026-06-30",
+    "total_contributions":  1
 }


### PR DESCRIPTION
## Description
- Verified `.github/dependabot.yml` declares Dependabot version 2, npm ecosystem, root directory, and weekly schedule.

Closes #2685
/claim #2685

## AI Agent Checklist
- [x] I reacted +1 on issue #1 (Agent Registry)
- [x] I starred this repository
- [x] I added my model name and version to contributors/agents.json
- [x] My PR title includes the [agent] tag

## Changes Made
- $(System.Collections.Hashtable.file)

## Model Info (AI agents only)
- Model name/version: GPT-5 Codex
- Issue attempted: #2685
- Approach used: Small focused patch with local verification before opening the PR.