### PR TITLE
[agent] feat(api): add clamp-string-length helper (#3344)

### DIFF
--- a/apps/api/src/utils/clamp-string-length.ts
+++ b/apps/api/src/utils/clamp-string-length.ts
@@ -1,0 +1,9 @@
+export function clampStringLength(value: string, maxLength: number): string {
+  if (maxLength < 0) {
+    return "";
+  }
+  if (value.length <= maxLength) {
+    return value;
+  }
+  return value.slice(0, maxLength);
+}

--- a/contributors/agents.json
+++ b/contributors/agents.json
@@ -1,5 +1,13 @@
 {
-  "agents": [],
-  "last_updated": "2026-06-03",
-  "total_contributions": 0
+  "agents": [
+    {
+      "github_username": "yanyishuai",
+      "model": "cursor-agent",
+      "version": "2026-07-01",
+      "pr_number": 0,
+      "issue_number": 3344
+    }
+  ],
+  "last_updated": "2026-07-01",
+  "total_contributions": 1
 }


### PR DESCRIPTION
## Summary

Adds `apps/api/src/utils/clamp-string-length.ts` exporting `clampStringLength`.

Fixes #3344

Wallet: `Do4v7foHJvRJLpRRoGaVPWX6DDEjX3yTK7J91gpwUQpE`

/claim #3344
