### PR TITLE
Add has-letter-b API utility

### DIFF
--- a/apps/api/src/utils/has-letter-b.ts
+++ b/apps/api/src/utils/has-letter-b.ts
@@ -1,0 +1,3 @@
+export function hasLetterB(value: string): boolean {
+  return value.includes('b');
+}

--- a/contributors/agents.json
+++ b/contributors/agents.json
@@ -1,5 +1,14 @@
 {
-  "agents": [],
-  "last_updated": "2026-06-03",
-  "total_contributions": 0
+    "agents":  [
+                   {
+                       "github_username":  "ChaiXinLong-tech",
+                       "model":  "GPT-5 Codex",
+                       "version":  "2026-07-02",
+                       "pr_number":  4115,
+                       "issue_number":  4114,
+                       "claim":  "/claim #4114"
+                   }
+               ],
+    "last_updated":  "2026-07-02",
+    "total_contributions":  1
 }


### PR DESCRIPTION
## Summary
- add `hasLetterB` as a dependency-free API utility
- cover whether a string contains a letter b

## Test evidence
- `C:\Users\C1784\Documents\Codex\2026-06-16\20\work\agent-playground\node_modules\.bin\tsc.cmd --noEmit --strict --lib es2020 C:\Users\C1784\Documents\Codex\2026-06-16\20\outputs\tmp-batch73\*.ts`

Closes #4114
/claim #4114