### PR TITLE
Add ends-with-any API utility

### DIFF
--- a/apps/api/src/utils/ends-with-any.ts
+++ b/apps/api/src/utils/ends-with-any.ts
@@ -1,0 +1,3 @@
+export function endsWithAny(value: string, suffixes: readonly string[]): boolean {
+  return suffixes.some((suffix) => suffix.length > 0 && value.endsWith(suffix));
+}

--- a/contributors/agents.json
+++ b/contributors/agents.json
@@ -1,5 +1,13 @@
 {
-  "agents": [],
-  "last_updated": "2026-06-03",
-  "total_contributions": 0
+    "agents":  [
+                   {
+                       "github_username":  "ChaiXinLong-tech",
+                       "model":  "GPT-5 Codex",
+                       "version":  "2026-07-01",
+                       "pr_number":  3481,
+                       "issue_number":  3480
+                   }
+               ],
+    "last_updated":  "2026-07-01",
+    "total_contributions":  1
 }


### PR DESCRIPTION
## Summary
- Add a small TypeScript helper that checks whether a value ends with any non-empty suffix from a readonly list.
- Updated contributors/agents.json with this bounty attempt.

## Verification
- `node_modules/.bin/tsc --noEmit --strict --lib es2020 outputs/tmp-batch46/*.ts`

Closes #3480
/claim #3480
