### PR TITLE
feat: add has-tilde-sign API utility

### DIFF
--- a/apps/api/src/utils/has-tilde-sign.ts
+++ b/apps/api/src/utils/has-tilde-sign.ts
@@ -1,0 +1,3 @@
+export function hasTildeSign(value: string): boolean {
+  return value.includes('~');
+}


### PR DESCRIPTION
## Summary
- Adds `hasTildeSign(value: string): boolean` at `apps/api/src/utils/has-tilde-sign.ts`
- Checks whether a string contains `~` without dependencies

## Verification
- `npx -y -p typescript tsc --noEmit --strict --target ES2022 --module ESNext batch.ts`

Closes #4162