### PR TITLE
[agent] feat(api): add messages route stub (#2752)

### DIFF
--- a/apps/api/src/routes/messages.ts
+++ b/apps/api/src/routes/messages.ts
@@ -1,0 +1,12 @@
+import { Router } from "express";
+
+const router = Router();
+
+router.get("/", (_req, res) => {
+  res.json({
+    data: [],
+    message: "Message route listing is not implemented yet.",
+  });
+});
+
+export default router;


### PR DESCRIPTION
## Summary

Adds Express router stub at `apps/api/src/routes/messages.ts` with placeholder GET /.

Fixes #2752

Wallet: `Do4v7foHJvRJLpRRoGaVPWX6DDEjX3yTK7J91gpwUQpE`

/claim #2752
