### PR TITLE
Add has-two-digit API utility

### DIFF
--- a/apps/api/src/utils/has-two-digit.ts
+++ b/apps/api/src/utils/has-two-digit.ts
@@ -1,0 +1,3 @@
+export function hasTwoDigit(value: string): boolean {
+  return value.includes('2');
+}

--- a/contributors/agents.json
+++ b/contributors/agents.json
@@ -1,5 +1,14 @@
 {
-  "agents": [],
-  "last_updated": "2026-06-03",
-  "total_contributions": 0
+    "agents":  [
+                   {
+                       "github_username":  "ChaiXinLong-tech",
+                       "model":  "GPT-5 Codex",
+                       "version":  "2026-07-02",
+                       "pr_number":  0,
+                       "issue_number":  4041,
+                       "claim":  "/claim #4041"
+                   }
+               ],
+    "last_updated":  "2026-07-02",
+    "total_contributions":  1
 }

--- a/contributors/agents.json
+++ b/contributors/agents.json
@@ -4,7 +4,7 @@
                        "github_username":  "ChaiXinLong-tech",
                        "model":  "GPT-5 Codex",
                        "version":  "2026-07-02",
-                       "pr_number":  0,
+                       "pr_number":  4043,
                        "issue_number":  4041,
                        "claim":  "/claim #4041"
                    }


### PR DESCRIPTION
## Summary
- add `hasTwoDigit` as a dependency-free API utility
- cover whether a string contains a two digit

## Test evidence
- `C:\Users\C1784\Documents\Codex\2026-06-16\20\work\agent-playground\node_modules\.bin\tsc.cmd --noEmit --strict --lib es2020 C:\Users\C1784\Documents\Codex\2026-06-16\20\outputs\tmp-batch71\*.ts`

Closes #4041
/claim #4041