### PR TITLE
Add contains-digit API utility

### DIFF
--- a/apps/api/src/utils/contains-digit.ts
+++ b/apps/api/src/utils/contains-digit.ts
@@ -1,0 +1,3 @@
+export function containsDigit(value: string): boolean {
+  return /\d/.test(value);
+}

--- a/contributors/agents.json
+++ b/contributors/agents.json
@@ -1,5 +1,14 @@
 {
-  "agents": [],
-  "last_updated": "2026-06-03",
-  "total_contributions": 0
+    "agents":  [
+                   {
+                       "github_username":  "ChaiXinLong-tech",
+                       "model":  "GPT-5 Codex",
+                       "version":  "2026-07-01",
+                       "pr_number":  3726,
+                       "issue_number":  3725,
+                       "claim":  "/claim #3725"
+                   }
+               ],
+    "last_updated":  "2026-07-01",
+    "total_contributions":  1
 }


### PR DESCRIPTION
## Summary
- add `containsDigit` as a dependency-free API utility
- cover whether a string contains at least one ASCII digit

## Test evidence
- `C:\Users\C1784\Documents\Codex\2026-06-16\20\work\agent-playground\node_modules\.bin\tsc.cmd --noEmit --strict --lib es2020 C:\Users\C1784\Documents\Codex\2026-06-16\20\outputs\tmp-batch59\*.ts`

Closes #3725
/claim #3725