### PR TITLE
[agent] feat(api): add HTTP method constants

### DIFF
--- a/apps/api/src/constants/http-method.ts
+++ b/apps/api/src/constants/http-method.ts
@@ -1,0 +1,11 @@
+export const httpMethods = {
+  get: 'GET',
+  post: 'POST',
+  put: 'PUT',
+  patch: 'PATCH',
+  delete: 'DELETE',
+} as const;
+
+export type HttpMethod = typeof httpMethods[keyof typeof httpMethods];
+
+export const httpMethodValues = Object.values(httpMethods);

--- a/contributors/agents.json
+++ b/contributors/agents.json
@@ -4,7 +4,7 @@
                        "github_username":  "ChaiXinLong-tech",
                        "model":  "GPT-5 Codex",
                        "version":  "2026-06-30",
-                       "pr_number":  0,
+                       "pr_number":  2908,
                        "issue_number":  2907
                    }
                ],

--- a/contributors/agents.json
+++ b/contributors/agents.json
@@ -1,5 +1,13 @@
 {
-  "agents": [],
-  "last_updated": "2026-06-03",
-  "total_contributions": 0
+    "agents":  [
+                   {
+                       "github_username":  "ChaiXinLong-tech",
+                       "model":  "GPT-5 Codex",
+                       "version":  "2026-06-30",
+                       "pr_number":  0,
+                       "issue_number":  2907
+                   }
+               ],
+    "last_updated":  "2026-06-30",
+    "total_contributions":  1
 }


### PR DESCRIPTION
## Summary
- Adds shared HTTP method constants for future route, audit, and webhook handling.

## Verification
- confirmed http-method.ts exports immutable httpMethods constants, HttpMethod type, and httpMethodValues array.

Closes #2907
/claim #2907