### PR TITLE
fix: clean up README typos and formatting (closes #2)

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,8 +3,7 @@
 <img width="663" height="183" alt="593560705-1a920eb5-e581-44ce-bcef-2ebf0566777f" src="https://github.com/user-attachments/assets/37891de4-a282-45a3-98aa-35598c4571c2" />
 
 
-TaskFlow is a full-stack task management SaaS monorepo built 
-with a modern TypeScript-first architecture.
+TaskFlow is a full-stack task management SaaS monorepo built with a modern TypeScript-first architecture.
 
 ## Workspace Structure
 
@@ -32,7 +31,7 @@ The web app includes pages for:
 The API includes:
 - Auth routes (register, login, OAuth callback, JWT refresh)
 - CRUD routes for users, tasks, and proposals
-- Payments routes (Stripe-focused service placeholder)
+- Payment routes (Stripe-focused service placeholder)
 - Reviews, messaging, notifications
 - File uploads and search
 - Admin routes
@@ -68,8 +67,7 @@ npm run dev -w apps/api
 
 ## Database
 
-Prisma schema is available in packages/db/prisma/schema.prisma 
-with models for:
+Prisma schema is available in `packages/db/prisma/schema.prisma` with models for:
 - Users
 - Tasks
 - Proposals
@@ -81,5 +79,4 @@ with models for:
 
 ## Environment Variables
 
-Each app/package expects its own .env values for DB, auth, 
-and integrations.
+Each app/package expects its own `.env` values for DB, auth, and integrations.


### PR DESCRIPTION
Closes #2. Fixed README issues:
- Removed literal  in description paragraph
- Fixed grammar: 'Payments routes' → 'Payment routes'
- Added inline code formatting for schema path and .env
- Removed trailing newline in Environment Variables section