### PR TITLE
[Agente Jhon] feat(api): add error message helper

### DIFF
--- a/packages/api/src/utils/get-error-message.ts
+++ b/packages/api/src/utils/get-error-message.ts
@@ -1,0 +1,28 @@
+/**
+ * Safely extracts an error message from an unknown error object.
+ * @param error - The error object.
+ * @param fallback - The fallback message if extraction fails (default: 'Unknown error').
+ * @returns The error message or fallback.
+ */
+export function getErrorMessage(error: unknown, fallback: string = 'Unknown error'): string {
+  if (error === null || error === undefined) {
+    return fallback;
+  }
+
+  if (typeof error === 'string') {
+    return error;
+  }
+
+  if (error instanceof Error) {
+    return error.message || fallback;
+  }
+
+  if (typeof error === 'object' && 'message' in error) {
+    const message = (error as { message: unknown }).message;
+    if (typeof message === 'string') {
+      return message;
+    }
+  }
+
+  return fallback;
+}

--- a/packages/api/src/utils/parse-date.ts
+++ b/packages/api/src/utils/parse-date.ts
@@ -1,0 +1,18 @@
+/**
+ * Safely parses a date from an unknown value.
+ * @param value - The value to parse.
+ * @param fallback - The fallback date if parsing fails (default: new Date(0)).
+ * @returns The parsed date or fallback.
+ */
+export function parseDate(value: unknown, fallback: Date = new Date(0)): Date {
+  if (value instanceof Date) {
+    return isNaN(value.getTime()) ? fallback : value;
+  }
+
+  if (typeof value === 'string' || typeof value === 'number') {
+    const date = new Date(value);
+    return isNaN(date.getTime()) ? fallback : date;
+  }
+
+  return fallback;
+}


### PR DESCRIPTION
Closes #3157
/claim #3157

## Changes
- Added `packages/api/src/utils/get-error-message.ts`.
- Exported `getErrorMessage` helper.
- Safely extracts error messages from unknown error objects.

**Payment wallet (USDC on Ethereum):** `0x46243c949f30280771c0675Bc8A16155A9B96e51`