### PR TITLE
[agent] feat: add group-by-key API utility

### DIFF
--- a/apps/api/src/utils/group-by-key.test.ts
+++ b/apps/api/src/utils/group-by-key.test.ts
@@ -1,0 +1,56 @@
+import { groupByKey } from "./group-by-key";
+
+describe("groupByKey", () => {
+  it("groups items by derived string key", () => {
+    const items = [
+      { type: "fruit", name: "apple" },
+      { type: "veg", name: "carrot" },
+      { type: "fruit", name: "banana" },
+    ];
+    const result = groupByKey(items, (item) => item.type);
+    expect(result.fruit).toHaveLength(2);
+    expect(result.veg).toHaveLength(1);
+    expect(result.fruit[0].name).toBe("apple");
+    expect(result.fruit[1].name).toBe("banana");
+    expect(result.veg[0].name).toBe("carrot");
+  });
+
+  it("returns empty object for empty array", () => {
+    const result = groupByKey([], () => "key");
+    expect(result).toEqual({});
+  });
+
+  it("handles numeric keys", () => {
+    const items = [{ id: 1 }, { id: 2 }, { id: 1 }];
+    const result = groupByKey(items, (item) => item.id);
+    expect(result[1]).toHaveLength(2);
+    expect(result[2]).toHaveLength(1);
+  });
+
+  it("preserves insertion order within groups", () => {
+    const items = [
+      { group: "a", val: 1 },
+      { group: "b", val: 2 },
+      { group: "a", val: 3 },
+    ];
+    const result = groupByKey(items, (item) => item.group);
+    expect(result.a).toEqual([
+      { group: "a", val: 1 },
+      { group: "a", val: 3 },
+    ]);
+    expect(result.b).toEqual([{ group: "b", val: 2 }]);
+  });
+
+  it("handles single item", () => {
+    const items = [{ category: "x", value: 42 }];
+    const result = groupByKey(items, (item) => item.category);
+    expect(result.x).toEqual([{ category: "x", value: 42 }]);
+  });
+
+  it("works with symbol keys", () => {
+    const sym = Symbol("test");
+    const items = [{ key: sym, value: 1 }];
+    const result = groupByKey(items, (item) => item.key);
+    expect(result[sym]).toEqual([{ key: sym, value: 1 }]);
+  });
+});

--- a/apps/api/src/utils/group-by-key.ts
+++ b/apps/api/src/utils/group-by-key.ts
@@ -1,0 +1,27 @@
+/**
+ * Groups a readonly array of items by a key derived from each item.
+ *
+ * @example
+ * groupByKey(
+ *   [{ type: "fruit", name: "apple" }, { type: "veg", name: "carrot" }, { type: "fruit", name: "banana" }],
+ *   (item) => item.type
+ * )
+ * // => { fruit: [{...}, {...}], veg: [{...}] }
+ */
+export function groupByKey<
+  T,
+  K extends string | number | symbol,
+>(
+  items: readonly T[],
+  keyFn: (item: T) => K,
+): Record<K, T[]> {
+  const result = {} as Record<K, T[]>;
+  for (const item of items) {
+    const key = keyFn(item);
+    if (!result[key]) {
+      result[key] = [];
+    }
+    result[key].push(item);
+  }
+  return result;
+}

--- a/contributors/agents.json
+++ b/contributors/agents.json
@@ -1,5 +1,13 @@
 {
-  "agents": [],
-  "last_updated": "2026-06-03",
+  "agents": [
+    {
+      "github_username": "di3go04",
+      "model": "glm-4.6",
+      "version": "latest",
+      "pr_number": null,
+      "issue_number": 3346
+    }
+  ],
+  "last_updated": "2026-07-01",
   "total_contributions": 0
 }


### PR DESCRIPTION
Adds a `groupByKey` utility that groups readonly arrays by derived property keys without runtime dependencies.

- TypeScript strict compatible
- Includes unit tests (6 cases)
- No runtime dependencies

Agent: glm-4.6 (di3go04)
Issue: #3346
Bounty: $50

Closes #3346