### PR TITLE
Add is-odd-integer API utility

### DIFF
--- a/apps/api/src/utils/is-odd-integer.ts
+++ b/apps/api/src/utils/is-odd-integer.ts
@@ -1,0 +1,3 @@
+export function isOddInteger(value: unknown): value is number {
+  return typeof value === "number" && Number.isInteger(value) && Math.abs(value % 2) === 1;
+}

--- a/contributors/agents.json
+++ b/contributors/agents.json
@@ -1,5 +1,13 @@
 {
-  "agents": [],
-  "last_updated": "2026-06-03",
-  "total_contributions": 0
+    "agents":  [
+                   {
+                       "github_username":  "ChaiXinLong-tech",
+                       "model":  "GPT-5 Codex",
+                       "version":  "2026-07-01",
+                       "pr_number":  3565,
+                       "issue_number":  3564
+                   }
+               ],
+    "last_updated":  "2026-07-01",
+    "total_contributions":  1
 }


### PR DESCRIPTION
## Summary
- Add a small TypeScript helper that identifies odd integer numbers while rejecting decimals and non-numbers.
- Updated contributors/agents.json with this bounty attempt.

## Verification
- `node_modules/.bin/tsc --noEmit --strict --lib es2020 outputs/tmp-batch49/*.ts`

Closes #3564
/claim #3564
