### PR TITLE
[agent] feat(api): add normalized take array helper

### DIFF
--- a/apps/api/src/utils/take-array.ts
+++ b/apps/api/src/utils/take-array.ts
@@ -1,0 +1,7 @@
+export function takeArray<T>(items: readonly T[], count: number): T[] {
+  if (!Number.isFinite(count) || count <= 0) {
+    return [];
+  }
+
+  return items.slice(0, Math.trunc(count));
+}

--- a/contributors/agents.json
+++ b/contributors/agents.json
@@ -1,13 +1,13 @@
 {
-    "agents":  [
-                   {
-                       "github_username":  "MRhuang1106",
-                       "model":  "GPT-5 Codex",
-                       "version":  "2026-06-30",
-                       "pr_number":  3041,
-                       "issue_number":  3021
-                   }
-               ],
-    "last_updated":  "2026-06-30",
-    "total_contributions":  1
+  "agents": [
+    {
+      "github_username": "MRhuang1106",
+      "model": "GPT-5 Codex",
+      "version": "2026-06-30",
+      "pr_number": 3041,
+      "issue_number": 3021
+    }
+  ],
+  "last_updated": "2026-06-30",
+  "total_contributions": 1
 }

--- a/contributors/agents.json
+++ b/contributors/agents.json
@@ -1,5 +1,13 @@
 {
-  "agents": [],
-  "last_updated": "2026-06-03",
-  "total_contributions": 0
+  "agents": [
+    {
+      "github_username": "MRhuang1106",
+      "model": "GPT-5 Codex",
+      "version": "2026-06-30",
+      "pr_number": 0,
+      "issue_number": 3021
+    }
+  ],
+  "last_updated": "2026-06-30",
+  "total_contributions": 1
 }

--- a/contributors/agents.json
+++ b/contributors/agents.json
@@ -1,13 +1,13 @@
 {
-  "agents": [
-    {
-      "github_username": "MRhuang1106",
-      "model": "GPT-5 Codex",
-      "version": "2026-06-30",
-      "pr_number": 0,
-      "issue_number": 3021
-    }
-  ],
-  "last_updated": "2026-06-30",
-  "total_contributions": 1
+    "agents":  [
+                   {
+                       "github_username":  "MRhuang1106",
+                       "model":  "GPT-5 Codex",
+                       "version":  "2026-06-30",
+                       "pr_number":  3041,
+                       "issue_number":  3021
+                   }
+               ],
+    "last_updated":  "2026-06-30",
+    "total_contributions":  1
 }


### PR DESCRIPTION
## Description
Adds a standalone 	akeArray helper for API utilities.

Closes #3021
/claim #3021

## AI Agent Checklist
- [x] I reacted on the Agent Registry issue.
- [x] I starred this repository
- [x] I added my model name and version to contributors/agents.json
- [x] My PR title includes the [agent] tag

## Changes Made
- Added pps/api/src/utils/take-array.ts exporting 	akeArray.
- Returns an empty array for non-finite, zero, or negative counts.
- Truncates fractional counts before slicing so behavior is explicit.
- Registered this contribution in contributors/agents.json.

## Verification
- Confirmed the helper is standalone and limited to the requested utility file.
- Confirmed repository API test script is currently a placeholder (echo "No API tests configured yet").
- Local Node/npm is not installed in this environment, so no TypeScript compiler run was available here.

## Model Info (AI agents only)
- Model name/version: GPT-5 Codex / 2026-06-30
- Issue attempted: #3021
- Approach used: Minimal TypeScript utility with count normalization before slicing.