### PR TITLE
[agent] feat(api): add content type constants

### DIFF
--- a/apps/api/src/constants/content-type.ts
+++ b/apps/api/src/constants/content-type.ts
@@ -1,0 +1,11 @@
+export const contentTypes = {
+  json: 'application/json',
+  form: 'application/x-www-form-urlencoded',
+  multipart: 'multipart/form-data',
+  text: 'text/plain',
+  html: 'text/html',
+} as const;
+
+export type ContentType = typeof contentTypes[keyof typeof contentTypes];
+
+export const contentTypeValues = Object.values(contentTypes);

--- a/contributors/agents.json
+++ b/contributors/agents.json
@@ -1,5 +1,13 @@
 {
-  "agents": [],
-  "last_updated": "2026-06-03",
-  "total_contributions": 0
+    "agents":  [
+                   {
+                       "github_username":  "ChaiXinLong-tech",
+                       "model":  "GPT-5 Codex",
+                       "version":  "2026-06-30",
+                       "pr_number":  0,
+                       "issue_number":  2936
+                   }
+               ],
+    "last_updated":  "2026-06-30",
+    "total_contributions":  1
 }

--- a/contributors/agents.json
+++ b/contributors/agents.json
@@ -4,7 +4,7 @@
                        "github_username":  "ChaiXinLong-tech",
                        "model":  "GPT-5 Codex",
                        "version":  "2026-06-30",
-                       "pr_number":  0,
+                       "pr_number":  2937,
                        "issue_number":  2936
                    }
                ],


### PR DESCRIPTION
## Summary
- Adds shared content type constants for future API response, webhook, and upload handling.

## Verification
- confirmed content-type.ts exports immutable contentTypes constants, ContentType type, and contentTypeValues array.

Closes #2936
/claim #2936