### PR TITLE
feat(api): introduce API error/success response helper

### DIFF
--- a/apps/api/src/helpers/response.ts
+++ b/apps/api/src/helpers/response.ts
@@ -1,0 +1,48 @@
+import { Response } from "express";
+
+export type ApiErrorCode =
+  | "BAD_REQUEST"
+  | "NOT_FOUND"
+  | "UNAUTHORIZED"
+  | "FORBIDDEN"
+  | "INTERNAL_ERROR";
+
+const STATUS_MAP: Record<ApiErrorCode, number> = {
+  BAD_REQUEST: 400,
+  UNAUTHORIZED: 401,
+  FORBIDDEN: 403,
+  NOT_FOUND: 404,
+  INTERNAL_ERROR: 500
+};
+
+/**
+ * Send a structured JSON error response.
+ *
+ * @example
+ * sendError(res, "NOT_FOUND", "User not found");
+ * // → HTTP 404 { error: "NOT_FOUND", message: "User not found" }
+ */
+export function sendError(
+  res: Response,
+  code: ApiErrorCode,
+  message: string
+): void {
+  const status = STATUS_MAP[code] ?? 500;
+  res.status(status).json({ error: code, message });
+}
+
+/**
+ * Send a structured JSON success response.
+ *
+ * @example
+ * sendOk(res, { id: "123" }, "Created", 201);
+ * // → HTTP 201 { data: { id: "123" }, message: "Created" }
+ */
+export function sendOk<T>(
+  res: Response,
+  data: T,
+  message = "OK",
+  status = 200
+): void {
+  res.status(status).json({ data, message });
+}

--- a/apps/api/src/index.ts
+++ b/apps/api/src/index.ts
@@ -1,6 +1,7 @@
 import express from "express";
 
 import usersRouter from "./routes/users";
+import { sendOk } from "./helpers/response";
 
 const app = express();
 const port = process.env.PORT || 4000;
@@ -8,7 +9,7 @@ const port = process.env.PORT || 4000;
 app.use(express.json());
 
 app.get("/health", (_req, res) => {
-  res.json({ status: "ok", service: "taskflow-api" });
+  sendOk(res, { service: "taskflow-api" }, "ok");
 });
 
 app.use("/users", usersRouter);


### PR DESCRIPTION
## Summary

Introduces a small, typed API response helper (`apps/api/src/helpers/response.ts`) and uses it from the `/health` route.

## Changes

**New file: `apps/api/src/helpers/response.ts`**
- `sendError(res, code, message)` — maps a typed `ApiErrorCode` to the correct HTTP status and returns `{ error, message }` JSON
- `sendOk(res, data, message?, status?)` — returns `{ data, message }` JSON for success responses
- `ApiErrorCode` union type covers: `BAD_REQUEST`, `UNAUTHORIZED`, `FORBIDDEN`, `NOT_FOUND`, `INTERNAL_ERROR`

**Updated: `apps/api/src/index.ts`**
- `/health` route now uses `sendOk` as a concrete demonstration of the helper

Closes #7