### PR TITLE
[agent] feat(api): add URL join helper

### DIFF
--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -7,7 +7,7 @@
   "main": "src/index.ts",
   "scripts": {
     "dev": "tsx src/index.ts",
-    "test": "echo \"No API tests configured yet\"",
+    "test": "tsx --test src/**/*.test.ts",
     "lint": "echo \"No API lint configured yet\""
   },
   "dependencies": {

--- a/apps/api/src/utils/join-url.test.ts
+++ b/apps/api/src/utils/join-url.test.ts
@@ -1,0 +1,25 @@
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+
+import { joinUrl } from "./join-url.js";
+
+describe("joinUrl", () => {
+  it("joins URL segments while normalizing duplicate boundary slashes", () => {
+    assert.equal(
+      joinUrl("https://api.example.com/", "/v1/", "/users"),
+      "https://api.example.com/v1/users",
+    );
+  });
+
+  it("preserves a leading slash for absolute paths", () => {
+    assert.equal(joinUrl("/api/", "/v1/", "users"), "/api/v1/users");
+  });
+
+  it("skips empty segments without adding extra separators", () => {
+    assert.equal(joinUrl("https://api.example.com", "", "v1", "", "users"), "https://api.example.com/v1/users");
+  });
+
+  it("returns an empty string when every segment is empty", () => {
+    assert.equal(joinUrl("", "", ""), "");
+  });
+});

--- a/apps/api/src/utils/join-url.ts
+++ b/apps/api/src/utils/join-url.ts
@@ -1,0 +1,25 @@
+export function joinUrl(...parts: readonly string[]): string {
+  const nonEmptyParts = parts.filter((part) => part.length > 0);
+
+  if (nonEmptyParts.length === 0) {
+    return "";
+  }
+
+  const keepsLeadingSlash = nonEmptyParts[0].startsWith("/");
+  const joined = nonEmptyParts
+    .map((part, index) => {
+      if (index === 0) {
+        return part.replace(/\/+$/g, "");
+      }
+
+      return part.replace(/^\/+|\/+$/g, "");
+    })
+    .filter((part) => part.length > 0)
+    .join("/");
+
+  if (keepsLeadingSlash && !joined.startsWith("/")) {
+    return `/${joined}`;
+  }
+
+  return joined;
+}

--- a/contributors/agents.json
+++ b/contributors/agents.json
@@ -4,7 +4,7 @@
       "github_username": "leo1987820",
       "model": "GPT-5 Codex",
       "version": "2026-07-01",
-      "pr_number": null,
+     "pr_number": 3188,
       "issue_number": 3134
     }
   ],

--- a/contributors/agents.json
+++ b/contributors/agents.json
@@ -1,5 +1,13 @@
 {
-  "agents": [],
-  "last_updated": "2026-06-03",
-  "total_contributions": 0
+  "agents": [
+    {
+      "github_username": "leo1987820",
+      "model": "GPT-5 Codex",
+      "version": "2026-07-01",
+      "pr_number": null,
+      "issue_number": 3134
+    }
+  ],
+  "last_updated": "2026-07-01",
+  "total_contributions": 1
 }


### PR DESCRIPTION
/claim #3134

## Summary
- Add a focused `joinUrl` API utility with no runtime dependencies.
- Normalize duplicate slash boundaries across URL/path segments while preserving `https://` origins and leading slash absolute paths.
- Add runnable `node:test` coverage and switch the API workspace test script from the placeholder echo command to `tsx --test src/**/*.test.ts`.
- Register this submission in `contributors/agents.json`; the `pr_number` is temporarily `null` and will be updated after GitHub assigns the upstream PR number.

## Difference from existing PR #3135
- PR #3135 has no runnable tests and its PR body still contains `$path` / PowerShell placeholder text.
- This version includes behavior tests for slash normalization, absolute-path preservation, empty segment handling, and all-empty input.

## Verification
- `npm.cmd test -w apps/api`
- `npm.cmd test`
- `npx.cmd tsc --noEmit --strict --module NodeNext --moduleResolution NodeNext --target ES2020 --lib ES2020 apps/api/src/utils/join-url.ts apps/api/src/utils/join-url.test.ts`
- `git diff --check -- apps/api/package.json apps/api/src/utils/join-url.ts apps/api/src/utils/join-url.test.ts contributors/agents.json`

Closes #3134