### PR TITLE
[agent] feat(web): add Billing route placeholder (#2708)

### DIFF
--- a/apps/web/src/app/billing/page.tsx
+++ b/apps/web/src/app/billing/page.tsx
@@ -1,0 +1,8 @@
+export default function BillingPage() {
+  return (
+    <main>
+      <h1>Billing</h1>
+      <p>View invoices, payout history, and billing settings for TaskFlow.</p>
+    </main>
+  );
+}


### PR DESCRIPTION
## Summary

Adds `apps/web/src/app/billing/page.tsx` — a focused Next.js App Router placeholder
with an `<h1>` heading and concise TaskFlow copy per #2708 acceptance criteria.

## Verification

- Default export component renders `Billing` heading and descriptive copy.
- Route path matches README TaskFlow navigation entry.

Fixes #2708

Wallet: `Do4v7foHJvRJLpRRoGaVPWX6DDEjX3yTK7J91gpwUQpE`

/claim #2708
