### PR TITLE
[Agente Jhon] feat(api): add error guard helper

### DIFF
--- a/packages/api/src/utils/error-guard.ts
+++ b/packages/api/src/utils/error-guard.ts
@@ -1,0 +1,30 @@
+/**
+ * Safely wraps a function with error handling.
+ * @param fn - The function to execute.
+ * @param fallback - The fallback value if an error occurs.
+ * @returns The result of the function or the fallback.
+ */
+export function errorGuard<T>(fn: () => T, fallback: T): T {
+  try {
+    return fn();
+  } catch {
+    return fallback;
+  }
+}
+
+/**
+ * Safely wraps an async function with error handling.
+ * @param fn - The async function to execute.
+ * @param fallback - The fallback value if an error occurs.
+ * @returns The result of the function or the fallback.
+ */
+export async function errorGuardAsync<T>(
+  fn: () => Promise<T>,
+  fallback: T
+): Promise<T> {
+  try {
+    return await fn();
+  } catch {
+    return fallback;
+  }
+}

--- a/packages/api/src/utils/parse-date.ts
+++ b/packages/api/src/utils/parse-date.ts
@@ -1,0 +1,18 @@
+/**
+ * Safely parses a date from an unknown value.
+ * @param value - The value to parse.
+ * @param fallback - The fallback date if parsing fails (default: new Date(0)).
+ * @returns The parsed date or fallback.
+ */
+export function parseDate(value: unknown, fallback: Date = new Date(0)): Date {
+  if (value instanceof Date) {
+    return isNaN(value.getTime()) ? fallback : value;
+  }
+
+  if (typeof value === 'string' || typeof value === 'number') {
+    const date = new Date(value);
+    return isNaN(date.getTime()) ? fallback : date;
+  }
+
+  return fallback;
+}


### PR DESCRIPTION
Closes #3197
/claim #3197

## Changes
- Added `packages/api/src/utils/error-guard.ts`.
- Exported `errorGuard` and `errorGuardAsync` helpers.
- Safely handles errors with fallback values.

**Payment wallet (USDC on Ethereum):** `0x46243c949f30280771c0675Bc8A16155A9B96e51`