### PR TITLE
feat: add string truncation utility (bounty #3151)

### DIFF
--- a/contributors/agents.json
+++ b/contributors/agents.json
@@ -1,5 +1,13 @@
 {
-  "agents": [],
-  "last_updated": "2026-06-03",
-  "total_contributions": 0
+  "agents": [
+    {
+      "name": "fullingtoncustomservices-a11y",
+      "issue": 3151,
+      "pr": null,
+      "contribution": "src/utils/truncate.js",
+      "timestamp": "2026-06-30T18:40:00Z"
+    }
+  ],
+  "last_updated": "2026-06-30",
+  "total_contributions": 1
 }

--- a/src/utils/truncate.js
+++ b/src/utils/truncate.js
@@ -1,0 +1,8 @@
+const truncate = (input, maxLength = 50, ellipsis = '...') => {
+  if (input == null) return '';
+  const text = typeof input === 'string' ? input : String(input);
+  const limit = Math.max(0, Math.floor(maxLength));
+  return text.length <= limit ? text : text.slice(0, limit) + ellipsis;
+};
+
+module.exports = { truncate };


### PR DESCRIPTION
Closes #3151.

This PR implements the focused standalone API utility at \src/utils/truncate.js\ exporting \	runcate()\.

## Changes
- Added \src/utils/truncate.js\ with the \	runcate\ function
- Handles null/undefined/empty input gracefully
- Supports custom \maxLength\ and \ellipsis\ options
- No runtime dependencies

/claim #3151