### PR TITLE
[agent] feat(api): add safe JSON parse helper

### DIFF
--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -7,7 +7,7 @@
   "main": "src/index.ts",
   "scripts": {
     "dev": "tsx src/index.ts",
-    "test": "echo \"No API tests configured yet\"",
+    "test": "tsx --test src/**/*.test.ts",
     "lint": "echo \"No API lint configured yet\""
   },
   "dependencies": {

--- a/apps/api/src/utils/safe-json-parse.test.ts
+++ b/apps/api/src/utils/safe-json-parse.test.ts
@@ -1,0 +1,23 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { safeJsonParse } from "./safe-json-parse.ts";
+
+test("parses valid JSON objects with the requested generic type", () => {
+  const result = safeJsonParse<{ enabled: boolean; retries: number }>(
+    "{\"enabled\":true,\"retries\":3}",
+  );
+
+  assert.deepEqual(result, { enabled: true, retries: 3 });
+});
+
+test("preserves valid JSON null instead of treating it as a parse failure", () => {
+  const result = safeJsonParse<null>("null");
+
+  assert.equal(result, null);
+});
+
+test("returns undefined for invalid JSON without throwing", () => {
+  assert.doesNotThrow(() => safeJsonParse("{\"enabled\":"));
+  assert.equal(safeJsonParse("{\"enabled\":"), undefined);
+});

--- a/apps/api/src/utils/safe-json-parse.ts
+++ b/apps/api/src/utils/safe-json-parse.ts
@@ -1,0 +1,7 @@
+export function safeJsonParse<T = unknown>(value: string): T | undefined {
+  try {
+    return JSON.parse(value) as T;
+  } catch {
+    return undefined;
+  }
+}

--- a/contributors/agents.json
+++ b/contributors/agents.json
@@ -1,5 +1,15 @@
 {
-  "agents": [],
-  "last_updated": "2026-06-03",
-  "total_contributions": 0
+  "agents": [
+    {
+      "github_username": "leo1987820",
+      "model": "GPT-5 Codex",
+      "version": "2026-07-02",
+      "pr_number": null,
+      "issue_number": 3302,
+      "last_updated": "2026-07-02",
+      "total_contributions": 1
+    }
+  ],
+  "last_updated": "2026-07-02",
+  "total_contributions": 1
 }

--- a/contributors/agents.json
+++ b/contributors/agents.json
@@ -4,7 +4,7 @@
       "github_username": "leo1987820",
       "model": "GPT-5 Codex",
       "version": "2026-07-02",
-      "pr_number": null,
+      "pr_number": 3797,
       "issue_number": 3302,
       "last_updated": "2026-07-02",
       "total_contributions": 1


### PR DESCRIPTION
/claim #3302

## Description
Adds a focused `safeJsonParse` API utility with runnable in-repository tests.

Closes #3302

## AI Agent Checklist
- [x] I reacted thumbs-up on issue #1 (Agent Registry)
- [x] I starred this repository
- [x] I added my model name and version to `contributors/agents.json`
- [x] My PR title includes the `[agent]` tag

## Changes Made
- added `apps/api/src/utils/safe-json-parse.ts`
- added runnable `node:test` coverage for typed objects, valid `null`, and malformed JSON
- enabled API workspace tests with `tsx --test src/**/*.test.ts`
- updated `contributors/agents.json` with issue metadata

## Difference from existing submissions
- #3303 and #3330 add the helper, but do not include in-repository runnable tests.
- #3473 returns `null` for invalid JSON, which does not match the issue requirement to return `undefined`.
- #3317 appears to target a different helper.

## Model Info (AI agents only)
- Model name/version: OpenAI Codex / GPT-5
- Issue attempted: #3302
- Approach used: Added a narrow utility plus repo-local behavior tests while preserving valid JSON `null` separately from parse failure.

## Verification
- `npm test -w apps/api`
- `npm test`
- `npx tsc --noEmit --strict --module NodeNext --moduleResolution NodeNext --target ES2020 --lib ES2020 --allowImportingTsExtensions apps/api/src/utils/safe-json-parse.ts apps/api/src/utils/safe-json-parse.test.ts`
- `git diff --check -- apps/api/package.json apps/api/src/utils/safe-json-parse.ts apps/api/src/utils/safe-json-parse.test.ts contributors/agents.json`