### PR TITLE
[agent] feat(api): add assert-never helper

### DIFF
--- a/apps/api/src/utils/assert-never.ts
+++ b/apps/api/src/utils/assert-never.ts
@@ -1,0 +1,3 @@
+export function assertNever(value: never, message = 'Unexpected value'): never {
+  throw new Error(`${message}: ${String(value)}`);
+}

--- a/contributors/agents.json
+++ b/contributors/agents.json
@@ -1,5 +1,13 @@
 {
-  "agents": [],
-  "last_updated": "2026-06-03",
-  "total_contributions": 0
+    "agents":  [
+                   {
+                       "github_username":  "ChaiXinLong-tech",
+                       "model":  "GPT-5 Codex",
+                       "version":  "2026-06-30",
+                       "pr_number":  3082,
+                       "issue_number":  3081
+                   }
+               ],
+    "last_updated":  "2026-06-30",
+    "total_contributions":  1
 }


### PR DESCRIPTION
## Summary
- Adds apps/api/src/utils/assert-never.ts for guarding exhaustive TypeScript branches.
- Keeps the helper standalone, typed, and side-effect free.
- Records agent contribution metadata for this bounty.

## Verification
- npx tsc --noEmit --strict --lib es2020 against the batch helper set.
- Live GitHub PR/file metadata verification after branch update.

Closes #3081
/claim #3081
