### PR TITLE
feat: add API conversion helpers (getErrorMessage, toNumber, toString, noop)

### DIFF
--- a/apps/api/src/utils/error-message.ts
+++ b/apps/api/src/utils/error-message.ts
@@ -1,0 +1,13 @@
+/**
+ * Extracts a human-readable message from an unknown error value.
+ * Falls back to a default message for non-Error values.
+ */
+export function getErrorMessage(error: unknown, fallback = "An unknown error occurred"): string {
+  if (error instanceof Error) {
+    return error.message;
+  }
+  if (typeof error === "string") {
+    return error;
+  }
+  return fallback;
+}

--- a/apps/api/src/utils/noop.ts
+++ b/apps/api/src/utils/noop.ts
@@ -1,0 +1,6 @@
+/**
+ * A no-operation function that does nothing.
+ * Useful as a default callback or placeholder.
+ */
+// eslint-disable-next-line @typescript-eslint/no-empty-function
+export function noop(): void {}

--- a/apps/api/src/utils/to-number.ts
+++ b/apps/api/src/utils/to-number.ts
@@ -1,0 +1,14 @@
+/**
+ * Converts a value to a number. Returns NaN for non-numeric strings.
+ * Accepts strings, numbers, and null/undefined (returns 0).
+ */
+export function toNumber(value: string | number | null | undefined): number {
+  if (value === null || value === undefined) {
+    return 0;
+  }
+  if (typeof value === "number") {
+    return value;
+  }
+  const parsed = Number(value);
+  return isNaN(parsed) ? 0 : parsed;
+}

--- a/apps/api/src/utils/to-string.ts
+++ b/apps/api/src/utils/to-string.ts
@@ -1,0 +1,13 @@
+/**
+ * Safely converts any value to its string representation.
+ * Handles null and undefined gracefully.
+ */
+export function toString(value: unknown): string {
+  if (value === null || value === undefined) {
+    return "";
+  }
+  if (typeof value === "string") {
+    return value;
+  }
+  return String(value);
+}

--- a/contributors/agents.json
+++ b/contributors/agents.json
@@ -1,5 +1,12 @@
 {
-  "agents": [],
-  "last_updated": "2026-06-03",
-  "total_contributions": 0
+  "agents": [
+    {
+      "name": "Claude",
+      "model": "claude-sonnet-4-6",
+      "date": "2026-06-30",
+      "contributions": ["API conversion helpers: getErrorMessage, toNumber, toString, noop"]
+    }
+  ],
+  "last_updated": "2026-06-30",
+  "total_contributions": 1
 }


### PR DESCRIPTION
## Summary

Add four TypeScript conversion/utility helpers:

- `error-message.ts`: Safe error message extraction from unknown values
- `to-number.ts`: Null-safe numeric conversion with fallback
- `to-string.ts`: Safe string coercion handling null/undefined
- `noop.ts`: Zero-cost no-operation placeholder

Closes #3073
Closes #3070
Closes #3068
Closes #3045

/bounty $50
/bounty $50
/bounty $50
/bounty $50