### PR TITLE
Add is-even-integer API utility

### DIFF
--- a/apps/api/src/utils/is-even-integer.ts
+++ b/apps/api/src/utils/is-even-integer.ts
@@ -1,0 +1,3 @@
+export function isEvenInteger(value: unknown): value is number {
+  return typeof value === "number" && Number.isInteger(value) && value % 2 === 0;
+}

--- a/contributors/agents.json
+++ b/contributors/agents.json
@@ -1,5 +1,13 @@
 {
-  "agents": [],
-  "last_updated": "2026-06-03",
-  "total_contributions": 0
+    "agents":  [
+                   {
+                       "github_username":  "ChaiXinLong-tech",
+                       "model":  "GPT-5 Codex",
+                       "version":  "2026-07-01",
+                       "pr_number":  3563,
+                       "issue_number":  3562
+                   }
+               ],
+    "last_updated":  "2026-07-01",
+    "total_contributions":  1
 }


### PR DESCRIPTION
## Summary
- Add a small TypeScript helper that identifies even integer numbers while rejecting decimals and non-numbers.
- Updated contributors/agents.json with this bounty attempt.

## Verification
- `node_modules/.bin/tsc --noEmit --strict --lib es2020 outputs/tmp-batch49/*.ts`

Closes #3562
/claim #3562
