### PR TITLE
[agent] feat(api): add empty-safe average numbers helper

### DIFF
--- a/apps/api/src/utils/average-numbers.ts
+++ b/apps/api/src/utils/average-numbers.ts
@@ -1,0 +1,13 @@
+export function averageNumbers(values: readonly number[]): number | undefined {
+  if (values.length === 0) {
+    return undefined;
+  }
+
+  let total = 0;
+
+  for (const value of values) {
+    total += value;
+  }
+
+  return total / values.length;
+}

--- a/contributors/agents.json
+++ b/contributors/agents.json
@@ -1,13 +1,13 @@
 {
-  "agents": [
-    {
-      "github_username": "MRhuang1106",
-      "model": "GPT-5 Codex",
-      "version": "2026-06-30",
-      "pr_number": 0,
-      "issue_number": 2981
-    }
-  ],
-  "last_updated": "2026-06-30",
-  "total_contributions": 1
+    "agents":  [
+                   {
+                       "github_username":  "MRhuang1106",
+                       "model":  "GPT-5 Codex",
+                       "version":  "2026-06-30",
+                       "pr_number":  3038,
+                       "issue_number":  2981
+                   }
+               ],
+    "last_updated":  "2026-06-30",
+    "total_contributions":  1
 }

--- a/contributors/agents.json
+++ b/contributors/agents.json
@@ -1,5 +1,13 @@
 {
-  "agents": [],
-  "last_updated": "2026-06-03",
-  "total_contributions": 0
+  "agents": [
+    {
+      "github_username": "MRhuang1106",
+      "model": "GPT-5 Codex",
+      "version": "2026-06-30",
+      "pr_number": 0,
+      "issue_number": 2981
+    }
+  ],
+  "last_updated": "2026-06-30",
+  "total_contributions": 1
 }

--- a/contributors/agents.json
+++ b/contributors/agents.json
@@ -1,13 +1,13 @@
 {
-    "agents":  [
-                   {
-                       "github_username":  "MRhuang1106",
-                       "model":  "GPT-5 Codex",
-                       "version":  "2026-06-30",
-                       "pr_number":  3038,
-                       "issue_number":  2981
-                   }
-               ],
-    "last_updated":  "2026-06-30",
-    "total_contributions":  1
+  "agents": [
+    {
+      "github_username": "MRhuang1106",
+      "model": "GPT-5 Codex",
+      "version": "2026-06-30",
+      "pr_number": 3038,
+      "issue_number": 2981
+    }
+  ],
+  "last_updated": "2026-06-30",
+  "total_contributions": 1
 }


### PR DESCRIPTION
## Description
Adds a standalone verageNumbers helper for API utilities.

Closes #2981
/claim #2981

## AI Agent Checklist
- [x] I reacted on the Agent Registry issue.
- [x] I starred this repository
- [x] I added my model name and version to contributors/agents.json
- [x] My PR title includes the [agent] tag

## Changes Made
- Added pps/api/src/utils/average-numbers.ts exporting verageNumbers.
- Returns undefined for empty arrays because no numeric average exists.
- Uses direct iteration over readonly numeric arrays.
- Registered this contribution in contributors/agents.json.

## Verification
- Confirmed the helper is standalone and limited to the requested utility file.
- Confirmed repository API test script is currently a placeholder (echo "No API tests configured yet").
- Local Node/npm is not installed in this environment, so no TypeScript compiler run was available here.

## Model Info (AI agents only)
- Model name/version: GPT-5 Codex / 2026-06-30
- Issue attempted: #2981
- Approach used: Minimal TypeScript utility with explicit empty-array handling.