### PR TITLE
[Agente Jhon] feat(api): add error guard helper

### DIFF
--- a/apps/api/src/utils/error-guard.ts
+++ b/apps/api/src/utils/error-guard.ts
@@ -1,0 +1,33 @@
+/**
+ * Safely wraps an async function with error handling.
+ * @param fn - The async function to execute.
+ * @param fallback - The fallback value if an error occurs.
+ * @returns The result of the function or the fallback.
+ */
+export async function errorGuard<T>(
+  fn: () => Promise<T>,
+  fallback: T
+): Promise<T> {
+  try {
+    return await fn();
+  } catch {
+    return fallback;
+  }
+}
+
+/**
+ * Safely wraps a synchronous function with error handling.
+ * @param fn - The synchronous function to execute.
+ * @param fallback - The fallback value if an error occurs.
+ * @returns The result of the function or the fallback.
+ */
+export function errorGuardSync<T>(
+  fn: () => T,
+  fallback: T
+): T {
+  try {
+    return fn();
+  } catch {
+    return fallback;
+  }
+}

--- a/apps/api/src/utils/to-string.ts
+++ b/apps/api/src/utils/to-string.ts
@@ -1,0 +1,29 @@
+/**
+ * Converts an unknown value to a string with a fallback.
+ * @param value - The value to convert.
+ * @param fallback - The fallback value if conversion fails (default: '').
+ * @returns A string.
+ */
+export function toString(value: unknown, fallback: string = ''): string {
+  if (value === null || value === undefined) {
+    return fallback;
+  }
+
+  if (typeof value === 'string') {
+    return value;
+  }
+
+  if (typeof value === 'number' || typeof value === 'boolean') {
+    return String(value);
+  }
+
+  if (typeof value === 'object') {
+    try {
+      return JSON.stringify(value);
+    } catch {
+      return fallback;
+    }
+  }
+
+  return fallback;
+}


### PR DESCRIPTION
Closes #3073
/claim #3073

## Changes
- Added `apps/api/src/utils/error-guard.ts`.
- Exported `errorGuard` (async) and `errorGuardSync` (sync).
- Handles errors gracefully and returns fallback values.