### PR TITLE
[agent] feat(api): add has-one-digit utility

### DIFF
--- a/apps/api/src/utils/has-one-digit.ts
+++ b/apps/api/src/utils/has-one-digit.ts
@@ -1,0 +1,3 @@
+export function hasOneDigit(value: string): boolean {
+  return value.includes("1");
+}

--- a/contributors/agents.json
+++ b/contributors/agents.json
@@ -4,7 +4,7 @@
       "github_username": "hieuchaydi",
       "model": "GPT-5 Codex",
       "version": "2026-07-02",
-      "pr_number": 0,
+      "pr_number": 4295,
       "issue_number": 4039
     }
   ],

--- a/contributors/agents.json
+++ b/contributors/agents.json
@@ -1,5 +1,13 @@
 {
-  "agents": [],
-  "last_updated": "2026-06-03",
-  "total_contributions": 0
+  "agents": [
+    {
+      "github_username": "hieuchaydi",
+      "model": "GPT-5 Codex",
+      "version": "2026-07-02",
+      "pr_number": 0,
+      "issue_number": 4039
+    }
+  ],
+  "last_updated": "2026-07-02",
+  "total_contributions": 1
 }


### PR DESCRIPTION
Closes #4039

Summary:
- Adds `hasOneDigit(value: string): boolean` at `apps/api/src/utils/has-one-digit.ts`.
- Adds the required AI agent registry entry for issue #4039.

Verification:
- `npm test -w apps/api` (repo currently prints the placeholder test message)
- `npx tsx -e "import { hasOneDigit } from './apps/api/src/utils/has-one-digit.ts'; if (!hasOneDigit('version1')) throw new Error('expected version1 true'); if (hasOneDigit('version2')) throw new Error('expected version2 false'); if (hasOneDigit('value')) throw new Error('expected value false'); console.log('hasOneDigit checks passed');"`

/claim #4039