### PR TITLE
feat(api): add sort direction helper

### DIFF
--- a/apps/api/src/utils/sort-direction.ts
+++ b/apps/api/src/utils/sort-direction.ts
@@ -1,0 +1,25 @@
+export type SortDirection = "asc" | "desc";
+
+const SORT_DIRECTIONS: ReadonlySet<string> = new Set<SortDirection>(["asc", "desc"]);
+
+/**
+ * Normalizes an API sort direction input to `asc` or `desc`.
+ *
+ * Returns `undefined` for missing or unsupported values so callers can
+ * distinguish invalid input from an explicit direction.
+ */
+export function normalizeSortDirection(value: unknown): SortDirection | undefined {
+  if (typeof value !== "string") {
+    return undefined;
+  }
+
+  const normalized = value.trim().toLowerCase();
+  return SORT_DIRECTIONS.has(normalized) ? (normalized as SortDirection) : undefined;
+}
+
+/**
+ * Checks whether a value is a supported sort direction.
+ */
+export function isSortDirection(value: unknown): value is SortDirection {
+  return normalizeSortDirection(value) !== undefined;
+}


### PR DESCRIPTION
## Summary
- adds a dependency-free `normalizeSortDirection` helper for API sort direction inputs
- exports a `SortDirection` type and `isSortDirection` type guard
- keeps invalid, missing, and non-string values explicit by returning `undefined`

Closes #2823

## Verification
```bash
./node_modules/.bin/tsc --strict --module NodeNext --moduleResolution NodeNext --target ES2022 --noEmit apps/api/src/utils/sort-direction.ts .hermes-sort-direction-check.ts
node --import tsx .hermes-sort-direction-check.ts
git diff --check
```

Runtime check output:
```text
{
  explicit: 'desc',
  normalized: [ 'asc', 'desc', undefined, undefined, undefined, undefined ]
}
```
