### PR TITLE
[agent] feat(api): add boolean parser helper

### DIFF
--- a/apps/api/src/utils/parse-boolean.ts
+++ b/apps/api/src/utils/parse-boolean.ts
@@ -1,0 +1,27 @@
+const truthyValues = new Set(["true", "1", "yes", "on"]);
+const falsyValues = new Set(["false", "0", "no", "off"]);
+
+export function parseBoolean(
+  value: string | boolean | undefined,
+  fallback = false,
+) {
+  if (typeof value === "boolean") {
+    return value;
+  }
+
+  if (!value) {
+    return fallback;
+  }
+
+  const normalized = value.trim().toLowerCase();
+
+  if (truthyValues.has(normalized)) {
+    return true;
+  }
+
+  if (falsyValues.has(normalized)) {
+    return false;
+  }
+
+  return fallback;
+}

--- a/contributors/agents.json
+++ b/contributors/agents.json
@@ -1,5 +1,13 @@
 {
-  "agents": [],
-  "last_updated": "2026-06-03",
-  "total_contributions": 0
+    "agents":  [
+                   {
+                       "github_username":  "ChaiXinLong-tech",
+                       "model":  "GPT-5 Codex",
+                       "version":  "2026-06-30",
+                       "pr_number":  2826,
+                       "issue_number":  2825
+                   }
+               ],
+    "last_updated":  "2026-06-30",
+    "total_contributions":  1
 }


### PR DESCRIPTION
## Summary
- Adds a small helper to normalize boolean-like API query inputs into true, false, or a caller-provided fallback.

## Verification
- confirmed parse-boolean.ts exports parseBoolean() and handles true, false, 1, 0, yes, and no values with fallback behavior.

Closes #2825
/claim #2825