### PR TITLE
[agent] feat(api): add clamp number helper

### DIFF
--- a/apps/api/src/utils/clamp-number.ts
+++ b/apps/api/src/utils/clamp-number.ts
@@ -1,0 +1,3 @@
+export function clampNumber(value: number, min: number, max: number): number {
+  return Math.min(Math.max(value, min), max);
+}

--- a/contributors/agents.json
+++ b/contributors/agents.json
@@ -4,7 +4,7 @@
                        "github_username":  "ChaiXinLong-tech",
                        "model":  "GPT-5 Codex",
                        "version":  "2026-06-30",
-                       "pr_number":  0,
+                       "pr_number":  2889,
                        "issue_number":  2888
                    }
                ],

--- a/contributors/agents.json
+++ b/contributors/agents.json
@@ -1,5 +1,13 @@
 {
-  "agents": [],
-  "last_updated": "2026-06-03",
-  "total_contributions": 0
+    "agents":  [
+                   {
+                       "github_username":  "ChaiXinLong-tech",
+                       "model":  "GPT-5 Codex",
+                       "version":  "2026-06-30",
+                       "pr_number":  0,
+                       "issue_number":  2888
+                   }
+               ],
+    "last_updated":  "2026-06-30",
+    "total_contributions":  1
 }


### PR DESCRIPTION
## Summary
- Adds a tiny numeric clamp helper for future pagination, budget, and scoring bounds.

## Verification
- confirmed clamp-number.ts exports clampNumber() and bounds values between min and max.

Closes #2888
/claim #2888