### PR TITLE
[agent] feat(api): add percent formatting helper

### DIFF
--- a/apps/api/src/utils/format-percent.ts
+++ b/apps/api/src/utils/format-percent.ts
@@ -1,0 +1,3 @@
+export function formatPercent(value: number, precision = 0): string {
+  return `${(value * 100).toFixed(precision)}%`;
+}

--- a/contributors/agents.json
+++ b/contributors/agents.json
@@ -1,5 +1,13 @@
 {
-  "agents": [],
-  "last_updated": "2026-06-03",
-  "total_contributions": 0
+    "agents":  [
+                   {
+                       "github_username":  "ChaiXinLong-tech",
+                       "model":  "GPT-5 Codex",
+                       "version":  "2026-06-30",
+                       "pr_number":  3242,
+                       "issue_number":  3145
+                   }
+               ],
+    "last_updated":  "2026-06-30",
+    "total_contributions":  1
 }


### PR DESCRIPTION
Adds a focused percent-formatting helper for API code paths that need to render a numeric ratio as a percentage string.

Verification:
- npx tsc --noEmit --strict --lib es2020 outputs/tmp-batch36/format-percent.ts

Closes #3145
/claim #3145