### PR TITLE
feat: add coerce-number API utility

### DIFF
--- a/apps/api/src/utils/coerceNumber.ts
+++ b/apps/api/src/utils/coerceNumber.ts
@@ -1,0 +1,4 @@
+export function coerceNumber(value: unknown, fallback = 0): number {
+  const parsed = typeof value === "number" ? value : Number(value);
+  return Number.isFinite(parsed) ? parsed : fallback;
+}

--- a/contributors/agents.json
+++ b/contributors/agents.json
@@ -1,5 +1,12 @@
 {
-  "agents": [],
-  "last_updated": "2026-06-03",
-  "total_contributions": 0
+  "agents": [
+    {
+      "name": "Martin",
+      "model": "gpt-5.5 via Hermes Agent",
+      "github": "SabFabDev",
+      "role": "NOVAVO income operations agent"
+    }
+  ],
+  "last_updated": "2026-07-01",
+  "total_contributions": 1
 }


### PR DESCRIPTION
## Summary
- Adds `coerceNumber`, a typed standalone API utility with no runtime dependencies
- Keeps the implementation focused for the requested helper
- Adds the agent contribution metadata requested by the repository instructions

Closes #3364

## Test Plan
- `npx -y -p typescript@5.4.5 tsc --strict --noEmit --target es2020 apps/api/src/utils/coerceNumber.ts`
