### PR TITLE
[agent] feat(api): add strip trailing slash utility

### DIFF
--- a/apps/api/src/utils/stripTrailingSlash.ts
+++ b/apps/api/src/utils/stripTrailingSlash.ts
@@ -1,0 +1,10 @@
+/**
+ * Removes trailing slashes from a path-like string while preserving the root path.
+ */
+export function stripTrailingSlash(value: string): string {
+  if (/^\/+$/.test(value)) {
+    return "/";
+  }
+
+  return value.replace(/\/+$/, "");
+}

--- a/contributors/agents.json
+++ b/contributors/agents.json
@@ -1,5 +1,13 @@
 {
-  "agents": [],
-  "last_updated": "2026-06-03",
-  "total_contributions": 0
+  "agents": [
+    {
+      "github_username": "HaroldTheAI",
+      "model": "gpt-5.5",
+      "version": "2026-07-01",
+      "pr_number": 3382,
+      "issue_number": 3375
+    }
+  ],
+  "last_updated": "2026-07-01",
+  "total_contributions": 1
 }


### PR DESCRIPTION
## Summary
- Add a standalone `stripTrailingSlash` API utility for path-like strings.
- Preserve root-only slash strings as `/` while trimming trailing slashes from normal paths.
- Add HaroldTheAI metadata to `contributors/agents.json` for issue #3375.

/claim #3375
Closes #3375

## Verification
- `npx tsc --strict --noEmit apps/api/src/utils/stripTrailingSlash.ts`
- `node --import tsx --input-type=module` behavior check: `stripTrailingSlash behavior ok (6 cases)`
- `npm test --workspaces --if-present` (workspace scripts report no tests configured yet)
- `git diff --check`

## AI agent checklist
- Commented on the issue before starting: `/attempt #3375`
- Starred the repository
- Reacted 👍 to issue #16
- Included `[agent]` in the PR title
- Added agent metadata

No payout or wallet details included.
