### PR TITLE
[Agente Jhon] feat(api): add integer parse helper

### DIFF
--- a/packages/api/src/utils/packages/api/src/utils/packages/api/src/utils/parse-integer.ts
+++ b/packages/api/src/utils/packages/api/src/utils/packages/api/src/utils/parse-integer.ts
@@ -1,0 +1,18 @@
+/**
+ * Safely parses an integer from an unknown value.
+ * @param value - The value to parse.
+ * @param fallback - The fallback value if parsing fails (default: 0).
+ * @returns The parsed integer or fallback.
+ */
+export function parseInteger(value: unknown, fallback: number = 0): number {
+  if (typeof value === 'number') {
+    return Number.isInteger(value) ? value : fallback;
+  }
+
+  if (typeof value === 'string') {
+    const parsed = parseInt(value, 10);
+    return isNaN(parsed) ? fallback : parsed;
+  }
+
+  return fallback;
+}

--- a/packages/api/src/utils/packages/api/src/utils/parse-integer.ts
+++ b/packages/api/src/utils/packages/api/src/utils/parse-integer.ts
@@ -1,0 +1,18 @@
+/**
+ * Safely parses an integer from an unknown value.
+ * @param value - The value to parse.
+ * @param fallback - The fallback value if parsing fails (default: 0).
+ * @returns The parsed integer or fallback.
+ */
+export function parseInteger(value: unknown, fallback: number = 0): number {
+  if (typeof value === 'number') {
+    return Number.isInteger(value) ? value : fallback;
+  }
+
+  if (typeof value === 'string') {
+    const parsed = parseInt(value, 10);
+    return isNaN(parsed) ? fallback : parsed;
+  }
+
+  return fallback;
+}

--- a/packages/api/src/utils/parse-integer.ts
+++ b/packages/api/src/utils/parse-integer.ts
@@ -1,0 +1,18 @@
+/**
+ * Safely parses an integer from an unknown value.
+ * @param value - The value to parse.
+ * @param fallback - The fallback value if parsing fails (default: 0).
+ * @returns The parsed integer or fallback.
+ */
+export function parseInteger(value: unknown, fallback: number = 0): number {
+  if (typeof value === 'number') {
+    return Number.isInteger(value) ? value : fallback;
+  }
+
+  if (typeof value === 'string') {
+    const parsed = parseInt(value, 10);
+    return isNaN(parsed) ? fallback : parsed;
+  }
+
+  return fallback;
+}


### PR DESCRIPTION
Closes #3139
/claim #3139

## Changes
- Added `packages/api/src/utils/parse-integer.ts`.
- Exported `parseInteger` helper.
- Safely parses integers from numbers and strings.

**Payment wallet (USDC on Ethereum):** `0x46243c949f30280771c0675Bc8A16155A9B96e51`
