### PR TITLE
fix(api): normalize health check response to consistent envelope

### DIFF
--- a/apps/api/src/index.ts
+++ b/apps/api/src/index.ts
@@ -7,8 +7,15 @@ const port = process.env.PORT || 4000;
 
 app.use(express.json());
 
+// Health check — consistent envelope: { status, data }
 app.get("/health", (_req, res) => {
-  res.json({ status: "ok", service: "taskflow-api" });
+  res.json({
+    status: "ok",
+    data: {
+      service: "taskflow-api",
+      uptime: process.uptime(),
+    },
+  });
 });
 
 app.use("/users", usersRouter);


### PR DESCRIPTION
## Summary

Updates the `GET /health` route to return a uniform `{ status, data }` envelope, consistent with the shape used across other API responses.

## Before
```json
{ "status": "ok", "service": "taskflow-api" }
```

## After
```json
{
  "status": "ok",
  "data": {
    "service": "taskflow-api",
    "uptime": 42.3
  }
}
```

Closes #8