### PR TITLE
[agent] feat(api): add admin route stub (#2779)

### DIFF
--- a/apps/api/src/routes/admin.ts
+++ b/apps/api/src/routes/admin.ts
@@ -1,0 +1,12 @@
+import { Router } from "express";
+
+const router = Router();
+
+router.get("/", (_req, res) => {
+  res.json({
+    data: [],
+    message: "Admin route listing is not implemented yet.",
+  });
+});
+
+export default router;


### PR DESCRIPTION
## Summary

Adds Express router stub at `apps/api/src/routes/admin.ts` with placeholder GET /.

Fixes #2779

Wallet: `Do4v7foHJvRJLpRRoGaVPWX6DDEjX3yTK7J91gpwUQpE`

/claim #2779
