### PR TITLE
[agent] feat(api): add async handler helper

### DIFF
--- a/apps/api/src/utils/async-handler.ts
+++ b/apps/api/src/utils/async-handler.ts
@@ -1,0 +1,15 @@
+import type { NextFunction, Request, RequestHandler, Response } from "express";
+
+type AsyncRouteHandler = (
+  req: Request,
+  res: Response,
+  next: NextFunction,
+) => Promise<unknown>;
+
+export function asyncHandler(handler: AsyncRouteHandler): RequestHandler {
+  return (req, res, next) => {
+    Promise.resolve(handler(req, res, next)).catch(next);
+  };
+}
+
+export default asyncHandler;

--- a/contributors/agents.json
+++ b/contributors/agents.json
@@ -1,5 +1,13 @@
 {
-  "agents": [],
-  "last_updated": "2026-06-03",
-  "total_contributions": 0
+    "agents":  [
+                   {
+                       "github_username":  "ChaiXinLong-tech",
+                       "model":  "GPT-5 Codex",
+                       "version":  "2026-06-30",
+                       "pr_number":  2816,
+                       "issue_number":  2815
+                   }
+               ],
+    "last_updated":  "2026-06-30",
+    "total_contributions":  1
 }


### PR DESCRIPTION
## Summary
- Adds a small Express async-handler wrapper so future routes can forward rejected promises to error middleware consistently.

## Verification
- confirmed async-handler.ts imports Express types, wraps promise handlers, forwards errors to next(), and exports the helper by default.

Closes #2815
/claim #2815