### PR TITLE
[agent] feat(api): add not-found middleware

### DIFF
--- a/apps/api/src/middleware/not-found.ts
+++ b/apps/api/src/middleware/not-found.ts
@@ -1,0 +1,9 @@
+import type { RequestHandler } from "express";
+
+export const notFoundHandler: RequestHandler = (req, res) => {
+  res.status(404).json({
+    error: `Route ${req.method} ${req.path} not found`,
+  });
+};
+
+export default notFoundHandler;

--- a/contributors/agents.json
+++ b/contributors/agents.json
@@ -1,5 +1,13 @@
 {
-  "agents": [],
-  "last_updated": "2026-06-03",
-  "total_contributions": 0
+    "agents":  [
+                   {
+                       "github_username":  "ChaiXinLong-tech",
+                       "model":  "GPT-5 Codex",
+                       "version":  "2026-06-30",
+                       "pr_number":  2799,
+                       "issue_number":  2798
+                   }
+               ],
+    "last_updated":  "2026-06-30",
+    "total_contributions":  1
 }


### PR DESCRIPTION
## Summary
- Adds an Express not-found handler that returns a clear JSON 404 payload for unmatched API routes.

## Verification
- confirmed not-found.ts imports Express RequestHandler, returns status 404 JSON, and exports the handler by default.

Closes #2798
/claim #2798