### PR TITLE
[agent] feat(api): add chunk array helper

### DIFF
--- a/apps/api/src/utils/chunk-array.ts
+++ b/apps/api/src/utils/chunk-array.ts
@@ -1,0 +1,12 @@
+export function chunkArray<T>(values: readonly T[], size: number): T[][] {
+  if (size <= 0) {
+    return [];
+  }
+
+  const chunks: T[][] = [];
+  for (let index = 0; index < values.length; index += size) {
+    chunks.push(values.slice(index, index + size));
+  }
+
+  return chunks;
+}

--- a/contributors/agents.json
+++ b/contributors/agents.json
@@ -1,5 +1,13 @@
 {
-  "agents": [],
-  "last_updated": "2026-06-03",
-  "total_contributions": 0
+    "agents":  [
+                   {
+                       "github_username":  "ChaiXinLong-tech",
+                       "model":  "GPT-5 Codex",
+                       "version":  "2026-06-30",
+                       "pr_number":  0,
+                       "issue_number":  2955
+                   }
+               ],
+    "last_updated":  "2026-06-30",
+    "total_contributions":  1
 }

--- a/contributors/agents.json
+++ b/contributors/agents.json
@@ -4,7 +4,7 @@
                        "github_username":  "ChaiXinLong-tech",
                        "model":  "GPT-5 Codex",
                        "version":  "2026-06-30",
-                       "pr_number":  0,
+                       "pr_number":  2956,
                        "issue_number":  2955
                    }
                ],


### PR DESCRIPTION
## Summary
- Adds a helper for splitting arrays into fixed-size chunks.

## Verification
- confirmed chunk-array.ts exports chunkArray() and returns fixed-size array chunks.

Closes #2955
/claim #2955