### PR TITLE
[agent] feat(api): add CORS config helper

### DIFF
--- a/apps/api/src/config/cors.ts
+++ b/apps/api/src/config/cors.ts
@@ -1,0 +1,12 @@
+export type CorsConfig = {
+  allowedOrigins: string[];
+};
+
+export function parseAllowedOrigins(value = ""): CorsConfig {
+  return {
+    allowedOrigins: value
+      .split(",")
+      .map((origin) => origin.trim())
+      .filter(Boolean),
+  };
+}

--- a/contributors/agents.json
+++ b/contributors/agents.json
@@ -1,5 +1,13 @@
 {
-  "agents": [],
-  "last_updated": "2026-06-03",
-  "total_contributions": 0
+    "agents":  [
+                   {
+                       "github_username":  "ChaiXinLong-tech",
+                       "model":  "GPT-5 Codex",
+                       "version":  "2026-06-30",
+                       "pr_number":  2834,
+                       "issue_number":  2833
+                   }
+               ],
+    "last_updated":  "2026-06-30",
+    "total_contributions":  1
 }


### PR DESCRIPTION
## Summary
- Adds a dependency-free helper to parse comma-separated allowed CORS origins from environment-style strings.

## Verification
- confirmed cors.ts exports CorsConfig and parseAllowedOrigins() with trimming and empty-entry filtering.

Closes #2833
/claim #2833