### PR TITLE
[agent] feat(api): add map-values helper

### DIFF
--- a/apps/api/src/utils/map-values.ts
+++ b/apps/api/src/utils/map-values.ts
@@ -1,0 +1,8 @@
+export function mapValues<TValue, TResult>(
+  value: Record<string, TValue>,
+  mapper: (value: TValue, key: string) => TResult,
+): Record<string, TResult> {
+  return Object.fromEntries(
+    Object.entries(value).map(([key, entry]) => [key, mapper(entry, key)]),
+  );
+}

--- a/contributors/agents.json
+++ b/contributors/agents.json
@@ -4,7 +4,7 @@
                        "github_username":  "ChaiXinLong-tech",
                        "model":  "GPT-5 Codex",
                        "version":  "2026-06-30",
-                       "pr_number":  0,
+                       "pr_number":  2904,
                        "issue_number":  2903
                    }
                ],

--- a/contributors/agents.json
+++ b/contributors/agents.json
@@ -1,5 +1,13 @@
 {
-  "agents": [],
-  "last_updated": "2026-06-03",
-  "total_contributions": 0
+    "agents":  [
+                   {
+                       "github_username":  "ChaiXinLong-tech",
+                       "model":  "GPT-5 Codex",
+                       "version":  "2026-06-30",
+                       "pr_number":  0,
+                       "issue_number":  2903
+                   }
+               ],
+    "last_updated":  "2026-06-30",
+    "total_contributions":  1
 }


### PR DESCRIPTION
## Summary
- Adds a typed helper for transforming object values while preserving keys.

## Verification
- confirmed map-values.ts exports mapValues() and maps entries through the provided callback.

Closes #2903
/claim #2903