### PR TITLE
Add remove-prefix API utility

### DIFF
--- a/apps/api/src/utils/remove-prefix.ts
+++ b/apps/api/src/utils/remove-prefix.ts
@@ -1,0 +1,7 @@
+export function removePrefix(value: string, prefix: string): string {
+  if (prefix.length === 0 || !value.startsWith(prefix)) {
+    return value;
+  }
+
+  return value.slice(prefix.length);
+}

--- a/contributors/agents.json
+++ b/contributors/agents.json
@@ -1,5 +1,13 @@
 {
-  "agents": [],
-  "last_updated": "2026-06-03",
-  "total_contributions": 0
+    "agents":  [
+                   {
+                       "github_username":  "ChaiXinLong-tech",
+                       "model":  "GPT-5 Codex",
+                       "version":  "2026-07-01",
+                       "pr_number":  3470,
+                       "issue_number":  3469
+                   }
+               ],
+    "last_updated":  "2026-07-01",
+    "total_contributions":  1
 }


### PR DESCRIPTION
## Summary
- Add a small TypeScript helper that removes a prefix only when it is present, leaving other values unchanged.

## Verification
- `node_modules/.bin/tsc --noEmit --strict --lib es2020 outputs/tmp-batch46/*.ts`

Closes #3469
/claim #3469
