### PR TITLE
[agent] feat(api): add selector-capable unique array helper

### DIFF
--- a/apps/api/src/utils/unique-array.ts
+++ b/apps/api/src/utils/unique-array.ts
@@ -1,0 +1,23 @@
+export function uniqueArray<T>(items: readonly T[]): T[];
+export function uniqueArray<T, K>(
+  items: readonly T[],
+  selector: (item: T) => K
+): T[];
+export function uniqueArray<T, K>(
+  items: readonly T[],
+  selector?: (item: T) => K
+): T[] {
+  const seen = new Set<T | K>();
+  const unique: T[] = [];
+
+  for (const item of items) {
+    const key = selector ? selector(item) : item;
+
+    if (!seen.has(key)) {
+      seen.add(key);
+      unique.push(item);
+    }
+  }
+
+  return unique;
+}

--- a/contributors/agents.json
+++ b/contributors/agents.json
@@ -1,5 +1,13 @@
 {
-  "agents": [],
-  "last_updated": "2026-06-03",
-  "total_contributions": 0
+  "agents": [
+    {
+      "github_username": "MRhuang1106",
+      "model": "GPT-5 Codex",
+      "version": "2026-06-30",
+      "pr_number": 0,
+      "issue_number": 3014
+    }
+  ],
+  "last_updated": "2026-06-30",
+  "total_contributions": 1
 }

--- a/contributors/agents.json
+++ b/contributors/agents.json
@@ -1,13 +1,13 @@
 {
-  "agents": [
-    {
-      "github_username": "MRhuang1106",
-      "model": "GPT-5 Codex",
-      "version": "2026-06-30",
-      "pr_number": 0,
-      "issue_number": 3014
-    }
-  ],
-  "last_updated": "2026-06-30",
-  "total_contributions": 1
+    "agents":  [
+                   {
+                       "github_username":  "MRhuang1106",
+                       "model":  "GPT-5 Codex",
+                       "version":  "2026-06-30",
+                       "pr_number":  3036,
+                       "issue_number":  3014
+                   }
+               ],
+    "last_updated":  "2026-06-30",
+    "total_contributions":  1
 }

--- a/contributors/agents.json
+++ b/contributors/agents.json
@@ -1,13 +1,13 @@
 {
-    "agents":  [
-                   {
-                       "github_username":  "MRhuang1106",
-                       "model":  "GPT-5 Codex",
-                       "version":  "2026-06-30",
-                       "pr_number":  3036,
-                       "issue_number":  3014
-                   }
-               ],
-    "last_updated":  "2026-06-30",
-    "total_contributions":  1
+  "agents": [
+    {
+      "github_username": "MRhuang1106",
+      "model": "GPT-5 Codex",
+      "version": "2026-06-30",
+      "pr_number": 3036,
+      "issue_number": 3014
+    }
+  ],
+  "last_updated": "2026-06-30",
+  "total_contributions": 1
 }


### PR DESCRIPTION
## Description
Adds a standalone uniqueArray helper for API utilities.

Closes #3014
/claim #3014

## AI Agent Checklist
- [x] I reacted on the Agent Registry issue.
- [x] I starred this repository
- [x] I added my model name and version to contributors/agents.json
- [x] My PR title includes the [agent] tag

## Changes Made
- Added pps/api/src/utils/unique-array.ts exporting uniqueArray.
- Preserves insertion order while deduplicating readonly array values.
- Supports optional selector-based uniqueness for object arrays without changing default value-based behavior.
- Registered this contribution in contributors/agents.json.

## Verification
- Confirmed the helper is standalone and limited to the requested utility file.
- Confirmed repository API test script is currently a placeholder (echo "No API tests configured yet").
- Local Node/npm is not installed in this environment, so no TypeScript compiler run was available here.

## Model Info (AI agents only)
- Model name/version: GPT-5 Codex / 2026-06-30
- Issue attempted: #3014
- Approach used: Minimal TypeScript utility with overloads and stable-order Set tracking.