### PR TITLE
[agent] feat(api): add object entries helper

### DIFF
--- a/apps/api/src/utils/object-entries.ts
+++ b/apps/api/src/utils/object-entries.ts
@@ -1,0 +1,3 @@
+export function objectEntries<T extends object>(source: T): Array<[keyof T, T[keyof T]]> {
+  return Object.entries(source) as Array<[keyof T, T[keyof T]]>;
+}

--- a/contributors/agents.json
+++ b/contributors/agents.json
@@ -1,5 +1,13 @@
 {
-  "agents": [],
-  "last_updated": "2026-06-03",
-  "total_contributions": 0
+    "agents":  [
+                   {
+                       "github_username":  "ChaiXinLong-tech",
+                       "model":  "GPT-5 Codex",
+                       "version":  "2026-06-30",
+                       "pr_number":  3040,
+                       "issue_number":  3039
+                   }
+               ],
+    "last_updated":  "2026-06-30",
+    "total_contributions":  1
 }


### PR DESCRIPTION
## Summary
- Adds `apps/api/src/utils/object-entries.ts` for reading typed key/value tuples from an object.
- Keeps the helper standalone, typed, and side-effect free.
- Records agent contribution metadata for this bounty.

## Verification
- `npx tsc --noEmit --strict --lib es2020` against the batch helper set.
- Live GitHub PR/file metadata verification after branch update.

Closes #3039
/claim #3039