### PR TITLE
feat: add more symbol utilities

### DIFF
--- a/apps/api/src/utils/contains-symbol.ts
+++ b/apps/api/src/utils/contains-symbol.ts
@@ -1,0 +1,3 @@
+export function containsSymbol(value: string, symbol: string): boolean {
+  return value.includes(symbol);
+}

--- a/apps/api/src/utils/includes-ampersand-symbol.ts
+++ b/apps/api/src/utils/includes-ampersand-symbol.ts
@@ -1,0 +1,5 @@
+import { containsSymbol } from "./contains-symbol";
+
+export function includesAmpersandSymbol(value: string): boolean {
+  return containsSymbol(value, "&");
+}

--- a/apps/api/src/utils/includes-caret-symbol.ts
+++ b/apps/api/src/utils/includes-caret-symbol.ts
@@ -1,0 +1,5 @@
+import { containsSymbol } from "./contains-symbol";
+
+export function includesCaretSymbol(value: string): boolean {
+  return containsSymbol(value, "^");
+}

--- a/apps/api/src/utils/includes-hash-symbol.ts
+++ b/apps/api/src/utils/includes-hash-symbol.ts
@@ -1,0 +1,5 @@
+import { containsSymbol } from "./contains-symbol";
+
+export function includesHashSymbol(value: string): boolean {
+  return containsSymbol(value, "#");
+}

--- a/apps/api/src/utils/includes-pipe-symbol.ts
+++ b/apps/api/src/utils/includes-pipe-symbol.ts
@@ -1,0 +1,5 @@
+import { containsSymbol } from "./contains-symbol";
+
+export function includesPipeSymbol(value: string): boolean {
+  return containsSymbol(value, "|");
+}

--- a/apps/api/src/utils/includes-tilde-symbol.ts
+++ b/apps/api/src/utils/includes-tilde-symbol.ts
@@ -1,0 +1,5 @@
+import { containsSymbol } from "./contains-symbol";
+
+export function includesTildeSymbol(value: string): boolean {
+  return containsSymbol(value, "~");
+}

--- a/apps/api/src/utils/is-ampersand-symbol-present.ts
+++ b/apps/api/src/utils/is-ampersand-symbol-present.ts
@@ -1,0 +1,5 @@
+import { containsSymbol } from "./contains-symbol";
+
+export function isAmpersandSymbolPresent(value: string): boolean {
+  return containsSymbol(value, "&");
+}

--- a/apps/api/src/utils/is-caret-symbol-present.ts
+++ b/apps/api/src/utils/is-caret-symbol-present.ts
@@ -1,0 +1,5 @@
+import { containsSymbol } from "./contains-symbol";
+
+export function isCaretSymbolPresent(value: string): boolean {
+  return containsSymbol(value, "^");
+}

--- a/apps/api/src/utils/is-pipe-symbol-present.ts
+++ b/apps/api/src/utils/is-pipe-symbol-present.ts
@@ -1,0 +1,5 @@
+import { containsSymbol } from "./contains-symbol";
+
+export function isPipeSymbolPresent(value: string): boolean {
+  return containsSymbol(value, "|");
+}

--- a/apps/api/src/utils/is-tilde-symbol-present.ts
+++ b/apps/api/src/utils/is-tilde-symbol-present.ts
@@ -1,0 +1,5 @@
+import { containsSymbol } from "./contains-symbol";
+
+export function isTildeSymbolPresent(value: string): boolean {
+  return containsSymbol(value, "~");
+}

--- a/apps/api/src/utils/is-underscore-symbol-present.ts
+++ b/apps/api/src/utils/is-underscore-symbol-present.ts
@@ -1,0 +1,5 @@
+import { containsSymbol } from "./contains-symbol";
+
+export function isUnderscoreSymbolPresent(value: string): boolean {
+  return containsSymbol(value, "_");
+}

--- a/apps/api/src/utils/symbol-presence-utils.test.ts
+++ b/apps/api/src/utils/symbol-presence-utils.test.ts
@@ -1,0 +1,30 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { includesAmpersandSymbol } from "./includes-ampersand-symbol";
+import { includesCaretSymbol } from "./includes-caret-symbol";
+import { includesHashSymbol } from "./includes-hash-symbol";
+import { includesPipeSymbol } from "./includes-pipe-symbol";
+import { includesTildeSymbol } from "./includes-tilde-symbol";
+import { isAmpersandSymbolPresent } from "./is-ampersand-symbol-present";
+import { isCaretSymbolPresent } from "./is-caret-symbol-present";
+import { isPipeSymbolPresent } from "./is-pipe-symbol-present";
+import { isTildeSymbolPresent } from "./is-tilde-symbol-present";
+import { isUnderscoreSymbolPresent } from "./is-underscore-symbol-present";
+
+test("checks underscore, ampersand, caret, tilde and pipe symbols", () => {
+  assert.equal(isUnderscoreSymbolPresent("agent_playground"), true);
+  assert.equal(isUnderscoreSymbolPresent("agent playground"), false);
+  assert.equal(isAmpersandSymbolPresent("rock & roll"), true);
+  assert.equal(isCaretSymbolPresent("2 ^ 3"), true);
+  assert.equal(isTildeSymbolPresent("home ~ user"), true);
+  assert.equal(isPipeSymbolPresent("a | b"), true);
+});
+
+test("checks includes-style symbol utilities", () => {
+  assert.equal(includesAmpersandSymbol("rock & roll"), true);
+  assert.equal(includesHashSymbol("issue #4714"), true);
+  assert.equal(includesCaretSymbol("2 ^ 3"), true);
+  assert.equal(includesTildeSymbol("home ~ user"), true);
+  assert.equal(includesPipeSymbol("a | b"), true);
+});


### PR DESCRIPTION
Adds the next set of bounty utilities around symbol presence and covers them with tests.

- underscore
- ampersand
- caret
- tilde
- pipe
- includes-style variants for ampersand, hash, caret, tilde and pipe

Verified with the utils test slice via 
px tsx --test.

Fixes #4710, #4698, #4694, #4692, #4690, #4688, #4686, #4684, #4682, #4680