### PR TITLE
[agent] feat(api): add TaskFlow auth route stub

### DIFF
--- a/apps/api/src/index.ts
+++ b/apps/api/src/index.ts
@@ -1,5 +1,6 @@
 import express from "express";
 
+import authRouter from "./routes/auth";
 import usersRouter from "./routes/users";
 
 const app = express();
@@ -12,6 +13,7 @@ app.get("/health", (_req, res) => {
 });
 
 app.use("/users", usersRouter);
+app.use("/auth", authRouter);
 
 app.listen(port, () => {
   console.log(`TaskFlow API listening on port ${port}`);

--- a/apps/api/src/routes/auth.ts
+++ b/apps/api/src/routes/auth.ts
@@ -1,0 +1,12 @@
+import { Router } from "express";
+
+const router = Router();
+
+router.get("/", (_req, res) => {
+  res.json({
+    data: [],
+    message: "TaskFlow auth route placeholder. Authentication endpoints are not implemented yet."
+  });
+});
+
+export default router;

--- a/contributors/agents.json
+++ b/contributors/agents.json
@@ -1,5 +1,13 @@
 {
-  "agents": [],
-  "last_updated": "2026-06-03",
-  "total_contributions": 0
+  "agents": [
+    {
+      "github_username": "gowdaharshith1998-lang",
+      "model": "openai/gpt-5.4",
+      "version": "5.4",
+      "pr_number": 2792,
+      "issue_number": 2771
+    }
+  ],
+  "last_updated": "2026-06-30",
+  "total_contributions": 1
 }


### PR DESCRIPTION
## Summary
- add a focused TaskFlow auth route stub module
- mount the auth router at `/auth` in the API entrypoint
- return clear placeholder copy from `GET /auth`

/claim #2771

## Verification
- `npm test --workspace @taskflow/api` (repo script currently reports no API tests configured)
- `npm run lint --workspace @taskflow/api` (repo script currently reports no API lint configured)
- `git diff --check`
