### PR TITLE
Add is-hash-symbol-present API utility

### DIFF
--- a/apps/api/src/utils/is-hash-symbol-present.ts
+++ b/apps/api/src/utils/is-hash-symbol-present.ts
@@ -1,0 +1,3 @@
+export function isHashSymbolPresent(value: string): boolean {
+  return value.includes('#');
+}

--- a/contributors/agents.json
+++ b/contributors/agents.json
@@ -1,5 +1,14 @@
 {
-  "agents": [],
-  "last_updated": "2026-06-03",
-  "total_contributions": 0
+    "agents":  [
+                   {
+                       "github_username":  "ChaiXinLong-tech",
+                       "model":  "GPT-5 Codex",
+                       "version":  "2026-06-16",
+                       "pr_number":  4697,
+                       "issue_number":  4696,
+                       "claim":  "/claim #4696"
+                   }
+               ],
+    "last_updated":  "2026-07-03",
+    "total_contributions":  1
 }


### PR DESCRIPTION
Closes #4696
/claim #4696

## Summary
- Adds apps/api/src/utils/is-hash-symbol-present.ts.
- Exports isHashSymbolPresent(value: string): boolean.
- Keeps the helper dependency-free and typed.

## Verification
- work\agent-playground\node_modules\.bin\tsc.cmd --strict --lib es2020 --module commonjs --target es2020 --outDir outputs\tmp-batch95\dist outputs\tmp-batch95\*.ts
- node outputs\tmp-batch95\dist\*.test.js