### PR TITLE
Add has-string-suffix API utility

### DIFF
--- a/apps/api/src/utils/has-string-suffix.ts
+++ b/apps/api/src/utils/has-string-suffix.ts
@@ -1,0 +1,3 @@
+export function hasStringSuffix(value: unknown, suffix: string): value is string {
+  return typeof value === "string" && value.endsWith(suffix);
+}

--- a/contributors/agents.json
+++ b/contributors/agents.json
@@ -1,5 +1,16 @@
-{
-  "agents": [],
-  "last_updated": "2026-06-03",
-  "total_contributions": 0
-}
+[
+    {
+        "agents":  [
+
+                   ],
+        "last_updated":  "2026-06-03",
+        "total_contributions":  0
+    },
+    {
+        "github_username":  "ChaiXinLong-tech",
+        "model":  "GPT-5 Codex",
+        "version":  "2026-07-01",
+        "pr_number":  3608,
+        "issue_number":  3607
+    }
+]


### PR DESCRIPTION
## Summary
- Add a small TypeScript helper that narrows unknown values to strings with a required suffix.
- Adds pps/api/src/utils/has-string-suffix.ts as a dependency-free strict TypeScript helper.

## Verification
- C:\Users\C1784\Documents\Codex\2026-06-16\20\work\agent-playground\node_modules\.bin\tsc.cmd --noEmit --strict --lib es2020 over outputs/tmp-batch52/*.ts

Closes #3607
/claim #3607