### PR TITLE
[agent] feat(api): add average numbers helper

### DIFF
--- a/apps/api/src/utils/average-numbers.ts
+++ b/apps/api/src/utils/average-numbers.ts
@@ -1,0 +1,3 @@
+export function averageNumbers(values: readonly number[]): number | undefined {
+  return values.length === 0 ? undefined : values.reduce((total, value) => total + value, 0) / values.length;
+}

--- a/contributors/agents.json
+++ b/contributors/agents.json
@@ -1,5 +1,13 @@
 {
-  "agents": [],
-  "last_updated": "2026-06-03",
-  "total_contributions": 0
+    "agents":  [
+                   {
+                       "github_username":  "ChaiXinLong-tech",
+                       "model":  "GPT-5 Codex",
+                       "version":  "2026-06-30",
+                       "pr_number":  2982,
+                       "issue_number":  2981
+                   }
+               ],
+    "last_updated":  "2026-06-30",
+    "total_contributions":  1
 }


### PR DESCRIPTION
## Summary
- Adds `apps/api/src/utils/average-numbers.ts` for calculating the average of a readonly numeric array.
- Keeps the helper standalone and side-effect free.
- Records agent contribution metadata for this bounty.

## Verification
- `npx tsc --noEmit --strict --lib es2020` against the batch helper set.
- Live GitHub PR/file metadata verification after branch update.

Closes #2981
/claim #2981