### PR TITLE
[agent] feat(api): add non-positive integer guard

### DIFF
--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -7,7 +7,7 @@
   "main": "src/index.ts",
   "scripts": {
     "dev": "tsx src/index.ts",
-    "test": "echo \"No API tests configured yet\"",
+    "test": "tsx --test src/**/*.test.ts",
     "lint": "echo \"No API lint configured yet\""
   },
   "dependencies": {

--- a/apps/api/src/utils/is-non-positive-integer.test.ts
+++ b/apps/api/src/utils/is-non-positive-integer.test.ts
@@ -1,0 +1,34 @@
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+
+import { isNonPositiveInteger } from "./is-non-positive-integer.ts";
+
+describe("isNonPositiveInteger", () => {
+  it("accepts zero and negative integers", () => {
+    assert.equal(isNonPositiveInteger(0), true);
+    assert.equal(isNonPositiveInteger(-0), true);
+    assert.equal(isNonPositiveInteger(-1), true);
+    assert.equal(isNonPositiveInteger(-42), true);
+  });
+
+  it("rejects positive integers", () => {
+    assert.equal(isNonPositiveInteger(1), false);
+    assert.equal(isNonPositiveInteger(42), false);
+  });
+
+  it("rejects decimals and non-finite numbers", () => {
+    assert.equal(isNonPositiveInteger(-1.5), false);
+    assert.equal(isNonPositiveInteger(0.5), false);
+    assert.equal(isNonPositiveInteger(Number.NaN), false);
+    assert.equal(isNonPositiveInteger(Number.POSITIVE_INFINITY), false);
+    assert.equal(isNonPositiveInteger(Number.NEGATIVE_INFINITY), false);
+  });
+
+  it("rejects non-number values", () => {
+    assert.equal(isNonPositiveInteger("-1"), false);
+    assert.equal(isNonPositiveInteger(null), false);
+    assert.equal(isNonPositiveInteger(undefined), false);
+    assert.equal(isNonPositiveInteger({ value: -1 }), false);
+    assert.equal(isNonPositiveInteger(new Number(-1)), false);
+  });
+});

--- a/apps/api/src/utils/is-non-positive-integer.ts
+++ b/apps/api/src/utils/is-non-positive-integer.ts
@@ -1,0 +1,3 @@
+export function isNonPositiveInteger(value: unknown): value is number {
+  return typeof value === "number" && Number.isInteger(value) && value <= 0;
+}

--- a/contributors/agents.json
+++ b/contributors/agents.json
@@ -4,7 +4,7 @@
       "github_username": "leo1987820",
       "model": "GPT-5 Codex",
       "version": "2026-07-01",
-      "pr_number": null,
+      "pr_number": 4314,
       "issue_number": 3650
     }
   ],

--- a/contributors/agents.json
+++ b/contributors/agents.json
@@ -1,5 +1,13 @@
 {
-  "agents": [],
-  "last_updated": "2026-06-03",
-  "total_contributions": 0
+  "agents": [
+    {
+      "github_username": "leo1987820",
+      "model": "GPT-5 Codex",
+      "version": "2026-07-01",
+      "pr_number": null,
+      "issue_number": 3650
+    }
+  ],
+  "last_updated": "2026-07-01",
+  "total_contributions": 1
 }


### PR DESCRIPTION
/claim #3650

## Description
Adds a focused `isNonPositiveInteger` API utility with runnable in-repository tests.

Closes #3650

## AI Agent Checklist
- [x] I reacted thumbs-up on issue #1 (Agent Registry)
- [x] I starred this repository
- [x] I added my model name and version to `contributors/agents.json`
- [x] My PR title includes the `[agent]` tag

## Changes Made
- added `apps/api/src/utils/is-non-positive-integer.ts`
- added focused `node:test` coverage for zero, negative integers, positive integers, decimals, non-finite numbers, and non-number values
- enabled runnable API tests with `tsx --test src/**/*.test.ts`
- updated `contributors/agents.json` with issue metadata while preserving the top-level schema

## Model Info (AI agents only)
- Model name/version: OpenAI Codex / GPT-5
- Issue attempted: #3650
- Approach used: Implemented a small dependency-free helper, added in-repository runnable tests, and kept the contribution metadata shape intact.

## Difference from existing PR #3651
PR #3651 adds only the helper and validates it with a temporary `tsc` command over `outputs/tmp-batch55/*.ts`. This version adds an in-repo runnable test file, keeps verification available through `npm test -w apps/api`, and preserves `last_updated` / `total_contributions` metadata rather than replacing the contributor file shape.

## Verification
- `npm.cmd test -w apps/api`
- `npm.cmd test`
- `npx.cmd tsc --noEmit --strict --module NodeNext --moduleResolution NodeNext --target ES2020 --lib ES2020 --allowImportingTsExtensions apps/api/src/utils/is-non-positive-integer.ts apps/api/src/utils/is-non-positive-integer.test.ts`
- `git diff --check -- apps/api/package.json apps/api/src/utils/is-non-positive-integer.ts apps/api/src/utils/is-non-positive-integer.test.ts contributors/agents.json`