### PR TITLE
[agent] feat(api): add route constants

### DIFF
--- a/apps/api/src/constants/api-routes.ts
+++ b/apps/api/src/constants/api-routes.ts
@@ -1,0 +1,21 @@
+export const API_ROUTE_PREFIXES = {
+  health: "/health",
+  auth: "/auth",
+  users: "/users",
+  tasks: "/tasks",
+  proposals: "/proposals",
+  payments: "/payments",
+  reviews: "/reviews",
+  messages: "/messages",
+  notifications: "/notifications",
+  files: "/files",
+  search: "/search",
+  admin: "/admin"
+} as const;
+
+export type ApiRouteKey = keyof typeof API_ROUTE_PREFIXES;
+export type ApiRoutePrefix = (typeof API_ROUTE_PREFIXES)[ApiRouteKey];
+
+export function getApiRoutePrefix(route: ApiRouteKey): ApiRoutePrefix {
+  return API_ROUTE_PREFIXES[route];
+}

--- a/contributors/agents.json
+++ b/contributors/agents.json
@@ -1,5 +1,13 @@
 {
-  "agents": [],
-  "last_updated": "2026-06-03",
-  "total_contributions": 0
+  "agents": [
+    {
+      "github_username": "sjj071023-prog",
+      "model": "GPT-5 Codex",
+      "version": "2026-07-01",
+      "pr_number": null,
+      "issue_number": 2819
+    }
+  ],
+  "last_updated": "2026-07-01",
+  "total_contributions": 1
 }

--- a/contributors/agents.json
+++ b/contributors/agents.json
@@ -4,7 +4,7 @@
       "github_username": "sjj071023-prog",
       "model": "GPT-5 Codex",
       "version": "2026-07-01",
-      "pr_number": null,
+      "pr_number": 3599,
       "issue_number": 2819
     }
   ],


### PR DESCRIPTION
Closes #2819

## Summary
- Add a central API route constants module for current and planned TaskFlow API route prefixes.
- Include a small typed helper for retrieving route prefixes by key.
- Add the required AI agent registry entry for this issue.

## Validation
- `/Users/sunjiajie/.cache/codex-runtimes/codex-primary-runtime/dependencies/node/bin/node --input-type=module -e "import('./apps/api/src/constants/api-routes.ts').then((m) => { if (m.API_ROUTE_PREFIXES.health !== '/health') throw new Error('health route mismatch'); if (m.API_ROUTE_PREFIXES.users !== '/users') throw new Error('users route mismatch'); if (m.getApiRoutePrefix('tasks') !== '/tasks') throw new Error('tasks route mismatch'); console.log('api route constants verified'); })"`
- `/Users/sunjiajie/.cache/codex-runtimes/codex-primary-runtime/dependencies/bin/pnpm --config.verify-deps-before-run=false -C apps/api test`
- `/Users/sunjiajie/.cache/codex-runtimes/codex-primary-runtime/dependencies/bin/pnpm --config.verify-deps-before-run=false -C apps/api lint`
