### PR TITLE
[agent] feat(api): add average number helper

### DIFF
--- a/apps/api/src/utils/average-number.ts
+++ b/apps/api/src/utils/average-number.ts
@@ -1,0 +1,7 @@
+export function averageNumber(values: readonly number[]): number | undefined {
+  if (values.length === 0) {
+    return undefined;
+  }
+
+  return values.reduce((total, value) => total + value, 0) / values.length;
+}

--- a/contributors/agents.json
+++ b/contributors/agents.json
@@ -1,5 +1,13 @@
 {
-  "agents": [],
-  "last_updated": "2026-06-03",
-  "total_contributions": 0
+    "agents":  [
+                   {
+                       "github_username":  "ChaiXinLong-tech",
+                       "model":  "GPT-5 Codex",
+                       "version":  "2026-07-01",
+                       "pr_number":  3259,
+                       "issue_number":  3258
+                   }
+               ],
+    "last_updated":  "2026-07-01",
+    "total_contributions":  1
 }


### PR DESCRIPTION
Adds a focused $(System.Collections.Hashtable.export) helper for API code paths that need a small, typed utility without pulling in a dependency.

Verification:
- node_modules/.bin/tsc --noEmit --strict --lib es2020 outputs/tmp-batch37/*.ts

Closes #3258
/claim #3258