### PR TITLE
[agent] feat(api): add route constants module

### DIFF
--- a/apps/api/src/constants/routes.ts
+++ b/apps/api/src/constants/routes.ts
@@ -1,0 +1,21 @@
+const normalizeSegment = (segment: string) => segment.replace(/^\/+|\/+$/g, "");
+
+export const buildApiRoute = (...segments: string[]) => {
+  const cleaned = segments.map(normalizeSegment).filter(Boolean);
+  return cleaned.length ? `/${cleaned.join("/")}` : "/";
+};
+
+export const API_ROUTE_PREFIXES = {
+  root: "/",
+  api: buildApiRoute("api"),
+  apiV1: buildApiRoute("api", "v1"),
+  apiV2: buildApiRoute("api", "v2")
+} as const;
+
+export const API_ROUTES = {
+  health: buildApiRoute("health"),
+  users: buildApiRoute("users"),
+  tasks: buildApiRoute("tasks"),
+  projects: buildApiRoute("projects"),
+  auth: buildApiRoute("auth")
+} as const;

--- a/apps/api/src/index.ts
+++ b/apps/api/src/index.ts
@@ -1,5 +1,6 @@
 import express from "express";
 
+import { API_ROUTES } from "./constants/routes";
 import usersRouter from "./routes/users";
 
 const app = express();
@@ -7,11 +8,11 @@ const port = process.env.PORT || 4000;
 
 app.use(express.json());
 
-app.get("/health", (_req, res) => {
+app.get(API_ROUTES.health, (_req, res) => {
   res.json({ status: "ok", service: "taskflow-api" });
 });
 
-app.use("/users", usersRouter);
+app.use(API_ROUTES.users, usersRouter);
 
 app.listen(port, () => {
   console.log(`TaskFlow API listening on port ${port}`);

--- a/contributors/agents.json
+++ b/contributors/agents.json
@@ -1,5 +1,13 @@
 {
-  "agents": [],
-  "last_updated": "2026-06-03",
-  "total_contributions": 0
+  "agents": [
+    {
+      "github_username": "gowdaharshith1998-lang",
+      "model": "gpt-5-codex",
+      "version": "unknown",
+      "pr_number": 3600,
+      "issue_number": 2819
+    }
+  ],
+  "last_updated": "2026-07-01",
+  "total_contributions": 1
 }


### PR DESCRIPTION
## Summary
- add a central `apps/api/src/constants/routes.ts` module for current and planned TaskFlow API route prefixes
- export a small `buildApiRoute` helper for normalized route construction
- switch the existing health and users mounts to use the shared constants

## Verification
- `npx tsx -e "import { API_ROUTES, API_ROUTE_PREFIXES, buildApiRoute } from './apps/api/src/constants/routes.ts'; console.log(JSON.stringify({ API_ROUTES, API_ROUTE_PREFIXES, custom: buildApiRoute('/api/', '/v1/', 'tasks/') }, null, 2));"`

Closes #2819