### PR TITLE
[agent] feat(api): add split-list helper

### DIFF
--- a/apps/api/src/utils/split-list.ts
+++ b/apps/api/src/utils/split-list.ts
@@ -1,0 +1,10 @@
+export function splitList(value: string | null | undefined): string[] {
+  if (!value) {
+    return [];
+  }
+
+  return value
+    .split(',')
+    .map((item) => item.trim())
+    .filter(Boolean);
+}

--- a/contributors/agents.json
+++ b/contributors/agents.json
@@ -1,5 +1,13 @@
 {
-  "agents": [],
-  "last_updated": "2026-06-03",
-  "total_contributions": 0
+    "agents":  [
+                   {
+                       "github_username":  "ChaiXinLong-tech",
+                       "model":  "GPT-5 Codex",
+                       "version":  "2026-06-30",
+                       "pr_number":  0,
+                       "issue_number":  2890
+                   }
+               ],
+    "last_updated":  "2026-06-30",
+    "total_contributions":  1
 }

--- a/contributors/agents.json
+++ b/contributors/agents.json
@@ -4,7 +4,7 @@
                        "github_username":  "ChaiXinLong-tech",
                        "model":  "GPT-5 Codex",
                        "version":  "2026-06-30",
-                       "pr_number":  0,
+                       "pr_number":  2891,
                        "issue_number":  2890
                    }
                ],


### PR DESCRIPTION
## Summary
- Adds a helper for normalizing comma-separated query strings into trimmed string arrays.

## Verification
- confirmed split-list.ts exports splitList() and filters empty comma-separated entries.

Closes #2890
/claim #2890