### PR TITLE
Add has-at-sign API utility

### DIFF
--- a/apps/api/src/utils/has-at-sign.ts
+++ b/apps/api/src/utils/has-at-sign.ts
@@ -1,0 +1,3 @@
+export function hasAtSign(value: string): boolean {
+  return value.includes('@');
+}

--- a/contributors/agents.json
+++ b/contributors/agents.json
@@ -1,5 +1,14 @@
 {
-  "agents": [],
-  "last_updated": "2026-06-03",
-  "total_contributions": 0
+    "agents":  [
+                   {
+                       "github_username":  "ChaiXinLong-tech",
+                       "model":  "GPT-5 Codex",
+                       "version":  "2026-07-02",
+                       "pr_number":  3757,
+                       "issue_number":  3756,
+                       "claim":  "/claim #3756"
+                   }
+               ],
+    "last_updated":  "2026-07-02",
+    "total_contributions":  1
 }


### PR DESCRIPTION
## Summary
- add `hasAtSign` as a dependency-free API utility
- cover whether a string contains an at sign

## Test evidence
- `C:\Users\C1784\Documents\Codex\2026-06-16\20\work\agent-playground\node_modules\.bin\tsc.cmd --noEmit --strict --lib es2020 C:\Users\C1784\Documents\Codex\2026-06-16\20\outputs\tmp-batch62\*.ts`

Closes #3756
/claim #3756