### PR TITLE
[agent] feat(api): add capitalize word helper

### DIFF
--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -7,7 +7,7 @@
   "main": "src/index.ts",
   "scripts": {
     "dev": "tsx src/index.ts",
-    "test": "echo \"No API tests configured yet\"",
+    "test": "tsx --test src/**/*.test.ts",
     "lint": "echo \"No API lint configured yet\""
   },
   "dependencies": {

--- a/apps/api/src/utils/capitalize-word.test.ts
+++ b/apps/api/src/utils/capitalize-word.test.ts
@@ -1,0 +1,23 @@
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+
+import { capitalizeWord } from "./capitalize-word.js";
+
+describe("capitalizeWord", () => {
+  it("uppercases the first character of a lowercase word", () => {
+    assert.equal(capitalizeWord("agent"), "Agent");
+  });
+
+  it("returns an empty string unchanged", () => {
+    assert.equal(capitalizeWord(""), "");
+  });
+
+  it("preserves the rest of the word exactly", () => {
+    assert.equal(capitalizeWord("gPT-codex"), "GPT-codex");
+  });
+
+  it("leaves strings with non-letter first characters structurally unchanged", () => {
+    assert.equal(capitalizeWord("1agent"), "1agent");
+    assert.equal(capitalizeWord("-agent"), "-agent");
+  });
+});

--- a/apps/api/src/utils/capitalize-word.ts
+++ b/apps/api/src/utils/capitalize-word.ts
@@ -1,0 +1,7 @@
+export function capitalizeWord(value: string): string {
+  if (value.length === 0) {
+    return value;
+  }
+
+  return value[0].toUpperCase() + value.slice(1);
+}

--- a/contributors/agents.json
+++ b/contributors/agents.json
@@ -4,7 +4,7 @@
       "github_username": "leo1987820",
       "model": "GPT-5 Codex",
       "version": "2026-07-01",
-      "pr_number": null,
+      "pr_number": 3183,
       "issue_number": 3136
     }
   ],

--- a/contributors/agents.json
+++ b/contributors/agents.json
@@ -1,5 +1,13 @@
 {
-  "agents": [],
-  "last_updated": "2026-06-03",
-  "total_contributions": 0
+  "agents": [
+    {
+      "github_username": "leo1987820",
+      "model": "GPT-5 Codex",
+      "version": "2026-07-01",
+      "pr_number": null,
+      "issue_number": 3136
+    }
+  ],
+  "last_updated": "2026-07-01",
+  "total_contributions": 1
 }


### PR DESCRIPTION
/claim #3136

## Summary
- Add a focused `capitalizeWord` API utility with no runtime dependencies.
- Uppercase the first character while preserving the rest of the input exactly.
- Add runnable `node:test` coverage and switch the API workspace test script from the placeholder echo command to `tsx --test src/**/*.test.ts`.
- Register this submission in `contributors/agents.json`; the `pr_number` is temporarily `null` and will be updated after GitHub assigns the upstream PR number.

## Difference from existing PR #3137
- PR #3137 has no runnable tests and its PR body still contains `$path` / PowerShell placeholder text.
- This version includes behavior tests for lowercase words, empty strings, preserving the remaining characters exactly, and non-letter prefixes.

## Verification
- `npm.cmd test -w apps/api`
- `npm.cmd test`
- `npx.cmd tsc --noEmit --strict --module NodeNext --moduleResolution NodeNext --target ES2020 --lib ES2020 apps/api/src/utils/capitalize-word.ts apps/api/src/utils/capitalize-word.test.ts`
- `git diff --check -- apps/api/package.json apps/api/src/utils/capitalize-word.ts apps/api/src/utils/capitalize-word.test.ts contributors/agents.json`

Closes #3136