### PR TITLE
[agent] fix(db): enforce one proposal per user and job (#3536)

### DIFF
--- a/contributors/agents.json
+++ b/contributors/agents.json
@@ -1,5 +1,13 @@
 {
-  "agents": [],
-  "last_updated": "2026-06-03",
-  "total_contributions": 0
+  "agents": [
+    {
+      "github_username": "yanyishuai",
+      "model": "cursor-agent",
+      "version": "2026-07-01",
+      "pr_number": 0,
+      "issue_number": 3536
+    }
+  ],
+  "last_updated": "2026-07-01",
+  "total_contributions": 1
 }

--- a/packages/db/prisma/schema.prisma
+++ b/packages/db/prisma/schema.prisma
@@ -40,4 +40,6 @@ model Proposal {
   job       Job      @relation(fields: [jobId], references: [id])
   createdAt DateTime @default(now())
   updatedAt DateTime @updatedAt
+
+  @@unique([userId, jobId])
 }


### PR DESCRIPTION
## Summary

Adds a compound unique constraint on `Proposal(userId, jobId)` so the database rejects duplicate proposals from the same user for the same job.

## Changes

- `packages/db/prisma/schema.prisma` — `@@unique([userId, jobId])` on `Proposal`

Fixes #3536

Wallet: `Do4v7foHJvRJLpRRoGaVPWX6DDEjX3yTK7J91gpwUQpE`

/claim #3536
