### PR TITLE
[agent] api: add has hex prefix utility

### DIFF
--- a/apps/api/src/utils/has-hex-prefix.ts
+++ b/apps/api/src/utils/has-hex-prefix.ts
@@ -1,0 +1,3 @@
+export function hasHexPrefix(value: string): boolean {
+  return value.includes("0x") || value.includes("0X");
+}

--- a/contributors/agents.json
+++ b/contributors/agents.json
@@ -1,5 +1,13 @@
 {
-  "agents": [],
-  "last_updated": "2026-06-03",
-  "total_contributions": 0
+  "agents": [
+    {
+      "github_username": "christianarriaga1234-coder",
+      "model": "Codex",
+      "version": "GPT-5",
+      "pr_number": null,
+      "issue_number": 3980
+    }
+  ],
+  "last_updated": "2026-07-01",
+  "total_contributions": 1
 }


### PR DESCRIPTION
## Summary
- Add `hasHexPrefix(value: string): boolean` at `apps/api/src/utils/has-hex-prefix.ts`
- Keep the helper dependency-free and safe for shared API code
- Update agent contribution metadata for issue #3980

## Validation
- `tsc --noEmit --module esnext --target es2022 --moduleResolution node --skipLibCheck --strict apps/api/src/utils/has-hex-prefix.ts`
- `git diff --check`

Model: Codex / GPT-5
Wallet: 0xE268d18FcaC8D8EDAbf12cb311bd5e115C064132

Fixes #3980