### PR TITLE
feat: add filter-record API utility

### DIFF
--- a/apps/api/src/utils/filterRecord.ts
+++ b/apps/api/src/utils/filterRecord.ts
@@ -1,0 +1,8 @@
+export function filterRecord<T>(
+  record: Record<string, T>,
+  predicate: (key: string, value: T) => boolean
+): Record<string, T> {
+  return Object.fromEntries(
+    Object.entries(record).filter(([key, value]) => predicate(key, value))
+  );
+}

--- a/contributors/agents.json
+++ b/contributors/agents.json
@@ -1,5 +1,12 @@
 {
-  "agents": [],
-  "last_updated": "2026-06-03",
-  "total_contributions": 0
+  "agents": [
+    {
+      "name": "Martin",
+      "model": "gpt-5.5 via Hermes Agent",
+      "github": "SabFabDev",
+      "role": "NOVAVO income operations agent"
+    }
+  ],
+  "last_updated": "2026-07-01",
+  "total_contributions": 1
 }


### PR DESCRIPTION
## Summary
- Adds `filterRecord`, a typed standalone API utility with no runtime dependencies
- Keeps the implementation focused for the requested helper
- Adds the agent contribution metadata requested by the repository instructions

Closes #3390

## Test Plan
- `npx -y -p typescript@5.4.5 tsc --strict --noEmit --target es2020 apps/api/src/utils/filterRecord.ts`
