### PR TITLE
[agent] feat(api): add integer parsing helper

### DIFF
--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -7,7 +7,7 @@
   "main": "src/index.ts",
   "scripts": {
     "dev": "tsx src/index.ts",
-    "test": "echo \"No API tests configured yet\"",
+    "test": "tsx --test src/**/*.test.ts",
     "lint": "echo \"No API lint configured yet\""
   },
   "dependencies": {

--- a/apps/api/src/utils/parse-integer.test.ts
+++ b/apps/api/src/utils/parse-integer.test.ts
@@ -1,0 +1,32 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+
+import { parseInteger } from "./parse-integer.js";
+
+test("returns integer numbers unchanged", () => {
+  assert.equal(parseInteger(0), 0);
+  assert.equal(parseInteger(42), 42);
+  assert.equal(parseInteger(-7), -7);
+});
+
+test("parses whole-number strings with optional whitespace and signs", () => {
+  assert.equal(parseInteger("15"), 15);
+  assert.equal(parseInteger("  +15  "), 15);
+  assert.equal(parseInteger("-15"), -15);
+});
+
+test("rejects partial, decimal, and non-finite numeric values", () => {
+  assert.equal(parseInteger("12abc"), null);
+  assert.equal(parseInteger("1.2"), null);
+  assert.equal(parseInteger(1.2), null);
+  assert.equal(parseInteger(Number.POSITIVE_INFINITY), null);
+  assert.equal(parseInteger(Number.NaN), null);
+});
+
+test("rejects empty, non-number, and unsafe integer values", () => {
+  assert.equal(parseInteger(""), null);
+  assert.equal(parseInteger("   "), null);
+  assert.equal(parseInteger(null), null);
+  assert.equal(parseInteger({ value: "1" }), null);
+  assert.equal(parseInteger(String(Number.MAX_SAFE_INTEGER + 1)), null);
+});

--- a/apps/api/src/utils/parse-integer.ts
+++ b/apps/api/src/utils/parse-integer.ts
@@ -1,0 +1,19 @@
+export function parseInteger(value: unknown): number | null {
+  if (typeof value === "number") {
+    return Number.isSafeInteger(value) ? value : null;
+  }
+
+  if (typeof value !== "string") {
+    return null;
+  }
+
+  const trimmed = value.trim();
+
+  if (!/^[+-]?\d+$/.test(trimmed)) {
+    return null;
+  }
+
+  const parsed = Number(trimmed);
+
+  return Number.isSafeInteger(parsed) ? parsed : null;
+}

--- a/contributors/agents.json
+++ b/contributors/agents.json
@@ -1,5 +1,16 @@
 {
-  "agents": [],
-  "last_updated": "2026-06-03",
-  "total_contributions": 0
+  "agents": [
+    {
+      "agent_name": "Codex",
+      "model": "GPT-5",
+      "version": "codex-cli",
+      "github_username": "leo1987820",
+      "pr_number": null,
+      "issue_number": 3139,
+      "contribution_type": "code",
+      "description": "Added a safe integer parsing helper with node:test coverage for strict string parsing and unsafe values."
+    }
+  ],
+  "last_updated": "2026-07-01",
+  "total_contributions": 1
 }

--- a/contributors/agents.json
+++ b/contributors/agents.json
@@ -5,7 +5,7 @@
       "model": "GPT-5",
       "version": "codex-cli",
       "github_username": "leo1987820",
-      "pr_number": 4435,
+      "pr_number": 4471,
       "issue_number": 3139,
       "contribution_type": "code",
       "description": "Added a safe integer parsing helper with node:test coverage for strict string parsing and unsafe values."

--- a/contributors/agents.json
+++ b/contributors/agents.json
@@ -5,7 +5,7 @@
       "model": "GPT-5",
       "version": "codex-cli",
       "github_username": "leo1987820",
-      "pr_number": null,
+      "pr_number": 4435,
       "issue_number": 3139,
       "contribution_type": "code",
       "description": "Added a safe integer parsing helper with node:test coverage for strict string parsing and unsafe values."


### PR DESCRIPTION
/claim #3139

## Summary
- adds `parseInteger(value)` under `apps/api/src/utils`
- safely parses integer numbers and whole-number strings
- rejects partial parsing cases such as `12abc`, decimals, non-finite values, unsafe integers, and non-number inputs
- enables the `apps/api` node:test runner and adds focused coverage

## Difference from existing attempts
- uses the required `apps/api/src/utils/parse-integer.ts` path
- avoids the nested `packages/api/...` path issue visible in another attempt
- includes runnable `node:test` coverage and TypeScript strict compilation evidence
- does not include payment wallet/private payout details in the public PR

## Verification
- `npm.cmd test -w apps/api`
- `npm.cmd test`
- `npx.cmd tsc --noEmit --strict --module NodeNext --moduleResolution NodeNext --target ES2020 --lib ES2020 apps/api/src/utils/parse-integer.ts apps/api/src/utils/parse-integer.test.ts`
- `git diff --check -- apps/api/package.json apps/api/src/utils/parse-integer.ts apps/api/src/utils/parse-integer.test.ts contributors/agents.json`