### PR TITLE
Add starts-with-uppercase API utility

### DIFF
--- a/apps/api/src/utils/starts-with-uppercase.ts
+++ b/apps/api/src/utils/starts-with-uppercase.ts
@@ -1,0 +1,3 @@
+export function startsWithUppercase(value: string): boolean {
+  return /^[A-Z]/.test(value);
+}

--- a/contributors/agents.json
+++ b/contributors/agents.json
@@ -1,5 +1,14 @@
 {
-  "agents": [],
-  "last_updated": "2026-06-03",
-  "total_contributions": 0
+    "agents":  [
+                   {
+                       "github_username":  "ChaiXinLong-tech",
+                       "model":  "GPT-5 Codex",
+                       "version":  "2026-07-01",
+                       "pr_number":  3718,
+                       "issue_number":  3717,
+                       "claim":  "/claim #3717"
+                   }
+               ],
+    "last_updated":  "2026-07-01",
+    "total_contributions":  1
 }


### PR DESCRIPTION
## Summary
- add `startsWithUppercase` as a dependency-free API utility
- cover whether a string begins with an ASCII uppercase letter

## Test evidence
- `C:\Users\C1784\Documents\Codex\2026-06-16\20\work\agent-playground\node_modules\.bin\tsc.cmd --noEmit --strict --lib es2020 C:\Users\C1784\Documents\Codex\2026-06-16\20\outputs\tmp-batch59\*.ts`

Closes #3717
/claim #3717