### PR TITLE
feat: add contains symbol utilities

### DIFF
--- a/apps/api/src/utils/contains-colon-symbol.ts
+++ b/apps/api/src/utils/contains-colon-symbol.ts
@@ -1,0 +1,5 @@
+import { containsSymbol } from "./contains-symbol";
+
+export function containsColonSymbol(value: string): boolean {
+  return containsSymbol(value, ":");
+}

--- a/apps/api/src/utils/contains-comma-symbol.ts
+++ b/apps/api/src/utils/contains-comma-symbol.ts
@@ -1,0 +1,5 @@
+import { containsSymbol } from "./contains-symbol";
+
+export function containsCommaSymbol(value: string): boolean {
+  return containsSymbol(value, ",");
+}

--- a/apps/api/src/utils/contains-question-mark-symbol.ts
+++ b/apps/api/src/utils/contains-question-mark-symbol.ts
@@ -1,0 +1,5 @@
+import { containsSymbol } from "./contains-symbol";
+
+export function containsQuestionMarkSymbol(value: string): boolean {
+  return containsSymbol(value, "?");
+}

--- a/apps/api/src/utils/contains-semicolon-symbol.ts
+++ b/apps/api/src/utils/contains-semicolon-symbol.ts
@@ -1,0 +1,5 @@
+import { containsSymbol } from "./contains-symbol";
+
+export function containsSemicolonSymbol(value: string): boolean {
+  return containsSymbol(value, ";");
+}

--- a/apps/api/src/utils/contains-symbol-utils.test.ts
+++ b/apps/api/src/utils/contains-symbol-utils.test.ts
@@ -1,0 +1,24 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { containsCommaSymbol } from "./contains-comma-symbol";
+import { containsColonSymbol } from "./contains-colon-symbol";
+import { containsQuestionMarkSymbol } from "./contains-question-mark-symbol";
+import { containsSemicolonSymbol } from "./contains-semicolon-symbol";
+import { containsUnderscoreSymbol } from "./contains-underscore-symbol";
+
+test("detects contains-style symbol utilities", () => {
+  assert.equal(containsUnderscoreSymbol("agent_playground"), true);
+  assert.equal(containsQuestionMarkSymbol("go?"), true);
+  assert.equal(containsCommaSymbol("alpha, beta"), true);
+  assert.equal(containsSemicolonSymbol("alpha; beta"), true);
+  assert.equal(containsColonSymbol("alpha: beta"), true);
+});
+
+test("returns false when the symbol is absent", () => {
+  assert.equal(containsUnderscoreSymbol("agent playground"), false);
+  assert.equal(containsQuestionMarkSymbol("go"), false);
+  assert.equal(containsCommaSymbol("alpha beta"), false);
+  assert.equal(containsSemicolonSymbol("alpha beta"), false);
+  assert.equal(containsColonSymbol("alpha beta"), false);
+});

--- a/apps/api/src/utils/contains-symbol.ts
+++ b/apps/api/src/utils/contains-symbol.ts
@@ -1,0 +1,3 @@
+export function containsSymbol(value: string, symbol: string): boolean {
+  return value.includes(symbol);
+}

--- a/apps/api/src/utils/contains-underscore-symbol.ts
+++ b/apps/api/src/utils/contains-underscore-symbol.ts
@@ -1,0 +1,5 @@
+import { containsSymbol } from "./contains-symbol";
+
+export function containsUnderscoreSymbol(value: string): boolean {
+  return containsSymbol(value, "_");
+}


### PR DESCRIPTION
Adds the contains* symbol utilities and a compact regression test for the current bounty cluster.

- contains underscore
- contains question mark
- contains comma
- contains semicolon
- contains colon

Verified with 
px tsx --test.

Fixes #4639, #4636, #4634, #4632, #4630