### PR TITLE
Add has-close-parenthesis-character API utility

### DIFF
--- a/apps/api/src/utils/has-close-parenthesis-character.ts
+++ b/apps/api/src/utils/has-close-parenthesis-character.ts
@@ -1,0 +1,3 @@
+export function hasCloseParenthesisCharacter(value: string): boolean {
+  return value.includes(")");
+}


### PR DESCRIPTION
/claim #4277

## Summary
- add `hasCloseParenthesisCharacter(value: string): boolean` at `apps/api/src/utils/has-close-parenthesis-character.ts`
- keep the helper dependency-free and scoped to the requested API utility

## Verification
- `npx --yes tsx --eval 'import { hasCloseParenthesisCharacter } from "./apps/api/src/utils/has-close-parenthesis-character.ts"; if (!hasCloseParenthesisCharacter("value)")) throw new Error("expected true"); if (hasCloseParenthesisCharacter("value")) throw new Error("expected false"); if (hasCloseParenthesisCharacter("value]")) throw new Error("expected false for adjacent non-match"); console.log("verification ok");'`
