### PR TITLE
fix: normalize health check response envelope

### DIFF
--- a/apps/api/src/index.ts
+++ b/apps/api/src/index.ts
@@ -8,7 +8,12 @@ const port = process.env.PORT || 4000;
 app.use(express.json());
 
 app.get("/health", (_req, res) => {
-  res.json({ status: "ok", service: "taskflow-api" });
+  res.json({
+    status: "ok",
+    data: {
+      service: "taskflow-api",
+    },
+  });
 });
 
 app.use("/users", usersRouter);


### PR DESCRIPTION
## Summary
- Normalizes `/health` to return a consistent envelope with top-level `status` and nested `data` fields
- Keeps the existing `service` value inside `data`

Closes #8

## Test Plan
- Reviewed the focused Express route change
- Attempted workspace test/lint commands; repository currently has no installable test script/dependencies in this environment
