### PR TITLE
[agent] feat(api): add between number guard

### DIFF
--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -7,7 +7,7 @@
   "main": "src/index.ts",
   "scripts": {
     "dev": "tsx src/index.ts",
-    "test": "echo \"No API tests configured yet\"",
+    "test": "tsx --test src/**/*.test.ts",
     "lint": "echo \"No API lint configured yet\""
   },
   "dependencies": {

--- a/apps/api/src/utils/is-between-number.test.ts
+++ b/apps/api/src/utils/is-between-number.test.ts
@@ -1,0 +1,29 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { isBetweenNumber } from "./is-between-number.ts";
+
+test("accepts finite numbers inside an inclusive range", () => {
+  assert.equal(isBetweenNumber(5, 1, 10), true);
+  assert.equal(isBetweenNumber(1, 1, 10), true);
+  assert.equal(isBetweenNumber(10, 1, 10), true);
+  assert.equal(isBetweenNumber(-2.5, -3, -2), true);
+});
+
+test("rejects values outside the inclusive range", () => {
+  assert.equal(isBetweenNumber(0, 1, 10), false);
+  assert.equal(isBetweenNumber(11, 1, 10), false);
+});
+
+test("rejects non-number and non-finite inputs", () => {
+  assert.equal(isBetweenNumber("5", 1, 10), false);
+  assert.equal(isBetweenNumber(null, 1, 10), false);
+  assert.equal(isBetweenNumber(Number.NaN, 1, 10), false);
+  assert.equal(isBetweenNumber(Number.POSITIVE_INFINITY, 1, 10), false);
+});
+
+test("rejects invalid range bounds", () => {
+  assert.equal(isBetweenNumber(5, 10, 1), false);
+  assert.equal(isBetweenNumber(5, Number.NaN, 10), false);
+  assert.equal(isBetweenNumber(5, 1, Number.POSITIVE_INFINITY), false);
+});

--- a/apps/api/src/utils/is-between-number.ts
+++ b/apps/api/src/utils/is-between-number.ts
@@ -1,0 +1,15 @@
+export function isBetweenNumber(
+  value: unknown,
+  min: number,
+  max: number,
+): value is number {
+  return (
+    typeof value === "number" &&
+    Number.isFinite(value) &&
+    Number.isFinite(min) &&
+    Number.isFinite(max) &&
+    min <= max &&
+    value >= min &&
+    value <= max
+  );
+}

--- a/contributors/agents.json
+++ b/contributors/agents.json
@@ -4,7 +4,7 @@
       "github_username": "leo1987820",
       "model": "GPT-5 Codex",
       "version": "2026-07-01",
-      "pr_number": null,
+      "pr_number": 4316,
       "issue_number": 3632
     }
   ],

--- a/contributors/agents.json
+++ b/contributors/agents.json
@@ -1,5 +1,13 @@
 {
-  "agents": [],
-  "last_updated": "2026-06-03",
-  "total_contributions": 0
+  "agents": [
+    {
+      "github_username": "leo1987820",
+      "model": "GPT-5 Codex",
+      "version": "2026-07-01",
+      "pr_number": null,
+      "issue_number": 3632
+    }
+  ],
+  "last_updated": "2026-07-01",
+  "total_contributions": 1
 }


### PR DESCRIPTION
Closes #3632
/claim #3632

## Summary
- add `apps/api/src/utils/is-between-number.ts` with a strict finite-number inclusive range guard
- enable the API workspace test script and add focused node:test coverage
- update `contributors/agents.json` while preserving the repository's object-shaped metadata format

## Difference from existing PRs
- Existing PR #3633 adds only the helper and does not include runnable tests.
- PR #3633 also changes `contributors/agents.json` from the expected object shape into a top-level array. This PR preserves the existing schema and only adds this contribution entry.
- This PR verifies inclusive min/max bounds, out-of-range values, non-number values, non-finite inputs, invalid bounds, and inverted ranges.

## Verification
- `npm.cmd test -w apps/api`
- `npm.cmd test`
- `npx.cmd tsc --noEmit --strict --module NodeNext --moduleResolution NodeNext --target ES2020 --lib ES2020 --allowImportingTsExtensions apps/api/src/utils/is-between-number.ts apps/api/src/utils/is-between-number.test.ts`
- `git diff --check -- apps/api/package.json apps/api/src/utils/is-between-number.ts apps/api/src/utils/is-between-number.test.ts contributors/agents.json`