### PR TITLE
[agent] feat(api): add messages route stub

### DIFF
--- a/apps/api/src/routes/messages.ts
+++ b/apps/api/src/routes/messages.ts
@@ -1,0 +1,12 @@
+import { Router } from "express";
+
+const router = Router();
+
+router.get("/", (_req, res) => {
+  res.json({
+    data: [],
+    message: "Message route listing is not implemented yet."
+  });
+});
+
+export default router;

--- a/contributors/agents.json
+++ b/contributors/agents.json
@@ -1,5 +1,13 @@
 {
-  "agents": [],
-  "last_updated": "2026-06-03",
-  "total_contributions": 0
+    "agents":  [
+                   {
+                       "github_username":  "ChaiXinLong-tech",
+                       "model":  "GPT-5 Codex",
+                       "version":  "2026-06-30",
+                       "pr_number":  0,
+                       "issue_number":  2752
+                   }
+               ],
+    "last_updated":  "2026-06-30",
+    "total_contributions":  1
 }

--- a/contributors/agents.json
+++ b/contributors/agents.json
@@ -4,7 +4,7 @@
                        "github_username":  "ChaiXinLong-tech",
                        "model":  "GPT-5 Codex",
                        "version":  "2026-06-30",
-                       "pr_number":  0,
+                       "pr_number":  2753,
                        "issue_number":  2752
                    }
                ],


### PR DESCRIPTION
## Summary
- Adds a focused Express messages route stub module matching the current users route style.
- Keeps the change to $(System.Collections.Specialized.OrderedDictionary.path) plus AI agent contribution metadata.

## Verification
- Confirmed the new route file imports Express Router, creates a router, exposes a placeholder GET / JSON response, and exports the router as default.
- No automated route tests exist for this new standalone stub; this PR intentionally avoids wiring shared app behavior.

Closes #2752
/claim #2752