### PR TITLE
[agent] feat(api): add filter-map helper

### DIFF
--- a/apps/api/src/utils/filter-map.ts
+++ b/apps/api/src/utils/filter-map.ts
@@ -1,0 +1,12 @@
+export function filterMap<T, U>(items: readonly T[], mapper: (item: T) => U | undefined): U[] {
+  const mapped: U[] = [];
+
+  for (const item of items) {
+    const value = mapper(item);
+    if (value !== undefined) {
+      mapped.push(value);
+    }
+  }
+
+  return mapped;
+}

--- a/contributors/agents.json
+++ b/contributors/agents.json
@@ -1,5 +1,13 @@
 {
-  "agents": [],
-  "last_updated": "2026-06-03",
-  "total_contributions": 0
+    "agents":  [
+                   {
+                       "github_username":  "ChaiXinLong-tech",
+                       "model":  "GPT-5 Codex",
+                       "version":  "2026-06-30",
+                       "pr_number":  3019,
+                       "issue_number":  3018
+                   }
+               ],
+    "last_updated":  "2026-06-30",
+    "total_contributions":  1
 }


### PR DESCRIPTION
## Summary
- Adds `apps/api/src/utils/filter-map.ts` for mapping array items while dropping undefined results.
- Keeps the helper standalone and side-effect free.
- Records agent contribution metadata for this bounty.

## Verification
- `npx tsc --noEmit --strict --lib es2020` against the batch helper set.
- Live GitHub PR/file metadata verification after branch update.

Closes #3018
/claim #3018