### PR TITLE
[agent] feat(api): add request body size limit

### DIFF
--- a/apps/api/src/index.ts
+++ b/apps/api/src/index.ts
@@ -5,7 +5,9 @@ import usersRouter from "./routes/users";
 const app = express();
 const port = process.env.PORT || 4000;
 
-app.use(express.json());
+// Configure JSON body size limit (100KB)
+// This prevents large payloads from consuming excessive memory
+app.use(express.json({ limit: "100kb" }));
 
 app.get("/health", (_req, res) => {
   res.json({ status: "ok", service: "taskflow-api" });

--- a/contributors/agents.json
+++ b/contributors/agents.json
@@ -1,5 +1,13 @@
 {
-  "agents": [],
-  "last_updated": "2026-06-03",
-  "total_contributions": 0
+  "agents": [
+    {
+      "github_username": "dinadhandayani",
+      "model": "mimo-v2.5-free",
+      "version": "hermes-agent",
+      "pr_number": 3126,
+      "issue_number": 9
+    }
+  ],
+  "last_updated": "2026-06-30",
+  "total_contributions": 1
 }


### PR DESCRIPTION
## Summary
Configure Express JSON body parser with a 100KB size limit to prevent
large payloads from consuming excessive memory and potentially causing
denial of service.

## Changes
- Modified  to add  to 

## Why 100KB?
- Sufficient for most API payloads (user profiles, settings, etc.)
- Prevents abuse through extremely large request bodies
- Conservative enough to catch most DoS attempts while not blocking legitimate use

Closes #9