### PR TITLE
feat: add API error handling helper

### DIFF
--- a/apps/api/src/routes/users.ts
+++ b/apps/api/src/routes/users.ts
@@ -1,5 +1,7 @@
 import { Router } from "express";
 
+import { sendApiError } from "../utils/apiError";
+
 const router = Router();
 
 router.get("/", (_req, res) => {
@@ -10,6 +12,15 @@ router.get("/", (_req, res) => {
 });
 
 router.post("/", (req, res) => {
+  if (!req.body || Object.keys(req.body).length === 0) {
+    return sendApiError(
+      res,
+      400,
+      "USER_PAYLOAD_REQUIRED",
+      "Provide a JSON request body before creating a user."
+    );
+  }
+
   res.status(201).json({
     data: {
       id: "stub-user-id",

--- a/apps/api/src/utils/apiError.ts
+++ b/apps/api/src/utils/apiError.ts
@@ -1,0 +1,26 @@
+import type { Response } from "express";
+
+export type ApiErrorPayload = {
+  status: "error";
+  error: {
+    code: string;
+    message: string;
+  };
+};
+
+export function sendApiError(
+  res: Response,
+  statusCode: number,
+  code: string,
+  message: string
+) {
+  const payload: ApiErrorPayload = {
+    status: "error",
+    error: {
+      code,
+      message
+    }
+  };
+
+  return res.status(statusCode).json(payload);
+}


### PR DESCRIPTION
## Summary
- Adds a small `sendApiError` helper for consistent API error responses
- Uses the helper from the `POST /users` route when the request body is missing

Closes #7

## Test Plan
- `npm test -- --runInBand`
