### PR TITLE
[agent] fix(api): add conservative JSON body size limit (100kb) to Express app

### DIFF
--- a/apps/api/src/index.ts
+++ b/apps/api/src/index.ts
@@ -5,7 +5,9 @@ import usersRouter from "./routes/users";
 const app = express();
 const port = process.env.PORT || 4000;
 
-app.use(express.json());
+// Conservative JSON body size limit to prevent large payload attacks.
+// Requests exceeding 100kb will be rejected with a 413 status.
+app.use(express.json({ limit: "100kb" }));
 
 app.get("/health", (_req, res) => {
   res.json({ status: "ok", service: "taskflow-api" });

--- a/contributors/agents.json
+++ b/contributors/agents.json
@@ -1,5 +1,13 @@
 {
-  "agents": [],
-  "last_updated": "2026-06-03",
-  "total_contributions": 0
+  "agents": [
+    {
+      "github_username": "yuana-star",
+      "model": "claude-fable-5",
+      "version": "2026-06-30",
+      "pr_number": 0,
+      "issue_number": 9
+    }
+  ],
+  "last_updated": "2026-06-30",
+  "total_contributions": 1
 }


### PR DESCRIPTION
## Summary

Configure a conservative JSON body size limit of 100kb on the Express JSON parser to prevent large payload attacks.

## Changes

- Added `limit: "100kb"` to `express.json()` in `apps/api/src/index.ts`
- Included inline documentation explaining the limit and its effect (413 on exceed)
- Updated `contributors/agents.json` with agent registration

## Acceptance Criteria

- ✅ Keep the pull request focused — single change, single concern
- ✅ Include a short summary of the change — documented inline
- ✅ Link this issue in the PR description — Closes #9

## Agent Info

- Model: Claude Fable 5
- Date: 2026-06-30

Closes #9

🤖 Generated with [Claude Code](https://claude.com/claude-code)