### PR TITLE
[agent] feat: add string-equals-ignore-case API utility

### DIFF
--- a/apps/api/src/utils/string-equals-ignore-case.test.ts
+++ b/apps/api/src/utils/string-equals-ignore-case.test.ts
@@ -1,0 +1,31 @@
+import { stringEqualsIgnoreCase } from "./string-equals-ignore-case";
+
+describe("stringEqualsIgnoreCase", () => {
+  it("returns true for identical strings", () => {
+    expect(stringEqualsIgnoreCase("hello", "hello")).toBe(true);
+  });
+
+  it("returns true for different cases", () => {
+    expect(stringEqualsIgnoreCase("Hello", "hello")).toBe(true);
+    expect(stringEqualsIgnoreCase("HELLO", "hello")).toBe(true);
+    expect(stringEqualsIgnoreCase("hello", "HELLO")).toBe(true);
+  });
+
+  it("returns false for different strings", () => {
+    expect(stringEqualsIgnoreCase("abc", "def")).toBe(false);
+  });
+
+  it("returns true for empty strings", () => {
+    expect(stringEqualsIgnoreCase("", "")).toBe(true);
+  });
+
+  it("handles mixed case", () => {
+    expect(stringEqualsIgnoreCase("HeLLo", "heLLo")).toBe(true);
+    expect(stringEqualsIgnoreCase("HeLLo", "hello")).toBe(true);
+  });
+
+  it("returns false for empty vs non-empty", () => {
+    expect(stringEqualsIgnoreCase("", "a")).toBe(false);
+    expect(stringEqualsIgnoreCase("a", "")).toBe(false);
+  });
+});

--- a/apps/api/src/utils/string-equals-ignore-case.ts
+++ b/apps/api/src/utils/string-equals-ignore-case.ts
@@ -1,0 +1,11 @@
+/**
+ * Compares two strings case-insensitively.
+ *
+ * @example
+ * stringEqualsIgnoreCase("Hello", "hello") // => true
+ * stringEqualsIgnoreCase("WORLD", "world") // => true
+ * stringEqualsIgnoreCase("abc", "def")     // => false
+ */
+export function stringEqualsIgnoreCase(a: string, b: string): boolean {
+  return a.toLowerCase() === b.toLowerCase();
+}

--- a/contributors/agents.json
+++ b/contributors/agents.json
@@ -1,5 +1,13 @@
 {
-  "agents": [],
-  "last_updated": "2026-06-03",
+  "agents": [
+    {
+      "github_username": "di3go04",
+      "model": "glm-4.6",
+      "version": "latest",
+      "pr_number": null,
+      "issue_number": 3621
+    }
+  ],
+  "last_updated": "2026-07-01",
   "total_contributions": 0
 }


### PR DESCRIPTION
Adds a `stringEqualsIgnoreCase` utility that compares two strings case-insensitively.

- TypeScript strict compatible
- Includes unit tests (6 cases)
- No runtime dependencies

Agent: glm-4.6 (di3go04)
Issue: #3621
Bounty: $50

Closes #3621