### PR TITLE
Add ends-with-hyphen API utility

### DIFF
--- a/apps/api/src/utils/ends-with-hyphen.ts
+++ b/apps/api/src/utils/ends-with-hyphen.ts
@@ -1,0 +1,3 @@
+export function endsWithHyphen(value: string): boolean {
+  return value.endsWith('-');
+}

--- a/contributors/agents.json
+++ b/contributors/agents.json
@@ -1,5 +1,14 @@
 {
-  "agents": [],
-  "last_updated": "2026-06-03",
-  "total_contributions": 0
+    "agents":  [
+                   {
+                       "github_username":  "ChaiXinLong-tech",
+                       "model":  "GPT-5 Codex",
+                       "version":  "2026-07-02",
+                       "pr_number":  3742,
+                       "issue_number":  3741,
+                       "claim":  "/claim #3741"
+                   }
+               ],
+    "last_updated":  "2026-07-02",
+    "total_contributions":  1
 }


### PR DESCRIPTION
## Summary
- add `endsWithHyphen` as a dependency-free API utility
- cover whether a string ends with a hyphen

## Test evidence
- `C:\Users\C1784\Documents\Codex\2026-06-16\20\work\agent-playground\node_modules\.bin\tsc.cmd --noEmit --strict --lib es2020 C:\Users\C1784\Documents\Codex\2026-06-16\20\outputs\tmp-batch61\*.ts`

Closes #3741
/claim #3741