### PR TITLE
[agent] feat(api): add merge-defined helper

### DIFF
--- a/apps/api/src/utils/merge-defined.ts
+++ b/apps/api/src/utils/merge-defined.ts
@@ -1,0 +1,11 @@
+export function mergeDefined<T extends Record<string, unknown>>(
+  target: T,
+  patch: Partial<T>,
+): T {
+  return {
+    ...target,
+    ...Object.fromEntries(
+      Object.entries(patch).filter(([, value]) => value !== undefined),
+    ),
+  } as T;
+}

--- a/contributors/agents.json
+++ b/contributors/agents.json
@@ -1,5 +1,13 @@
 {
-  "agents": [],
-  "last_updated": "2026-06-03",
-  "total_contributions": 0
+    "agents":  [
+                   {
+                       "github_username":  "ChaiXinLong-tech",
+                       "model":  "GPT-5 Codex",
+                       "version":  "2026-06-30",
+                       "pr_number":  0,
+                       "issue_number":  2905
+                   }
+               ],
+    "last_updated":  "2026-06-30",
+    "total_contributions":  1
 }

--- a/contributors/agents.json
+++ b/contributors/agents.json
@@ -4,7 +4,7 @@
                        "github_username":  "ChaiXinLong-tech",
                        "model":  "GPT-5 Codex",
                        "version":  "2026-06-30",
-                       "pr_number":  0,
+                       "pr_number":  2906,
                        "issue_number":  2905
                    }
                ],


### PR DESCRIPTION
## Summary
- Adds a helper for overlaying only defined values onto an existing object.

## Verification
- confirmed merge-defined.ts exports mergeDefined() and skips undefined patch entries.

Closes #2905
/claim #2905