### PR TITLE
refactor: add JSDoc header and TODO stubs for user routes (fixes #1, #10)

### DIFF
--- a/apps/api/src/routes/users.ts
+++ b/apps/api/src/routes/users.ts
@@ -1,7 +1,18 @@
+/**
+ * User routes
+ *
+ * Provides user listing and creation stubs for the TaskFlow API.
+ *
+ * @module routes/users
+ */
 import { Router } from "express";
 
 const router = Router();
 
+// TODO: Replace with paginated user listing.
+// - Accept query params: ?page=1&limit=20
+// - Return typed users array with total count
+// - Apply auth middleware when available
 router.get("/", (_req, res) => {
   res.json({
     data: [],
@@ -9,6 +20,10 @@ router.get("/", (_req, res) => {
   });
 });
 
+// TODO: Replace with validated user creation.
+// - Validate email/password via Zod schema
+// - Hash password before persisting
+// - Return created user without sensitive fields
 router.post("/", (req, res) => {
   res.status(201).json({
     data: {


### PR DESCRIPTION
Adds module-level JSDoc and actionable TODO comments to `apps/api/src/routes/users.ts`.

- JSDoc explains the route module purpose  
- TODOs outline pagination, Zod validation, auth, and password hashing  
- Closes #1, #10 /bounty $50