### PR TITLE
[agent] feat(api): add trailing slash stripping helper

### DIFF
--- a/apps/api/src/utils/strip-trailing-slash.ts
+++ b/apps/api/src/utils/strip-trailing-slash.ts
@@ -1,0 +1,7 @@
+export function stripTrailingSlash(value: string): string {
+  if (value === "/") {
+    return value;
+  }
+
+  return value.replace(/\/+$/g, "");
+}

--- a/contributors/agents.json
+++ b/contributors/agents.json
@@ -1,5 +1,13 @@
 {
-  "agents": [],
-  "last_updated": "2026-06-03",
-  "total_contributions": 0
+    "agents":  [
+                   {
+                       "github_username":  "ChaiXinLong-tech",
+                       "model":  "GPT-5 Codex",
+                       "version":  "2026-06-30",
+                       "pr_number":  3244,
+                       "issue_number":  3243
+                   }
+               ],
+    "last_updated":  "2026-06-30",
+    "total_contributions":  1
 }


### PR DESCRIPTION
Adds a focused trailing-slash utility for API code paths that need stable path or URL strings without trailing slash characters.

Verification:
- npx tsc --noEmit --strict --lib es2020 outputs/tmp-batch36/strip-trailing-slash.ts

Closes #3243
/claim #3243