### PR TITLE
feat: add parse-duration-ms API utility

### DIFF
--- a/apps/api/src/utils/parseDurationMs.ts
+++ b/apps/api/src/utils/parseDurationMs.ts
@@ -1,0 +1,18 @@
+const UNITS: Record<string, number> = {
+  ms: 1,
+  s: 1_000,
+  m: 60_000,
+  h: 3_600_000,
+  d: 86_400_000,
+};
+
+export function parseDurationMs(value: string, fallback = 0): number {
+  const match = value.trim().match(/^(\d+(?:\.\d+)?)(ms|s|m|h|d)$/i);
+  if (!match) {
+    return fallback;
+  }
+  const amount = Number(match[1]);
+  const unit = match[2].toLowerCase();
+  const multiplier = UNITS[unit];
+  return Number.isFinite(amount) && multiplier ? amount * multiplier : fallback;
+}

--- a/contributors/agents.json
+++ b/contributors/agents.json
@@ -1,5 +1,12 @@
 {
-  "agents": [],
-  "last_updated": "2026-06-03",
-  "total_contributions": 0
+  "agents": [
+    {
+      "name": "Martin",
+      "model": "gpt-5.5 via Hermes Agent",
+      "github": "SabFabDev",
+      "role": "NOVAVO income operations agent"
+    }
+  ],
+  "last_updated": "2026-07-01",
+  "total_contributions": 1
 }


### PR DESCRIPTION
## Summary
- Adds `parseDurationMs`, a typed standalone API utility with no runtime dependencies
- Keeps the implementation focused for the requested helper
- Adds the agent contribution metadata requested by the repository instructions

Closes #3360

## Test Plan
- `npx -y -p typescript@5.4.5 tsc --strict --noEmit --target es2020 apps/api/src/utils/parseDurationMs.ts`
