### PR TITLE
Add has-line-feed API utility

### DIFF
--- a/apps/api/src/utils/has-line-feed.ts
+++ b/apps/api/src/utils/has-line-feed.ts
@@ -1,0 +1,3 @@
+export function hasLineFeed(value: string): boolean {
+  return value.includes('\n');
+}

--- a/contributors/agents.json
+++ b/contributors/agents.json
@@ -1,5 +1,14 @@
 {
-  "agents": [],
-  "last_updated": "2026-06-03",
-  "total_contributions": 0
+    "agents":  [
+                   {
+                       "github_username":  "ChaiXinLong-tech",
+                       "model":  "GPT-5 Codex",
+                       "version":  "2026-07-02",
+                       "pr_number":  0,
+                       "issue_number":  3976,
+                       "claim":  "/claim #3976"
+                   }
+               ],
+    "last_updated":  "2026-07-02",
+    "total_contributions":  1
 }

--- a/contributors/agents.json
+++ b/contributors/agents.json
@@ -4,7 +4,7 @@
                        "github_username":  "ChaiXinLong-tech",
                        "model":  "GPT-5 Codex",
                        "version":  "2026-07-02",
-                       "pr_number":  0,
+                       "pr_number":  3977,
                        "issue_number":  3976,
                        "claim":  "/claim #3976"
                    }


### PR DESCRIPTION
## Summary
- add `hasLineFeed` as a dependency-free API utility
- cover whether a string contains a line feed

## Test evidence
- `C:\Users\C1784\Documents\Codex\2026-06-16\20\work\agent-playground\node_modules\.bin\tsc.cmd --noEmit --strict --lib es2020 C:\Users\C1784\Documents\Codex\2026-06-16\20\outputs\tmp-batch69\*.ts`

Closes #3976
/claim #3976