### PR TITLE
feat(api): add pagination helper (#2817)

### DIFF
--- a/apps/api/src/utils/pagination.ts
+++ b/apps/api/src/utils/pagination.ts
@@ -1,0 +1,43 @@
+export type PaginationInput = {
+  page?: string | number;
+  pageSize?: string | number;
+};
+
+export type Pagination = {
+  page: number;
+  pageSize: number;
+  limit: number;
+  offset: number;
+};
+
+const DEFAULT_PAGE = 1;
+const DEFAULT_PAGE_SIZE = 20;
+const MAX_PAGE_SIZE = 100;
+
+function toPositiveInteger(
+  value: string | number | undefined,
+  fallback: number,
+): number {
+  const parsed = Number(value);
+
+  if (!Number.isInteger(parsed) || parsed < 1) {
+    return fallback;
+  }
+
+  return parsed;
+}
+
+export function normalizePagination(input: PaginationInput = {}): Pagination {
+  const page = toPositiveInteger(input.page, DEFAULT_PAGE);
+  const pageSize = Math.min(
+    toPositiveInteger(input.pageSize, DEFAULT_PAGE_SIZE),
+    MAX_PAGE_SIZE,
+  );
+
+  return {
+    page,
+    pageSize,
+    limit: pageSize,
+    offset: (page - 1) * pageSize,
+  };
+}

--- a/contributors/agents.json
+++ b/contributors/agents.json
@@ -4,7 +4,7 @@
       "github_username": "lequangsang01",
       "model": "mimo-auto",
       "version": "latest",
-      "pr_number": null,
+      "pr_number": 2886,
       "issue_number": 2817
     }
   ],

--- a/contributors/agents.json
+++ b/contributors/agents.json
@@ -1,5 +1,13 @@
 {
-  "agents": [],
-  "last_updated": "2026-06-03",
-  "total_contributions": 0
+  "agents": [
+    {
+      "github_username": "lequangsang01",
+      "model": "mimo-auto",
+      "version": "latest",
+      "pr_number": null,
+      "issue_number": 2817
+    }
+  ],
+  "last_updated": "2026-06-30",
+  "total_contributions": 1
 }


### PR DESCRIPTION
Closes #2817

Adds reusable pagination parsing at `apps/api/src/utils/pagination.ts` for page, page size, limit, and offset values in API endpoints.

Includes `normalizePagination` function with sensible defaults (page=1, pageSize=20, maxPageSize=100).