### PR TITLE
feat: add detect symbol utilities

### DIFF
--- a/apps/api/src/utils/contains-symbol.ts
+++ b/apps/api/src/utils/contains-symbol.ts
@@ -1,0 +1,3 @@
+export function containsSymbol(value: string, symbol: string): boolean {
+  return value.includes(symbol);
+}

--- a/apps/api/src/utils/detect-ampersand-symbol.ts
+++ b/apps/api/src/utils/detect-ampersand-symbol.ts
@@ -1,0 +1,5 @@
+import { containsSymbol } from "./contains-symbol";
+
+export function detectAmpersandSymbol(value: string): boolean {
+  return containsSymbol(value, "&");
+}

--- a/apps/api/src/utils/detect-caret-symbol.ts
+++ b/apps/api/src/utils/detect-caret-symbol.ts
@@ -1,0 +1,5 @@
+import { containsSymbol } from "./contains-symbol";
+
+export function detectCaretSymbol(value: string): boolean {
+  return containsSymbol(value, "^");
+}

--- a/apps/api/src/utils/detect-hash-symbol.ts
+++ b/apps/api/src/utils/detect-hash-symbol.ts
@@ -1,0 +1,5 @@
+import { containsSymbol } from "./contains-symbol";
+
+export function detectHashSymbol(value: string): boolean {
+  return containsSymbol(value, "#");
+}

--- a/apps/api/src/utils/detect-pipe-symbol.ts
+++ b/apps/api/src/utils/detect-pipe-symbol.ts
@@ -1,0 +1,5 @@
+import { containsSymbol } from "./contains-symbol";
+
+export function detectPipeSymbol(value: string): boolean {
+  return containsSymbol(value, "|");
+}

--- a/apps/api/src/utils/detect-symbol-utils.test.ts
+++ b/apps/api/src/utils/detect-symbol-utils.test.ts
@@ -1,0 +1,24 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { detectAmpersandSymbol } from "./detect-ampersand-symbol";
+import { detectCaretSymbol } from "./detect-caret-symbol";
+import { detectHashSymbol } from "./detect-hash-symbol";
+import { detectPipeSymbol } from "./detect-pipe-symbol";
+import { detectTildeSymbol } from "./detect-tilde-symbol";
+
+test("detects ampersand, hash, caret, tilde and pipe symbols", () => {
+  assert.equal(detectAmpersandSymbol("rock & roll"), true);
+  assert.equal(detectHashSymbol("issue #4652"), true);
+  assert.equal(detectCaretSymbol("2 ^ 3"), true);
+  assert.equal(detectTildeSymbol("home ~ user"), true);
+  assert.equal(detectPipeSymbol("a | b"), true);
+});
+
+test("returns false when none of the symbols are present", () => {
+  assert.equal(detectAmpersandSymbol("agent playground"), false);
+  assert.equal(detectHashSymbol("agent playground"), false);
+  assert.equal(detectCaretSymbol("agent playground"), false);
+  assert.equal(detectTildeSymbol("agent playground"), false);
+  assert.equal(detectPipeSymbol("agent playground"), false);
+});

--- a/apps/api/src/utils/detect-tilde-symbol.ts
+++ b/apps/api/src/utils/detect-tilde-symbol.ts
@@ -1,0 +1,5 @@
+import { containsSymbol } from "./contains-symbol";
+
+export function detectTildeSymbol(value: string): boolean {
+  return containsSymbol(value, "~");
+}


### PR DESCRIPTION
Adds the detect* symbol utilities and covers them with a compact test slice.

- detect ampersand
- detect hash
- detect caret
- detect tilde
- detect pipe

Verified with 
px tsx --test.

Fixes #4660, #4658, #4656, #4654, #4652