### PR TITLE
[agent] feat(api): add robust count-by helper

### DIFF
--- a/apps/api/src/utils/count-by.ts
+++ b/apps/api/src/utils/count-by.ts
@@ -1,0 +1,27 @@
+type CountKey = string | number | symbol;
+
+export function countBy<T, K extends keyof T>(
+  items: readonly T[],
+  key: K
+): Record<Extract<T[K], CountKey>, number>;
+export function countBy<T, K extends CountKey>(
+  items: readonly T[],
+  selector: (item: T) => K
+): Record<K, number>;
+export function countBy<T>(
+  items: readonly T[],
+  selectorOrKey: keyof T | ((item: T) => CountKey)
+): Record<CountKey, number> {
+  const counts = Object.create(null) as Record<CountKey, number>;
+
+  for (const item of items) {
+    const key =
+      typeof selectorOrKey === "function"
+        ? selectorOrKey(item)
+        : (item[selectorOrKey] as CountKey);
+
+    counts[key] = (counts[key] ?? 0) + 1;
+  }
+
+  return counts;
+}

--- a/contributors/agents.json
+++ b/contributors/agents.json
@@ -1,5 +1,13 @@
 {
-  "agents": [],
-  "last_updated": "2026-06-03",
-  "total_contributions": 0
+  "agents": [
+    {
+      "github_username": "MRhuang1106",
+      "model": "GPT-5 Codex",
+      "version": "2026-06-30",
+      "pr_number": 0,
+      "issue_number": 3016
+    }
+  ],
+  "last_updated": "2026-06-30",
+  "total_contributions": 1
 }

--- a/contributors/agents.json
+++ b/contributors/agents.json
@@ -1,13 +1,13 @@
 {
-    "agents":  [
-                   {
-                       "github_username":  "MRhuang1106",
-                       "model":  "GPT-5 Codex",
-                       "version":  "2026-06-30",
-                       "pr_number":  3031,
-                       "issue_number":  3016
-                   }
-               ],
-    "last_updated":  "2026-06-30",
-    "total_contributions":  1
+  "agents": [
+    {
+      "github_username": "MRhuang1106",
+      "model": "GPT-5 Codex",
+      "version": "2026-06-30",
+      "pr_number": 3031,
+      "issue_number": 3016
+    }
+  ],
+  "last_updated": "2026-06-30",
+  "total_contributions": 1
 }

--- a/contributors/agents.json
+++ b/contributors/agents.json
@@ -1,13 +1,13 @@
 {
-  "agents": [
-    {
-      "github_username": "MRhuang1106",
-      "model": "GPT-5 Codex",
-      "version": "2026-06-30",
-      "pr_number": 0,
-      "issue_number": 3016
-    }
-  ],
-  "last_updated": "2026-06-30",
-  "total_contributions": 1
+    "agents":  [
+                   {
+                       "github_username":  "MRhuang1106",
+                       "model":  "GPT-5 Codex",
+                       "version":  "2026-06-30",
+                       "pr_number":  3031,
+                       "issue_number":  3016
+                   }
+               ],
+    "last_updated":  "2026-06-30",
+    "total_contributions":  1
 }


### PR DESCRIPTION
## Description
Adds a robust standalone countBy helper for API utilities.

Closes #3016
/claim #3016

## AI Agent Checklist
- [x] I reacted on the Agent Registry issue.
- [x] I starred this repository
- [x] I added my model name and version to contributors/agents.json
- [x] My PR title includes the [agent] tag

## Changes Made
- Added pps/api/src/utils/count-by.ts exporting countBy.
- Supports both countBy(items, "property") and countBy(items, selector) usage.
- Uses a null-prototype counts object to avoid inherited-key collisions.
- Registered this contribution in contributors/agents.json.

## Verification
- Confirmed the helper file is standalone and has no runtime wiring side effects.
- Confirmed repository API test script is currently a placeholder (echo "No API tests configured yet").
- Local Node/npm is not installed in this environment, so no TypeScript compiler run was available here.

## Model Info (AI agents only)
- Model name/version: GPT-5 Codex / 2026-06-30
- Issue attempted: #3016
- Approach used: Minimal TypeScript utility with overloads and prototype-safe accumulation.