### PR TITLE
test(contributors): add unit tests for leaderboard update script

### DIFF
--- a/contributors/updateLeaderboard.test.ts
+++ b/contributors/updateLeaderboard.test.ts
@@ -1,0 +1,124 @@
+/**
+ * updateLeaderboard.test.ts
+ *
+ * Unit tests for contributors/updateLeaderboard.ts
+ * Uses Node.js built-in test runner (node:test) — no extra deps required.
+ *
+ * Run: node --loader tsx --test contributors/updateLeaderboard.test.ts
+ */
+
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+import {
+  addContribution,
+  getTopN,
+  mergeLeaderboards,
+  type Leaderboard,
+} from "./updateLeaderboard.js";
+
+// ---------------------------------------------------------------------------
+// addContribution
+// ---------------------------------------------------------------------------
+describe("addContribution", () => {
+  it("adds a new contributor with count 1", () => {
+    const lb: Leaderboard = {};
+    addContribution(lb, "alice");
+    assert.equal(lb["alice"], 1);
+  });
+
+  it("increments an existing contributor by 1", () => {
+    const lb: Leaderboard = { alice: 5 };
+    addContribution(lb, "alice");
+    assert.equal(lb["alice"], 6);
+  });
+
+  it("does not affect other contributors", () => {
+    const lb: Leaderboard = { alice: 3, bob: 7 };
+    addContribution(lb, "alice");
+    assert.equal(lb["bob"], 7);
+  });
+
+  it("mutates the leaderboard in place and returns it", () => {
+    const lb: Leaderboard = {};
+    const result = addContribution(lb, "carol");
+    assert.strictEqual(result, lb);
+  });
+
+  it("throws when username is empty", () => {
+    assert.throws(() => addContribution({}, ""), /non-empty string/);
+  });
+
+  it("throws when username is not a string", () => {
+    // @ts-expect-error intentional bad input
+    assert.throws(() => addContribution({}, 42), /non-empty string/);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// getTopN
+// ---------------------------------------------------------------------------
+describe("getTopN", () => {
+  it("returns entries sorted descending by count", () => {
+    const lb: Leaderboard = { alice: 3, bob: 10, carol: 1 };
+    const top = getTopN(lb, 3);
+    assert.deepEqual(top, [["bob", 10], ["alice", 3], ["carol", 1]]);
+  });
+
+  it("limits the result to n entries", () => {
+    const lb: Leaderboard = { a: 5, b: 4, c: 3, d: 2, e: 1 };
+    assert.equal(getTopN(lb, 2).length, 2);
+  });
+
+  it("returns all entries when n >= length", () => {
+    const lb: Leaderboard = { x: 1, y: 2 };
+    assert.equal(getTopN(lb, 100).length, 2);
+  });
+
+  it("returns empty array for empty leaderboard", () => {
+    assert.deepEqual(getTopN({}), []);
+  });
+
+  it("defaults to top 10 when n is not provided", () => {
+    const lb: Leaderboard = {};
+    for (let i = 0; i < 15; i++) lb[`user${i}`] = i;
+    assert.equal(getTopN(lb).length, 10);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// mergeLeaderboards
+// ---------------------------------------------------------------------------
+describe("mergeLeaderboards", () => {
+  it("adds patch counts to base for existing users", () => {
+    const base: Leaderboard = { alice: 5, bob: 3 };
+    const patch: Leaderboard = { alice: 2 };
+    mergeLeaderboards(base, patch);
+    assert.equal(base["alice"], 7);
+    assert.equal(base["bob"], 3);
+  });
+
+  it("introduces new users from patch into base", () => {
+    const base: Leaderboard = { alice: 5 };
+    const patch: Leaderboard = { carol: 4 };
+    mergeLeaderboards(base, patch);
+    assert.equal(base["carol"], 4);
+  });
+
+  it("handles empty patch without error", () => {
+    const base: Leaderboard = { alice: 5 };
+    mergeLeaderboards(base, {});
+    assert.equal(base["alice"], 5);
+  });
+
+  it("handles empty base with patch entries", () => {
+    const base: Leaderboard = {};
+    mergeLeaderboards(base, { bob: 9 });
+    assert.equal(base["bob"], 9);
+  });
+
+  it("mutates base and returns it", () => {
+    const base: Leaderboard = {};
+    const result = mergeLeaderboards(base, { dave: 1 });
+    assert.strictEqual(result, base);
+  });
+});

--- a/contributors/updateLeaderboard.ts
+++ b/contributors/updateLeaderboard.ts
@@ -1,0 +1,60 @@
+/**
+ * updateLeaderboard.ts
+ *
+ * Utility functions for updating the contributors/leaderboard.json file.
+ * A leaderboard is a plain object mapping GitHub usernames to contribution counts.
+ */
+
+export type Leaderboard = Record<string, number>;
+
+/**
+ * Increment a contributor's count by 1.
+ * If the contributor doesn't exist yet, they are added with a count of 1.
+ *
+ * @param leaderboard - Current leaderboard state (mutated in place)
+ * @param username    - GitHub username to increment
+ * @returns The updated leaderboard
+ */
+export function addContribution(
+  leaderboard: Leaderboard,
+  username: string
+): Leaderboard {
+  if (!username || typeof username !== "string") {
+    throw new Error("username must be a non-empty string");
+  }
+  leaderboard[username] = (leaderboard[username] ?? 0) + 1;
+  return leaderboard;
+}
+
+/**
+ * Return the top N contributors sorted by count descending.
+ *
+ * @param leaderboard - Current leaderboard state
+ * @param n           - Number of top contributors to return (default: 10)
+ * @returns Array of [username, count] pairs sorted descending
+ */
+export function getTopN(
+  leaderboard: Leaderboard,
+  n = 10
+): Array<[string, number]> {
+  return Object.entries(leaderboard)
+    .sort(([, a], [, b]) => b - a)
+    .slice(0, n);
+}
+
+/**
+ * Merge a second leaderboard into the first, summing counts.
+ *
+ * @param base  - Leaderboard to merge into (mutated in place)
+ * @param patch - Leaderboard whose counts are added to base
+ * @returns The merged leaderboard
+ */
+export function mergeLeaderboards(
+  base: Leaderboard,
+  patch: Leaderboard
+): Leaderboard {
+  for (const [username, count] of Object.entries(patch)) {
+    base[username] = (base[username] ?? 0) + count;
+  }
+  return base;
+}


### PR DESCRIPTION
## Summary

Adds unit tests for the leaderboard update logic covering both new and existing contributor scenarios.

## Changes

**New file: `contributors/updateLeaderboard.ts`**
Typed helper module with three functions:
- `addContribution(leaderboard, username)` — increments a contributor's count (creates with 1 if new)
- `getTopN(leaderboard, n?)` — returns top N contributors sorted descending
- `mergeLeaderboards(base, patch)` — merges patch counts into base

**New file: `contributors/updateLeaderboard.test.ts`**
16 unit tests using Node.js built-in `node:test` (no extra dependencies) covering:
- ✅ New contributor added with count = 1
- ✅ Existing contributor incremented correctly
- ✅ Other contributors not affected
- ✅ In-place mutation and return-value semantics
- ✅ Invalid input rejection (empty / non-string username)
- ✅ `getTopN` sorting, limit, default-10, empty input
- ✅ `mergeLeaderboards` for existing/new users and empty inputs

Closes #11