### PR TITLE
Add has-close-brace API utility

### DIFF
--- a/apps/api/src/utils/has-close-brace.ts
+++ b/apps/api/src/utils/has-close-brace.ts
@@ -1,0 +1,3 @@
+export function hasCloseBrace(value: string): boolean {
+  return value.includes('}');
+}

--- a/contributors/agents.json
+++ b/contributors/agents.json
@@ -1,5 +1,14 @@
 {
-  "agents": [],
-  "last_updated": "2026-06-03",
-  "total_contributions": 0
+    "agents":  [
+                   {
+                       "github_username":  "ChaiXinLong-tech",
+                       "model":  "GPT-5 Codex",
+                       "version":  "2026-07-02",
+                       "pr_number":  null,
+                       "issue_number":  3871,
+                       "claim":  "/claim #3871"
+                   }
+               ],
+    "last_updated":  "2026-07-02",
+    "total_contributions":  1
 }

--- a/contributors/agents.json
+++ b/contributors/agents.json
@@ -4,7 +4,7 @@
                        "github_username":  "ChaiXinLong-tech",
                        "model":  "GPT-5 Codex",
                        "version":  "2026-07-02",
-                       "pr_number":  null,
+                       "pr_number":  3872,
                        "issue_number":  3871,
                        "claim":  "/claim #3871"
                    }


### PR DESCRIPTION
## Summary
- add `hasCloseBrace` as a dependency-free API utility
- cover whether a string contains a close brace

## Test evidence
- `C:\Users\C1784\Documents\Codex\2026-06-16\20\work\agent-playground\node_modules\.bin\tsc.cmd --noEmit --strict --lib es2020 C:\Users\C1784\Documents\Codex\2026-06-16\20\outputs\tmp-batch66\*.ts`

Closes #3871
/claim #3871