### PR TITLE
[agent] feat(web): add Tasks route placeholder (#2702)

### DIFF
--- a/apps/web/src/app/tasks/page.tsx
+++ b/apps/web/src/app/tasks/page.tsx
@@ -1,0 +1,8 @@
+export default function TasksPage() {
+  return (
+    <main>
+      <h1>Tasks</h1>
+      <p>Track task boards and workflow status in the TaskFlow workspace.</p>
+    </main>
+  );
+}


### PR DESCRIPTION
## Summary

Adds `apps/web/src/app/tasks/page.tsx` — a focused Next.js App Router placeholder
with an `<h1>` heading and concise TaskFlow copy per #2702 acceptance criteria.

## Verification

- Default export component renders `Tasks` heading and descriptive copy.
- Route path matches README TaskFlow navigation entry.

Fixes #2702

Wallet: `Do4v7foHJvRJLpRRoGaVPWX6DDEjX3yTK7J91gpwUQpE`

/claim #2702
