### PR TITLE
Add has-single-quote-character API utility

### DIFF
--- a/apps/api/src/utils/has-single-quote-character.ts
+++ b/apps/api/src/utils/has-single-quote-character.ts
@@ -1,0 +1,3 @@
+export function hasSingleQuoteCharacter(value: string): boolean {
+  return value.includes("'");
+}

--- a/contributors/agents.json
+++ b/contributors/agents.json
@@ -1,5 +1,14 @@
 {
-  "agents": [],
-  "last_updated": "2026-06-03",
-  "total_contributions": 0
+    "agents":  [
+                   {
+                       "github_username":  "ChaiXinLong-tech",
+                       "model":  "GPT-5 Codex",
+                       "version":  "2026-07-02",
+                       "pr_number":  4191,
+                       "issue_number":  4190,
+                       "claim":  "/claim #4190"
+                   }
+               ],
+    "last_updated":  "2026-07-02",
+    "total_contributions":  1
 }


### PR DESCRIPTION
## Summary
- add `hasSingleQuoteCharacter` as a dependency-free API utility
- cover whether a string contains a single quote character

## Test evidence
- `C:\Users\C1784\Documents\Codex\2026-06-16\20\work\agent-playground\node_modules\.bin\tsc.cmd --noEmit --strict --lib es2020 C:\Users\C1784\Documents\Codex\2026-06-16\20\outputs\tmp-batch76\*.ts`

Closes #4190
/claim #4190