### PR TITLE
[agent] feat(api): add partition array helper

### DIFF
--- a/apps/api/src/utils/partition-array.ts
+++ b/apps/api/src/utils/partition-array.ts
@@ -1,0 +1,17 @@
+export type PartitionResult<T> = {
+  pass: T[];
+  fail: T[];
+};
+
+export function partitionArray<T>(
+  values: readonly T[],
+  predicate: (value: T) => boolean,
+): PartitionResult<T> {
+  return values.reduce<PartitionResult<T>>(
+    (result, value) => {
+      result[predicate(value) ? 'pass' : 'fail'].push(value);
+      return result;
+    },
+    { pass: [], fail: [] },
+  );
+}

--- a/contributors/agents.json
+++ b/contributors/agents.json
@@ -4,7 +4,7 @@
                        "github_username":  "ChaiXinLong-tech",
                        "model":  "GPT-5 Codex",
                        "version":  "2026-06-30",
-                       "pr_number":  0,
+                       "pr_number":  2958,
                        "issue_number":  2957
                    }
                ],

--- a/contributors/agents.json
+++ b/contributors/agents.json
@@ -1,5 +1,13 @@
 {
-  "agents": [],
-  "last_updated": "2026-06-03",
-  "total_contributions": 0
+    "agents":  [
+                   {
+                       "github_username":  "ChaiXinLong-tech",
+                       "model":  "GPT-5 Codex",
+                       "version":  "2026-06-30",
+                       "pr_number":  0,
+                       "issue_number":  2957
+                   }
+               ],
+    "last_updated":  "2026-06-30",
+    "total_contributions":  1
 }


### PR DESCRIPTION
## Summary
- Adds a helper for splitting arrays into matching and non-matching groups.

## Verification
- confirmed partition-array.ts exports partitionArray() with pass and fail result arrays.

Closes #2957
/claim #2957