### PR TITLE
feat(api): add payment status constants

### DIFF
--- a/apps/api/src/utils/payment-status.ts
+++ b/apps/api/src/utils/payment-status.ts
@@ -1,0 +1,25 @@
+export const PAYMENT_STATUS = {
+  Pending: "pending",
+  Authorized: "authorized",
+  Paid: "paid",
+  Failed: "failed",
+  Refunded: "refunded",
+} as const;
+
+export type PaymentStatus = (typeof PAYMENT_STATUS)[keyof typeof PAYMENT_STATUS];
+
+export const PAYMENT_STATUS_VALUES = Object.values(PAYMENT_STATUS) as readonly PaymentStatus[];
+
+/**
+ * Checks whether a value is one of the supported API payment statuses.
+ */
+export function isPaymentStatus(value: unknown): value is PaymentStatus {
+  return typeof value === "string" && PAYMENT_STATUS_VALUES.includes(value as PaymentStatus);
+}
+
+/**
+ * Parses an unknown API input into a supported payment status.
+ */
+export function parsePaymentStatus(value: unknown): PaymentStatus | undefined {
+  return isPaymentStatus(value) ? value : undefined;
+}


### PR DESCRIPTION
## Summary
- adds dependency-free payment status constants for consistent API state handling
- exports a `PaymentStatus` type and `PAYMENT_STATUS_VALUES` tuple for validation/listing
- adds `isPaymentStatus` and `parsePaymentStatus` helpers for endpoint input handling

Closes #2845

## Verification
```bash
./node_modules/.bin/tsc --strict --module NodeNext --moduleResolution NodeNext --target ES2022 --noEmit apps/api/src/utils/payment-status.ts .hermes-payment-status-check.ts
node --import tsx .hermes-payment-status-check.ts
git diff --check
npm run test --workspace @taskflow/api
npm run lint --workspace @taskflow/api
```

Runtime check output:
```text
{
  paid: 'paid',
  values: [ 'pending', 'authorized', 'paid', 'failed', 'refunded' ],
  parsed: 'failed'
}
```

Note: API workspace test/lint scripts currently echo that no API tests/lint are configured yet.
