### PR TITLE
[agent] feat: add more character helpers

### DIFF
--- a/apps/api/src/utils/character-batch-4518.test.ts
+++ b/apps/api/src/utils/character-batch-4518.test.ts
@@ -1,0 +1,42 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { hasUppercaseOCharacter } from "./has-uppercase-o-character";
+import { hasLowercaseNCharacter } from "./has-lowercase-n-character";
+import { hasUppercaseNCharacter } from "./has-uppercase-n-character";
+import { hasLowercaseMCharacter } from "./has-lowercase-m-character";
+import { hasUppercaseMCharacter } from "./has-uppercase-m-character";
+import { hasUppercaseKCharacter } from "./has-uppercase-k-character";
+import { hasLowercaseJCharacter } from "./has-lowercase-j-character";
+import { hasUppercaseJCharacter } from "./has-uppercase-j-character";
+import { hasLowercaseICharacter } from "./has-lowercase-i-character";
+import { hasUppercaseICharacter } from "./has-uppercase-i-character";
+import { hasUppercaseHCharacter } from "./has-uppercase-h-character";
+import { hasLowercaseGCharacter } from "./has-lowercase-g-character";
+
+const cases = [
+  { name: "hasUppercaseOCharacter", fn: hasUppercaseOCharacter, positive: "O", negative: "abc" },
+  { name: "hasLowercaseNCharacter", fn: hasLowercaseNCharacter, positive: "n", negative: "abc" },
+  { name: "hasUppercaseNCharacter", fn: hasUppercaseNCharacter, positive: "N", negative: "abc" },
+  { name: "hasLowercaseMCharacter", fn: hasLowercaseMCharacter, positive: "m", negative: "abc" },
+  { name: "hasUppercaseMCharacter", fn: hasUppercaseMCharacter, positive: "M", negative: "abc" },
+  { name: "hasUppercaseKCharacter", fn: hasUppercaseKCharacter, positive: "K", negative: "abc" },
+  { name: "hasLowercaseJCharacter", fn: hasLowercaseJCharacter, positive: "j", negative: "abc" },
+  { name: "hasUppercaseJCharacter", fn: hasUppercaseJCharacter, positive: "J", negative: "abc" },
+  { name: "hasLowercaseICharacter", fn: hasLowercaseICharacter, positive: "i", negative: "abc" },
+  { name: "hasUppercaseICharacter", fn: hasUppercaseICharacter, positive: "I", negative: "abc" },
+  { name: "hasUppercaseHCharacter", fn: hasUppercaseHCharacter, positive: "H", negative: "abc" },
+  { name: "hasLowercaseGCharacter", fn: hasLowercaseGCharacter, positive: "g", negative: "abc" },
+];
+
+test("returns true when the target character is present", () => {
+  for (const c of cases) {
+    assert.equal(c.fn(c.positive), true, c.name);
+  }
+});
+
+test("returns false when the target character is absent", () => {
+  for (const c of cases) {
+    assert.equal(c.fn(c.negative), false, c.name);
+  }
+});

--- a/apps/api/src/utils/has-lowercase-g-character.ts
+++ b/apps/api/src/utils/has-lowercase-g-character.ts
@@ -1,0 +1,3 @@
+export function hasLowercaseGCharacter(value: string): boolean {
+  return value.includes("g");
+}

--- a/apps/api/src/utils/has-lowercase-i-character.ts
+++ b/apps/api/src/utils/has-lowercase-i-character.ts
@@ -1,0 +1,3 @@
+export function hasLowercaseICharacter(value: string): boolean {
+  return value.includes("i");
+}

--- a/apps/api/src/utils/has-lowercase-j-character.ts
+++ b/apps/api/src/utils/has-lowercase-j-character.ts
@@ -1,0 +1,3 @@
+export function hasLowercaseJCharacter(value: string): boolean {
+  return value.includes("j");
+}

--- a/apps/api/src/utils/has-lowercase-m-character.ts
+++ b/apps/api/src/utils/has-lowercase-m-character.ts
@@ -1,0 +1,3 @@
+export function hasLowercaseMCharacter(value: string): boolean {
+  return value.includes("m");
+}

--- a/apps/api/src/utils/has-lowercase-n-character.ts
+++ b/apps/api/src/utils/has-lowercase-n-character.ts
@@ -1,0 +1,3 @@
+export function hasLowercaseNCharacter(value: string): boolean {
+  return value.includes("n");
+}

--- a/apps/api/src/utils/has-uppercase-h-character.ts
+++ b/apps/api/src/utils/has-uppercase-h-character.ts
@@ -1,0 +1,3 @@
+export function hasUppercaseHCharacter(value: string): boolean {
+  return value.includes("H");
+}

--- a/apps/api/src/utils/has-uppercase-i-character.ts
+++ b/apps/api/src/utils/has-uppercase-i-character.ts
@@ -1,0 +1,3 @@
+export function hasUppercaseICharacter(value: string): boolean {
+  return value.includes("I");
+}

--- a/apps/api/src/utils/has-uppercase-j-character.ts
+++ b/apps/api/src/utils/has-uppercase-j-character.ts
@@ -1,0 +1,3 @@
+export function hasUppercaseJCharacter(value: string): boolean {
+  return value.includes("J");
+}

--- a/apps/api/src/utils/has-uppercase-k-character.ts
+++ b/apps/api/src/utils/has-uppercase-k-character.ts
@@ -1,0 +1,3 @@
+export function hasUppercaseKCharacter(value: string): boolean {
+  return value.includes("K");
+}

--- a/apps/api/src/utils/has-uppercase-m-character.ts
+++ b/apps/api/src/utils/has-uppercase-m-character.ts
@@ -1,0 +1,3 @@
+export function hasUppercaseMCharacter(value: string): boolean {
+  return value.includes("M");
+}

--- a/apps/api/src/utils/has-uppercase-n-character.ts
+++ b/apps/api/src/utils/has-uppercase-n-character.ts
@@ -1,0 +1,3 @@
+export function hasUppercaseNCharacter(value: string): boolean {
+  return value.includes("N");
+}

--- a/apps/api/src/utils/has-uppercase-o-character.ts
+++ b/apps/api/src/utils/has-uppercase-o-character.ts
@@ -1,0 +1,3 @@
+export function hasUppercaseOCharacter(value: string): boolean {
+  return value.includes("O");
+}

--- a/contributors/agents.json
+++ b/contributors/agents.json
@@ -4,7 +4,7 @@
       "github_username": "voladoradepapantla-netizen",
       "model": "gpt-5",
       "version": "2026-07-03",
-      "pr_number": 0,
+      "pr_number": 4742,
       "issue_number": 4518
     }
   ],

--- a/contributors/agents.json
+++ b/contributors/agents.json
@@ -1,5 +1,13 @@
 {
-  "agents": [],
-  "last_updated": "2026-06-03",
-  "total_contributions": 0
+  "agents": [
+    {
+      "github_username": "voladoradepapantla-netizen",
+      "model": "gpt-5",
+      "version": "2026-07-03",
+      "pr_number": 0,
+      "issue_number": 4518
+    }
+  ],
+  "last_updated": "2026-07-03",
+  "total_contributions": 1
 }


### PR DESCRIPTION
Adds a small batch of dependency-free character helpers:
- hasUppercaseOCharacter
- hasLowercaseNCharacter, hasUppercaseNCharacter
- hasLowercaseMCharacter, hasUppercaseMCharacter
- hasUppercaseKCharacter
- hasLowercaseJCharacter, hasUppercaseJCharacter
- hasLowercaseICharacter, hasUppercaseICharacter
- hasUppercaseHCharacter
- hasLowercaseGCharacter

Verified with `tsx --test` and strict `tsc` compilation.

Closes #4518
Closes #4516
Closes #4514
Closes #4512
Closes #4510
Closes #4499
Closes #4497
Closes #4495
Closes #4493
Closes #4491
Closes #4489
Closes #4487