### PR TITLE
[agent] feat: add input validation + error handling helper (closes #6, closes #7)

### DIFF
--- a/apps/api/src/lib/errors.ts
+++ b/apps/api/src/lib/errors.ts
@@ -1,0 +1,68 @@
+import { Response } from "express";
+
+/**
+ * Standardised API error response helpers.
+ * Keep error shapes consistent across all routes.
+ */
+
+export interface ApiErrorBody {
+  errors: Array<{ message: string; code?: string }>;
+  message: string;
+}
+
+function sendError(
+  res: Response,
+  status: number,
+  errors: Array<{ message: string; code?: string }>,
+  summary: string,
+): void {
+  res.status(status).json({ errors, message: summary });
+}
+
+/** 400 — malformed request body, missing fields, invalid types */
+export function badRequest(
+  res: Response,
+  errors: Array<string | { message: string; code?: string }>,
+): void {
+  const normalised = errors.map((e) =>
+    typeof e === "string" ? { message: e } : e,
+  );
+  sendError(res, 400, normalised, "Bad request.");
+}
+
+/** 404 — resource not found */
+export function notFound(
+  res: Response,
+  resource = "Resource",
+): void {
+  sendError(res, 404, [{ message: `${resource} not found.` }], "Not found.");
+}
+
+/** 409 — conflict (duplicate, state mismatch, etc.) */
+export function conflict(
+  res: Response,
+  detail: string,
+): void {
+  sendError(res, 409, [{ message: detail }], "Conflict.");
+}
+
+/** 422 — validation failed */
+export function validationFailed(
+  res: Response,
+  errors: string[],
+): void {
+  sendError(
+    res,
+    422,
+    errors.map((e) => ({ message: e })),
+    "Validation failed.",
+  );
+}
+
+/** 500 — unexpected server error */
+export function internalError(
+  res: Response,
+  detail = "An unexpected error occurred.",
+): void {
+  sendError(res, 500, [{ message: detail }], "Internal server error.");
+}

--- a/apps/api/src/routes/users.ts
+++ b/apps/api/src/routes/users.ts
@@ -1,4 +1,5 @@
 import { Router, Request, Response, NextFunction } from "express";
+import { validationFailed } from "../lib/errors";
 
 const router = Router();
 
@@ -29,7 +30,7 @@ function validateCreateUser(req: Request, res: Response, next: NextFunction): vo
   }
 
   if (errors.length > 0) {
-    res.status(422).json({ errors, message: "Validation failed." });
+    validationFailed(res, errors);
     return;
   }
 

--- a/apps/api/src/routes/users.ts
+++ b/apps/api/src/routes/users.ts
@@ -1,6 +1,42 @@
-import { Router } from "express";
+import { Router, Request, Response, NextFunction } from "express";
 
 const router = Router();
+
+// ── Validation helpers ──────────────────────────────────────────
+
+const EMAIL_RE = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
+
+function validateCreateUser(req: Request, res: Response, next: NextFunction): void {
+  const { email, name } = req.body;
+  const errors: string[] = [];
+
+  if (!email || typeof email !== "string") {
+    errors.push("email is required and must be a string.");
+  } else if (!EMAIL_RE.test(email)) {
+    errors.push("email must be a valid email address.");
+  }
+
+  if (name !== undefined && typeof name !== "string") {
+    errors.push("name must be a string when provided.");
+  }
+
+  const allowedFields = ["email", "name"];
+  const unknownFields = Object.keys(req.body).filter(
+    (key) => !allowedFields.includes(key)
+  );
+  if (unknownFields.length > 0) {
+    errors.push(`unknown field${unknownFields.length > 1 ? "s" : ""}: ${unknownFields.join(", ")}.`);
+  }
+
+  if (errors.length > 0) {
+    res.status(422).json({ errors, message: "Validation failed." });
+    return;
+  }
+
+  next();
+}
+
+// ── Routes ──────────────────────────────────────────────────────
 
 router.get("/", (_req, res) => {
   res.json({
@@ -9,11 +45,14 @@ router.get("/", (_req, res) => {
   });
 });
 
-router.post("/", (req, res) => {
+router.post("/", validateCreateUser, (req, res) => {
+  const { email, name } = req.body;
+
   res.status(201).json({
     data: {
       id: "stub-user-id",
-      ...req.body
+      email,
+      ...(name !== undefined && { name })
     },
     message: "User creation is not implemented yet."
   });


### PR DESCRIPTION
## Summary
Two related improvements:
1. Add input validation to POST /users (#6)
2. Introduce reusable error response helpers (#7)

### #6 - Input validation
- Validate email required + format
- name optional string
- Reject unknown fields
- 422 structured errors

### #7 - Error helper
- Created lib/errors.ts with badRequest, notFound, conflict, validationFailed, internalError
- Consistent { errors, message } shape
- Users route uses shared validationFailed

Closes #6
Closes #7