### PR TITLE
feat(api): add file status constants (#2864)

### DIFF
--- a/apps/api/src/constants/file-status.ts
+++ b/apps/api/src/constants/file-status.ts
@@ -1,0 +1,11 @@
+export const fileStatuses = {
+  uploaded: "uploaded",
+  processing: "processing",
+  available: "available",
+  failed: "failed",
+  deleted: "deleted",
+} as const;
+
+export type FileStatus = (typeof fileStatuses)[keyof typeof fileStatuses];
+
+export const fileStatusValues = Object.values(fileStatuses);

--- a/contributors/agents.json
+++ b/contributors/agents.json
@@ -4,7 +4,7 @@
       "github_username": "lequangsang01",
       "model": "mimo-auto",
       "version": "latest",
-      "pr_number": null,
+      "pr_number": 2885,
       "issue_number": 2864
     }
   ],

--- a/contributors/agents.json
+++ b/contributors/agents.json
@@ -1,5 +1,13 @@
 {
-  "agents": [],
-  "last_updated": "2026-06-03",
-  "total_contributions": 0
+  "agents": [
+    {
+      "github_username": "lequangsang01",
+      "model": "mimo-auto",
+      "version": "latest",
+      "pr_number": null,
+      "issue_number": 2864
+    }
+  ],
+  "last_updated": "2026-06-30",
+  "total_contributions": 1
 }


### PR DESCRIPTION
Closes #2864

Adds file status constants at `apps/api/src/constants/file-status.ts` for upload, processing, and deletion state handling.

Includes `fileStatuses` object, `FileStatus` type, and `fileStatusValues` array.