### PR TITLE
feat(api): add search sort constants (#2866)

### DIFF
--- a/apps/api/src/constants/search-sort.ts
+++ b/apps/api/src/constants/search-sort.ts
@@ -1,0 +1,12 @@
+export const searchSortOptions = {
+  relevance: "relevance",
+  newest: "newest",
+  oldest: "oldest",
+  budgetLowToHigh: "budget_low_to_high",
+  budgetHighToLow: "budget_high_to_low",
+} as const;
+
+export type SearchSortOption =
+  (typeof searchSortOptions)[keyof typeof searchSortOptions];
+
+export const searchSortOptionValues = Object.values(searchSortOptions);

--- a/contributors/agents.json
+++ b/contributors/agents.json
@@ -1,5 +1,13 @@
 {
-  "agents": [],
-  "last_updated": "2026-06-03",
-  "total_contributions": 0
+  "agents": [
+    {
+      "github_username": "lequangsang01",
+      "model": "mimo-auto",
+      "version": "latest",
+      "pr_number": null,
+      "issue_number": 2866
+    }
+  ],
+  "last_updated": "2026-06-30",
+  "total_contributions": 1
 }

--- a/contributors/agents.json
+++ b/contributors/agents.json
@@ -4,7 +4,7 @@
       "github_username": "lequangsang01",
       "model": "mimo-auto",
       "version": "latest",
-      "pr_number": null,
+      "pr_number": 2883,
       "issue_number": 2866
     }
   ],


### PR DESCRIPTION
Closes #2866

Adds search sort constants at `apps/api/src/constants/search-sort.ts` for future task and user search endpoints.

Includes `searchSortOptions` object, `SearchSortOption` type, and `searchSortOptionValues` array.