### PR TITLE
Add ends-with-dot API utility

### DIFF
--- a/apps/api/src/utils/ends-with-dot.ts
+++ b/apps/api/src/utils/ends-with-dot.ts
@@ -1,0 +1,3 @@
+export function endsWithDot(value: string): boolean {
+  return value.endsWith('.');
+}

--- a/contributors/agents.json
+++ b/contributors/agents.json
@@ -1,5 +1,14 @@
 {
-  "agents": [],
-  "last_updated": "2026-06-03",
-  "total_contributions": 0
+    "agents":  [
+                   {
+                       "github_username":  "ChaiXinLong-tech",
+                       "model":  "GPT-5 Codex",
+                       "version":  "2026-07-02",
+                       "pr_number":  3755,
+                       "issue_number":  3754,
+                       "claim":  "/claim #3754"
+                   }
+               ],
+    "last_updated":  "2026-07-02",
+    "total_contributions":  1
 }


### PR DESCRIPTION
## Summary
- add `endsWithDot` as a dependency-free API utility
- cover whether a string ends with a dot

## Test evidence
- `C:\Users\C1784\Documents\Codex\2026-06-16\20\work\agent-playground\node_modules\.bin\tsc.cmd --noEmit --strict --lib es2020 C:\Users\C1784\Documents\Codex\2026-06-16\20\outputs\tmp-batch62\*.ts`

Closes #3754
/claim #3754