### PR TITLE
feat(api): add email normalization helper (#2847)

### DIFF
--- a/apps/api/src/utils/normalize-email.ts
+++ b/apps/api/src/utils/normalize-email.ts
@@ -1,0 +1,3 @@
+export function normalizeEmail(value: string): string {
+  return value.trim().toLowerCase();
+}

--- a/contributors/agents.json
+++ b/contributors/agents.json
@@ -1,5 +1,13 @@
 {
-  "agents": [],
-  "last_updated": "2026-06-03",
-  "total_contributions": 0
+  "agents": [
+    {
+      "github_username": "lequangsang01",
+      "model": "mimo-auto",
+      "version": "latest",
+      "pr_number": null,
+      "issue_number": 2847
+    }
+  ],
+  "last_updated": "2026-06-30",
+  "total_contributions": 1
 }

--- a/contributors/agents.json
+++ b/contributors/agents.json
@@ -4,7 +4,7 @@
       "github_username": "lequangsang01",
       "model": "mimo-auto",
       "version": "latest",
-      "pr_number": null,
+      "pr_number": 2887,
       "issue_number": 2847
     }
   ],


### PR DESCRIPTION
Closes #2847

Adds a dependency-free email normalization helper at `apps/api/src/utils/normalize-email.ts` to trim and lowercase email inputs before API validation or lookup.