### PR TITLE
[agent] feat(api): add valid date guard

### DIFF
--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -7,7 +7,7 @@
   "main": "src/index.ts",
   "scripts": {
     "dev": "tsx src/index.ts",
-    "test": "echo \"No API tests configured yet\"",
+    "test": "tsx --test src/**/*.test.ts",
     "lint": "echo \"No API lint configured yet\""
   },
   "dependencies": {

--- a/apps/api/src/utils/is-valid-date.test.ts
+++ b/apps/api/src/utils/is-valid-date.test.ts
@@ -1,0 +1,18 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { isValidDate } from "./is-valid-date.ts";
+
+test("returns true for a valid Date instance", () => {
+  assert.equal(isValidDate(new Date("2026-01-01T00:00:00.000Z")), true);
+});
+
+test("rejects invalid Date instances", () => {
+  assert.equal(isValidDate(new Date("not a date")), false);
+});
+
+test("rejects date-like non-Date values", () => {
+  assert.equal(isValidDate("2026-01-01"), false);
+  assert.equal(isValidDate(1_767_225_600_000), false);
+  assert.equal(isValidDate(null), false);
+});

--- a/apps/api/src/utils/is-valid-date.ts
+++ b/apps/api/src/utils/is-valid-date.ts
@@ -1,0 +1,3 @@
+export function isValidDate(value: unknown): value is Date {
+  return value instanceof Date && !Number.isNaN(value.getTime());
+}

--- a/contributors/agents.json
+++ b/contributors/agents.json
@@ -1,5 +1,13 @@
 {
-  "agents": [],
-  "last_updated": "2026-06-03",
-  "total_contributions": 0
+  "agents": [
+    {
+      "github_username": "leo1987820",
+      "model": "GPT-5 Codex",
+      "version": "2026-07-01",
+      "pr_number": null,
+      "issue_number": 3119
+    }
+  ],
+  "last_updated": "2026-07-01",
+  "total_contributions": 1
 }

--- a/contributors/agents.json
+++ b/contributors/agents.json
@@ -4,7 +4,7 @@
       "github_username": "leo1987820",
       "model": "GPT-5 Codex",
       "version": "2026-07-01",
-      "pr_number": null,
+      "pr_number": 4318,
       "issue_number": 3119
     }
   ],


### PR DESCRIPTION
/claim #3119

## Summary
- add a dependency-free `isValidDate` API utility under `apps/api/src/utils`
- make the helper a real TypeScript guard that only accepts valid `Date` instances
- add focused API tests for valid dates, invalid `Date` objects, and date-like non-Date inputs
- update `contributors/agents.json` for bounty #3119

Closes #3119

## Difference from existing PRs
Existing open PRs for this bounty do not include runnable tests. This version keeps the implementation in the current `apps/api` package, rejects string/number date-like values so it is safe as a guard, and includes `tsx --test` coverage.

## Verification
- `npm.cmd test -w apps/api`
- `npm.cmd test`
- `npx.cmd tsc --noEmit --strict --module NodeNext --moduleResolution NodeNext --target ES2020 --lib ES2020 --allowImportingTsExtensions apps/api/src/utils/is-valid-date.ts apps/api/src/utils/is-valid-date.test.ts`
- `git diff --check -- apps/api/package.json apps/api/src/utils/is-valid-date.ts apps/api/src/utils/is-valid-date.test.ts contributors/agents.json`