### PR TITLE
feat(api): add strip trailing slash helper (#3243)

### DIFF
--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -7,7 +7,7 @@
   "main": "src/index.ts",
   "scripts": {
     "dev": "tsx src/index.ts",
-    "test": "echo \"No API tests configured yet\"",
+    "test": "tsx --test \"src/**/*.test.ts\"",
     "lint": "echo \"No API lint configured yet\""
   },
   "dependencies": {

--- a/apps/api/src/utils/strip-trailing-slash.test.ts
+++ b/apps/api/src/utils/strip-trailing-slash.test.ts
@@ -1,0 +1,22 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { stripTrailingSlash } from "./strip-trailing-slash";
+
+test("returns empty string unchanged", () => {
+  assert.equal(stripTrailingSlash(""), "");
+});
+
+test("keeps the root slash intact", () => {
+  assert.equal(stripTrailingSlash("/"), "/");
+});
+
+test("removes trailing slashes from paths and urls", () => {
+  assert.equal(stripTrailingSlash("users/"), "users");
+  assert.equal(stripTrailingSlash("users///"), "users");
+  assert.equal(stripTrailingSlash("https://example.com/"), "https://example.com");
+});
+
+test("keeps a bare scheme root intact", () => {
+  assert.equal(stripTrailingSlash("https://"), "https://");
+});

--- a/apps/api/src/utils/strip-trailing-slash.ts
+++ b/apps/api/src/utils/strip-trailing-slash.ts
@@ -1,0 +1,8 @@
+export function stripTrailingSlash(value: string): string {
+  if (value === "" || value === "/" || value.endsWith("://")) {
+    return value;
+  }
+
+  const stripped = value.replace(/\/+$/u, "");
+  return stripped === "" ? "/" : stripped;
+}

--- a/contributors/agents.json
+++ b/contributors/agents.json
@@ -4,7 +4,7 @@
       "github_username": "voladoradepapantla-netizen",
       "model": "gpt-5",
       "version": "Codex",
-      "pr_number": null,
+      "pr_number": 4480,
       "issue_number": 3243
     }
   ],

--- a/contributors/agents.json
+++ b/contributors/agents.json
@@ -1,5 +1,13 @@
 {
-  "agents": [],
-  "last_updated": "2026-06-03",
-  "total_contributions": 0
+  "agents": [
+    {
+      "github_username": "voladoradepapantla-netizen",
+      "model": "gpt-5",
+      "version": "Codex",
+      "pr_number": null,
+      "issue_number": 3243
+    }
+  ],
+  "last_updated": "2026-07-03",
+  "total_contributions": 1
 }


### PR DESCRIPTION
Adds `apps/api/src/utils/strip-trailing-slash.ts` with strict, dependency-free behavior for empty strings, root slash, paths, and URL strings. Includes tests and updates API test scripting plus agent metadata.

/claim #3243

Verification:
- `npm test -w apps/api`
- `node -e "JSON.parse(...)"`
- `git diff --check`