### PR TITLE
feat(api): add mergeDefined helper

### DIFF
--- a/apps/api/src/utils/merge-defined.ts
+++ b/apps/api/src/utils/merge-defined.ts
@@ -1,0 +1,16 @@
+export function mergeDefined<T extends object>(
+  target: T,
+  patch: Partial<T>,
+): T {
+  const result = { ...target };
+
+  for (const [key, value] of Object.entries(patch) as Array<
+    [keyof T, T[keyof T] | undefined]
+  >) {
+    if (value !== undefined) {
+      result[key] = value;
+    }
+  }
+
+  return result;
+}


### PR DESCRIPTION
## Summary
- Add `mergeDefined` for merging patch values while leaving existing fields unchanged when a patch value is `undefined`.
- Preserve defined falsy values such as `false` and `null`.

Fixes #2905.

## Verification
- `npm run test --workspace @taskflow/api`
- `npm run lint --workspace @taskflow/api`
- Imported `mergeDefined` from `apps/api/src/utils/merge-defined.ts` and checked that `undefined` is skipped while `false` and `null` are applied.
