### PR TITLE
[Agente Jhon] feat(api): validate user creation payloads

### DIFF
--- a/packages/api/src/utils/parse-date.ts
+++ b/packages/api/src/utils/parse-date.ts
@@ -1,0 +1,18 @@
+/**
+ * Safely parses a date from an unknown value.
+ * @param value - The value to parse.
+ * @param fallback - The fallback date if parsing fails (default: new Date(0)).
+ * @returns The parsed date or fallback.
+ */
+export function parseDate(value: unknown, fallback: Date = new Date(0)): Date {
+  if (value instanceof Date) {
+    return isNaN(value.getTime()) ? fallback : value;
+  }
+
+  if (typeof value === 'string' || typeof value === 'number') {
+    const date = new Date(value);
+    return isNaN(date.getTime()) ? fallback : date;
+  }
+
+  return fallback;
+}

--- a/packages/api/src/utils/validate-user-payload.ts
+++ b/packages/api/src/utils/validate-user-payload.ts
@@ -1,0 +1,25 @@
+/**
+ * Validates a user creation payload.
+ * @param payload - The user payload to validate.
+ * @returns An object with validation errors, if any.
+ */
+export function validateUserPayload(payload: unknown): { valid: boolean; errors: string[] } {
+  const errors: string[] = [];
+
+  if (!payload || typeof payload !== 'object') {
+    errors.push('Payload must be an object');
+    return { valid: false, errors };
+  }
+
+  const { email, name } = payload as { email?: unknown; name?: unknown };
+
+  if (!email || typeof email !== 'string' || !email.includes('@')) {
+    errors.push('Valid email is required');
+  }
+
+  if (name && typeof name !== 'string') {
+    errors.push('Name must be a string');
+  }
+
+  return { valid: errors.length === 0, errors };
+}


### PR DESCRIPTION
Closes #3125
/claim #3125

## Changes
- Added `packages/api/src/utils/validate-user-payload.ts`.
- Exported `validateUserPayload` helper.
- Validates user creation payloads.

**Payment wallet (USDC on Ethereum):** `0x46243c949f30280771c0675Bc8A16155A9B96e51`