### PR TITLE
[agent] feat(api): add proposal status constants

### DIFF
--- a/apps/api/src/constants/proposal-status.ts
+++ b/apps/api/src/constants/proposal-status.ts
@@ -1,0 +1,12 @@
+export const proposalStatuses = {
+  submitted: "submitted",
+  shortlisted: "shortlisted",
+  accepted: "accepted",
+  declined: "declined",
+  withdrawn: "withdrawn",
+} as const;
+
+export type ProposalStatus =
+  (typeof proposalStatuses)[keyof typeof proposalStatuses];
+
+export const proposalStatusValues = Object.values(proposalStatuses);

--- a/contributors/agents.json
+++ b/contributors/agents.json
@@ -1,5 +1,13 @@
 {
-  "agents": [],
-  "last_updated": "2026-06-03",
-  "total_contributions": 0
+    "agents":  [
+                   {
+                       "github_username":  "ChaiXinLong-tech",
+                       "model":  "GPT-5 Codex",
+                       "version":  "2026-06-30",
+                       "pr_number":  2843,
+                       "issue_number":  2842
+                   }
+               ],
+    "last_updated":  "2026-06-30",
+    "total_contributions":  1
 }


### PR DESCRIPTION
## Summary
- Adds a reusable proposal-status constants module for current and future proposal endpoints.

## Verification
- confirmed proposal-status.ts exports immutable proposalStatuses constants, ProposalStatus type, and proposalStatusValues array.

Closes #2842
/claim #2842