### PR TITLE
[agent] feat(api): add promise-like guard

### DIFF
--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -7,7 +7,7 @@
   "main": "src/index.ts",
   "scripts": {
     "dev": "tsx src/index.ts",
-    "test": "echo \"No API tests configured yet\"",
+    "test": "tsx --test src/**/*.test.ts",
     "lint": "echo \"No API lint configured yet\""
   },
   "dependencies": {

--- a/apps/api/src/utils/is-promise-like.test.ts
+++ b/apps/api/src/utils/is-promise-like.test.ts
@@ -1,0 +1,32 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+
+import { isPromiseLike } from "./is-promise-like.ts";
+
+test("returns true for Promise instances and thenable values", () => {
+  assert.equal(isPromiseLike(Promise.resolve("ok")), true);
+  assert.equal(isPromiseLike({ then() {} }), true);
+
+  function callableThenable() {}
+  Object.assign(callableThenable, { then() {} });
+  assert.equal(isPromiseLike(callableThenable), true);
+});
+
+test("returns false for values without a callable then property", () => {
+  assert.equal(isPromiseLike(null), false);
+  assert.equal(isPromiseLike(undefined), false);
+  assert.equal(isPromiseLike("then"), false);
+  assert.equal(isPromiseLike(1), false);
+  assert.equal(isPromiseLike({}), false);
+  assert.equal(isPromiseLike({ then: "not a function" }), false);
+});
+
+test("returns false when reading then throws", () => {
+  const value = Object.defineProperty({}, "then", {
+    get() {
+      throw new Error("untrusted then accessor");
+    },
+  });
+
+  assert.equal(isPromiseLike(value), false);
+});

--- a/apps/api/src/utils/is-promise-like.ts
+++ b/apps/api/src/utils/is-promise-like.ts
@@ -1,0 +1,11 @@
+export function isPromiseLike(value: unknown): value is PromiseLike<unknown> {
+  if ((typeof value !== "object" && typeof value !== "function") || value === null) {
+    return false;
+  }
+
+  try {
+    return typeof (value as { then?: unknown }).then === "function";
+  } catch {
+    return false;
+  }
+}

--- a/contributors/agents.json
+++ b/contributors/agents.json
@@ -4,7 +4,7 @@
       "github_username": "leo1987820",
       "model": "GPT-5 Codex",
       "version": "2026-07-01",
-      "pr_number": null,
+      "pr_number": 4435,
       "issue_number": 3128
     }
   ],

--- a/contributors/agents.json
+++ b/contributors/agents.json
@@ -1,5 +1,13 @@
 {
-  "agents": [],
-  "last_updated": "2026-06-03",
-  "total_contributions": 0
+  "agents": [
+    {
+      "github_username": "leo1987820",
+      "model": "GPT-5 Codex",
+      "version": "2026-07-01",
+      "pr_number": null,
+      "issue_number": 3128
+    }
+  ],
+  "last_updated": "2026-07-01",
+  "total_contributions": 1
 }


### PR DESCRIPTION
/claim #3128

## Summary
- Add a named `isPromiseLike` API utility for Promise/thenable detection.
- Treat objects and functions with a callable `then` as promise-like.
- Return `false` for primitives, nullish values, non-callable `then`, and unsafe `then` accessors that throw.

## Why this is stronger than the existing open attempt
- Includes runnable `node:test` coverage under `apps/api`.
- Covers Promise instances, object thenables, callable thenables, invalid primitives, non-callable `then`, and throwing `then` getters.
- Keeps the helper narrow and exported without broad unrelated changes.

## Validation
- RED: `npm.cmd test -w apps/api` failed before implementation with `ERR_MODULE_NOT_FOUND` for `is-promise-like.ts`.
- GREEN: `npm.cmd test -w apps/api`
- GREEN: `npm.cmd test`
- GREEN: `npx.cmd tsc --noEmit --strict --module NodeNext --moduleResolution NodeNext --target ES2020 --lib ES2020 --allowImportingTsExtensions apps/api/src/utils/is-promise-like.ts apps/api/src/utils/is-promise-like.test.ts`
- GREEN: `git diff --check -- apps/api/package.json apps/api/src/utils/is-promise-like.ts apps/api/src/utils/is-promise-like.test.ts contributors/agents.json`

Note: `contributors/agents.json` currently has `pr_number: null`; please backfill the generated PR number after creation.