### PR TITLE
[agent] feat(api): add typed filter-map helper

### DIFF
--- a/apps/api/src/utils/filter-map.ts
+++ b/apps/api/src/utils/filter-map.ts
@@ -1,0 +1,20 @@
+type Defined<T> = Exclude<T, undefined>;
+
+export function filterMap<T, U>(
+  items: readonly T[],
+  mapper: (item: T, index: number) => U
+): Defined<U>[] {
+  const mapped: Defined<U>[] = [];
+  let index = 0;
+
+  for (const item of items) {
+    const value = mapper(item, index);
+    index += 1;
+
+    if (value !== undefined) {
+      mapped.push(value as Defined<U>);
+    }
+  }
+
+  return mapped;
+}

--- a/contributors/agents.json
+++ b/contributors/agents.json
@@ -1,13 +1,13 @@
 {
-    "agents":  [
-                   {
-                       "github_username":  "MRhuang1106",
-                       "model":  "GPT-5 Codex",
-                       "version":  "2026-06-30",
-                       "pr_number":  3033,
-                       "issue_number":  3018
-                   }
-               ],
-    "last_updated":  "2026-06-30",
-    "total_contributions":  1
+  "agents": [
+    {
+      "github_username": "MRhuang1106",
+      "model": "GPT-5 Codex",
+      "version": "2026-06-30",
+      "pr_number": 3033,
+      "issue_number": 3018
+    }
+  ],
+  "last_updated": "2026-06-30",
+  "total_contributions": 1
 }

--- a/contributors/agents.json
+++ b/contributors/agents.json
@@ -1,5 +1,13 @@
 {
-  "agents": [],
-  "last_updated": "2026-06-03",
-  "total_contributions": 0
+  "agents": [
+    {
+      "github_username": "MRhuang1106",
+      "model": "GPT-5 Codex",
+      "version": "2026-06-30",
+      "pr_number": 0,
+      "issue_number": 3018
+    }
+  ],
+  "last_updated": "2026-06-30",
+  "total_contributions": 1
 }

--- a/contributors/agents.json
+++ b/contributors/agents.json
@@ -1,13 +1,13 @@
 {
-  "agents": [
-    {
-      "github_username": "MRhuang1106",
-      "model": "GPT-5 Codex",
-      "version": "2026-06-30",
-      "pr_number": 0,
-      "issue_number": 3018
-    }
-  ],
-  "last_updated": "2026-06-30",
-  "total_contributions": 1
+    "agents":  [
+                   {
+                       "github_username":  "MRhuang1106",
+                       "model":  "GPT-5 Codex",
+                       "version":  "2026-06-30",
+                       "pr_number":  3033,
+                       "issue_number":  3018
+                   }
+               ],
+    "last_updated":  "2026-06-30",
+    "total_contributions":  1
 }


### PR DESCRIPTION
## Description
Adds a standalone ilterMap helper for API utilities.

Closes #3018
/claim #3018

## AI Agent Checklist
- [x] I reacted on the Agent Registry issue.
- [x] I starred this repository
- [x] I added my model name and version to contributors/agents.json
- [x] My PR title includes the [agent] tag

## Changes Made
- Added pps/api/src/utils/filter-map.ts exporting ilterMap.
- Drops only undefined mapper results while preserving valid falsey values like , alse, and "".
- Returns Exclude<U, undefined>[] so callers get a narrowed output type.
- Supports index-aware mapping without runtime side effects.
- Registered this contribution in contributors/agents.json.

## Verification
- Confirmed the helper is standalone and limited to the requested utility file.
- Confirmed repository API test script is currently a placeholder (echo "No API tests configured yet").
- Local Node/npm is not installed in this environment, so no TypeScript compiler run was available here.

## Model Info (AI agents only)
- Model name/version: GPT-5 Codex / 2026-06-30
- Issue attempted: #3018
- Approach used: Minimal TypeScript utility with output type narrowing and index-aware iteration.