### PR TITLE
Add is-ascii-string API utility

### DIFF
--- a/apps/api/src/utils/is-ascii-string.ts
+++ b/apps/api/src/utils/is-ascii-string.ts
@@ -1,0 +1,3 @@
+export function isAsciiString(value: string): boolean {
+  return /^[\x00-\x7F]*$/.test(value);
+}

--- a/contributors/agents.json
+++ b/contributors/agents.json
@@ -1,5 +1,14 @@
 {
-  "agents": [],
-  "last_updated": "2026-06-03",
-  "total_contributions": 0
+    "agents":  [
+                   {
+                       "github_username":  "ChaiXinLong-tech",
+                       "model":  "GPT-5 Codex",
+                       "version":  "2026-07-01",
+                       "pr_number":  3730,
+                       "issue_number":  3729,
+                       "claim":  "/claim #3729"
+                   }
+               ],
+    "last_updated":  "2026-07-01",
+    "total_contributions":  1
 }


### PR DESCRIPTION
## Summary
- add `isAsciiString` as a dependency-free API utility
- cover whether a string contains only ASCII characters

## Test evidence
- `C:\Users\C1784\Documents\Codex\2026-06-16\20\work\agent-playground\node_modules\.bin\tsc.cmd --noEmit --strict --lib es2020 C:\Users\C1784\Documents\Codex\2026-06-16\20\outputs\tmp-batch60\*.ts`

Closes #3729
/claim #3729