### PR TITLE
[agent] feat: add strip-string-suffix API utility

### DIFF
--- a/apps/api/src/utils/strip-string-suffix.test.ts
+++ b/apps/api/src/utils/strip-string-suffix.test.ts
@@ -1,0 +1,27 @@
+import { stripStringSuffix } from "./strip-string-suffix";
+
+describe("stripStringSuffix", () => {
+  it("removes suffix when present", () => {
+    expect(stripStringSuffix("hello.txt", ".txt")).toBe("hello");
+  });
+
+  it("returns original when suffix not present", () => {
+    expect(stripStringSuffix("hello.txt", ".csv")).toBe("hello.txt");
+  });
+
+  it("returns original when suffix is empty", () => {
+    expect(stripStringSuffix("hello", "")).toBe("hello");
+  });
+
+  it("returns empty string when str equals suffix", () => {
+    expect(stripStringSuffix(".txt", ".txt")).toBe("");
+  });
+
+  it("handles partial suffix match correctly", () => {
+    expect(stripStringSuffix("hello.txtxt", ".txt")).toBe("hello.txtxt".slice(0, "hello.txtxt".length - ".txt".length));
+  });
+
+  it("returns original for empty string", () => {
+    expect(stripStringSuffix("", ".txt")).toBe("");
+  });
+});

--- a/apps/api/src/utils/strip-string-suffix.ts
+++ b/apps/api/src/utils/strip-string-suffix.ts
@@ -1,0 +1,13 @@
+/**
+ * Removes a suffix from a string if present.
+ *
+ * @example
+ * stripStringSuffix("hello.txt", ".txt") // => "hello"
+ * stripStringSuffix("hello.txt", ".csv") // => "hello.txt"
+ */
+export function stripStringSuffix(str: string, suffix: string): string {
+  if (suffix.length > 0 && str.endsWith(suffix)) {
+    return str.slice(0, str.length - suffix.length);
+  }
+  return str;
+}

--- a/contributors/agents.json
+++ b/contributors/agents.json
@@ -1,5 +1,13 @@
 {
-  "agents": [],
-  "last_updated": "2026-06-03",
+  "agents": [
+    {
+      "github_username": "di3go04",
+      "model": "glm-4.6",
+      "version": "latest",
+      "pr_number": null,
+      "issue_number": 3613
+    }
+  ],
+  "last_updated": "2026-07-01",
   "total_contributions": 0
 }


### PR DESCRIPTION
Adds a `stripStringSuffix` utility that removes a suffix from a string if present.

- TypeScript strict compatible
- Includes unit tests (6 cases)
- No runtime dependencies

Agent: glm-4.6 (di3go04)
Issue: #3613
Bounty: $50

Closes #3613