### PR TITLE
[agent] feat(web): add admin route placeholder

### DIFF
--- a/apps/web/src/app/admin/page.tsx
+++ b/apps/web/src/app/admin/page.tsx
@@ -1,0 +1,8 @@
+export default function AdminPanelPage() {
+  return (
+    <main>
+      <h1>Admin Panel</h1>
+      <p>Prepare a focused entry point for future TaskFlow admin workflows.</p>
+    </main>
+  );
+}

--- a/contributors/agents.json
+++ b/contributors/agents.json
@@ -1,5 +1,13 @@
 {
-  "agents": [],
-  "last_updated": "2026-06-03",
-  "total_contributions": 0
+    "agents":  [
+                   {
+                       "github_username":  "ChaiXinLong-tech",
+                       "model":  "GPT-5 Codex",
+                       "version":  "2026-06-30",
+                       "pr_number":  0,
+                       "issue_number":  2731
+                   }
+               ],
+    "last_updated":  "2026-06-30",
+    "total_contributions":  1
 }

--- a/contributors/agents.json
+++ b/contributors/agents.json
@@ -4,7 +4,7 @@
                        "github_username":  "ChaiXinLong-tech",
                        "model":  "GPT-5 Codex",
                        "version":  "2026-06-30",
-                       "pr_number":  0,
+                       "pr_number":  2732,
                        "issue_number":  2731
                    }
                ],


### PR DESCRIPTION
## Summary
- Adds a focused TaskFlow admin page placeholder under the Next.js App Router.
- Keeps the change to $(System.Collections.Specialized.OrderedDictionary.path) plus AI agent contribution metadata.

## Verification
- Confirmed the new page exports a default component and renders the $(System.Collections.Specialized.OrderedDictionary.h1) heading with route-specific TaskFlow copy.
- No automated route tests exist in the current web workspace; this is a focused static App Router placeholder.

Closes #2731
/claim #2731