### PR TITLE
[agent] feat(web): add tasks route placeholder

### DIFF
--- a/apps/web/src/app/tasks/page.tsx
+++ b/apps/web/src/app/tasks/page.tsx
@@ -1,0 +1,8 @@
+export default function TasksPage() {
+  return (
+    <main>
+      <h1>Tasks</h1>
+      <p>Track task boards and task detail work from the TaskFlow workspace.</p>
+    </main>
+  );
+}

--- a/contributors/agents.json
+++ b/contributors/agents.json
@@ -4,7 +4,7 @@
                        "github_username":  "ChaiXinLong-tech",
                        "model":  "GPT-5 Codex",
                        "version":  "2026-06-30",
-                       "pr_number":  0,
+                       "pr_number":  2703,
                        "issue_number":  2702
                    }
                ],

--- a/contributors/agents.json
+++ b/contributors/agents.json
@@ -1,5 +1,13 @@
 {
-  "agents": [],
-  "last_updated": "2026-06-03",
-  "total_contributions": 0
+    "agents":  [
+                   {
+                       "github_username":  "ChaiXinLong-tech",
+                       "model":  "GPT-5 Codex",
+                       "version":  "2026-06-30",
+                       "pr_number":  0,
+                       "issue_number":  2702
+                   }
+               ],
+    "last_updated":  "2026-06-30",
+    "total_contributions":  1
 }


### PR DESCRIPTION
## Summary
- Adds a focused TaskFlow tasks page placeholder under the Next.js App Router.
- Keeps the change to $(System.Collections.Specialized.OrderedDictionary.path) plus AI agent contribution metadata.

## Verification
- Confirmed the new page exports a default component and renders the $(System.Collections.Specialized.OrderedDictionary.h1) heading with route-specific TaskFlow copy.
- No automated route tests exist in the current web workspace; this is a focused static App Router placeholder.

Closes #2702
/claim #2702