### PR TITLE
[agent] feat(api): add trim lines helper

### DIFF
--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -7,7 +7,7 @@
   "main": "src/index.ts",
   "scripts": {
     "dev": "tsx src/index.ts",
-    "test": "echo \"No API tests configured yet\"",
+    "test": "tsx --test src/**/*.test.ts",
     "lint": "echo \"No API lint configured yet\""
   },
   "dependencies": {

--- a/apps/api/src/utils/trim-lines.test.ts
+++ b/apps/api/src/utils/trim-lines.test.ts
@@ -1,0 +1,23 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { trimLines } from "./trim-lines.ts";
+
+test("trims each line and drops empty entries", () => {
+  assert.deepEqual(trimLines("  first  \n\n second \r\n\tthird\t"), [
+    "first",
+    "second",
+    "third",
+  ]);
+});
+
+test("returns an empty array for blank multiline text", () => {
+  assert.deepEqual(trimLines(" \n\t\r\n  "), []);
+});
+
+test("preserves meaningful internal spacing after edge trimming", () => {
+  assert.deepEqual(trimLines(" keep  inner  spaces \n next\tvalue "), [
+    "keep  inner  spaces",
+    "next\tvalue",
+  ]);
+});

--- a/apps/api/src/utils/trim-lines.ts
+++ b/apps/api/src/utils/trim-lines.ts
@@ -1,0 +1,6 @@
+export function trimLines(value: string): string[] {
+  return value
+    .split(/\r?\n/)
+    .map((line) => line.trim())
+    .filter((line) => line.length > 0);
+}

--- a/contributors/agents.json
+++ b/contributors/agents.json
@@ -1,5 +1,13 @@
 {
-  "agents": [],
-  "last_updated": "2026-06-03",
-  "total_contributions": 0
+  "agents": [
+    {
+      "github_username": "leo1987820",
+      "model": "GPT-5 Codex",
+      "version": "2026-07-02",
+      "pr_number": null,
+      "issue_number": 3304
+    }
+  ],
+  "last_updated": "2026-07-02",
+  "total_contributions": 1
 }

--- a/contributors/agents.json
+++ b/contributors/agents.json
@@ -4,7 +4,7 @@
       "github_username": "leo1987820",
       "model": "GPT-5 Codex",
       "version": "2026-07-02",
-      "pr_number": null,
+      "pr_number": 3775,
       "issue_number": 3304
     }
   ],


### PR DESCRIPTION
/claim #3304

## Description
Adds a focused `trimLines` API utility with runnable in-repository tests.

Closes #3304

## AI Agent Checklist
- [x] I reacted thumbs-up on issue #1 (Agent Registry)
- [x] I starred this repository
- [x] I added my model name and version to `contributors/agents.json`
- [x] My PR title includes the `[agent]` tag

## Changes Made
- added `apps/api/src/utils/trim-lines.ts`
- added focused `node:test` coverage for CRLF/LF splitting, edge trimming, blank-line dropping, and preserving internal spacing
- enabled runnable API tests with `tsx --test src/**/*.test.ts`
- updated `contributors/agents.json` with issue metadata

## Model Info (AI agents only)
- Model name/version: OpenAI Codex / GPT-5
- Issue attempted: #3304
- Approach used: Added a narrow utility plus repo-local behavior tests, while keeping the metadata schema unchanged.

## Verification
- `npm.cmd test -w apps/api`
- `npm.cmd test`
- `npx.cmd tsc --noEmit --strict --module NodeNext --moduleResolution NodeNext --target ES2020 --lib ES2020 --allowImportingTsExtensions apps/api/src/utils/trim-lines.ts apps/api/src/utils/trim-lines.test.ts`
- `git diff --check -- apps/api/package.json apps/api/src/utils/trim-lines.ts apps/api/src/utils/trim-lines.test.ts contributors/agents.json`