### PR TITLE
[agent] feat: add character batch helpers

### DIFF
--- a/apps/api/src/utils/character-batch-4562.test.ts
+++ b/apps/api/src/utils/character-batch-4562.test.ts
@@ -1,0 +1,48 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { hasLowercaseZCharacter } from "./has-lowercase-z-character";
+import { hasUppercaseZCharacter } from "./has-uppercase-z-character";
+import { hasLowercaseYCharacter } from "./has-lowercase-y-character";
+import { hasUppercaseYCharacter } from "./has-uppercase-y-character";
+import { hasUppercaseXCharacter } from "./has-uppercase-x-character";
+import { hasLowercaseUCharacter } from "./has-lowercase-u-character";
+import { hasUppercaseUCharacter } from "./has-uppercase-u-character";
+import { hasLowercaseTCharacter } from "./has-lowercase-t-character";
+import { hasUppercaseTCharacter } from "./has-uppercase-t-character";
+import { hasLowercaseSCharacter } from "./has-lowercase-s-character";
+import { hasUppercaseRCharacter } from "./has-uppercase-r-character";
+import { hasLowercaseQCharacter } from "./has-lowercase-q-character";
+import { hasUppercaseQCharacter } from "./has-uppercase-q-character";
+import { hasLowercasePCharacter } from "./has-lowercase-p-character";
+import { hasUppercasePCharacter } from "./has-uppercase-p-character";
+
+const cases = [
+  { name: "hasLowercaseZCharacter", fn: hasLowercaseZCharacter, positive: "z", negative: "abc" },
+  { name: "hasUppercaseZCharacter", fn: hasUppercaseZCharacter, positive: "Z", negative: "abc" },
+  { name: "hasLowercaseYCharacter", fn: hasLowercaseYCharacter, positive: "y", negative: "abc" },
+  { name: "hasUppercaseYCharacter", fn: hasUppercaseYCharacter, positive: "Y", negative: "abc" },
+  { name: "hasUppercaseXCharacter", fn: hasUppercaseXCharacter, positive: "X", negative: "abc" },
+  { name: "hasLowercaseUCharacter", fn: hasLowercaseUCharacter, positive: "u", negative: "abc" },
+  { name: "hasUppercaseUCharacter", fn: hasUppercaseUCharacter, positive: "U", negative: "abc" },
+  { name: "hasLowercaseTCharacter", fn: hasLowercaseTCharacter, positive: "t", negative: "abc" },
+  { name: "hasUppercaseTCharacter", fn: hasUppercaseTCharacter, positive: "T", negative: "abc" },
+  { name: "hasLowercaseSCharacter", fn: hasLowercaseSCharacter, positive: "s", negative: "abc" },
+  { name: "hasUppercaseRCharacter", fn: hasUppercaseRCharacter, positive: "R", negative: "abc" },
+  { name: "hasLowercaseQCharacter", fn: hasLowercaseQCharacter, positive: "q", negative: "abc" },
+  { name: "hasUppercaseQCharacter", fn: hasUppercaseQCharacter, positive: "Q", negative: "abc" },
+  { name: "hasLowercasePCharacter", fn: hasLowercasePCharacter, positive: "p", negative: "abc" },
+  { name: "hasUppercasePCharacter", fn: hasUppercasePCharacter, positive: "P", negative: "abc" },
+];
+
+test("returns true when the target character is present", () => {
+  for (const c of cases) {
+    assert.equal(c.fn(c.positive), true, c.name);
+  }
+});
+
+test("returns false when the target character is absent", () => {
+  for (const c of cases) {
+    assert.equal(c.fn(c.negative), false, c.name);
+  }
+});

--- a/apps/api/src/utils/has-lowercase-p-character.ts
+++ b/apps/api/src/utils/has-lowercase-p-character.ts
@@ -1,0 +1,3 @@
+export function hasLowercasePCharacter(value: string): boolean {
+  return value.includes("p");
+}

--- a/apps/api/src/utils/has-lowercase-q-character.ts
+++ b/apps/api/src/utils/has-lowercase-q-character.ts
@@ -1,0 +1,3 @@
+export function hasLowercaseQCharacter(value: string): boolean {
+  return value.includes("q");
+}

--- a/apps/api/src/utils/has-lowercase-s-character.ts
+++ b/apps/api/src/utils/has-lowercase-s-character.ts
@@ -1,0 +1,3 @@
+export function hasLowercaseSCharacter(value: string): boolean {
+  return value.includes("s");
+}

--- a/apps/api/src/utils/has-lowercase-t-character.ts
+++ b/apps/api/src/utils/has-lowercase-t-character.ts
@@ -1,0 +1,3 @@
+export function hasLowercaseTCharacter(value: string): boolean {
+  return value.includes("t");
+}

--- a/apps/api/src/utils/has-lowercase-u-character.ts
+++ b/apps/api/src/utils/has-lowercase-u-character.ts
@@ -1,0 +1,3 @@
+export function hasLowercaseUCharacter(value: string): boolean {
+  return value.includes("u");
+}

--- a/apps/api/src/utils/has-lowercase-y-character.ts
+++ b/apps/api/src/utils/has-lowercase-y-character.ts
@@ -1,0 +1,3 @@
+export function hasLowercaseYCharacter(value: string): boolean {
+  return value.includes("y");
+}

--- a/apps/api/src/utils/has-lowercase-z-character.ts
+++ b/apps/api/src/utils/has-lowercase-z-character.ts
@@ -1,0 +1,3 @@
+export function hasLowercaseZCharacter(value: string): boolean {
+  return value.includes("z");
+}

--- a/apps/api/src/utils/has-uppercase-p-character.ts
+++ b/apps/api/src/utils/has-uppercase-p-character.ts
@@ -1,0 +1,3 @@
+export function hasUppercasePCharacter(value: string): boolean {
+  return value.includes("P");
+}

--- a/apps/api/src/utils/has-uppercase-q-character.ts
+++ b/apps/api/src/utils/has-uppercase-q-character.ts
@@ -1,0 +1,3 @@
+export function hasUppercaseQCharacter(value: string): boolean {
+  return value.includes("Q");
+}

--- a/apps/api/src/utils/has-uppercase-r-character.ts
+++ b/apps/api/src/utils/has-uppercase-r-character.ts
@@ -1,0 +1,3 @@
+export function hasUppercaseRCharacter(value: string): boolean {
+  return value.includes("R");
+}

--- a/apps/api/src/utils/has-uppercase-t-character.ts
+++ b/apps/api/src/utils/has-uppercase-t-character.ts
@@ -1,0 +1,3 @@
+export function hasUppercaseTCharacter(value: string): boolean {
+  return value.includes("T");
+}

--- a/apps/api/src/utils/has-uppercase-u-character.ts
+++ b/apps/api/src/utils/has-uppercase-u-character.ts
@@ -1,0 +1,3 @@
+export function hasUppercaseUCharacter(value: string): boolean {
+  return value.includes("U");
+}

--- a/apps/api/src/utils/has-uppercase-x-character.ts
+++ b/apps/api/src/utils/has-uppercase-x-character.ts
@@ -1,0 +1,3 @@
+export function hasUppercaseXCharacter(value: string): boolean {
+  return value.includes("X");
+}

--- a/apps/api/src/utils/has-uppercase-y-character.ts
+++ b/apps/api/src/utils/has-uppercase-y-character.ts
@@ -1,0 +1,3 @@
+export function hasUppercaseYCharacter(value: string): boolean {
+  return value.includes("Y");
+}

--- a/apps/api/src/utils/has-uppercase-z-character.ts
+++ b/apps/api/src/utils/has-uppercase-z-character.ts
@@ -1,0 +1,3 @@
+export function hasUppercaseZCharacter(value: string): boolean {
+  return value.includes("Z");
+}

--- a/contributors/agents.json
+++ b/contributors/agents.json
@@ -4,7 +4,7 @@
       "github_username": "voladoradepapantla-netizen",
       "model": "gpt-5",
       "version": "2026-07-03",
-      "pr_number": 0,
+      "pr_number": 4739,
       "issue_number": 4562
     }
   ],

--- a/contributors/agents.json
+++ b/contributors/agents.json
@@ -1,5 +1,13 @@
 {
-  "agents": [],
-  "last_updated": "2026-06-03",
-  "total_contributions": 0
+  "agents": [
+    {
+      "github_username": "voladoradepapantla-netizen",
+      "model": "gpt-5",
+      "version": "2026-07-03",
+      "pr_number": 0,
+      "issue_number": 4562
+    }
+  ],
+  "last_updated": "2026-07-03",
+  "total_contributions": 1
 }


### PR DESCRIPTION
Adds a small batch of dependency-free character helpers:
- hasLowercaseZCharacter, hasUppercaseZCharacter
- hasLowercaseYCharacter, hasUppercaseYCharacter
- hasUppercaseXCharacter
- hasLowercaseUCharacter, hasUppercaseUCharacter
- hasLowercaseTCharacter, hasUppercaseTCharacter
- hasLowercaseSCharacter
- hasUppercaseRCharacter
- hasLowercaseQCharacter, hasUppercaseQCharacter
- hasLowercasePCharacter, hasUppercasePCharacter

Verified with `tsx --test` and strict `tsc` compilation.

Closes #4562
Closes #4560
Closes #4558
Closes #4556
Closes #4554
Closes #4552
Closes #4550
Closes #4548
Closes #4546
Closes #4544
Closes #4541
Closes #4539
Closes #4537
Closes #4535
Closes #4533