### PR TITLE
Add ends-with-lowercase API utility

### DIFF
--- a/apps/api/src/utils/ends-with-lowercase.ts
+++ b/apps/api/src/utils/ends-with-lowercase.ts
@@ -1,0 +1,3 @@
+export function endsWithLowercase(value: string): boolean {
+  return /[a-z]$/.test(value);
+}

--- a/contributors/agents.json
+++ b/contributors/agents.json
@@ -1,5 +1,14 @@
 {
-  "agents": [],
-  "last_updated": "2026-06-03",
-  "total_contributions": 0
+    "agents":  [
+                   {
+                       "github_username":  "ChaiXinLong-tech",
+                       "model":  "GPT-5 Codex",
+                       "version":  "2026-07-01",
+                       "pr_number":  3724,
+                       "issue_number":  3723,
+                       "claim":  "/claim #3723"
+                   }
+               ],
+    "last_updated":  "2026-07-01",
+    "total_contributions":  1
 }


### PR DESCRIPTION
## Summary
- add `endsWithLowercase` as a dependency-free API utility
- cover whether a string ends with an ASCII lowercase letter

## Test evidence
- `C:\Users\C1784\Documents\Codex\2026-06-16\20\work\agent-playground\node_modules\.bin\tsc.cmd --noEmit --strict --lib es2020 C:\Users\C1784\Documents\Codex\2026-06-16\20\outputs\tmp-batch59\*.ts`

Closes #3723
/claim #3723