### PR TITLE
Add has-close-paren API utility

### DIFF
--- a/apps/api/src/utils/has-close-paren.ts
+++ b/apps/api/src/utils/has-close-paren.ts
@@ -1,0 +1,3 @@
+export function hasCloseParen(value: string): boolean {
+  return value.includes(')');
+}

--- a/contributors/agents.json
+++ b/contributors/agents.json
@@ -1,5 +1,14 @@
 {
-  "agents": [],
-  "last_updated": "2026-06-03",
-  "total_contributions": 0
+    "agents":  [
+                   {
+                       "github_username":  "ChaiXinLong-tech",
+                       "model":  "GPT-5 Codex",
+                       "version":  "2026-07-02",
+                       "pr_number":  null,
+                       "issue_number":  3863,
+                       "claim":  "/claim #3863"
+                   }
+               ],
+    "last_updated":  "2026-07-02",
+    "total_contributions":  1
 }

--- a/contributors/agents.json
+++ b/contributors/agents.json
@@ -4,7 +4,7 @@
                        "github_username":  "ChaiXinLong-tech",
                        "model":  "GPT-5 Codex",
                        "version":  "2026-07-02",
-                       "pr_number":  null,
+                       "pr_number":  3864,
                        "issue_number":  3863,
                        "claim":  "/claim #3863"
                    }


### PR DESCRIPTION
## Summary
- add `hasCloseParen` as a dependency-free API utility
- cover whether a string contains a close parenthesis

## Test evidence
- `C:\Users\C1784\Documents\Codex\2026-06-16\20\work\agent-playground\node_modules\.bin\tsc.cmd --noEmit --strict --lib es2020 C:\Users\C1784\Documents\Codex\2026-06-16\20\outputs\tmp-batch65\*.ts`

Closes #3863
/claim #3863