### PR TITLE
[agent] feat(api): add query string builder helper

### DIFF
--- a/apps/api/src/utils/build-query-string.ts
+++ b/apps/api/src/utils/build-query-string.ts
@@ -1,0 +1,20 @@
+export type QueryParams = Record<
+  string,
+  string | number | boolean | null | undefined
+>;
+
+export function buildQueryString(params: QueryParams) {
+  const searchParams = new URLSearchParams();
+
+  for (const [key, value] of Object.entries(params)) {
+    if (value === undefined || value === null || value === "") {
+      continue;
+    }
+
+    searchParams.set(key, String(value));
+  }
+
+  const queryString = searchParams.toString();
+
+  return queryString ? `?${queryString}` : "";
+}

--- a/contributors/agents.json
+++ b/contributors/agents.json
@@ -1,5 +1,13 @@
 {
-  "agents": [],
-  "last_updated": "2026-06-03",
-  "total_contributions": 0
+    "agents":  [
+                   {
+                       "github_username":  "ChaiXinLong-tech",
+                       "model":  "GPT-5 Codex",
+                       "version":  "2026-06-30",
+                       "pr_number":  2861,
+                       "issue_number":  2860
+                   }
+               ],
+    "last_updated":  "2026-06-30",
+    "total_contributions":  1
 }


### PR DESCRIPTION
## Summary
- Adds a small URLSearchParams-based helper for building query strings while skipping empty values.

## Verification
- confirmed build-query-string.ts exports buildQueryString() and skips undefined, null, and empty-string values.

Closes #2860
/claim #2860