### PR TITLE
[agent] feat(api): add defined-value picker helper

### DIFF
--- a/apps/api/src/utils/pick-defined.ts
+++ b/apps/api/src/utils/pick-defined.ts
@@ -1,0 +1,5 @@
+export function pickDefined<T extends Record<string, unknown>>(input: T) {
+  return Object.fromEntries(
+    Object.entries(input).filter(([, value]) => value !== undefined),
+  ) as Partial<T>;
+}

--- a/contributors/agents.json
+++ b/contributors/agents.json
@@ -1,5 +1,13 @@
 {
-  "agents": [],
-  "last_updated": "2026-06-03",
-  "total_contributions": 0
+    "agents":  [
+                   {
+                       "github_username":  "ChaiXinLong-tech",
+                       "model":  "GPT-5 Codex",
+                       "version":  "2026-06-30",
+                       "pr_number":  2859,
+                       "issue_number":  2858
+                   }
+               ],
+    "last_updated":  "2026-06-30",
+    "total_contributions":  1
 }


### PR DESCRIPTION
## Summary
- Adds a helper to remove undefined values from flat API payload objects before persistence or response shaping.

## Verification
- confirmed pick-defined.ts exports pickDefined() and filters only undefined values while preserving null and other values.

Closes #2858
/claim #2858