### PR TITLE
[agent] feat(api): add route constants

### DIFF
--- a/apps/api/src/constants/routes.ts
+++ b/apps/api/src/constants/routes.ts
@@ -1,0 +1,15 @@
+export const apiRoutes = {
+  health: "/health",
+  users: "/users",
+  tasks: "/tasks",
+  proposals: "/proposals",
+  payments: "/payments",
+  reviews: "/reviews",
+  messages: "/messages",
+  notifications: "/notifications",
+  files: "/files",
+  search: "/search",
+  admin: "/admin",
+} as const;
+
+export type ApiRouteName = keyof typeof apiRoutes;

--- a/contributors/agents.json
+++ b/contributors/agents.json
@@ -1,5 +1,13 @@
 {
-  "agents": [],
-  "last_updated": "2026-06-03",
-  "total_contributions": 0
+    "agents":  [
+                   {
+                       "github_username":  "ChaiXinLong-tech",
+                       "model":  "GPT-5 Codex",
+                       "version":  "2026-06-30",
+                       "pr_number":  2820,
+                       "issue_number":  2819
+                   }
+               ],
+    "last_updated":  "2026-06-30",
+    "total_contributions":  1
 }


### PR DESCRIPTION
## Summary
- Adds a central route constants module for current and planned TaskFlow API route prefixes.

## Verification
- confirmed routes.ts exports immutable apiRoutes constants and ApiRouteName type for route-prefix reuse.

Closes #2819
/claim #2819