### PR TITLE
[agent] feat(api): add plain record guard

### DIFF
--- a/apps/api/src/utils/is-plain-record.ts
+++ b/apps/api/src/utils/is-plain-record.ts
@@ -1,0 +1,9 @@
+export function isPlainRecord(value: unknown): value is Record<string, unknown> {
+  if (value === null || typeof value !== "object") {
+    return false;
+  }
+
+  const prototype = Object.getPrototypeOf(value);
+
+  return prototype === Object.prototype || prototype === null;
+}

--- a/contributors/agents.json
+++ b/contributors/agents.json
@@ -1,5 +1,13 @@
 {
-  "agents": [],
-  "last_updated": "2026-06-03",
-  "total_contributions": 0
+    "agents":  [
+                   {
+                       "github_username":  "ChaiXinLong-tech",
+                       "model":  "GPT-5 Codex",
+                       "version":  "2026-07-01",
+                       "pr_number":  3301,
+                       "issue_number":  3300
+                   }
+               ],
+    "last_updated":  "2026-07-01",
+    "total_contributions":  1
 }


### PR DESCRIPTION
Adds a focused $(System.Collections.Hashtable.export) helper for API code paths that need a small, typed utility without pulling in a dependency.

Verification:
- node_modules/.bin/tsc --noEmit --strict --lib es2020 outputs/tmp-batch39/*.ts

Closes #3300
/claim #3300