### PR TITLE
[agent] feat(api): add HTTP status constants

### DIFF
--- a/apps/api/src/utils/http-status.ts
+++ b/apps/api/src/utils/http-status.ts
@@ -1,0 +1,15 @@
+export const httpStatus = {
+  ok: 200,
+  created: 201,
+  accepted: 202,
+  noContent: 204,
+  badRequest: 400,
+  unauthorized: 401,
+  forbidden: 403,
+  notFound: 404,
+  conflict: 409,
+  validationError: 422,
+  internalServerError: 500,
+} as const;
+
+export type HttpStatusName = keyof typeof httpStatus;

--- a/contributors/agents.json
+++ b/contributors/agents.json
@@ -1,5 +1,13 @@
 {
-  "agents": [],
-  "last_updated": "2026-06-03",
-  "total_contributions": 0
+    "agents":  [
+                   {
+                       "github_username":  "ChaiXinLong-tech",
+                       "model":  "GPT-5 Codex",
+                       "version":  "2026-06-30",
+                       "pr_number":  2797,
+                       "issue_number":  2796
+                   }
+               ],
+    "last_updated":  "2026-06-30",
+    "total_contributions":  1
 }


### PR DESCRIPTION
## Summary
- Adds a small named status-code map for API route and middleware code.

## Verification
- confirmed http-status.ts exports an immutable httpStatus map and HttpStatusName type.

Closes #2796
/claim #2796