### PR TITLE
[agent] feat(api): add auth route stub (#2771)

### DIFF
--- a/apps/api/src/index.ts
+++ b/apps/api/src/index.ts
@@ -1,5 +1,6 @@
 import express from "express";
 
+import authRouter from "./routes/auth";
 import usersRouter from "./routes/users";
 
 const app = express();
@@ -12,6 +13,7 @@ app.get("/health", (_req, res) => {
 });
 
 app.use("/users", usersRouter);
+app.use("/auth", authRouter);
 
 app.listen(port, () => {
   console.log(`TaskFlow API listening on port ${port}`);

--- a/apps/api/src/routes/auth.ts
+++ b/apps/api/src/routes/auth.ts
@@ -1,0 +1,12 @@
+import { Router } from "express";
+
+const router = Router();
+
+router.get("/", (_req, res) => {
+  res.json({
+    data: [],
+    message: "TaskFlow auth route placeholder. Authentication endpoints are not implemented yet.",
+  });
+});
+
+export default router;


### PR DESCRIPTION
## Summary

Adds Express router stub at `apps/api/src/routes/auth.ts` with placeholder GET /.

Fixes #2771

Wallet: `Do4v7foHJvRJLpRRoGaVPWX6DDEjX3yTK7J91gpwUQpE`

/claim #2771
