### PR TITLE
feat(api): add safe negative integer guard

### DIFF
--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -7,7 +7,7 @@
   "main": "src/index.ts",
   "scripts": {
     "dev": "tsx src/index.ts",
-    "test": "echo \"No API tests configured yet\"",
+    "test": "tsx --test src/**/*.test.ts",
     "lint": "echo \"No API lint configured yet\""
   },
   "dependencies": {

--- a/apps/api/src/utils/is-safe-negative-integer.test.ts
+++ b/apps/api/src/utils/is-safe-negative-integer.test.ts
@@ -1,0 +1,35 @@
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+
+import { isSafeNegativeInteger } from "./is-safe-negative-integer.ts";
+
+describe("isSafeNegativeInteger", () => {
+  it("accepts negative safe integers", () => {
+    assert.equal(isSafeNegativeInteger(-1), true);
+    assert.equal(isSafeNegativeInteger(-42), true);
+    assert.equal(isSafeNegativeInteger(Number.MIN_SAFE_INTEGER), true);
+  });
+
+  it("rejects zero and positive safe integers", () => {
+    assert.equal(isSafeNegativeInteger(-0), false);
+    assert.equal(isSafeNegativeInteger(0), false);
+    assert.equal(isSafeNegativeInteger(1), false);
+    assert.equal(isSafeNegativeInteger(Number.MAX_SAFE_INTEGER), false);
+  });
+
+  it("rejects unsafe integers and decimals", () => {
+    assert.equal(isSafeNegativeInteger(Number.MIN_SAFE_INTEGER - 1), false);
+    assert.equal(isSafeNegativeInteger(-1.5), false);
+    assert.equal(isSafeNegativeInteger(1.5), false);
+  });
+
+  it("rejects non-finite numbers and non-number values", () => {
+    assert.equal(isSafeNegativeInteger(Number.NaN), false);
+    assert.equal(isSafeNegativeInteger(Number.NEGATIVE_INFINITY), false);
+    assert.equal(isSafeNegativeInteger(Number.POSITIVE_INFINITY), false);
+    assert.equal(isSafeNegativeInteger("-1"), false);
+    assert.equal(isSafeNegativeInteger(null), false);
+    assert.equal(isSafeNegativeInteger(undefined), false);
+    assert.equal(isSafeNegativeInteger(new Number(-1)), false);
+  });
+});

--- a/apps/api/src/utils/is-safe-negative-integer.ts
+++ b/apps/api/src/utils/is-safe-negative-integer.ts
@@ -1,0 +1,3 @@
+export function isSafeNegativeInteger(value: unknown): value is number {
+  return typeof value === "number" && Number.isSafeInteger(value) && value < 0;
+}

--- a/contributors/agents.json
+++ b/contributors/agents.json
@@ -1,5 +1,13 @@
 {
-  "agents": [],
-  "last_updated": "2026-06-03",
-  "total_contributions": 0
+  "agents": [
+    {
+      "github_username": "leo1987820",
+      "model": "GPT-5 Codex",
+      "version": "2026-07-01",
+      "pr_number": null,
+      "issue_number": 3654
+    }
+  ],
+  "last_updated": "2026-07-01",
+  "total_contributions": 1
 }

--- a/contributors/agents.json
+++ b/contributors/agents.json
@@ -4,7 +4,7 @@
       "github_username": "leo1987820",
       "model": "GPT-5 Codex",
       "version": "2026-07-01",
-      "pr_number": null,
+      "pr_number": 4153,
       "issue_number": 3654
     }
   ],


### PR DESCRIPTION
Closes #3654
/claim #3654

## Summary
- Add `isSafeNegativeInteger` as a dependency-free API utility and TypeScript type guard.
- Configure the API workspace to run `tsx --test src/**/*.test.ts`.
- Add runnable coverage for negative safe integers, zero, positive integers, unsafe integers, decimals, non-finite numbers, and non-number values.
- Register this contribution in `contributors/agents.json` while preserving the repository's top-level metadata shape.

## Difference from existing PRs
PR #3656 adds only the helper and validates it with a temporary `tsc` command over `outputs/tmp-batch55/*.ts`; it also rewrites contributor metadata in a weaker shape. PR #3665 is still draft, has no in-repo runnable tests, and returns a plain `boolean` instead of a type predicate.

## Verification
- `npm.cmd test -w apps/api`
- `npm.cmd test`
- `npx.cmd tsc --noEmit --strict --module NodeNext --moduleResolution NodeNext --target ES2020 --lib ES2020 --allowImportingTsExtensions apps/api/src/utils/is-safe-negative-integer.ts apps/api/src/utils/is-safe-negative-integer.test.ts`
- `git diff --check -- apps/api/package.json apps/api/src/utils/is-safe-negative-integer.ts apps/api/src/utils/is-safe-negative-integer.test.ts contributors/agents.json`