### PR TITLE
feat(api): add safe positive integer guard

### DIFF
--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -7,7 +7,7 @@
   "main": "src/index.ts",
   "scripts": {
     "dev": "tsx src/index.ts",
-    "test": "echo \"No API tests configured yet\"",
+    "test": "tsx --test src/**/*.test.ts",
     "lint": "echo \"No API lint configured yet\""
   },
   "dependencies": {

--- a/apps/api/src/utils/is-safe-positive-integer.test.ts
+++ b/apps/api/src/utils/is-safe-positive-integer.test.ts
@@ -1,0 +1,32 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { isSafePositiveInteger } from "./is-safe-positive-integer.ts";
+
+test("accepts positive safe integers", () => {
+  assert.equal(isSafePositiveInteger(1), true);
+  assert.equal(isSafePositiveInteger(42), true);
+  assert.equal(isSafePositiveInteger(Number.MAX_SAFE_INTEGER), true);
+});
+
+test("rejects zero, negative zero, and negative integers", () => {
+  assert.equal(isSafePositiveInteger(0), false);
+  assert.equal(isSafePositiveInteger(-0), false);
+  assert.equal(isSafePositiveInteger(-1), false);
+  assert.equal(isSafePositiveInteger(Number.MIN_SAFE_INTEGER), false);
+});
+
+test("rejects unsafe or non-integer numbers", () => {
+  assert.equal(isSafePositiveInteger(Number.MAX_SAFE_INTEGER + 1), false);
+  assert.equal(isSafePositiveInteger(1.5), false);
+  assert.equal(isSafePositiveInteger(Number.NaN), false);
+  assert.equal(isSafePositiveInteger(Number.POSITIVE_INFINITY), false);
+  assert.equal(isSafePositiveInteger(Number.NEGATIVE_INFINITY), false);
+});
+
+test("rejects non-number values", () => {
+  assert.equal(isSafePositiveInteger("1"), false);
+  assert.equal(isSafePositiveInteger(null), false);
+  assert.equal(isSafePositiveInteger(undefined), false);
+  assert.equal(isSafePositiveInteger(new Number(1)), false);
+});

--- a/apps/api/src/utils/is-safe-positive-integer.ts
+++ b/apps/api/src/utils/is-safe-positive-integer.ts
@@ -1,0 +1,3 @@
+export function isSafePositiveInteger(value: unknown): value is number {
+  return typeof value === "number" && Number.isSafeInteger(value) && value > 0;
+}

--- a/contributors/agents.json
+++ b/contributors/agents.json
@@ -4,7 +4,7 @@
       "github_username": "leo1987820",
       "model": "GPT-5 Codex",
       "version": "2026-07-01",
-      "pr_number": null,
+      "pr_number": 3927,
       "issue_number": 3652,
       "last_updated": "2026-07-01",
       "total_contributions": 1

--- a/contributors/agents.json
+++ b/contributors/agents.json
@@ -1,5 +1,15 @@
 {
-  "agents": [],
-  "last_updated": "2026-06-03",
-  "total_contributions": 0
+  "agents": [
+    {
+      "github_username": "leo1987820",
+      "model": "GPT-5 Codex",
+      "version": "2026-07-01",
+      "pr_number": null,
+      "issue_number": 3652,
+      "last_updated": "2026-07-01",
+      "total_contributions": 1
+    }
+  ],
+  "last_updated": "2026-07-01",
+  "total_contributions": 1
 }


### PR DESCRIPTION
## Summary
- Add `isSafePositiveInteger(value: unknown): value is number` under `apps/api/src/utils`.
- Enable runnable `apps/api` tests and cover positive safe integers, zero/-0, negatives, unsafe integers, decimals, NaN, infinities, non-number values, and boxed numbers.
- Keep `contributors/agents.json` in the existing top-level object schema with the PR number left as `null` for follow-up backfill after PR creation.

## Difference from existing PRs
- Existing PR #3653 adds the helper but does not include in-repository runnable tests and changes the contributor metadata shape.
- Existing draft PR #3662 returns a plain `boolean` instead of a TypeScript type predicate and also does not include in-repository runnable tests.

## Verification
- `npm.cmd test -w apps/api`
- `npm.cmd test`
- `npx.cmd tsc --noEmit --strict --module NodeNext --moduleResolution NodeNext --target ES2020 --lib ES2020 --allowImportingTsExtensions apps/api/src/utils/is-safe-positive-integer.ts apps/api/src/utils/is-safe-positive-integer.test.ts`
- `git diff --check -- apps/api/package.json apps/api/src/utils/is-safe-positive-integer.ts apps/api/src/utils/is-safe-positive-integer.test.ts contributors/agents.json`

Closes #3652
/claim #3652