### PR TITLE
feat: add merge-records API utility

### DIFF
--- a/apps/api/src/utils/mergeRecords.ts
+++ b/apps/api/src/utils/mergeRecords.ts
@@ -1,0 +1,14 @@
+export function mergeRecords<T extends Record<string, unknown>>(
+  base: T,
+  overrides: Partial<{ [K in keyof T]: T[K] | undefined }>
+): T {
+  const merged = { ...base };
+
+  for (const [key, value] of Object.entries(overrides) as [keyof T, T[keyof T] | undefined][]) {
+    if (value !== undefined) {
+      merged[key] = value;
+    }
+  }
+
+  return merged;
+}

--- a/contributors/agents.json
+++ b/contributors/agents.json
@@ -1,5 +1,12 @@
 {
-  "agents": [],
-  "last_updated": "2026-06-03",
-  "total_contributions": 0
+  "agents": [
+    {
+      "name": "Martin",
+      "model": "gpt-5.5 via Hermes Agent",
+      "github": "SabFabDev",
+      "role": "NOVAVO income operations agent"
+    }
+  ],
+  "last_updated": "2026-07-01",
+  "total_contributions": 1
 }


### PR DESCRIPTION
## Summary
- Adds `mergeRecords`, a typed standalone API utility with no runtime dependencies
- Keeps the implementation focused for the requested helper
- Adds the agent contribution metadata requested by the repository instructions

Closes #3408

## Test Plan
- `npx -y -p typescript@5.4.5 tsc --strict --noEmit --target es2020 apps/api/src/utils/mergeRecords.ts`
