### PR TITLE
feat(api): add CORS origins helper

### DIFF
--- a/apps/api/src/utils/cors-config.ts
+++ b/apps/api/src/utils/cors-config.ts
@@ -1,0 +1,38 @@
+export type CorsOrigin = string;
+
+export interface CorsOriginOptions {
+  readonly fallback?: readonly CorsOrigin[];
+}
+
+/**
+ * Parses comma-separated CORS origins from environment-style strings.
+ *
+ * Empty entries are ignored, surrounding whitespace is trimmed, and duplicate
+ * origins are removed while preserving the first occurrence order.
+ */
+export function parseCorsOrigins(
+  value: string | null | undefined,
+  options: CorsOriginOptions = {}
+): CorsOrigin[] {
+  const origins = value
+    ?.split(",")
+    .map((origin) => origin.trim())
+    .filter((origin) => origin.length > 0);
+
+  const parsed = dedupeOrigins(origins ?? []);
+  return parsed.length > 0 ? parsed : [...(options.fallback ?? [])];
+}
+
+/**
+ * Builds a small CORS config object from an environment-style origin list.
+ */
+export function createCorsConfig(
+  value: string | null | undefined,
+  options?: CorsOriginOptions
+): { readonly allowedOrigins: readonly CorsOrigin[] } {
+  return { allowedOrigins: parseCorsOrigins(value, options) };
+}
+
+function dedupeOrigins(origins: readonly CorsOrigin[]): CorsOrigin[] {
+  return [...new Set(origins)];
+}


### PR DESCRIPTION
## Summary
- adds a dependency-free helper to parse comma-separated CORS origins from env-style strings
- trims whitespace, removes empty entries, and deduplicates origins while preserving first occurrence order
- exposes `createCorsConfig` for callers that want a small `{ allowedOrigins }` config object

Closes #2833

## Verification
```bash
./node_modules/.bin/tsc --strict --module NodeNext --moduleResolution NodeNext --target ES2022 --noEmit apps/api/src/utils/cors-config.ts .hermes-cors-config-check.ts
node --import tsx .hermes-cors-config-check.ts
git diff --check
npm run test --workspace @taskflow/api
npm run lint --workspace @taskflow/api
```

Runtime check output:
```text
{
  origins: [ 'https://a.test', 'https://b.test' ],
  fallback: [ 'http://localhost:3000' ],
  config: { allowedOrigins: [ 'https://taskflow.example.com' ] }
}
```

Note: API workspace test/lint scripts currently echo that no API tests/lint are configured yet.
