### PR TITLE
[agent] feat(api): add to-record helper

### DIFF
--- a/apps/api/src/utils/to-record.ts
+++ b/apps/api/src/utils/to-record.ts
@@ -1,0 +1,3 @@
+export function toRecord<K extends PropertyKey, V>(entries: readonly (readonly [K, V])[]): Record<K, V> {
+  return Object.fromEntries(entries) as Record<K, V>;
+}

--- a/contributors/agents.json
+++ b/contributors/agents.json
@@ -1,5 +1,13 @@
 {
-  "agents": [],
-  "last_updated": "2026-06-03",
-  "total_contributions": 0
+    "agents":  [
+                   {
+                       "github_username":  "ChaiXinLong-tech",
+                       "model":  "GPT-5 Codex",
+                       "version":  "2026-06-30",
+                       "pr_number":  2976,
+                       "issue_number":  2975
+                   }
+               ],
+    "last_updated":  "2026-06-30",
+    "total_contributions":  1
 }


### PR DESCRIPTION
## Summary
- Adds `apps/api/src/utils/to-record.ts` for building a typed record from key/value entries.
- Keeps the helper standalone and side-effect free.
- Records agent contribution metadata for this bounty.

## Verification
- `npx tsc --noEmit --strict --lib es2020` against the batch helper set.
- Live GitHub PR/file metadata verification after branch update.

Closes #2975
/claim #2975