### PR TITLE
feat(api): validate user creation payloads with tests

### DIFF
--- a/apps/api/src/__tests__/users.test.ts
+++ b/apps/api/src/__tests__/users.test.ts
@@ -1,0 +1,95 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import express from "express";
+import request from "supertest";
+import usersRouter from "../routes/users";
+
+function createApp() {
+  const app = express();
+  app.use(express.json());
+  app.use("/users", usersRouter);
+  return app;
+}
+
+describe("GET /users", () => {
+  it("returns an empty list initially", async () => {
+    const app = createApp();
+    const res = await request(app).get("/users");
+    expect(res.status).toBe(200);
+    expect(res.body.data).toEqual([]);
+  });
+});
+
+describe("POST /users", () => {
+  it("creates a user with valid email and name", async () => {
+    const app = createApp();
+    const res = await request(app)
+      .post("/users")
+      .send({ email: "alice@example.com", name: "Alice" });
+    expect(res.status).toBe(201);
+    expect(res.body.data).toMatchObject({
+      email: "alice@example.com",
+      name: "Alice",
+    });
+    expect(res.body.data.id).toBeDefined();
+  });
+
+  it("rejects missing email", async () => {
+    const app = createApp();
+    const res = await request(app).post("/users").send({ name: "Bob" });
+    expect(res.status).toBe(400);
+    expect(res.body.error).toBeDefined();
+  });
+
+  it("rejects invalid email", async () => {
+    const app = createApp();
+    const res = await request(app).post("/users").send({ email: "not-an-email" });
+    expect(res.status).toBe(400);
+    expect(res.body.error).toBeDefined();
+  });
+
+  it("rejects client-supplied id", async () => {
+    const app = createApp();
+    const res = await request(app)
+      .post("/users")
+      .send({ email: "test@test.com", id: "client-given-id" });
+    expect(res.status).toBe(201);
+    // id should be server-generated, not the client value
+    expect(res.body.data.id).not.toBe("client-given-id");
+  });
+
+  it("ignores extra fields from request body", async () => {
+    const app = createApp();
+    const res = await request(app)
+      .post("/users")
+      .send({ email: "a@b.com", role: "admin", admin: true });
+    expect(res.status).toBe(201);
+    // Extra fields should not appear in response
+    expect(res.body.data.role).toBeUndefined();
+    expect(res.body.data.admin).toBeUndefined();
+  });
+
+  it("makes created users visible via GET", async () => {
+    const app = createApp();
+    await request(app)
+      .post("/users")
+      .send({ email: "alice@example.com", name: "Alice" });
+    const list = await request(app).get("/users");
+    expect(list.body.data).toHaveLength(1);
+    expect(list.body.data[0].email).toBe("alice@example.com");
+  });
+
+  it("rejects non-string email", async () => {
+    const app = createApp();
+    const res = await request(app).post("/users").send({ email: 123 });
+    expect(res.status).toBe(400);
+  });
+
+  it("rejects non-string name", async () => {
+    const app = createApp();
+    const res = await request(app).post("/users").send({
+      email: "test@test.com",
+      name: 42,
+    });
+    expect(res.status).toBe(400);
+  });
+});

--- a/apps/api/src/routes/users.ts
+++ b/apps/api/src/routes/users.ts
@@ -1,21 +1,58 @@
 import { Router } from "express";
+import crypto from "crypto";
 
 const router = Router();
 
+interface CreateUserPayload {
+  email?: string;
+  name?: string;
+}
+
+interface User {
+  id: string;
+  email: string;
+  name: string | null;
+}
+
+// In-memory user store (placeholder until Prisma is connected)
+const users: User[] = [];
+
 router.get("/", (_req, res) => {
   res.json({
-    data: [],
-    message: "User listing is not implemented yet."
+    data: users,
   });
 });
 
 router.post("/", (req, res) => {
+  const { email, name } = req.body as CreateUserPayload;
+
+  // Validate required email field
+  if (!email || typeof email !== "string" || !email.includes("@")) {
+    res.status(400).json({
+      error: "Invalid or missing email address",
+    });
+    return;
+  }
+
+  // Validate optional name field
+  if (name !== undefined && typeof name !== "string") {
+    res.status(400).json({
+      error: "Name must be a string",
+    });
+    return;
+  }
+
+  // Generate id server-side — reject client-supplied ids
+  const user: User = {
+    id: crypto.randomUUID(),
+    email: email.trim().toLowerCase(),
+    name: name?.trim() ?? null,
+  };
+
+  users.push(user);
+
   res.status(201).json({
-    data: {
-      id: "stub-user-id",
-      ...req.body
-    },
-    message: "User creation is not implemented yet."
+    data: user,
   });
 });
 

--- a/apps/api/vitest.config.ts
+++ b/apps/api/vitest.config.ts
@@ -1,0 +1,9 @@
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+  test: {
+    globals: true,
+    environment: "node",
+    include: ["src/**/*.test.ts"],
+  },
+});


### PR DESCRIPTION
## Summary

Adds server-side validation to the POST /users endpoint:
- Rejects missing or invalid email
- Rejects non-string name
- Generates id server-side (ignores client-supplied id)
- Strips extra fields from request body

Also adds a comprehensive test suite covering:
- Successful user creation
- Missing/invalid email rejection
- Client id injection prevention
- Extra field stripping
- GET persistence verification
- Type validation for email and name fields

Closes #2207
Closes #6
Closes #12

/claim #2207