### PR TITLE
fix: add slash bounty marker to issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE/bounty_task.md
+++ b/.github/ISSUE_TEMPLATE/bounty_task.md
@@ -18,4 +18,4 @@ Describe the task, expected context, and files likely involved.
 
 ## Bounty Amount
 
-$50
+/bounty $50


### PR DESCRIPTION
Closes #687.

## Summary
- update the bounty task issue template default from plain $50 to /bounty $50
- keep the change focused to the issue template

## Verification
- `Select-String -Path .github\\ISSUE_TEMPLATE\\bounty_task.md -Pattern '/bounty \\' -AllMatches` returned `marker_count=1`