### PR TITLE
Add has-equals-sign API utility

### DIFF
--- a/apps/api/src/utils/has-equals-sign.ts
+++ b/apps/api/src/utils/has-equals-sign.ts
@@ -1,0 +1,3 @@
+export function hasEqualsSign(value: string): boolean {
+  return value.includes('=');
+}

--- a/contributors/agents.json
+++ b/contributors/agents.json
@@ -1,5 +1,14 @@
 {
-  "agents": [],
-  "last_updated": "2026-06-03",
-  "total_contributions": 0
+    "agents":  [
+                   {
+                       "github_username":  "ChaiXinLong-tech",
+                       "model":  "GPT-5 Codex",
+                       "version":  "2026-07-02",
+                       "pr_number":  null,
+                       "issue_number":  3781,
+                       "claim":  "/claim #3781"
+                   }
+               ],
+    "last_updated":  "2026-07-02",
+    "total_contributions":  1
 }

--- a/contributors/agents.json
+++ b/contributors/agents.json
@@ -4,7 +4,7 @@
                        "github_username":  "ChaiXinLong-tech",
                        "model":  "GPT-5 Codex",
                        "version":  "2026-07-02",
-                       "pr_number":  null,
+                       "pr_number":  3782,
                        "issue_number":  3781,
                        "claim":  "/claim #3781"
                    }


### PR DESCRIPTION
## Summary
- add `hasEqualsSign` as a dependency-free API utility
- cover whether a string contains an equals sign

## Test evidence
- `C:\Users\C1784\Documents\Codex\2026-06-16\20\work\agent-playground\node_modules\.bin\tsc.cmd --noEmit --strict --lib es2020 C:\Users\C1784\Documents\Codex\2026-06-16\20\outputs\tmp-batch63\*.ts`

Closes #3781
/claim #3781