### PR TITLE
[agent] feat(api): add truncate string helper

### DIFF
--- a/apps/api/src/utils/truncate-string.ts
+++ b/apps/api/src/utils/truncate-string.ts
@@ -1,0 +1,7 @@
+export function truncateString(value: string, maxLength: number, suffix = '...'): string {
+  if (value.length <= maxLength) {
+    return value;
+  }
+
+  return `${value.slice(0, Math.max(0, maxLength - suffix.length))}${suffix}`;
+}

--- a/apps/api/src/utils/truncate-string.ts
+++ b/apps/api/src/utils/truncate-string.ts
@@ -3,5 +3,9 @@ export function truncateString(value: string, maxLength: number, suffix = '...')
     return value;
   }
 
-  return `${value.slice(0, Math.max(0, maxLength - suffix.length))}${suffix}`;
+  if (maxLength <= suffix.length) {
+    return suffix.slice(0, Math.max(0, maxLength));
+  }
+
+  return `${value.slice(0, maxLength - suffix.length)}${suffix}`;
 }

--- a/contributors/agents.json
+++ b/contributors/agents.json
@@ -1,5 +1,13 @@
 {
-  "agents": [],
-  "last_updated": "2026-06-03",
-  "total_contributions": 0
+    "agents":  [
+                   {
+                       "github_username":  "ChaiXinLong-tech",
+                       "model":  "GPT-5 Codex",
+                       "version":  "2026-06-30",
+                       "pr_number":  0,
+                       "issue_number":  2901
+                   }
+               ],
+    "last_updated":  "2026-06-30",
+    "total_contributions":  1
 }

--- a/contributors/agents.json
+++ b/contributors/agents.json
@@ -4,7 +4,7 @@
                        "github_username":  "ChaiXinLong-tech",
                        "model":  "GPT-5 Codex",
                        "version":  "2026-06-30",
-                       "pr_number":  0,
+                       "pr_number":  2902,
                        "issue_number":  2901
                    }
                ],


### PR DESCRIPTION
## Summary
- Adds a small helper for truncating long API display strings with a configurable suffix.

## Verification
- confirmed truncate-string.ts exports truncateString() and preserves short strings unchanged.

Closes #2901
/claim #2901