### PR TITLE
[agent] feat(api): add date parsing helper

### DIFF
--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -7,7 +7,7 @@
   "main": "src/index.ts",
   "scripts": {
     "dev": "tsx src/index.ts",
-    "test": "echo \"No API tests configured yet\"",
+    "test": "tsx --test src/**/*.test.ts",
     "lint": "echo \"No API lint configured yet\""
   },
   "dependencies": {

--- a/apps/api/src/utils/parse-date.test.ts
+++ b/apps/api/src/utils/parse-date.test.ts
@@ -1,0 +1,26 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { parseDate } from "./parse-date.js";
+
+test("parses valid date strings and timestamps", () => {
+  assert.equal(parseDate("2026-07-01T00:00:00.000Z")?.toISOString(), "2026-07-01T00:00:00.000Z");
+  assert.equal(parseDate(Date.UTC(2026, 6, 1))?.toISOString(), "2026-07-01T00:00:00.000Z");
+});
+
+test("clones Date inputs instead of returning the original object", () => {
+  const original = new Date("2026-07-01T00:00:00.000Z");
+  const parsed = parseDate(original);
+
+  assert.notEqual(parsed, original);
+  assert.equal(parsed?.toISOString(), "2026-07-01T00:00:00.000Z");
+});
+
+test("returns undefined for invalid or unsupported values", () => {
+  assert.equal(parseDate("not a date"), undefined);
+  assert.equal(parseDate(new Date(Number.NaN)), undefined);
+  assert.equal(parseDate(Number.NaN), undefined);
+  assert.equal(parseDate(Number.POSITIVE_INFINITY), undefined);
+  assert.equal(parseDate(null), undefined);
+  assert.equal(parseDate({ value: "2026-07-01" }), undefined);
+});

--- a/apps/api/src/utils/parse-date.ts
+++ b/apps/api/src/utils/parse-date.ts
@@ -1,0 +1,27 @@
+export function parseDate(value: unknown): Date | undefined {
+  if (value instanceof Date) {
+    return cloneIfValid(value);
+  }
+
+  if (typeof value === "number") {
+    if (!Number.isFinite(value)) {
+      return undefined;
+    }
+
+    return cloneIfValid(new Date(value));
+  }
+
+  if (typeof value === "string") {
+    return cloneIfValid(new Date(value));
+  }
+
+  return undefined;
+}
+
+function cloneIfValid(date: Date): Date | undefined {
+  if (Number.isNaN(date.getTime())) {
+    return undefined;
+  }
+
+  return new Date(date.getTime());
+}

--- a/contributors/agents.json
+++ b/contributors/agents.json
@@ -1,5 +1,13 @@
 {
-  "agents": [],
-  "last_updated": "2026-06-03",
-  "total_contributions": 0
+  "agents": [
+    {
+      "github_username": "leo1987820",
+      "model": "GPT-5 Codex",
+      "version": "2026-07-01",
+      "pr_number": null,
+      "issue_number": 3130
+    }
+  ],
+  "last_updated": "2026-07-01",
+  "total_contributions": 1
 }

--- a/contributors/agents.json
+++ b/contributors/agents.json
@@ -4,7 +4,7 @@
       "github_username": "leo1987820",
       "model": "GPT-5 Codex",
       "version": "2026-07-01",
-      "pr_number": null,
+      "pr_number": 3185,
       "issue_number": 3130
     }
   ],


### PR DESCRIPTION
/claim #3130

## Summary
- Add a focused `parseDate` API utility with no runtime dependencies.
- Accept valid date strings, finite timestamps, and `Date` instances; return a cloned `Date` or `undefined` for invalid/unsupported inputs.
- Add runnable `node:test` coverage and switch the API workspace test script from the placeholder echo command to `tsx --test src/**/*.test.ts`.
- Register this submission in `contributors/agents.json`; the `pr_number` is temporarily `null` and should be updated after GitHub assigns the upstream PR number.

## Difference from existing PR #3131
- PR #3131 has no runnable tests and its PR body still contains `$path` / PowerShell placeholder text.
- This version includes behavior tests for valid strings, timestamps, cloned `Date` inputs, invalid dates, non-finite numbers, and unsupported values.

## Verification
- `npm.cmd test -w apps/api`
- `npm.cmd test`
- `npx.cmd tsc --noEmit --strict --module NodeNext --moduleResolution NodeNext --target ES2020 --lib ES2020 apps/api/src/utils/parse-date.ts apps/api/src/utils/parse-date.test.ts`
- `git diff --check -- apps/api/package.json apps/api/src/utils/parse-date.ts apps/api/src/utils/parse-date.test.ts contributors/agents.json`

Closes #3130