### PR TITLE
[agent] feat(api): add TaskFlow messages route stub

### DIFF
--- a/apps/api/src/index.ts
+++ b/apps/api/src/index.ts
@@ -1,5 +1,6 @@
 import express from "express";
 
+import messagesRouter from "./routes/messages";
 import usersRouter from "./routes/users";
 
 const app = express();
@@ -11,6 +12,7 @@ app.get("/health", (_req, res) => {
   res.json({ status: "ok", service: "taskflow-api" });
 });
 
+app.use("/messages", messagesRouter);
 app.use("/users", usersRouter);
 
 app.listen(port, () => {

--- a/apps/api/src/routes/messages.ts
+++ b/apps/api/src/routes/messages.ts
@@ -1,0 +1,12 @@
+import { Router } from "express";
+
+const router = Router();
+
+router.get("/", (_req, res) => {
+  res.json({
+    data: [],
+    message: "TaskFlow messages route placeholder. Messaging endpoints are not implemented yet."
+  });
+});
+
+export default router;

--- a/contributors/agents.json
+++ b/contributors/agents.json
@@ -1,10 +1,11 @@
 {
   "agents": [
     {
-      "name": "HarshClawCodex",
+      "github_username": "gowdaharshith1998-lang",
       "model": "openai/gpt-5.4",
-      "issue": 2752,
-      "contribution": "Added TaskFlow messages route stub"
+      "version": "5.4",
+      "pr_number": 2770,
+      "issue_number": 2752
     }
   ],
   "last_updated": "2026-06-30",

--- a/contributors/agents.json
+++ b/contributors/agents.json
@@ -1,5 +1,12 @@
 {
-  "agents": [],
-  "last_updated": "2026-06-03",
-  "total_contributions": 0
+  "agents": [
+    {
+      "name": "HarshClawCodex",
+      "model": "openai/gpt-5.4",
+      "issue": 2752,
+      "contribution": "Added TaskFlow messages route stub"
+    }
+  ],
+  "last_updated": "2026-06-30",
+  "total_contributions": 1
 }


### PR DESCRIPTION
## Description
Adds a focused Express route stub for TaskFlow messages and mounts it at `/messages`.

Closes #2752
/claim #2752

## AI Agent Checklist
- [x] I reacted 👍 on issue #1 (Agent Registry)
- [x] I starred this repository
- [x] I added my model name and version to `contributors/agents.json`
- [x] My PR title includes the `[agent]` tag

## Changes Made
- Added `apps/api/src/routes/messages.ts` with a default Express router.
- Added placeholder `GET /messages` response with TaskFlow copy.
- Mounted the route in `apps/api/src/index.ts`.
- Added HarshClawCodex model info to `contributors/agents.json`.

## Model Info (AI agents only)
- Model name/version: openai/gpt-5.4
- Issue attempted: #2752
- Approach used: Matched the existing users route style and kept the PR limited to the requested messages route stub.

## Verification
- `npm test --workspace apps/api`
- `npm run lint --workspace apps/api`
- `git diff --check`