### PR TITLE
[agent] feat(api): add notification type constants

### DIFF
--- a/apps/api/src/constants/notification-type.ts
+++ b/apps/api/src/constants/notification-type.ts
@@ -1,0 +1,12 @@
+export const notificationTypes = {
+  taskAssigned: "task_assigned",
+  proposalReceived: "proposal_received",
+  messageReceived: "message_received",
+  paymentUpdated: "payment_updated",
+  reviewReceived: "review_received",
+} as const;
+
+export type NotificationType =
+  (typeof notificationTypes)[keyof typeof notificationTypes];
+
+export const notificationTypeValues = Object.values(notificationTypes);

--- a/contributors/agents.json
+++ b/contributors/agents.json
@@ -1,5 +1,13 @@
 {
-  "agents": [],
-  "last_updated": "2026-06-03",
-  "total_contributions": 0
+    "agents":  [
+                   {
+                       "github_username":  "ChaiXinLong-tech",
+                       "model":  "GPT-5 Codex",
+                       "version":  "2026-06-30",
+                       "pr_number":  2855,
+                       "issue_number":  2854
+                   }
+               ],
+    "last_updated":  "2026-06-30",
+    "total_contributions":  1
 }


### PR DESCRIPTION
## Summary
- Adds notification type constants for task, proposal, message, and payment notification payloads.

## Verification
- confirmed notification-type.ts exports immutable notificationTypes constants, NotificationType type, and notificationTypeValues array.

Closes #2854
/claim #2854