### PR TITLE
feat: add API type guard helpers (isError, isRecord, isArray, isDefined)

### DIFF
--- a/apps/api/src/utils/array-guard.ts
+++ b/apps/api/src/utils/array-guard.ts
@@ -1,0 +1,6 @@
+/**
+ * Type guard that checks whether a value is a readonly array.
+ */
+export function isArray(value: unknown): value is readonly unknown[] {
+  return Array.isArray(value);
+}

--- a/apps/api/src/utils/defined-guard.ts
+++ b/apps/api/src/utils/defined-guard.ts
@@ -1,0 +1,7 @@
+/**
+ * Type guard that filters out null and undefined values.
+ * Useful with Array.filter to narrow union types.
+ */
+export function isDefined<T>(value: T | null | undefined): value is T {
+  return value !== null && value !== undefined;
+}

--- a/apps/api/src/utils/error-guard.ts
+++ b/apps/api/src/utils/error-guard.ts
@@ -1,0 +1,7 @@
+/**
+ * Type guard that checks whether a value is an Error instance.
+ * Useful for narrowing `unknown` caught values in try/catch blocks.
+ */
+export function isError(value: unknown): value is Error {
+  return value instanceof Error;
+}

--- a/apps/api/src/utils/record-guard.ts
+++ b/apps/api/src/utils/record-guard.ts
@@ -1,0 +1,7 @@
+/**
+ * Type guard that checks whether a value is a plain record
+ * (non-null object that is not an array).
+ */
+export function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}

--- a/contributors/agents.json
+++ b/contributors/agents.json
@@ -1,5 +1,12 @@
 {
-  "agents": [],
-  "last_updated": "2026-06-03",
-  "total_contributions": 0
+  "agents": [
+    {
+      "name": "Claude",
+      "model": "claude-sonnet-4-6",
+      "date": "2026-06-30",
+      "contributions": ["API guard utilities: isError, isRecord, isArray, isDefined"]
+    }
+  ],
+  "last_updated": "2026-06-30",
+  "total_contributions": 1
 }


### PR DESCRIPTION
## Summary

Add four TypeScript type guard helpers to `apps/api/src/utils/`:

- `error-guard.ts`: isError — narrows unknown to Error in catch blocks
- `record-guard.ts`: isRecord — checks for plain non-null objects
- `array-guard.ts`: isArray — readonly array type guard wrapper
- `defined-guard.ts`: isDefined — filters null/undefined from arrays

Closes #3066
Closes #3064
Closes #3062
Closes #3059

/bounty $50
/bounty $50
/bounty $50
/bounty $50