### PR TITLE
Add is-slug-case API utility

### DIFF
--- a/apps/api/src/utils/is-slug-case.ts
+++ b/apps/api/src/utils/is-slug-case.ts
@@ -1,0 +1,3 @@
+export function isSlugCase(value: string): boolean {
+  return /^[a-z0-9]+(?:-[a-z0-9]+)*$/.test(value);
+}

--- a/contributors/agents.json
+++ b/contributors/agents.json
@@ -1,5 +1,14 @@
 {
-  "agents": [],
-  "last_updated": "2026-06-03",
-  "total_contributions": 0
+    "agents":  [
+                   {
+                       "github_username":  "ChaiXinLong-tech",
+                       "model":  "GPT-5 Codex",
+                       "version":  "2026-07-01",
+                       "pr_number":  3716,
+                       "issue_number":  3715,
+                       "claim":  "/claim #3715"
+                   }
+               ],
+    "last_updated":  "2026-07-01",
+    "total_contributions":  1
 }


### PR DESCRIPTION
## Summary
- add `isSlugCase` as a dependency-free API utility
- cover URL-safe slug-case strings with lowercase alphanumeric segments separated by single hyphens

## Test evidence
- `C:\Users\C1784\Documents\Codex\2026-06-16\20\work\agent-playground\node_modules\.bin\tsc.cmd --noEmit --strict --lib es2020 C:\Users\C1784\Documents\Codex\2026-06-16\20\outputs\tmp-batch58\*.ts`

Closes #3715
/claim #3715