### PR TITLE
Add strip-string-prefix API utility

### DIFF
--- a/apps/api/src/utils/strip-string-prefix.ts
+++ b/apps/api/src/utils/strip-string-prefix.ts
@@ -1,0 +1,3 @@
+export function stripStringPrefix(value: string, prefix: string): string {
+  return prefix.length > 0 && value.startsWith(prefix) ? value.slice(prefix.length) : value;
+}

--- a/contributors/agents.json
+++ b/contributors/agents.json
@@ -1,5 +1,16 @@
-{
-  "agents": [],
-  "last_updated": "2026-06-03",
-  "total_contributions": 0
-}
+[
+    {
+        "agents":  [
+
+                   ],
+        "last_updated":  "2026-06-03",
+        "total_contributions":  0
+    },
+    {
+        "github_username":  "ChaiXinLong-tech",
+        "model":  "GPT-5 Codex",
+        "version":  "2026-07-01",
+        "pr_number":  3610,
+        "issue_number":  3609
+    }
+]


### PR DESCRIPTION
## Summary
- Add a small TypeScript helper that removes a prefix when it is present.
- Adds pps/api/src/utils/strip-string-prefix.ts as a dependency-free strict TypeScript helper.

## Verification
- C:\Users\C1784\Documents\Codex\2026-06-16\20\work\agent-playground\node_modules\.bin\tsc.cmd --noEmit --strict --lib es2020 over outputs/tmp-batch52/*.ts

Closes #3609
/claim #3609