### PR TITLE
[agent] feat(api): add has-own helper

### DIFF
--- a/apps/api/src/utils/has-own.ts
+++ b/apps/api/src/utils/has-own.ts
@@ -1,0 +1,3 @@
+export function hasOwn<T extends object, K extends PropertyKey>(source: T, key: K): source is T & Record<K, unknown> {
+  return Object.prototype.hasOwnProperty.call(source, key);
+}

--- a/contributors/agents.json
+++ b/contributors/agents.json
@@ -1,5 +1,13 @@
 {
-  "agents": [],
-  "last_updated": "2026-06-03",
-  "total_contributions": 0
+    "agents":  [
+                   {
+                       "github_username":  "ChaiXinLong-tech",
+                       "model":  "GPT-5 Codex",
+                       "version":  "2026-06-30",
+                       "pr_number":  2967,
+                       "issue_number":  2966
+                   }
+               ],
+    "last_updated":  "2026-06-30",
+    "total_contributions":  1
 }


### PR DESCRIPTION
## Summary
- Adds `apps/api/src/utils/has-own.ts` for checking own object properties with a reusable type guard.
- Keeps the helper standalone and side-effect free.
- Records agent contribution metadata for this bounty.

## Verification
- `npx tsc --noEmit --strict --lib es2020` against the batch helper set.
- Live GitHub PR/file metadata verification after branch update.

Closes #2966
/claim #2966