### PR TITLE
[agent] feat: add string and collection helpers

### DIFF
--- a/apps/api/src/utils/compact-array.ts
+++ b/apps/api/src/utils/compact-array.ts
@@ -1,0 +1,11 @@
+export function compactArray<T>(values: readonly (T | null | undefined)[]): T[] {
+  const result: T[] = [];
+
+  for (const value of values) {
+    if (value !== null && value !== undefined) {
+      result.push(value);
+    }
+  }
+
+  return result;
+}

--- a/apps/api/src/utils/ends-with-any.ts
+++ b/apps/api/src/utils/ends-with-any.ts
@@ -1,0 +1,9 @@
+export function endsWithAny(value: string, suffixes: readonly string[]): boolean {
+  for (const suffix of suffixes) {
+    if (suffix.length > 0 && value.endsWith(suffix)) {
+      return true;
+    }
+  }
+
+  return false;
+}

--- a/apps/api/src/utils/ensure-array.ts
+++ b/apps/api/src/utils/ensure-array.ts
@@ -1,0 +1,11 @@
+export function ensureArray<T>(value: T | readonly T[] | null | undefined): T[] {
+  if (value == null) {
+    return [];
+  }
+
+  if (Array.isArray(value)) {
+    return [...value];
+  }
+
+  return [value as T];
+}

--- a/apps/api/src/utils/lowercase-record-keys.ts
+++ b/apps/api/src/utils/lowercase-record-keys.ts
@@ -1,0 +1,13 @@
+export type LowercaseRecordKeys<T extends Record<string, unknown>> = {
+  [K in keyof T as K extends string ? Lowercase<K> : never]: T[K];
+};
+
+export function lowercaseRecordKeys<T extends Record<string, unknown>>(value: T): LowercaseRecordKeys<T> {
+  const result: Record<string, unknown> = {};
+
+  for (const [key, entry] of Object.entries(value)) {
+    result[key.toLowerCase()] = entry;
+  }
+
+  return result as LowercaseRecordKeys<T>;
+}

--- a/apps/api/src/utils/omit-undefined.ts
+++ b/apps/api/src/utils/omit-undefined.ts
@@ -1,0 +1,17 @@
+export type OmitUndefined<T extends Record<string, unknown>> = {
+  [K in keyof T as undefined extends T[K] ? never : K]: T[K];
+} & {
+  [K in keyof T as undefined extends T[K] ? K : never]?: Exclude<T[K], undefined>;
+};
+
+export function omitUndefined<T extends Record<string, unknown>>(value: T): OmitUndefined<T> {
+  const result: Record<string, unknown> = {};
+
+  for (const [key, entry] of Object.entries(value)) {
+    if (entry !== undefined) {
+      result[key] = entry;
+    }
+  }
+
+  return result as OmitUndefined<T>;
+}

--- a/apps/api/src/utils/pick-defined-values.ts
+++ b/apps/api/src/utils/pick-defined-values.ts
@@ -1,0 +1,5 @@
+import { omitUndefined, type OmitUndefined } from "./omit-undefined";
+
+export function pickDefinedValues<T extends Record<string, unknown>>(value: T): OmitUndefined<T> {
+  return omitUndefined(value);
+}

--- a/apps/api/src/utils/range-number.ts
+++ b/apps/api/src/utils/range-number.ts
@@ -1,0 +1,18 @@
+export function rangeNumber(start: number, end: number, step = 1): number[] {
+  if (!Number.isFinite(start) || !Number.isFinite(end) || !Number.isFinite(step)) {
+    throw new TypeError("rangeNumber requires finite numbers");
+  }
+
+  if (step === 0) {
+    throw new RangeError("rangeNumber step must not be 0");
+  }
+
+  const increment = Math.abs(step) * (start <= end ? 1 : -1);
+  const values: number[] = [];
+
+  for (let current = start; increment > 0 ? current <= end : current >= end; current += increment) {
+    values.push(current);
+  }
+
+  return values;
+}

--- a/apps/api/src/utils/remove-prefix.ts
+++ b/apps/api/src/utils/remove-prefix.ts
@@ -1,0 +1,3 @@
+export function removePrefix(value: string, prefix: string): string {
+  return prefix.length > 0 && value.startsWith(prefix) ? value.slice(prefix.length) : value;
+}

--- a/apps/api/src/utils/remove-suffix.ts
+++ b/apps/api/src/utils/remove-suffix.ts
@@ -1,0 +1,3 @@
+export function removeSuffix(value: string, suffix: string): string {
+  return suffix.length > 0 && value.endsWith(suffix) ? value.slice(0, value.length - suffix.length) : value;
+}

--- a/apps/api/src/utils/starts-with-any.ts
+++ b/apps/api/src/utils/starts-with-any.ts
@@ -1,0 +1,9 @@
+export function startsWithAny(value: string, prefixes: readonly string[]): boolean {
+  for (const prefix of prefixes) {
+    if (prefix.length > 0 && value.startsWith(prefix)) {
+      return true;
+    }
+  }
+
+  return false;
+}

--- a/apps/api/src/utils/string-helper-batch.test.ts
+++ b/apps/api/src/utils/string-helper-batch.test.ts
@@ -1,0 +1,83 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { compactArray } from "./compact-array";
+import { endsWithAny } from "./ends-with-any";
+import { ensureArray } from "./ensure-array";
+import { lowercaseRecordKeys } from "./lowercase-record-keys";
+import { omitUndefined } from "./omit-undefined";
+import { pickDefinedValues } from "./pick-defined-values";
+import { rangeNumber } from "./range-number";
+import { removePrefix } from "./remove-prefix";
+import { removeSuffix } from "./remove-suffix";
+import { startsWithAny } from "./starts-with-any";
+import { titleCase } from "./title-case";
+import { uniqueStrings } from "./unique-strings";
+
+test("endsWithAny checks any non-empty suffix", () => {
+  assert.equal(endsWithAny("agent-playground", ["ground", "", "play"]), true);
+  assert.equal(endsWithAny("agent-playground", ["", "agent"]), false);
+});
+
+test("startsWithAny checks any non-empty prefix", () => {
+  assert.equal(startsWithAny("agent-playground", ["agent", ""]), true);
+  assert.equal(startsWithAny("agent-playground", ["", "play"]), false);
+});
+
+test("removePrefix removes only matching prefixes", () => {
+  assert.equal(removePrefix("agent-playground", "agent-"), "playground");
+  assert.equal(removePrefix("agent-playground", "play"), "agent-playground");
+});
+
+test("removeSuffix removes only matching suffixes", () => {
+  assert.equal(removeSuffix("agent-playground", "-playground"), "agent");
+  assert.equal(removeSuffix("agent-playground", "agent"), "agent-playground");
+});
+
+test("ensureArray always returns a mutable array", () => {
+  const source = ["a", "b"] as const;
+  const single = ensureArray("value");
+  const existing = ensureArray(source);
+
+  assert.deepEqual(ensureArray(null), []);
+  assert.deepEqual(ensureArray(undefined), []);
+  assert.deepEqual(single, ["value"]);
+  assert.deepEqual(existing, ["a", "b"]);
+  assert.notStrictEqual(existing, source);
+});
+
+test("compactArray removes nullish values", () => {
+  const values = compactArray(["a", null, undefined, "b"]);
+
+  assert.deepEqual(values, ["a", "b"]);
+});
+
+test("uniqueStrings preserves first-seen order", () => {
+  assert.deepEqual(uniqueStrings(["b", "a", "b", "c", "a"]), ["b", "a", "c"]);
+});
+
+test("titleCase capitalizes word starts", () => {
+  assert.equal(titleCase("hello world from codex"), "Hello World From Codex");
+});
+
+test("lowercaseRecordKeys lowercases keys", () => {
+  assert.deepEqual(lowercaseRecordKeys({ Foo: 1, BarBaz: "x" }), { foo: 1, barbaz: "x" });
+});
+
+test("omitUndefined removes undefined values", () => {
+  assert.deepEqual(omitUndefined({ a: 1, b: undefined, c: "x" }), { a: 1, c: "x" });
+});
+
+test("pickDefinedValues mirrors omitUndefined", () => {
+  assert.deepEqual(pickDefinedValues({ a: 1, b: undefined, c: "x" }), { a: 1, c: "x" });
+});
+
+test("rangeNumber builds inclusive ranges in either direction", () => {
+  assert.deepEqual(rangeNumber(1, 4), [1, 2, 3, 4]);
+  assert.deepEqual(rangeNumber(4, 1), [4, 3, 2, 1]);
+  assert.deepEqual(rangeNumber(1, 5, 2), [1, 3, 5]);
+});
+
+test("rangeNumber rejects invalid step values", () => {
+  assert.throws(() => rangeNumber(1, 3, 0), /step must not be 0/);
+});

--- a/apps/api/src/utils/title-case.ts
+++ b/apps/api/src/utils/title-case.ts
@@ -1,0 +1,3 @@
+export function titleCase(value: string): string {
+  return value.replace(/(^|\s)(\S)/g, (_match, prefix: string, char: string) => `${prefix}${char.toUpperCase()}`);
+}

--- a/apps/api/src/utils/unique-strings.ts
+++ b/apps/api/src/utils/unique-strings.ts
@@ -1,0 +1,13 @@
+export function uniqueStrings(values: readonly string[]): string[] {
+  const seen = new Set<string>();
+  const result: string[] = [];
+
+  for (const value of values) {
+    if (!seen.has(value)) {
+      seen.add(value);
+      result.push(value);
+    }
+  }
+
+  return result;
+}

--- a/contributors/agents.json
+++ b/contributors/agents.json
@@ -4,7 +4,7 @@
       "github_username": "voladoradepapantla-netizen",
       "model": "gpt-5",
       "version": "2026-07-03",
-      "pr_number": 0,
+      "pr_number": 4735,
       "issue_number": 3480
     }
   ],

--- a/contributors/agents.json
+++ b/contributors/agents.json
@@ -1,5 +1,13 @@
 {
-  "agents": [],
-  "last_updated": "2026-06-03",
-  "total_contributions": 0
+  "agents": [
+    {
+      "github_username": "voladoradepapantla-netizen",
+      "model": "gpt-5",
+      "version": "2026-07-03",
+      "pr_number": 0,
+      "issue_number": 3480
+    }
+  ],
+  "last_updated": "2026-07-03",
+  "total_contributions": 1
 }


### PR DESCRIPTION
Adds a small batch of dependency-free TypeScript helpers:
- endsWithAny, startsWithAny, removePrefix, removeSuffix
- compactArray, ensureArray, uniqueStrings, titleCase
- lowercaseRecordKeys, omitUndefined, pickDefinedValues, rangeNumber

Verified with `tsx --test` and strict `tsc` compilation.

Closes #3480
Closes #3478
Closes #3476
Closes #3469
Closes #3298
Closes #3274
Closes #3276
Closes #3280
Closes #3282
Closes #3296
Closes #3406
Closes #3316