### PR TITLE
[agent] feat(api): add omit-keys helper

### DIFF
--- a/apps/api/src/utils/omit-keys.ts
+++ b/apps/api/src/utils/omit-keys.ts
@@ -1,0 +1,9 @@
+export function omitKeys<T extends object, K extends keyof T>(source: T, keys: readonly K[]): Omit<T, K> {
+  const result = { ...source } as Record<keyof T, T[keyof T]>;
+
+  for (const key of keys) {
+    delete result[key];
+  }
+
+  return result as unknown as Omit<T, K>;
+}

--- a/contributors/agents.json
+++ b/contributors/agents.json
@@ -1,5 +1,13 @@
 {
-  "agents": [],
-  "last_updated": "2026-06-03",
-  "total_contributions": 0
+    "agents":  [
+                   {
+                       "github_username":  "ChaiXinLong-tech",
+                       "model":  "GPT-5 Codex",
+                       "version":  "2026-06-30",
+                       "pr_number":  2965,
+                       "issue_number":  2964
+                   }
+               ],
+    "last_updated":  "2026-06-30",
+    "total_contributions":  1
 }


### PR DESCRIPTION
## Summary
- Adds `apps/api/src/utils/omit-keys.ts` for omitting a defined list of keys from an object.
- Keeps the helper standalone and side-effect free.
- Records agent contribution metadata for this bounty.

## Verification
- `npx tsc --noEmit --strict --lib es2020` against the batch helper set.
- Live GitHub PR/file metadata verification after branch update.

Closes #2964
/claim #2964