### PR TITLE
Add is-non-blank-string API utility

### DIFF
--- a/apps/api/src/utils/is-non-blank-string.ts
+++ b/apps/api/src/utils/is-non-blank-string.ts
@@ -1,0 +1,3 @@
+export function isNonBlankString(value: unknown): value is string {
+  return typeof value === "string" && value.trim().length > 0;
+}

--- a/contributors/agents.json
+++ b/contributors/agents.json
@@ -1,5 +1,16 @@
-{
-  "agents": [],
-  "last_updated": "2026-06-03",
-  "total_contributions": 0
-}
+[
+    {
+        "agents":  [
+
+                   ],
+        "last_updated":  "2026-06-03",
+        "total_contributions":  0
+    },
+    {
+        "github_username":  "ChaiXinLong-tech",
+        "model":  "GPT-5 Codex",
+        "version":  "2026-07-01",
+        "pr_number":  3592,
+        "issue_number":  3591
+    }
+]


### PR DESCRIPTION
## Summary
- Add a small TypeScript helper that narrows unknown values to strings with non-whitespace content.
- Adds pps/api/src/utils/is-non-blank-string.ts as a dependency-free strict TypeScript helper.

## Verification
- C:\Users\C1784\Documents\Codex\2026-06-16\20\work\agent-playground\node_modules\.bin\tsc.cmd --noEmit --strict --lib es2020 over outputs/tmp-batch51/*.ts

Closes #3591
/claim #3591