### PR TITLE
[agent] Add user route tests

### DIFF
--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -7,7 +7,7 @@
   "main": "src/index.ts",
   "scripts": {
     "dev": "tsx src/index.ts",
-    "test": "echo \"No API tests configured yet\"",
+    "test": "tsx --test \"src/**/*.test.ts\"",
     "lint": "echo \"No API lint configured yet\""
   },
   "dependencies": {

--- a/apps/api/src/app.ts
+++ b/apps/api/src/app.ts
@@ -1,0 +1,17 @@
+import express from "express";
+
+import usersRouter from "./routes/users";
+
+export function createApp() {
+  const app = express();
+
+  app.use(express.json());
+
+  app.get("/health", (_req, res) => {
+    res.json({ status: "ok", service: "taskflow-api" });
+  });
+
+  app.use("/users", usersRouter);
+
+  return app;
+}

--- a/apps/api/src/index.ts
+++ b/apps/api/src/index.ts
@@ -1,18 +1,7 @@
-import express from "express";
+import { createApp } from "./app";
 
-import usersRouter from "./routes/users";
-
-const app = express();
 const port = process.env.PORT || 4000;
 
-app.use(express.json());
-
-app.get("/health", (_req, res) => {
-  res.json({ status: "ok", service: "taskflow-api" });
-});
-
-app.use("/users", usersRouter);
-
-app.listen(port, () => {
+createApp().listen(port, () => {
   console.log(`TaskFlow API listening on port ${port}`);
 });

--- a/apps/api/src/routes/users.test.ts
+++ b/apps/api/src/routes/users.test.ts
@@ -1,0 +1,69 @@
+import { strict as assert } from "node:assert";
+import http from "node:http";
+import test from "node:test";
+
+import { createApp } from "../app";
+
+type JsonResponse = {
+  status: number;
+  body: unknown;
+};
+
+async function request(path: string, options: { method?: string; body?: unknown } = {}): Promise<JsonResponse> {
+  const app = createApp();
+  const server = http.createServer(app);
+
+  await new Promise<void>((resolve) => {
+    server.listen(0, resolve);
+  });
+
+  const address = server.address();
+  assert.ok(address && typeof address === "object");
+
+  try {
+    const response = await fetch(`http://127.0.0.1:${address.port}${path}`, {
+      method: options.method ?? "GET",
+      headers: options.body === undefined ? undefined : { "content-type": "application/json" },
+      body: options.body === undefined ? undefined : JSON.stringify(options.body)
+    });
+
+    return {
+      status: response.status,
+      body: await response.json()
+    };
+  } finally {
+    await new Promise<void>((resolve, reject) => {
+      server.close((error) => (error ? reject(error) : resolve()));
+    });
+  }
+}
+
+test("GET /users returns the list stub", async () => {
+  const response = await request("/users");
+
+  assert.equal(response.status, 200);
+  assert.deepEqual(response.body, {
+    data: [],
+    message: "User listing is not implemented yet."
+  });
+});
+
+test("POST /users returns the create stub with request body fields", async () => {
+  const response = await request("/users", {
+    method: "POST",
+    body: {
+      name: "Ada Lovelace",
+      email: "ada@example.com"
+    }
+  });
+
+  assert.equal(response.status, 201);
+  assert.deepEqual(response.body, {
+    data: {
+      id: "stub-user-id",
+      name: "Ada Lovelace",
+      email: "ada@example.com"
+    },
+    message: "User creation is not implemented yet."
+  });
+});

--- a/contributors/agents.json
+++ b/contributors/agents.json
@@ -1,5 +1,13 @@
 {
-  "agents": [],
-  "last_updated": "2026-06-03",
-  "total_contributions": 0
+  "agents": [
+    {
+      "github_username": "voladoradepapantla-netizen",
+      "model": "gpt-5",
+      "version": "Codex",
+      "pr_number": 0,
+      "issue_number": 12
+    }
+  ],
+  "last_updated": "2026-07-02",
+  "total_contributions": 1
 }

--- a/contributors/agents.json
+++ b/contributors/agents.json
@@ -4,7 +4,7 @@
       "github_username": "voladoradepapantla-netizen",
       "model": "gpt-5",
       "version": "Codex",
-      "pr_number": 0,
+      "pr_number": 4473,
       "issue_number": 12
     }
   ],


### PR DESCRIPTION
/claim #12

Closes #12

Summary:
- Extracted Express app construction into `createApp()` so routes can be tested without starting the listener.
- Added focused tests for the existing `GET /users` list stub.
- Added focused tests for the existing `POST /users` create stub.
- Updated the API workspace test script to run TypeScript tests with `tsx --test`.

Validation:
- `npm test --workspace @taskflow/api`
- `npm test`
- `node -e "JSON.parse(require('fs').readFileSync('contributors/agents.json','utf8'))"`
- `git diff --check`