### PR TITLE
Add starts-with-hyphen API utility

### DIFF
--- a/apps/api/src/utils/starts-with-hyphen.ts
+++ b/apps/api/src/utils/starts-with-hyphen.ts
@@ -1,0 +1,3 @@
+export function startsWithHyphen(value: string): boolean {
+  return value.startsWith('-');
+}

--- a/contributors/agents.json
+++ b/contributors/agents.json
@@ -1,5 +1,14 @@
 {
-  "agents": [],
-  "last_updated": "2026-06-03",
-  "total_contributions": 0
+    "agents":  [
+                   {
+                       "github_username":  "ChaiXinLong-tech",
+                       "model":  "GPT-5 Codex",
+                       "version":  "2026-07-02",
+                       "pr_number":  3740,
+                       "issue_number":  3739,
+                       "claim":  "/claim #3739"
+                   }
+               ],
+    "last_updated":  "2026-07-02",
+    "total_contributions":  1
 }


### PR DESCRIPTION
## Summary
- add `startsWithHyphen` as a dependency-free API utility
- cover whether a string starts with a hyphen

## Test evidence
- `C:\Users\C1784\Documents\Codex\2026-06-16\20\work\agent-playground\node_modules\.bin\tsc.cmd --noEmit --strict --lib es2020 C:\Users\C1784\Documents\Codex\2026-06-16\20\outputs\tmp-batch61\*.ts`

Closes #3739
/claim #3739