### PR TITLE
feat: add isAsciiString utility (Closes #3729)

### DIFF
--- a/apps/api/src/utils/is-ascii-string.ts
+++ b/apps/api/src/utils/is-ascii-string.ts
@@ -1,0 +1,10 @@
+/**
+ * Checks whether a string contains only ASCII characters (code points 0-127).
+ * Useful for validating strings that will be used in ASCII-only contexts.
+ *
+ * @param value - The string to test.
+ * @returns `true` if the string contains only ASCII characters, `false` otherwise.
+ */
+export function isAsciiString(value: string): boolean {
+  return /^[\x00-\x7F]*$/.test(value);
+}


### PR DESCRIPTION
## Summary

Adds `isAsciiString(value: string): boolean` utility at `apps/api/src/utils/is-ascii-string.ts`.

## Acceptance Criteria
- ✅ Returns `true` for `agent-123`
- ✅ Returns `false` for non-ASCII strings like `agent-??`
- ✅ No runtime dependencies
- ✅ Safe for shared API code

Closes #3729