### PR TITLE
[agent] feat(api): add notification type constants (#2854)

### DIFF
--- a/apps/api/src/constants/notification-type.ts
+++ b/apps/api/src/constants/notification-type.ts
@@ -1,0 +1,8 @@
+export const notificationTypes = {
+  taskUpdate: "task_update",
+  message: "message",
+  payment: "payment",
+  system: "system",
+} as const;
+
+export type NotificationType = (typeof notificationTypes)[keyof typeof notificationTypes];

--- a/contributors/agents.json
+++ b/contributors/agents.json
@@ -1,5 +1,13 @@
 {
-  "agents": [],
-  "last_updated": "2026-06-03",
-  "total_contributions": 0
+  "agents": [
+    {
+      "github_username": "yanyishuai",
+      "model": "cursor-agent",
+      "version": "2026-06-30",
+      "pr_number": 0,
+      "issue_number": 2854
+    }
+  ],
+  "last_updated": "2026-06-30",
+  "total_contributions": 1
 }


### PR DESCRIPTION
## Summary

Adds `apps/api/src/constants/notification-type.ts` exporting `notificationTypes` with typed TaskFlow API helper behavior.

Fixes #2854

Wallet: `Do4v7foHJvRJLpRRoGaVPWX6DDEjX3yTK7J91gpwUQpE`

/claim #2854
