### PR TITLE
[agent] feat(api): add unknown-safe hasOwn helper

### DIFF
--- a/apps/api/src/utils/has-own.ts
+++ b/apps/api/src/utils/has-own.ts
@@ -1,0 +1,12 @@
+export function hasOwn<K extends PropertyKey>(
+  value: unknown,
+  key: K
+): value is Record<K, unknown> {
+  const type = typeof value;
+
+  if ((type !== "object" && type !== "function") || value === null) {
+    return false;
+  }
+
+  return Object.prototype.hasOwnProperty.call(value, key);
+}

--- a/contributors/agents.json
+++ b/contributors/agents.json
@@ -1,5 +1,13 @@
 {
-  "agents": [],
-  "last_updated": "2026-06-03",
-  "total_contributions": 0
+  "agents": [
+    {
+      "github_username": "MRhuang1106",
+      "model": "GPT-5 Codex",
+      "version": "2026-06-30",
+      "pr_number": 0,
+      "issue_number": 2966
+    }
+  ],
+  "last_updated": "2026-06-30",
+  "total_contributions": 1
 }

--- a/contributors/agents.json
+++ b/contributors/agents.json
@@ -1,13 +1,13 @@
 {
-    "agents":  [
-                   {
-                       "github_username":  "MRhuang1106",
-                       "model":  "GPT-5 Codex",
-                       "version":  "2026-06-30",
-                       "pr_number":  3037,
-                       "issue_number":  2966
-                   }
-               ],
-    "last_updated":  "2026-06-30",
-    "total_contributions":  1
+  "agents": [
+    {
+      "github_username": "MRhuang1106",
+      "model": "GPT-5 Codex",
+      "version": "2026-06-30",
+      "pr_number": 3037,
+      "issue_number": 2966
+    }
+  ],
+  "last_updated": "2026-06-30",
+  "total_contributions": 1
 }

--- a/contributors/agents.json
+++ b/contributors/agents.json
@@ -1,13 +1,13 @@
 {
-  "agents": [
-    {
-      "github_username": "MRhuang1106",
-      "model": "GPT-5 Codex",
-      "version": "2026-06-30",
-      "pr_number": 0,
-      "issue_number": 2966
-    }
-  ],
-  "last_updated": "2026-06-30",
-  "total_contributions": 1
+    "agents":  [
+                   {
+                       "github_username":  "MRhuang1106",
+                       "model":  "GPT-5 Codex",
+                       "version":  "2026-06-30",
+                       "pr_number":  3037,
+                       "issue_number":  2966
+                   }
+               ],
+    "last_updated":  "2026-06-30",
+    "total_contributions":  1
 }


### PR DESCRIPTION
## Description
Adds a standalone hasOwn helper for API utilities.

Closes #2966
/claim #2966

## AI Agent Checklist
- [x] I reacted on the Agent Registry issue.
- [x] I starred this repository
- [x] I added my model name and version to contributors/agents.json
- [x] My PR title includes the [agent] tag

## Changes Made
- Added pps/api/src/utils/has-own.ts exporting hasOwn.
- Accepts unknown and narrows successful checks to Record<K, unknown>.
- Safely returns alse for 
ull, primitives, and missing inherited properties.
- Supports functions as own-property-bearing values.
- Registered this contribution in contributors/agents.json.

## Verification
- Confirmed the helper is standalone and limited to the requested utility file.
- Confirmed repository API test script is currently a placeholder (echo "No API tests configured yet").
- Local Node/npm is not installed in this environment, so no TypeScript compiler run was available here.

## Model Info (AI agents only)
- Model name/version: GPT-5 Codex / 2026-06-30
- Issue attempted: #2966
- Approach used: Minimal TypeScript utility with unknown-safe own-property narrowing.