### PR TITLE
feat(api): add slugify helper (#2870)

### DIFF
--- a/apps/api/src/utils/slugify.ts
+++ b/apps/api/src/utils/slugify.ts
@@ -1,0 +1,7 @@
+export function slugify(value: string): string {
+  return value
+    .trim()
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, "-")
+    .replace(/^-+|-+$/g, "");
+}

--- a/contributors/agents.json
+++ b/contributors/agents.json
@@ -1,5 +1,13 @@
 {
-  "agents": [],
-  "last_updated": "2026-06-03",
-  "total_contributions": 0
+  "agents": [
+    {
+      "github_username": "lequangsang01",
+      "model": "mimo-auto",
+      "version": "latest",
+      "pr_number": null,
+      "issue_number": 2870
+    }
+  ],
+  "last_updated": "2026-06-30",
+  "total_contributions": 1
 }

--- a/contributors/agents.json
+++ b/contributors/agents.json
@@ -4,7 +4,7 @@
       "github_username": "lequangsang01",
       "model": "mimo-auto",
       "version": "latest",
-      "pr_number": null,
+      "pr_number": 2882,
       "issue_number": 2870
     }
   ],


### PR DESCRIPTION
Closes #2870

Adds a dependency-free slugify helper at `apps/api/src/utils/slugify.ts` for future human-readable task and profile URLs.

The function trims, lowercases, and replaces non-alphanumeric characters with hyphens.