### PR TITLE
feat: add has-caret-sign API utility

### DIFF
--- a/apps/api/src/utils/has-caret-sign.ts
+++ b/apps/api/src/utils/has-caret-sign.ts
@@ -1,0 +1,3 @@
+export function hasCaretSign(value: string): boolean {
+  return value.includes('^');
+}


### PR DESCRIPTION
## Summary
- Adds `hasCaretSign(value: string): boolean` at `apps/api/src/utils/has-caret-sign.ts`
- Checks whether a string contains `^` without dependencies

## Verification
- `npx -y -p typescript tsc --noEmit --strict --target ES2022 --module ESNext apps/api/src/utils/has-caret-sign.ts`
- `npm --workspace @taskflow/api test`

Closes #4146