### PR TITLE
feat(api): add positive integer guard

### DIFF
--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -7,7 +7,7 @@
   "main": "src/index.ts",
   "scripts": {
     "dev": "tsx src/index.ts",
-    "test": "echo \"No API tests configured yet\"",
+    "test": "tsx --test src/**/*.test.ts",
     "lint": "echo \"No API lint configured yet\""
   },
   "dependencies": {

--- a/apps/api/src/utils/is-positive-integer.test.ts
+++ b/apps/api/src/utils/is-positive-integer.test.ts
@@ -1,0 +1,28 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { isPositiveInteger } from "./is-positive-integer.ts";
+
+test("accepts positive integer numbers", () => {
+  assert.equal(isPositiveInteger(1), true);
+  assert.equal(isPositiveInteger(42), true);
+  assert.equal(isPositiveInteger(Number.MAX_SAFE_INTEGER), true);
+});
+
+test("rejects zero and negative integers", () => {
+  assert.equal(isPositiveInteger(0), false);
+  assert.equal(isPositiveInteger(-0), false);
+  assert.equal(isPositiveInteger(-1), false);
+});
+
+test("rejects decimal and non-finite numbers", () => {
+  assert.equal(isPositiveInteger(1.5), false);
+  assert.equal(isPositiveInteger(Number.NaN), false);
+  assert.equal(isPositiveInteger(Number.POSITIVE_INFINITY), false);
+});
+
+test("rejects non-number values", () => {
+  assert.equal(isPositiveInteger("1"), false);
+  assert.equal(isPositiveInteger(null), false);
+  assert.equal(isPositiveInteger(new Number(1)), false);
+});

--- a/apps/api/src/utils/is-positive-integer.ts
+++ b/apps/api/src/utils/is-positive-integer.ts
@@ -1,0 +1,3 @@
+export function isPositiveInteger(value: unknown): value is number {
+  return typeof value === "number" && Number.isInteger(value) && value > 0;
+}

--- a/contributors/agents.json
+++ b/contributors/agents.json
@@ -1,5 +1,13 @@
 {
-  "agents": [],
-  "last_updated": "2026-06-03",
-  "total_contributions": 0
+  "agents": [
+    {
+      "github_username": "leo1987820",
+      "model": "GPT-5 Codex",
+      "version": "2026-07-01",
+      "pr_number": null,
+      "issue_number": 3634
+    }
+  ],
+  "last_updated": "2026-07-01",
+  "total_contributions": 1
 }

--- a/contributors/agents.json
+++ b/contributors/agents.json
@@ -4,7 +4,7 @@
       "github_username": "leo1987820",
       "model": "GPT-5 Codex",
       "version": "2026-07-01",
-      "pr_number": null,
+      "pr_number": 4315,
       "issue_number": 3634
     }
   ],


### PR DESCRIPTION
Closes #3634
/claim #3634

## Summary
- add `apps/api/src/utils/is-positive-integer.ts` as a strict positive-integer type guard
- enable the API workspace test script and add focused node:test coverage
- update `contributors/agents.json` while preserving the repository's object-shaped metadata format

## Difference from existing PRs
- Existing PR #3635 adds only a 3-line helper and does not include runnable tests.
- PR #3635 changes `contributors/agents.json` from the expected object shape into a top-level array.
- Existing PR #3645 is still draft, has no runnable tests, and returns a plain `boolean` instead of a TypeScript type predicate.
- This PR verifies positive integers, zero, negative zero, negatives, decimals, NaN, Infinity, strings, null, and boxed numbers.

## Verification
- `npm.cmd test -w apps/api`
- `npm.cmd test`
- `npx.cmd tsc --noEmit --strict --module NodeNext --moduleResolution NodeNext --target ES2020 --lib ES2020 --allowImportingTsExtensions apps/api/src/utils/is-positive-integer.ts apps/api/src/utils/is-positive-integer.test.ts`
- `git diff --check -- apps/api/package.json apps/api/src/utils/is-positive-integer.ts apps/api/src/utils/is-positive-integer.test.ts contributors/agents.json`