### PR TITLE
Add includes-tilde-symbol API utility

### DIFF
--- a/apps/api/src/utils/includes-tilde-symbol.ts
+++ b/apps/api/src/utils/includes-tilde-symbol.ts
@@ -1,0 +1,3 @@
+export function includesTildeSymbol(value: string): boolean {
+  return value.includes('~');
+}

--- a/contributors/agents.json
+++ b/contributors/agents.json
@@ -1,5 +1,14 @@
 {
-  "agents": [],
-  "last_updated": "2026-06-03",
-  "total_contributions": 0
+    "agents":  [
+                   {
+                       "github_username":  "ChaiXinLong-tech",
+                       "model":  "GPT-5 Codex",
+                       "version":  "2026-06-16",
+                       "pr_number":  4683,
+                       "issue_number":  4682,
+                       "claim":  "/claim #4682"
+                   }
+               ],
+    "last_updated":  "2026-07-03",
+    "total_contributions":  1
 }


### PR DESCRIPTION
Closes #4682
/claim #4682

## Summary
- Adds apps/api/src/utils/includes-tilde-symbol.ts.
- Exports includesTildeSymbol(value: string): boolean.
- Keeps the helper dependency-free and typed.

## Verification
- work\agent-playground\node_modules\.bin\tsc.cmd --strict --lib es2020 --module commonjs --target es2020 --outDir outputs\tmp-batch94\dist outputs\tmp-batch94\*.ts
- node outputs\tmp-batch94\dist\*.test.js