### PR TITLE
feat: add additional character presence utilities

### DIFF
--- a/apps/api/src/utils/character-presence-advanced-utils.test.ts
+++ b/apps/api/src/utils/character-presence-advanced-utils.test.ts
@@ -1,0 +1,108 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { hasBacktickCharacter } from "./has-backtick-character";
+import { hasTildeSign } from "./has-tilde-sign";
+import { hasUnderscoreCharacter } from "./has-underscore-character";
+import { hasExclamationSign } from "./has-exclamation-sign";
+import { hasQuestionMarkSign } from "./has-question-mark-sign";
+import { hasSemicolonCharacter } from "./has-semicolon-character";
+import { hasCaretSign } from "./has-caret-sign";
+import { hasCloseAngle } from "./has-close-angle";
+import { hasOpenAngle } from "./has-open-angle";
+import { hasSlashCharacter } from "./has-slash-character";
+import { hasColonCharacter } from "./has-colon-character";
+import { hasPeriodSign } from "./has-period-sign";
+import { hasLetterZ } from "./has-letter-z";
+import { hasLetterX } from "./has-letter-x";
+import { hasLetterC } from "./has-letter-c";
+import { hasLetterB } from "./has-letter-b";
+import { hasSpaceCharacter } from "./has-space-character";
+import { hasNineDigit } from "./has-nine-digit";
+import { hasEightDigit } from "./has-eight-digit";
+import { hasSevenDigit } from "./has-seven-digit";
+import { hasSixDigit } from "./has-six-digit";
+import { hasFiveDigit } from "./has-five-digit";
+import { hasFourDigit } from "./has-four-digit";
+import { hasThreeDigit } from "./has-three-digit";
+import { hasTwoDigit } from "./has-two-digit";
+import { hasOneDigit } from "./has-one-digit";
+import { hasZeroDigit } from "./has-zero-digit";
+import { hasHashSign } from "./has-hash-sign";
+import { hasAmpersandSign } from "./has-ampersand-sign";
+import { hasPipeSign } from "./has-pipe-sign";
+import { hasAsteriskSign } from "./has-asterisk-sign";
+import { hasUnderscoreSign } from "./has-underscore-sign";
+import { hasMinusSign } from "./has-minus-sign";
+import { hasCloseParenthesisCharacter } from "./has-close-parenthesis-character";
+import { hasOpenParenthesisCharacter } from "./has-open-parenthesis-character";
+import { hasCloseBraceCharacter } from "./has-close-brace-character";
+import { hasOpenBraceCharacter } from "./has-open-brace-character";
+import { hasAtSignCharacter } from "./has-at-sign-character";
+import { hasHexPrefix } from "./has-hex-prefix";
+import { hasDigitCharacter } from "./has-digit-character";
+import { hasLineFeed } from "./has-line-feed";
+import { hasNonbreakingSpace } from "./has-nonbreaking-space";
+import { hasVerticalTab } from "./has-vertical-tab";
+import { hasFormFeed } from "./has-form-feed";
+import { hasCarriageReturn } from "./has-carriage-return";
+
+const cases = [
+  { name: "hasBacktickCharacter", fn: hasBacktickCharacter, positive: "`", negative: "abc" },
+  { name: "hasTildeSign", fn: hasTildeSign, positive: "~", negative: "abc" },
+  { name: "hasUnderscoreCharacter", fn: hasUnderscoreCharacter, positive: "_", negative: "abc" },
+  { name: "hasExclamationSign", fn: hasExclamationSign, positive: "!", negative: "abc" },
+  { name: "hasQuestionMarkSign", fn: hasQuestionMarkSign, positive: "?", negative: "abc" },
+  { name: "hasSemicolonCharacter", fn: hasSemicolonCharacter, positive: ";", negative: "abc" },
+  { name: "hasCaretSign", fn: hasCaretSign, positive: "^", negative: "abc" },
+  { name: "hasCloseAngle", fn: hasCloseAngle, positive: ">", negative: "abc" },
+  { name: "hasOpenAngle", fn: hasOpenAngle, positive: "<", negative: "abc" },
+  { name: "hasSlashCharacter", fn: hasSlashCharacter, positive: "/", negative: "abc" },
+  { name: "hasColonCharacter", fn: hasColonCharacter, positive: ":", negative: "abc" },
+  { name: "hasPeriodSign", fn: hasPeriodSign, positive: ".", negative: "abc" },
+  { name: "hasLetterZ", fn: hasLetterZ, positive: "z", negative: "abc" },
+  { name: "hasLetterX", fn: hasLetterX, positive: "x", negative: "abc" },
+  { name: "hasLetterC", fn: hasLetterC, positive: "c", negative: "d" },
+  { name: "hasLetterB", fn: hasLetterB, positive: "b", negative: "d" },
+  { name: "hasSpaceCharacter", fn: hasSpaceCharacter, positive: "a b", negative: "abc" },
+  { name: "hasNineDigit", fn: hasNineDigit, positive: "9", negative: "abc" },
+  { name: "hasEightDigit", fn: hasEightDigit, positive: "8", negative: "abc" },
+  { name: "hasSevenDigit", fn: hasSevenDigit, positive: "7", negative: "abc" },
+  { name: "hasSixDigit", fn: hasSixDigit, positive: "6", negative: "abc" },
+  { name: "hasFiveDigit", fn: hasFiveDigit, positive: "5", negative: "abc" },
+  { name: "hasFourDigit", fn: hasFourDigit, positive: "4", negative: "abc" },
+  { name: "hasThreeDigit", fn: hasThreeDigit, positive: "3", negative: "abc" },
+  { name: "hasTwoDigit", fn: hasTwoDigit, positive: "2", negative: "abc" },
+  { name: "hasOneDigit", fn: hasOneDigit, positive: "1", negative: "abc" },
+  { name: "hasZeroDigit", fn: hasZeroDigit, positive: "0", negative: "abc" },
+  { name: "hasHashSign", fn: hasHashSign, positive: "#", negative: "abc" },
+  { name: "hasAmpersandSign", fn: hasAmpersandSign, positive: "&", negative: "abc" },
+  { name: "hasPipeSign", fn: hasPipeSign, positive: "|", negative: "abc" },
+  { name: "hasAsteriskSign", fn: hasAsteriskSign, positive: "*", negative: "abc" },
+  { name: "hasUnderscoreSign", fn: hasUnderscoreSign, positive: "_", negative: "abc" },
+  { name: "hasMinusSign", fn: hasMinusSign, positive: "-", negative: "abc" },
+  { name: "hasCloseParenthesisCharacter", fn: hasCloseParenthesisCharacter, positive: ")", negative: "abc" },
+  { name: "hasOpenParenthesisCharacter", fn: hasOpenParenthesisCharacter, positive: "(", negative: "abc" },
+  { name: "hasCloseBraceCharacter", fn: hasCloseBraceCharacter, positive: "}", negative: "abc" },
+  { name: "hasOpenBraceCharacter", fn: hasOpenBraceCharacter, positive: "{", negative: "abc" },
+  { name: "hasAtSignCharacter", fn: hasAtSignCharacter, positive: "@", negative: "abc" },
+  { name: "hasHexPrefix", fn: hasHexPrefix, positive: "0xdeadbeef", negative: "abc" },
+  { name: "hasDigitCharacter", fn: hasDigitCharacter, positive: "abc1", negative: "abc" },
+  { name: "hasLineFeed", fn: hasLineFeed, positive: "a\nb", negative: "abc" },
+  { name: "hasNonbreakingSpace", fn: hasNonbreakingSpace, positive: "a b", negative: "abc" },
+  { name: "hasVerticalTab", fn: hasVerticalTab, positive: "a\u000bb", negative: "abc" },
+  { name: "hasFormFeed", fn: hasFormFeed, positive: "a\fb", negative: "abc" },
+  { name: "hasCarriageReturn", fn: hasCarriageReturn, positive: "a\rb", negative: "abc" },
+];
+
+test("returns true when the target character is present", () => {
+  for (const c of cases) {
+    assert.equal(c.fn(c.positive), true, c.name);
+  }
+});
+
+test("returns false when the target character is absent", () => {
+  for (const c of cases) {
+    assert.equal(c.fn(c.negative), false, c.name);
+  }
+});

--- a/apps/api/src/utils/has-ampersand-sign.ts
+++ b/apps/api/src/utils/has-ampersand-sign.ts
@@ -1,0 +1,3 @@
+export function hasAmpersandSign(value: string): boolean {
+  return value.includes("&");
+}

--- a/apps/api/src/utils/has-asterisk-sign.ts
+++ b/apps/api/src/utils/has-asterisk-sign.ts
@@ -1,0 +1,3 @@
+export function hasAsteriskSign(value: string): boolean {
+  return value.includes("*");
+}

--- a/apps/api/src/utils/has-at-sign-character.ts
+++ b/apps/api/src/utils/has-at-sign-character.ts
@@ -1,0 +1,3 @@
+export function hasAtSignCharacter(value: string): boolean {
+  return value.includes("@");
+}

--- a/apps/api/src/utils/has-backtick-character.ts
+++ b/apps/api/src/utils/has-backtick-character.ts
@@ -1,0 +1,3 @@
+export function hasBacktickCharacter(value: string): boolean {
+  return value.includes("`");
+}

--- a/apps/api/src/utils/has-caret-sign.ts
+++ b/apps/api/src/utils/has-caret-sign.ts
@@ -1,0 +1,3 @@
+export function hasCaretSign(value: string): boolean {
+  return value.includes("^");
+}

--- a/apps/api/src/utils/has-carriage-return.ts
+++ b/apps/api/src/utils/has-carriage-return.ts
@@ -1,0 +1,3 @@
+export function hasCarriageReturn(value: string): boolean {
+  return value.includes("\r");
+}

--- a/apps/api/src/utils/has-close-angle.ts
+++ b/apps/api/src/utils/has-close-angle.ts
@@ -1,0 +1,3 @@
+export function hasCloseAngle(value: string): boolean {
+  return value.includes(">");
+}

--- a/apps/api/src/utils/has-close-brace-character.ts
+++ b/apps/api/src/utils/has-close-brace-character.ts
@@ -1,0 +1,3 @@
+export function hasCloseBraceCharacter(value: string): boolean {
+  return value.includes("}");
+}

--- a/apps/api/src/utils/has-close-parenthesis-character.ts
+++ b/apps/api/src/utils/has-close-parenthesis-character.ts
@@ -1,0 +1,3 @@
+export function hasCloseParenthesisCharacter(value: string): boolean {
+  return value.includes(")");
+}

--- a/apps/api/src/utils/has-colon-character.ts
+++ b/apps/api/src/utils/has-colon-character.ts
@@ -1,0 +1,3 @@
+export function hasColonCharacter(value: string): boolean {
+  return value.includes(":");
+}

--- a/apps/api/src/utils/has-digit-character.ts
+++ b/apps/api/src/utils/has-digit-character.ts
@@ -1,0 +1,3 @@
+export function hasDigitCharacter(value: string): boolean {
+  return /[0-9]/.test(value);
+}

--- a/apps/api/src/utils/has-eight-digit.ts
+++ b/apps/api/src/utils/has-eight-digit.ts
@@ -1,0 +1,3 @@
+export function hasEightDigit(value: string): boolean {
+  return value.includes("8");
+}

--- a/apps/api/src/utils/has-exclamation-sign.ts
+++ b/apps/api/src/utils/has-exclamation-sign.ts
@@ -1,0 +1,3 @@
+export function hasExclamationSign(value: string): boolean {
+  return value.includes("!");
+}

--- a/apps/api/src/utils/has-five-digit.ts
+++ b/apps/api/src/utils/has-five-digit.ts
@@ -1,0 +1,3 @@
+export function hasFiveDigit(value: string): boolean {
+  return value.includes("5");
+}

--- a/apps/api/src/utils/has-form-feed.ts
+++ b/apps/api/src/utils/has-form-feed.ts
@@ -1,0 +1,3 @@
+export function hasFormFeed(value: string): boolean {
+  return value.includes("\f");
+}

--- a/apps/api/src/utils/has-four-digit.ts
+++ b/apps/api/src/utils/has-four-digit.ts
@@ -1,0 +1,3 @@
+export function hasFourDigit(value: string): boolean {
+  return value.includes("4");
+}

--- a/apps/api/src/utils/has-hash-sign.ts
+++ b/apps/api/src/utils/has-hash-sign.ts
@@ -1,0 +1,3 @@
+export function hasHashSign(value: string): boolean {
+  return value.includes("#");
+}

--- a/apps/api/src/utils/has-hex-prefix.ts
+++ b/apps/api/src/utils/has-hex-prefix.ts
@@ -1,0 +1,3 @@
+export function hasHexPrefix(value: string): boolean {
+  return value.includes("0x");
+}

--- a/apps/api/src/utils/has-letter-b.ts
+++ b/apps/api/src/utils/has-letter-b.ts
@@ -1,0 +1,3 @@
+export function hasLetterB(value: string): boolean {
+  return value.includes("b");
+}

--- a/apps/api/src/utils/has-letter-c.ts
+++ b/apps/api/src/utils/has-letter-c.ts
@@ -1,0 +1,3 @@
+export function hasLetterC(value: string): boolean {
+  return value.includes("c");
+}

--- a/apps/api/src/utils/has-letter-x.ts
+++ b/apps/api/src/utils/has-letter-x.ts
@@ -1,0 +1,3 @@
+export function hasLetterX(value: string): boolean {
+  return value.includes("x");
+}

--- a/apps/api/src/utils/has-letter-z.ts
+++ b/apps/api/src/utils/has-letter-z.ts
@@ -1,0 +1,3 @@
+export function hasLetterZ(value: string): boolean {
+  return value.includes("z");
+}

--- a/apps/api/src/utils/has-line-feed.ts
+++ b/apps/api/src/utils/has-line-feed.ts
@@ -1,0 +1,3 @@
+export function hasLineFeed(value: string): boolean {
+  return value.includes("\n");
+}

--- a/apps/api/src/utils/has-minus-sign.ts
+++ b/apps/api/src/utils/has-minus-sign.ts
@@ -1,0 +1,3 @@
+export function hasMinusSign(value: string): boolean {
+  return value.includes("-");
+}

--- a/apps/api/src/utils/has-nine-digit.ts
+++ b/apps/api/src/utils/has-nine-digit.ts
@@ -1,0 +1,3 @@
+export function hasNineDigit(value: string): boolean {
+  return value.includes("9");
+}

--- a/apps/api/src/utils/has-nonbreaking-space.ts
+++ b/apps/api/src/utils/has-nonbreaking-space.ts
@@ -1,0 +1,3 @@
+export function hasNonbreakingSpace(value: string): boolean {
+  return value.includes("\u00A0");
+}

--- a/apps/api/src/utils/has-one-digit.ts
+++ b/apps/api/src/utils/has-one-digit.ts
@@ -1,0 +1,3 @@
+export function hasOneDigit(value: string): boolean {
+  return value.includes("1");
+}

--- a/apps/api/src/utils/has-open-angle.ts
+++ b/apps/api/src/utils/has-open-angle.ts
@@ -1,0 +1,3 @@
+export function hasOpenAngle(value: string): boolean {
+  return value.includes("<");
+}

--- a/apps/api/src/utils/has-open-brace-character.ts
+++ b/apps/api/src/utils/has-open-brace-character.ts
@@ -1,0 +1,3 @@
+export function hasOpenBraceCharacter(value: string): boolean {
+  return value.includes("{");
+}

--- a/apps/api/src/utils/has-open-parenthesis-character.ts
+++ b/apps/api/src/utils/has-open-parenthesis-character.ts
@@ -1,0 +1,3 @@
+export function hasOpenParenthesisCharacter(value: string): boolean {
+  return value.includes("(");
+}

--- a/apps/api/src/utils/has-period-sign.ts
+++ b/apps/api/src/utils/has-period-sign.ts
@@ -1,0 +1,3 @@
+export function hasPeriodSign(value: string): boolean {
+  return value.includes(".");
+}

--- a/apps/api/src/utils/has-pipe-sign.ts
+++ b/apps/api/src/utils/has-pipe-sign.ts
@@ -1,0 +1,3 @@
+export function hasPipeSign(value: string): boolean {
+  return value.includes("|");
+}

--- a/apps/api/src/utils/has-question-mark-sign.ts
+++ b/apps/api/src/utils/has-question-mark-sign.ts
@@ -1,0 +1,3 @@
+export function hasQuestionMarkSign(value: string): boolean {
+  return value.includes("?");
+}

--- a/apps/api/src/utils/has-semicolon-character.ts
+++ b/apps/api/src/utils/has-semicolon-character.ts
@@ -1,0 +1,3 @@
+export function hasSemicolonCharacter(value: string): boolean {
+  return value.includes(";");
+}

--- a/apps/api/src/utils/has-seven-digit.ts
+++ b/apps/api/src/utils/has-seven-digit.ts
@@ -1,0 +1,3 @@
+export function hasSevenDigit(value: string): boolean {
+  return value.includes("7");
+}

--- a/apps/api/src/utils/has-six-digit.ts
+++ b/apps/api/src/utils/has-six-digit.ts
@@ -1,0 +1,3 @@
+export function hasSixDigit(value: string): boolean {
+  return value.includes("6");
+}

--- a/apps/api/src/utils/has-slash-character.ts
+++ b/apps/api/src/utils/has-slash-character.ts
@@ -1,0 +1,3 @@
+export function hasSlashCharacter(value: string): boolean {
+  return value.includes("/");
+}

--- a/apps/api/src/utils/has-space-character.ts
+++ b/apps/api/src/utils/has-space-character.ts
@@ -1,0 +1,3 @@
+export function hasSpaceCharacter(value: string): boolean {
+  return value.includes(" ");
+}

--- a/apps/api/src/utils/has-three-digit.ts
+++ b/apps/api/src/utils/has-three-digit.ts
@@ -1,0 +1,3 @@
+export function hasThreeDigit(value: string): boolean {
+  return value.includes("3");
+}

--- a/apps/api/src/utils/has-tilde-sign.ts
+++ b/apps/api/src/utils/has-tilde-sign.ts
@@ -1,0 +1,3 @@
+export function hasTildeSign(value: string): boolean {
+  return value.includes("~");
+}

--- a/apps/api/src/utils/has-two-digit.ts
+++ b/apps/api/src/utils/has-two-digit.ts
@@ -1,0 +1,3 @@
+export function hasTwoDigit(value: string): boolean {
+  return value.includes("2");
+}

--- a/apps/api/src/utils/has-underscore-character.ts
+++ b/apps/api/src/utils/has-underscore-character.ts
@@ -1,0 +1,3 @@
+export function hasUnderscoreCharacter(value: string): boolean {
+  return value.includes("_");
+}

--- a/apps/api/src/utils/has-underscore-sign.ts
+++ b/apps/api/src/utils/has-underscore-sign.ts
@@ -1,0 +1,3 @@
+export function hasUnderscoreSign(value: string): boolean {
+  return value.includes("_");
+}

--- a/apps/api/src/utils/has-vertical-tab.ts
+++ b/apps/api/src/utils/has-vertical-tab.ts
@@ -1,0 +1,3 @@
+export function hasVerticalTab(value: string): boolean {
+  return value.includes("\v");
+}

--- a/apps/api/src/utils/has-zero-digit.ts
+++ b/apps/api/src/utils/has-zero-digit.ts
@@ -1,0 +1,3 @@
+export function hasZeroDigit(value: string): boolean {
+  return value.includes("0");
+}


### PR DESCRIPTION
Adds the remaining low-level character utilities and a regression test for the batch.

Covered characters and checks: backtick, tilde sign, underscore character, exclamation sign, question mark sign, semicolon, caret sign, open/close angle, slash, colon, period sign, letters b/c/x/z, space, digits 0-9, hash sign, ampersand sign, pipe sign, asterisk sign, underscore sign, minus sign, open/close parentheses, open/close braces, at sign, hex prefix, digit character, line feed, nonbreaking space, vertical tab, form feed, carriage return.

Verified with 
px tsx --test apps/api/src/utils/character-presence-advanced-utils.test.ts.

Fixes #4184, #4162, #4160, #4158, #4156, #4154, #4146, #4144, #4142, #4140, #4138, #4122, #4120, #4118, #4116, #4114, #4112, #4110, #4108, #4106, #4104, #4048, #4046, #4044, #4041, #4039, #4002, #4000, #3998, #3996, #3994, #3985, #3982, #3980, #3978, #3976, #3968, #3966, #3964, #3962