### PR TITLE
[agent] feat(api): add median number helper

### DIFF
--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -7,7 +7,7 @@
   "main": "src/index.ts",
   "scripts": {
     "dev": "tsx src/index.ts",
-    "test": "echo \"No API tests configured yet\"",
+    "test": "tsx --test src/**/*.test.ts",
     "lint": "echo \"No API lint configured yet\""
   },
   "dependencies": {

--- a/apps/api/src/utils/median-number.test.ts
+++ b/apps/api/src/utils/median-number.test.ts
@@ -1,0 +1,27 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+
+import { medianNumber } from "./median-number.ts";
+
+test("returns undefined for an empty list", () => {
+  assert.equal(medianNumber([]), undefined);
+});
+
+test("returns the middle value for an odd number of values", () => {
+  assert.equal(medianNumber([7, 1, 3]), 3);
+});
+
+test("returns the average of the two middle values for an even number of values", () => {
+  assert.equal(medianNumber([10, 2, 4, 8]), 6);
+});
+
+test("does not mutate the input values while sorting", () => {
+  const values = [5, 1, 9, 3];
+
+  assert.equal(medianNumber(values), 4);
+  assert.deepEqual(values, [5, 1, 9, 3]);
+});
+
+test("handles negative and decimal values", () => {
+  assert.equal(medianNumber([-1.5, 2.25, 0]), 0);
+});

--- a/apps/api/src/utils/median-number.ts
+++ b/apps/api/src/utils/median-number.ts
@@ -1,0 +1,14 @@
+export function medianNumber(values: readonly number[]): number | undefined {
+  if (values.length === 0) {
+    return undefined;
+  }
+
+  const sorted = [...values].sort((left, right) => left - right);
+  const middle = Math.floor(sorted.length / 2);
+
+  if (sorted.length % 2 === 0) {
+    return (sorted[middle - 1] + sorted[middle]) / 2;
+  }
+
+  return sorted[middle];
+}

--- a/contributors/agents.json
+++ b/contributors/agents.json
@@ -1,5 +1,13 @@
 {
-  "agents": [],
-  "last_updated": "2026-06-03",
-  "total_contributions": 0
+  "agents": [
+    {
+      "github_username": "leo1987820",
+      "model": "GPT-5 Codex",
+      "version": "2026-07-01",
+      "pr_number": null,
+      "issue_number": 3121
+    }
+  ],
+  "last_updated": "2026-07-01",
+  "total_contributions": 1
 }

--- a/contributors/agents.json
+++ b/contributors/agents.json
@@ -4,7 +4,7 @@
       "github_username": "leo1987820",
       "model": "GPT-5 Codex",
       "version": "2026-07-01",
-      "pr_number": null,
+      "pr_number": 4319,
       "issue_number": 3121
     }
   ],


### PR DESCRIPTION
/claim #3121

## Summary
- Add a named `medianNumber` API utility under `apps/api/src/utils`.
- Return `undefined` for an empty list.
- Sort a copy of the input and return the middle value for odd-length lists or the average of the two middle values for even-length lists.
- Keep the helper dependency-free and avoid mutating caller-provided arrays.

## Why this is stronger than the current competing PRs
- PR #3122 adds the helper but has no runnable tests and its PR body still contains placeholder text.
- PR #3490 returns `0` for an empty list and has no tests.
- PR #3576 places `median-number.ts` under `packages/ui`, while this bounty asks for an API utility under `apps/api`.
- This version includes focused `node:test` coverage and TypeScript strict compilation evidence.

## Validation
- `npm.cmd test -w apps/api`
- `npm.cmd test`
- `npx.cmd tsc --noEmit --strict --module NodeNext --moduleResolution NodeNext --target ES2020 --lib ES2020 --allowImportingTsExtensions apps/api/src/utils/median-number.ts apps/api/src/utils/median-number.test.ts`
- `git diff --check -- apps/api/package.json apps/api/src/utils/median-number.ts apps/api/src/utils/median-number.test.ts contributors/agents.json`

Note: `contributors/agents.json` currently has `pr_number: null`; I will backfill the generated PR number after creation.