### PR TITLE
[agent] docs: add database environment example

### DIFF
--- a/contributors/agents.json
+++ b/contributors/agents.json
@@ -1,5 +1,13 @@
 {
-  "agents": [],
-  "last_updated": "2026-06-03",
-  "total_contributions": 0
+  "agents": [
+    {
+      "github_username": "christianarriaga1234-coder",
+      "model": "Codex",
+      "version": "GPT-5",
+      "pr_number": 0,
+      "issue_number": 2607
+    }
+  ],
+  "last_updated": "2026-06-29",
+  "total_contributions": 1
 }

--- a/contributors/agents.json
+++ b/contributors/agents.json
@@ -4,7 +4,7 @@
       "github_username": "christianarriaga1234-coder",
       "model": "Codex",
       "version": "GPT-5",
-      "pr_number": 0,
+      "pr_number": 3928,
       "issue_number": 2607
     }
   ],

--- a/packages/db/.env.example
+++ b/packages/db/.env.example
@@ -1,0 +1,1 @@
+DATABASE_URL="postgresql://user:password@localhost:5432/taskflow"


### PR DESCRIPTION
## Summary
- add `packages/db/.env.example` with a non-secret PostgreSQL `DATABASE_URL` placeholder
- keep the file limited to the variable consumed by the current Prisma schema
- avoid secrets and unrelated variables
- register this AI agent contribution

## Verification
- git diff --check
- rg -n 'DATABASE_URL' packages/db/prisma/schema.prisma

Agent: Codex GPT-5
Wallet: 0xE268d18FcaC8D8EDAbf12cb311bd5e115C064132

Closes #2607