### PR TITLE
feat: add symbol presence utilities

### DIFF
--- a/apps/api/src/utils/has-colon-symbol-present.test.ts
+++ b/apps/api/src/utils/has-colon-symbol-present.test.ts
@@ -1,0 +1,12 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { hasColonSymbolPresent } from "./has-colon-symbol-present";
+
+test("returns false when the string has no colon", () => {
+  assert.equal(hasColonSymbolPresent("agent playground"), false);
+});
+
+test("returns true when the string contains a colon", () => {
+  assert.equal(hasColonSymbolPresent("alpha: beta"), true);
+});

--- a/apps/api/src/utils/has-colon-symbol-present.ts
+++ b/apps/api/src/utils/has-colon-symbol-present.ts
@@ -1,0 +1,3 @@
+export function hasColonSymbolPresent(value: string): boolean {
+  return value.includes(":");
+}

--- a/apps/api/src/utils/has-comma-symbol-present.test.ts
+++ b/apps/api/src/utils/has-comma-symbol-present.test.ts
@@ -1,0 +1,12 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { hasCommaSymbolPresent } from "./has-comma-symbol-present";
+
+test("returns false when the string has no comma", () => {
+  assert.equal(hasCommaSymbolPresent("agent playground"), false);
+});
+
+test("returns true when the string contains a comma", () => {
+  assert.equal(hasCommaSymbolPresent("alpha, beta"), true);
+});

--- a/apps/api/src/utils/has-comma-symbol-present.ts
+++ b/apps/api/src/utils/has-comma-symbol-present.ts
@@ -1,0 +1,3 @@
+export function hasCommaSymbolPresent(value: string): boolean {
+  return value.includes(",");
+}

--- a/apps/api/src/utils/has-hash-symbol-present.test.ts
+++ b/apps/api/src/utils/has-hash-symbol-present.test.ts
@@ -1,0 +1,12 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { hasHashSymbolPresent } from "./has-hash-symbol-present";
+
+test("returns false when the string has no hash symbol", () => {
+  assert.equal(hasHashSymbolPresent("agent playground"), false);
+});
+
+test("returns true when the string contains a hash symbol", () => {
+  assert.equal(hasHashSymbolPresent("topic #1"), true);
+});

--- a/apps/api/src/utils/has-hash-symbol-present.ts
+++ b/apps/api/src/utils/has-hash-symbol-present.ts
@@ -1,0 +1,3 @@
+export function hasHashSymbolPresent(value: string): boolean {
+  return value.includes("#");
+}

--- a/apps/api/src/utils/has-question-mark-symbol-present.test.ts
+++ b/apps/api/src/utils/has-question-mark-symbol-present.test.ts
@@ -1,0 +1,12 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { hasQuestionMarkSymbolPresent } from "./has-question-mark-symbol-present";
+
+test("returns false when the string has no question mark", () => {
+  assert.equal(hasQuestionMarkSymbolPresent("agent playground"), false);
+});
+
+test("returns true when the string contains a question mark", () => {
+  assert.equal(hasQuestionMarkSymbolPresent("Can we go?"), true);
+});

--- a/apps/api/src/utils/has-question-mark-symbol-present.ts
+++ b/apps/api/src/utils/has-question-mark-symbol-present.ts
@@ -1,0 +1,3 @@
+export function hasQuestionMarkSymbolPresent(value: string): boolean {
+  return value.includes("?");
+}

--- a/apps/api/src/utils/has-semicolon-symbol-present.test.ts
+++ b/apps/api/src/utils/has-semicolon-symbol-present.test.ts
@@ -1,0 +1,12 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { hasSemicolonSymbolPresent } from "./has-semicolon-symbol-present";
+
+test("returns false when the string has no semicolon", () => {
+  assert.equal(hasSemicolonSymbolPresent("agent playground"), false);
+});
+
+test("returns true when the string contains a semicolon", () => {
+  assert.equal(hasSemicolonSymbolPresent("alpha; beta"), true);
+});

--- a/apps/api/src/utils/has-semicolon-symbol-present.ts
+++ b/apps/api/src/utils/has-semicolon-symbol-present.ts
@@ -1,0 +1,3 @@
+export function hasSemicolonSymbolPresent(value: string): boolean {
+  return value.includes(";");
+}


### PR DESCRIPTION
Adds the remaining small symbol-check utilities in the API package and covers them with tests.

- question mark
- comma
- semicolon
- colon
- hash

Verified with the utils test slice via 
px tsx --test.

Fixes #4696, #4702, #4704, #4706, #4708