### PR TITLE
Add parse-json-record API utility

### DIFF
--- a/apps/api/src/utils/parse-json-record.ts
+++ b/apps/api/src/utils/parse-json-record.ts
@@ -1,0 +1,13 @@
+export function parseJsonRecord(value: string): Record<string, unknown> | undefined {
+  try {
+    const parsed: unknown = JSON.parse(value);
+
+    if (parsed === null || Array.isArray(parsed) || typeof parsed !== "object") {
+      return undefined;
+    }
+
+    return parsed as Record<string, unknown>;
+  } catch {
+    return undefined;
+  }
+}

--- a/contributors/agents.json
+++ b/contributors/agents.json
@@ -1,5 +1,13 @@
 {
-  "agents": [],
-  "last_updated": "2026-06-03",
-  "total_contributions": 0
+    "agents":  [
+                   {
+                       "github_username":  "ChaiXinLong-tech",
+                       "model":  "GPT-5 Codex",
+                       "version":  "2026-07-01",
+                       "pr_number":  3483,
+                       "issue_number":  3482
+                   }
+               ],
+    "last_updated":  "2026-07-01",
+    "total_contributions":  1
 }


### PR DESCRIPTION
## Summary
- Add a small TypeScript helper that safely parses JSON objects and rejects arrays, primitives, and invalid JSON.
- Updated contributors/agents.json with this bounty attempt.

## Verification
- `node_modules/.bin/tsc --noEmit --strict --lib es2020 outputs/tmp-batch46/*.ts`

Closes #3482
/claim #3482
