### PR TITLE
[agent] feat(api): add budget range constants (#2896)

### DIFF
--- a/apps/api/src/constants/budget-range.ts
+++ b/apps/api/src/constants/budget-range.ts
@@ -1,0 +1,8 @@
+export const budgetRanges = {
+  micro: { min: 0, max: 99 },
+  small: { min: 100, max: 499 },
+  medium: { min: 500, max: 1999 },
+  large: { min: 2000, max: Number.POSITIVE_INFINITY },
+} as const;
+
+export type BudgetRangeName = keyof typeof budgetRanges;

--- a/contributors/agents.json
+++ b/contributors/agents.json
@@ -1,5 +1,13 @@
 {
-  "agents": [],
-  "last_updated": "2026-06-03",
-  "total_contributions": 0
+  "agents": [
+    {
+      "github_username": "yanyishuai",
+      "model": "cursor-agent",
+      "version": "2026-06-30",
+      "pr_number": 0,
+      "issue_number": 2896
+    }
+  ],
+  "last_updated": "2026-06-30",
+  "total_contributions": 1
 }


### PR DESCRIPTION
## Summary

Adds `apps/api/src/constants/budget-range.ts` exporting `budgetRanges` with typed TaskFlow API helper behavior.

Fixes #2896

Wallet: `Do4v7foHJvRJLpRRoGaVPWX6DDEjX3yTK7J91gpwUQpE`

/claim #2896
