### PR TITLE
Add has-three-digit API utility

### DIFF
--- a/apps/api/src/utils/has-three-digit.ts
+++ b/apps/api/src/utils/has-three-digit.ts
@@ -1,0 +1,3 @@
+export function hasThreeDigit(value: string): boolean {
+  return value.includes('3');
+}

--- a/contributors/agents.json
+++ b/contributors/agents.json
@@ -1,5 +1,14 @@
 {
-  "agents": [],
-  "last_updated": "2026-06-03",
-  "total_contributions": 0
+    "agents":  [
+                   {
+                       "github_username":  "ChaiXinLong-tech",
+                       "model":  "GPT-5 Codex",
+                       "version":  "2026-07-02",
+                       "pr_number":  0,
+                       "issue_number":  4044,
+                       "claim":  "/claim #4044"
+                   }
+               ],
+    "last_updated":  "2026-07-02",
+    "total_contributions":  1
 }

--- a/contributors/agents.json
+++ b/contributors/agents.json
@@ -4,7 +4,7 @@
                        "github_username":  "ChaiXinLong-tech",
                        "model":  "GPT-5 Codex",
                        "version":  "2026-07-02",
-                       "pr_number":  0,
+                       "pr_number":  4045,
                        "issue_number":  4044,
                        "claim":  "/claim #4044"
                    }


### PR DESCRIPTION
## Summary
- add `hasThreeDigit` as a dependency-free API utility
- cover whether a string contains a three digit

## Test evidence
- `C:\Users\C1784\Documents\Codex\2026-06-16\20\work\agent-playground\node_modules\.bin\tsc.cmd --noEmit --strict --lib es2020 C:\Users\C1784\Documents\Codex\2026-06-16\20\outputs\tmp-batch71\*.ts`

Closes #4044
/claim #4044