### PR TITLE
[agent] feat(api): add key-by helper

### DIFF
--- a/apps/api/src/utils/key-by.ts
+++ b/apps/api/src/utils/key-by.ts
@@ -1,0 +1,9 @@
+export function keyBy<T>(
+  values: readonly T[],
+  keySelector: (value: T) => string,
+): Record<string, T> {
+  return values.reduce<Record<string, T>>((record, value) => {
+    record[keySelector(value)] = value;
+    return record;
+  }, {});
+}

--- a/contributors/agents.json
+++ b/contributors/agents.json
@@ -4,7 +4,7 @@
                        "github_username":  "ChaiXinLong-tech",
                        "model":  "GPT-5 Codex",
                        "version":  "2026-06-30",
-                       "pr_number":  0,
+                       "pr_number":  2952,
                        "issue_number":  2951
                    }
                ],

--- a/contributors/agents.json
+++ b/contributors/agents.json
@@ -1,5 +1,13 @@
 {
-  "agents": [],
-  "last_updated": "2026-06-03",
-  "total_contributions": 0
+    "agents":  [
+                   {
+                       "github_username":  "ChaiXinLong-tech",
+                       "model":  "GPT-5 Codex",
+                       "version":  "2026-06-30",
+                       "pr_number":  0,
+                       "issue_number":  2951
+                   }
+               ],
+    "last_updated":  "2026-06-30",
+    "total_contributions":  1
 }


### PR DESCRIPTION
## Summary
- Adds a typed helper for indexing arrays by a string key selector.

## Verification
- confirmed key-by.ts exports keyBy() and maps array values into a keyed record.

Closes #2951
/claim #2951