### PR TITLE
[agent] feat(api): add response helper

### DIFF
--- a/apps/api/src/utils/api-response.ts
+++ b/apps/api/src/utils/api-response.ts
@@ -1,0 +1,15 @@
+export type ApiResponse<T> =
+  | { data: T; error?: never }
+  | { data?: never; error: string };
+
+export function ok<T>(data: T): ApiResponse<T> {
+  return { data };
+}
+
+export function created<T>(data: T): ApiResponse<T> {
+  return { data };
+}
+
+export function fail(error: string): ApiResponse<never> {
+  return { error };
+}

--- a/contributors/agents.json
+++ b/contributors/agents.json
@@ -1,5 +1,13 @@
 {
-  "agents": [],
-  "last_updated": "2026-06-03",
-  "total_contributions": 0
+    "agents":  [
+                   {
+                       "github_username":  "ChaiXinLong-tech",
+                       "model":  "GPT-5 Codex",
+                       "version":  "2026-06-30",
+                       "pr_number":  2795,
+                       "issue_number":  2794
+                   }
+               ],
+    "last_updated":  "2026-06-30",
+    "total_contributions":  1
 }


### PR DESCRIPTION
## Summary
- Adds a tiny typed response helper module so future API handlers can return consistent success and error payloads.

## Verification
- confirmed api-response.ts exports ApiResponse, ok(), created(), and fail() helpers without introducing runtime dependencies.

Closes #2794
/claim #2794