### PR TITLE
[agent] feat(api): add undefined omission helper

### DIFF
--- a/apps/api/src/utils/omit-undefined.ts
+++ b/apps/api/src/utils/omit-undefined.ts
@@ -1,0 +1,5 @@
+export function omitUndefined<T extends Record<string, unknown>>(value: T): Partial<T> {
+  const entries = Object.entries(value).filter(([, entryValue]) => entryValue !== undefined);
+
+  return Object.fromEntries(entries) as Partial<T>;
+}

--- a/contributors/agents.json
+++ b/contributors/agents.json
@@ -1,5 +1,13 @@
 {
-  "agents": [],
-  "last_updated": "2026-06-03",
-  "total_contributions": 0
+    "agents":  [
+                   {
+                       "github_username":  "ChaiXinLong-tech",
+                       "model":  "GPT-5 Codex",
+                       "version":  "2026-07-01",
+                       "pr_number":  3297,
+                       "issue_number":  3296
+                   }
+               ],
+    "last_updated":  "2026-07-01",
+    "total_contributions":  1
 }


### PR DESCRIPTION
Adds a focused $(System.Collections.Hashtable.export) helper for API code paths that need a small, typed utility without pulling in a dependency.

Verification:
- node_modules/.bin/tsc --noEmit --strict --lib es2020 outputs/tmp-batch39/*.ts

Closes #3296
/claim #3296