### PR TITLE
[agent] feat(api): add record value trimming helper

### DIFF
--- a/apps/api/src/utils/trim-record-values.ts
+++ b/apps/api/src/utils/trim-record-values.ts
@@ -1,0 +1,8 @@
+export function trimRecordValues<T extends Record<string, unknown>>(input: T): T {
+  return Object.fromEntries(
+    Object.entries(input).map(([key, value]) => [
+      key,
+      typeof value === "string" ? value.trim() : value,
+    ]),
+  ) as T;
+}

--- a/contributors/agents.json
+++ b/contributors/agents.json
@@ -1,5 +1,13 @@
 {
-  "agents": [],
-  "last_updated": "2026-06-03",
-  "total_contributions": 0
+    "agents":  [
+                   {
+                       "github_username":  "ChaiXinLong-tech",
+                       "model":  "GPT-5 Codex",
+                       "version":  "2026-06-30",
+                       "pr_number":  2851,
+                       "issue_number":  2850
+                   }
+               ],
+    "last_updated":  "2026-06-30",
+    "total_contributions":  1
 }


### PR DESCRIPTION
## Summary
- Adds a tiny helper to trim string values in flat API input records while preserving non-string fields.

## Verification
- confirmed trim-record-values.ts exports trimRecordValues() and preserves non-string values.

Closes #2850
/claim #2850