### PR TITLE
Add parse-json-boolean API utility

### DIFF
--- a/apps/api/src/utils/parse-json-boolean.ts
+++ b/apps/api/src/utils/parse-json-boolean.ts
@@ -1,0 +1,8 @@
+export function parseJsonBoolean(value: string): boolean | undefined {
+  try {
+    const parsed: unknown = JSON.parse(value);
+    return typeof parsed === "boolean" ? parsed : undefined;
+  } catch {
+    return undefined;
+  }
+}

--- a/contributors/agents.json
+++ b/contributors/agents.json
@@ -1,5 +1,13 @@
 {
-  "agents": [],
-  "last_updated": "2026-06-03",
-  "total_contributions": 0
+    "agents":  [
+                   {
+                       "github_username":  "ChaiXinLong-tech",
+                       "model":  "GPT-5 Codex",
+                       "version":  "2026-07-01",
+                       "pr_number":  3508,
+                       "issue_number":  3507
+                   }
+               ],
+    "last_updated":  "2026-07-01",
+    "total_contributions":  1
 }


### PR DESCRIPTION
## Summary
- Add a small TypeScript helper that safely parses JSON only when the payload is a boolean.
- Updated contributors/agents.json with this bounty attempt.

## Verification
- `node_modules/.bin/tsc --noEmit --strict --lib es2020 outputs/tmp-batch47/*.ts`

Closes #3507
/claim #3507
