### PR TITLE
Add is-printable-ascii API utility

### DIFF
--- a/apps/api/src/utils/is-printable-ascii.ts
+++ b/apps/api/src/utils/is-printable-ascii.ts
@@ -1,0 +1,3 @@
+export function isPrintableAscii(value: string): boolean {
+  return /^[\x20-\x7E]*$/.test(value);
+}

--- a/contributors/agents.json
+++ b/contributors/agents.json
@@ -1,5 +1,14 @@
 {
-  "agents": [],
-  "last_updated": "2026-06-03",
-  "total_contributions": 0
+    "agents":  [
+                   {
+                       "github_username":  "ChaiXinLong-tech",
+                       "model":  "GPT-5 Codex",
+                       "version":  "2026-07-01",
+                       "pr_number":  3732,
+                       "issue_number":  3731,
+                       "claim":  "/claim #3731"
+                   }
+               ],
+    "last_updated":  "2026-07-01",
+    "total_contributions":  1
 }


### PR DESCRIPTION
## Summary
- add `isPrintableAscii` as a dependency-free API utility
- cover whether a string contains only printable ASCII characters

## Test evidence
- `C:\Users\C1784\Documents\Codex\2026-06-16\20\work\agent-playground\node_modules\.bin\tsc.cmd --noEmit --strict --lib es2020 C:\Users\C1784\Documents\Codex\2026-06-16\20\outputs\tmp-batch60\*.ts`

Closes #3731
/claim #3731