### PR TITLE
feat: add character sign utilities

### DIFF
--- a/apps/api/src/utils/character-sign-utils.test.ts
+++ b/apps/api/src/utils/character-sign-utils.test.ts
@@ -1,0 +1,39 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { hasAtSignCharacter } from "./has-at-sign-character";
+import { hasBangCharacter } from "./has-bang-character";
+import { hasDotCharacter } from "./has-dot-character";
+import { hasDollarSignCharacter } from "./has-dollar-sign-character";
+import { hasEqualsSignCharacter } from "./has-equals-sign-character";
+import { hasForwardSlashCharacter } from "./has-forward-slash-character";
+import { hasMinusSignCharacter } from "./has-minus-sign-character";
+import { hasOpenParenCharacter } from "./has-open-paren-character";
+import { hasPercentSignCharacter } from "./has-percent-sign-character";
+import { hasPlusSignCharacter } from "./has-plus-sign-character";
+
+test("detects the sign and punctuation characters", () => {
+  assert.equal(hasBangCharacter("wow!"), true);
+  assert.equal(hasDotCharacter("v1.0"), true);
+  assert.equal(hasMinusSignCharacter("x-y"), true);
+  assert.equal(hasDollarSignCharacter("$100"), true);
+  assert.equal(hasForwardSlashCharacter("a/b"), true);
+  assert.equal(hasOpenParenCharacter("(a)"), true);
+  assert.equal(hasEqualsSignCharacter("a=b"), true);
+  assert.equal(hasPlusSignCharacter("a+b"), true);
+  assert.equal(hasPercentSignCharacter("50%"), true);
+  assert.equal(hasAtSignCharacter("user@example.com"), true);
+});
+
+test("returns false when the character is absent", () => {
+  assert.equal(hasBangCharacter("wow"), false);
+  assert.equal(hasDotCharacter("v1-0"), false);
+  assert.equal(hasMinusSignCharacter("xy"), false);
+  assert.equal(hasDollarSignCharacter("100"), false);
+  assert.equal(hasForwardSlashCharacter("ab"), false);
+  assert.equal(hasOpenParenCharacter("a)"), false);
+  assert.equal(hasEqualsSignCharacter("ab"), false);
+  assert.equal(hasPlusSignCharacter("ab"), false);
+  assert.equal(hasPercentSignCharacter("50"), false);
+  assert.equal(hasAtSignCharacter("userexample.com"), false);
+});

--- a/apps/api/src/utils/contains-symbol.ts
+++ b/apps/api/src/utils/contains-symbol.ts
@@ -1,0 +1,3 @@
+export function containsSymbol(value: string, symbol: string): boolean {
+  return value.includes(symbol);
+}

--- a/apps/api/src/utils/has-at-sign-character.ts
+++ b/apps/api/src/utils/has-at-sign-character.ts
@@ -1,0 +1,5 @@
+import { containsSymbol } from "./contains-symbol";
+
+export function hasAtSignCharacter(value: string): boolean {
+  return containsSymbol(value, "@");
+}

--- a/apps/api/src/utils/has-bang-character.ts
+++ b/apps/api/src/utils/has-bang-character.ts
@@ -1,0 +1,5 @@
+import { containsSymbol } from "./contains-symbol";
+
+export function hasBangCharacter(value: string): boolean {
+  return containsSymbol(value, "!");
+}

--- a/apps/api/src/utils/has-dollar-sign-character.ts
+++ b/apps/api/src/utils/has-dollar-sign-character.ts
@@ -1,0 +1,5 @@
+import { containsSymbol } from "./contains-symbol";
+
+export function hasDollarSignCharacter(value: string): boolean {
+  return containsSymbol(value, "$");
+}

--- a/apps/api/src/utils/has-dot-character.ts
+++ b/apps/api/src/utils/has-dot-character.ts
@@ -1,0 +1,5 @@
+import { containsSymbol } from "./contains-symbol";
+
+export function hasDotCharacter(value: string): boolean {
+  return containsSymbol(value, ".");
+}

--- a/apps/api/src/utils/has-equals-sign-character.ts
+++ b/apps/api/src/utils/has-equals-sign-character.ts
@@ -1,0 +1,5 @@
+import { containsSymbol } from "./contains-symbol";
+
+export function hasEqualsSignCharacter(value: string): boolean {
+  return containsSymbol(value, "=");
+}

--- a/apps/api/src/utils/has-forward-slash-character.ts
+++ b/apps/api/src/utils/has-forward-slash-character.ts
@@ -1,0 +1,5 @@
+import { containsSymbol } from "./contains-symbol";
+
+export function hasForwardSlashCharacter(value: string): boolean {
+  return containsSymbol(value, "/");
+}

--- a/apps/api/src/utils/has-minus-sign-character.ts
+++ b/apps/api/src/utils/has-minus-sign-character.ts
@@ -1,0 +1,5 @@
+import { containsSymbol } from "./contains-symbol";
+
+export function hasMinusSignCharacter(value: string): boolean {
+  return containsSymbol(value, "-");
+}

--- a/apps/api/src/utils/has-open-paren-character.ts
+++ b/apps/api/src/utils/has-open-paren-character.ts
@@ -1,0 +1,5 @@
+import { containsSymbol } from "./contains-symbol";
+
+export function hasOpenParenCharacter(value: string): boolean {
+  return containsSymbol(value, "(");
+}

--- a/apps/api/src/utils/has-percent-sign-character.ts
+++ b/apps/api/src/utils/has-percent-sign-character.ts
@@ -1,0 +1,5 @@
+import { containsSymbol } from "./contains-symbol";
+
+export function hasPercentSignCharacter(value: string): boolean {
+  return containsSymbol(value, "%");
+}

--- a/apps/api/src/utils/has-plus-sign-character.ts
+++ b/apps/api/src/utils/has-plus-sign-character.ts
@@ -1,0 +1,5 @@
+import { containsSymbol } from "./contains-symbol";
+
+export function hasPlusSignCharacter(value: string): boolean {
+  return containsSymbol(value, "+");
+}


### PR DESCRIPTION
Adds the sign-character utilities and a compact regression test slice.

- bang
- dot
- minus sign
- dollar sign
- forward slash
- open paren
- equals sign
- plus sign
- percent sign
- at sign

Verified with 
px tsx --test.

Fixes #4597, #4595, #4593, #4591, #4589, #4587, #4585, #4583, #4581, #4579