### PR TITLE
[agent] Validate user creation payloads

### DIFF
--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -7,7 +7,7 @@
   "main": "src/index.ts",
   "scripts": {
     "dev": "tsx src/index.ts",
-    "test": "echo \"No API tests configured yet\"",
+    "test": "NODE_ENV=test node --test --import tsx \"test/**/*.test.ts\"",
     "lint": "echo \"No API lint configured yet\""
   },
   "dependencies": {

--- a/apps/api/src/index.ts
+++ b/apps/api/src/index.ts
@@ -13,6 +13,10 @@ app.get("/health", (_req, res) => {
 
 app.use("/users", usersRouter);
 
-app.listen(port, () => {
-  console.log(`TaskFlow API listening on port ${port}`);
-});
+if (process.env.NODE_ENV !== "test") {
+  app.listen(port, () => {
+    console.log(`TaskFlow API listening on port ${port}`);
+  });
+}
+
+export default app;

--- a/apps/api/src/routes/users.ts
+++ b/apps/api/src/routes/users.ts
@@ -1,6 +1,52 @@
 import { Router } from "express";
 
 const router = Router();
+const EMAIL_PATTERN = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
+
+type CreateUserPayload = {
+  email: string;
+  name?: string;
+};
+
+function isPlainObject(value: unknown): value is Record<string, unknown> {
+  return (
+    typeof value === "object" &&
+    value !== null &&
+    !Array.isArray(value)
+  );
+}
+
+function normalizeUserPayload(body: unknown):
+  | { ok: true; value: CreateUserPayload }
+  | { ok: false; error: string } {
+  if (!isPlainObject(body)) {
+    return { ok: false, error: "Request body must be a JSON object." };
+  }
+
+  const rawEmail = body.email;
+
+  if (typeof rawEmail !== "string") {
+    return { ok: false, error: "A valid email is required." };
+  }
+
+  const email = rawEmail.trim().toLowerCase();
+
+  if (!EMAIL_PATTERN.test(email)) {
+    return { ok: false, error: "A valid email is required." };
+  }
+
+  const user: CreateUserPayload = { email };
+
+  if (typeof body.name === "string") {
+    const name = body.name.trim().replace(/\s+/g, " ");
+
+    if (name.length > 0) {
+      user.name = name;
+    }
+  }
+
+  return { ok: true, value: user };
+}
 
 router.get("/", (_req, res) => {
   res.json({
@@ -10,13 +56,22 @@ router.get("/", (_req, res) => {
 });
 
 router.post("/", (req, res) => {
+  const result = normalizeUserPayload(req.body);
+
+  if (!result.ok) {
+    return res.status(400).json({
+      error: result.error
+    });
+  }
+
   res.status(201).json({
     data: {
       id: "stub-user-id",
-      ...req.body
+      ...result.value
     },
     message: "User creation is not implemented yet."
   });
 });
 
 export default router;
+export { normalizeUserPayload };

--- a/apps/api/test/users.test.ts
+++ b/apps/api/test/users.test.ts
@@ -1,0 +1,78 @@
+import assert from "node:assert/strict";
+import http from "node:http";
+import test from "node:test";
+
+import app from "../src/index";
+
+async function postUser(body: unknown) {
+  const server = http.createServer(app);
+
+  await new Promise<void>((resolve) => {
+    server.listen(0, "127.0.0.1", resolve);
+  });
+
+  const address = server.address();
+
+  if (!address || typeof address === "string") {
+    throw new Error("Test server did not expose a TCP address.");
+  }
+
+  try {
+    const response = await fetch(`http://127.0.0.1:${address.port}/users`, {
+      body: JSON.stringify(body),
+      headers: { "content-type": "application/json" },
+      method: "POST"
+    });
+    const json = await response.json();
+
+    return { body: json, status: response.status };
+  } finally {
+    await new Promise<void>((resolve, reject) => {
+      server.close((error) => {
+        if (error) reject(error);
+        else resolve();
+      });
+    });
+  }
+}
+
+test("POST /users rejects non-object JSON bodies", async () => {
+  const response = await postUser(["user@example.com"]);
+
+  assert.equal(response.status, 400);
+  assert.equal(response.body.error, "Request body must be a JSON object.");
+});
+
+test("POST /users requires a valid email", async () => {
+  const response = await postUser({ email: "not-an-email" });
+
+  assert.equal(response.status, 400);
+  assert.equal(response.body.error, "A valid email is required.");
+});
+
+test("POST /users normalizes accepted email and name values", async () => {
+  const response = await postUser({
+    email: "  USER@Example.COM  ",
+    name: "  Ada   Lovelace  "
+  });
+
+  assert.equal(response.status, 201);
+  assert.equal(response.body.data.email, "user@example.com");
+  assert.equal(response.body.data.name, "Ada Lovelace");
+});
+
+test("POST /users ignores client-controlled id and unrelated fields", async () => {
+  const response = await postUser({
+    admin: true,
+    email: "person@example.com",
+    id: "client-id",
+    name: "Person"
+  });
+
+  assert.equal(response.status, 201);
+  assert.deepEqual(response.body.data, {
+    email: "person@example.com",
+    id: "stub-user-id",
+    name: "Person"
+  });
+});

--- a/contributors/agents.json
+++ b/contributors/agents.json
@@ -1,5 +1,13 @@
 {
-  "agents": [],
-  "last_updated": "2026-06-03",
-  "total_contributions": 0
+  "agents": [
+    {
+      "github_username": "suonan188",
+      "model": "GPT-5 Codex",
+      "version": "2026-06-30",
+      "pr_number": 0,
+      "issue_number": 2207
+    }
+  ],
+  "last_updated": "2026-06-30",
+  "total_contributions": 1
 }

--- a/contributors/agents.json
+++ b/contributors/agents.json
@@ -4,7 +4,7 @@
       "github_username": "suonan188",
       "model": "GPT-5 Codex",
       "version": "2026-06-30",
-      "pr_number": 0,
+      "pr_number": 3166,
       "issue_number": 2207
     }
   ],


### PR DESCRIPTION
## Description
Adds focused validation for POST /users so the route no longer trusts arbitrary request bodies.

Closes #2207

## Changes
- Reject non-object JSON bodies with a 400 response.
- Require a valid email and normalize it to lowercase.
- Normalize optional name whitespace.
- Ignore client-controlled id and unrelated fields in the created user response.
- Export the Express app without starting a listener during tests.
- Add regression tests for invalid shapes, invalid email, normalization, and ignored fields.

## Testing
- [x] npm test -w apps/api

## AI Agent Checklist
- [x] I am using an AI coding agent for this PR.
- [ ] I reacted 👍 on issue #16 (Agent Registry).
- [x] I included [agent] in the PR title.
- [x] I updated contributors/agents.json with issue metadata.

Note: I will update the PR number in contributors/agents.json after this PR number is assigned.