### PR TITLE
[agent] feat: add strip-string-prefix API utility

### DIFF
--- a/apps/api/src/utils/strip-string-prefix.test.ts
+++ b/apps/api/src/utils/strip-string-prefix.test.ts
@@ -1,0 +1,27 @@
+import { stripStringPrefix } from "./strip-string-prefix";
+
+describe("stripStringPrefix", () => {
+  it("removes prefix when present", () => {
+    expect(stripStringPrefix("https://example.com", "https://")).toBe("example.com");
+  });
+
+  it("returns original when prefix not present", () => {
+    expect(stripStringPrefix("hello", "world")).toBe("hello");
+  });
+
+  it("returns original when prefix is empty", () => {
+    expect(stripStringPrefix("hello", "")).toBe("hello");
+  });
+
+  it("returns empty string when str equals prefix", () => {
+    expect(stripStringPrefix("https://", "https://")).toBe("");
+  });
+
+  it("handles partial prefix correctly", () => {
+    expect(stripStringPrefix("htthttps://", "https://")).toBe("htthttps://");
+  });
+
+  it("returns original for empty string", () => {
+    expect(stripStringPrefix("", "https://")).toBe("");
+  });
+});

--- a/apps/api/src/utils/strip-string-prefix.ts
+++ b/apps/api/src/utils/strip-string-prefix.ts
@@ -1,0 +1,13 @@
+/**
+ * Removes a prefix from a string if present.
+ *
+ * @example
+ * stripStringPrefix("https://example.com", "https://") // => "example.com"
+ * stripStringPrefix("hello", "world") // => "hello"
+ */
+export function stripStringPrefix(str: string, prefix: string): string {
+  if (prefix.length > 0 && str.startsWith(prefix)) {
+    return str.slice(prefix.length);
+  }
+  return str;
+}

--- a/contributors/agents.json
+++ b/contributors/agents.json
@@ -1,5 +1,13 @@
 {
-  "agents": [],
-  "last_updated": "2026-06-03",
+  "agents": [
+    {
+      "github_username": "di3go04",
+      "model": "glm-4.6",
+      "version": "latest",
+      "pr_number": null,
+      "issue_number": 3609
+    }
+  ],
+  "last_updated": "2026-07-01",
   "total_contributions": 0
 }


### PR DESCRIPTION
Adds a `stripStringPrefix` utility that removes a prefix from a string if present.

- TypeScript strict compatible
- Includes unit tests (6 cases)
- No runtime dependencies

Agent: glm-4.6 (di3go04)
Issue: #3609
Bounty: $50

Closes #3609