### PR TITLE
[agent] feat(api): add empty object guard

### DIFF
--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -7,7 +7,7 @@
   "main": "src/index.ts",
   "scripts": {
     "dev": "tsx src/index.ts",
-    "test": "echo \"No API tests configured yet\"",
+    "test": "tsx --test src/**/*.test.ts",
     "lint": "echo \"No API lint configured yet\""
   },
   "dependencies": {

--- a/apps/api/src/utils/is-empty-object.test.ts
+++ b/apps/api/src/utils/is-empty-object.test.ts
@@ -1,0 +1,19 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { isEmptyObject } from "./is-empty-object.ts";
+
+test("returns true for a plain object with no own keys", () => {
+  assert.equal(isEmptyObject({}), true);
+});
+
+test("rejects objects with string or symbol keys", () => {
+  assert.equal(isEmptyObject({ value: undefined }), false);
+  assert.equal(isEmptyObject({ [Symbol("hidden")]: true }), false);
+});
+
+test("rejects arrays, nullish values, and non-plain objects", () => {
+  assert.equal(isEmptyObject([]), false);
+  assert.equal(isEmptyObject(null), false);
+  assert.equal(isEmptyObject(new Date()), false);
+});

--- a/apps/api/src/utils/is-empty-object.ts
+++ b/apps/api/src/utils/is-empty-object.ts
@@ -1,0 +1,8 @@
+export function isEmptyObject(value: unknown): value is Record<PropertyKey, never> {
+  return (
+    value !== null &&
+    typeof value === "object" &&
+    Object.getPrototypeOf(value) === Object.prototype &&
+    Reflect.ownKeys(value).length === 0
+  );
+}

--- a/contributors/agents.json
+++ b/contributors/agents.json
@@ -1,5 +1,13 @@
 {
-  "agents": [],
-  "last_updated": "2026-06-03",
-  "total_contributions": 0
+  "agents": [
+    {
+      "github_username": "leo1987820",
+      "model": "GPT-5 Codex",
+      "version": "2026-07-01",
+      "pr_number": null,
+      "issue_number": 3117
+    }
+  ],
+  "last_updated": "2026-07-01",
+  "total_contributions": 1
 }

--- a/contributors/agents.json
+++ b/contributors/agents.json
@@ -4,7 +4,7 @@
       "github_username": "leo1987820",
       "model": "GPT-5 Codex",
       "version": "2026-07-01",
-      "pr_number": null,
+      "pr_number": 4317,
       "issue_number": 3117
     }
   ],


### PR DESCRIPTION
/claim #3117

## Summary
- add a dependency-free `isEmptyObject` API utility under `apps/api/src/utils`
- make the helper reject arrays, nullish values, and non-plain objects
- check all own keys via `Reflect.ownKeys` so symbol-keyed objects are not treated as empty
- add focused `node:test` coverage and update `contributors/agents.json` for bounty #3117

Closes #3117

## Difference from existing PRs
Existing open PRs for this bounty either lack runnable tests, modify unrelated `leaderboard.json` data, use non-standard contributor metadata, or place helpers outside the current `apps/api` workspace pattern. This version keeps the diff scoped to the API utility, test setup, focused tests, and the required agent metadata.

## Verification
- `npm.cmd test -w apps/api`
- `npm.cmd test`
- `npx.cmd tsc --noEmit --strict --module NodeNext --moduleResolution NodeNext --target ES2020 --lib ES2020 --allowImportingTsExtensions apps/api/src/utils/is-empty-object.ts apps/api/src/utils/is-empty-object.test.ts`
- `git diff --check -- apps/api/package.json apps/api/src/utils/is-empty-object.ts apps/api/src/utils/is-empty-object.test.ts contributors/agents.json`