### PR TITLE
feat(api): add input validation to user routes

### DIFF
--- a/apps/api/src/routes/users.ts
+++ b/apps/api/src/routes/users.ts
@@ -1,15 +1,43 @@
-import { Router } from "express";
+import { Router, Request, Response } from "express";
 
 const router = Router();
 
-router.get("/", (_req, res) => {
+// Validation helper: checks that required string fields are present and non-empty
+function validateUserBody(body: Record<string, unknown>): string | null {
+  if (!body || typeof body !== "object") {
+    return "Request body must be a JSON object.";
+  }
+  if (!body.name || typeof body.name !== "string" || body.name.trim() === "") {
+    return "Field 'name' is required and must be a non-empty string.";
+  }
+  if (!body.email || typeof body.email !== "string" || body.email.trim() === "") {
+    return "Field 'email' is required and must be a non-empty string.";
+  }
+  // Basic email shape check
+  const emailRe = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
+  if (!emailRe.test(body.email as string)) {
+    return "Field 'email' must be a valid email address.";
+  }
+  return null;
+}
+
+router.get("/", (_req: Request, res: Response) => {
   res.json({
     data: [],
     message: "User listing is not implemented yet."
   });
 });
 
-router.post("/", (req, res) => {
+router.post("/", (req: Request, res: Response) => {
+  const validationError = validateUserBody(req.body);
+  if (validationError) {
+    res.status(400).json({
+      data: null,
+      message: validationError
+    });
+    return;
+  }
+
   res.status(201).json({
     data: {
       id: "stub-user-id",


### PR DESCRIPTION
## Summary

Adds lightweight input validation to the user `POST /users` route so invalid request shapes return a clear `400` error response instead of passing through silently.

## Changes

- Introduced `validateUserBody` helper that checks:
  - Body is a JSON object
  - `name` is a required, non-empty string
  - `email` is a required, non-empty string with a valid email shape (via regex)
- Invalid requests now return `HTTP 400` with a descriptive message
- Valid requests continue to return `HTTP 201` as before

Closes #6