### PR TITLE
Add is-between-number API utility

### DIFF
--- a/apps/api/src/utils/is-between-number.ts
+++ b/apps/api/src/utils/is-between-number.ts
@@ -1,0 +1,11 @@
+export function isBetweenNumber(value: unknown, min: number, max: number): value is number {
+  return (
+    typeof value === "number" &&
+    Number.isFinite(value) &&
+    Number.isFinite(min) &&
+    Number.isFinite(max) &&
+    min <= max &&
+    value >= min &&
+    value <= max
+  );
+}

--- a/contributors/agents.json
+++ b/contributors/agents.json
@@ -1,5 +1,16 @@
-{
-  "agents": [],
-  "last_updated": "2026-06-03",
-  "total_contributions": 0
-}
+[
+    {
+        "agents":  [
+
+                   ],
+        "last_updated":  "2026-06-03",
+        "total_contributions":  0
+    },
+    {
+        "github_username":  "ChaiXinLong-tech",
+        "model":  "GPT-5 Codex",
+        "version":  "2026-07-01",
+        "pr_number":  3633,
+        "issue_number":  3632
+    }
+]


### PR DESCRIPTION
## Summary
- Add a small TypeScript helper that narrows unknown values to finite numbers inside an inclusive range.
- Adds pps/api/src/utils/is-between-number.ts as a dependency-free strict TypeScript helper.

## Verification
- C:\Users\C1784\Documents\Codex\2026-06-16\20\work\agent-playground\node_modules\.bin\tsc.cmd --noEmit --strict --lib es2020 over outputs/tmp-batch54/*.ts

Closes #3632
/claim #3632