### PR TITLE
[agent] feat(api): add task status constants

### DIFF
--- a/apps/api/src/constants/task-status.ts
+++ b/apps/api/src/constants/task-status.ts
@@ -1,0 +1,14 @@
+export const taskStatuses = {
+  draft: "draft",
+  open: "open",
+  assigned: "assigned",
+  inProgress: "in_progress",
+  review: "review",
+  completed: "completed",
+  cancelled: "cancelled",
+} as const;
+
+export type TaskStatus =
+  (typeof taskStatuses)[keyof typeof taskStatuses];
+
+export const taskStatusValues = Object.values(taskStatuses);

--- a/contributors/agents.json
+++ b/contributors/agents.json
@@ -1,5 +1,13 @@
 {
-  "agents": [],
-  "last_updated": "2026-06-03",
-  "total_contributions": 0
+    "agents":  [
+                   {
+                       "github_username":  "ChaiXinLong-tech",
+                       "model":  "GPT-5 Codex",
+                       "version":  "2026-06-30",
+                       "pr_number":  2841,
+                       "issue_number":  2840
+                   }
+               ],
+    "last_updated":  "2026-06-30",
+    "total_contributions":  1
 }


### PR DESCRIPTION
## Summary
- Adds a central task-status constants module for TaskFlow API task lifecycle values.

## Verification
- confirmed task-status.ts exports immutable taskStatuses constants, TaskStatus type, and taskStatusValues array.

Closes #2840
/claim #2840