### PR TITLE
[agent] feat: add character and digit helpers

### DIFF
--- a/apps/api/src/utils/character-batch-4406.test.ts
+++ b/apps/api/src/utils/character-batch-4406.test.ts
@@ -1,0 +1,36 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { hasUppercaseDCharacter } from "./has-uppercase-d-character";
+import { hasLowercaseCCharacter } from "./has-lowercase-c-character";
+import { hasUppercaseCCharacter } from "./has-uppercase-c-character";
+import { hasLowercaseBCharacter } from "./has-lowercase-b-character";
+import { hasUppercaseBCharacter } from "./has-uppercase-b-character";
+import { hasEightDigitCharacter } from "./has-eight-digit-character";
+import { hasSevenDigitCharacter } from "./has-seven-digit-character";
+import { hasSixDigitCharacter } from "./has-six-digit-character";
+import { hasFiveDigitCharacter } from "./has-five-digit-character";
+
+const cases = [
+  { name: "hasUppercaseDCharacter", fn: hasUppercaseDCharacter, positive: "D", negative: "xyz" },
+  { name: "hasLowercaseCCharacter", fn: hasLowercaseCCharacter, positive: "c", negative: "xyz" },
+  { name: "hasUppercaseCCharacter", fn: hasUppercaseCCharacter, positive: "C", negative: "xyz" },
+  { name: "hasLowercaseBCharacter", fn: hasLowercaseBCharacter, positive: "b", negative: "xyz" },
+  { name: "hasUppercaseBCharacter", fn: hasUppercaseBCharacter, positive: "B", negative: "xyz" },
+  { name: "hasEightDigitCharacter", fn: hasEightDigitCharacter, positive: "8", negative: "xyz" },
+  { name: "hasSevenDigitCharacter", fn: hasSevenDigitCharacter, positive: "7", negative: "xyz" },
+  { name: "hasSixDigitCharacter", fn: hasSixDigitCharacter, positive: "6", negative: "xyz" },
+  { name: "hasFiveDigitCharacter", fn: hasFiveDigitCharacter, positive: "5", negative: "xyz" },
+];
+
+test("returns true when the target character is present", () => {
+  for (const c of cases) {
+    assert.equal(c.fn(c.positive), true, c.name);
+  }
+});
+
+test("returns false when the target character is absent", () => {
+  for (const c of cases) {
+    assert.equal(c.fn(c.negative), false, c.name);
+  }
+});

--- a/apps/api/src/utils/has-eight-digit-character.ts
+++ b/apps/api/src/utils/has-eight-digit-character.ts
@@ -1,0 +1,3 @@
+export function hasEightDigitCharacter(value: string): boolean {
+  return value.includes("8");
+}

--- a/apps/api/src/utils/has-five-digit-character.ts
+++ b/apps/api/src/utils/has-five-digit-character.ts
@@ -1,0 +1,3 @@
+export function hasFiveDigitCharacter(value: string): boolean {
+  return value.includes("5");
+}

--- a/apps/api/src/utils/has-lowercase-b-character.ts
+++ b/apps/api/src/utils/has-lowercase-b-character.ts
@@ -1,0 +1,3 @@
+export function hasLowercaseBCharacter(value: string): boolean {
+  return value.includes("b");
+}

--- a/apps/api/src/utils/has-lowercase-c-character.ts
+++ b/apps/api/src/utils/has-lowercase-c-character.ts
@@ -1,0 +1,3 @@
+export function hasLowercaseCCharacter(value: string): boolean {
+  return value.includes("c");
+}

--- a/apps/api/src/utils/has-seven-digit-character.ts
+++ b/apps/api/src/utils/has-seven-digit-character.ts
@@ -1,0 +1,3 @@
+export function hasSevenDigitCharacter(value: string): boolean {
+  return value.includes("7");
+}

--- a/apps/api/src/utils/has-six-digit-character.ts
+++ b/apps/api/src/utils/has-six-digit-character.ts
@@ -1,0 +1,3 @@
+export function hasSixDigitCharacter(value: string): boolean {
+  return value.includes("6");
+}

--- a/apps/api/src/utils/has-uppercase-b-character.ts
+++ b/apps/api/src/utils/has-uppercase-b-character.ts
@@ -1,0 +1,3 @@
+export function hasUppercaseBCharacter(value: string): boolean {
+  return value.includes("B");
+}

--- a/apps/api/src/utils/has-uppercase-c-character.ts
+++ b/apps/api/src/utils/has-uppercase-c-character.ts
@@ -1,0 +1,3 @@
+export function hasUppercaseCCharacter(value: string): boolean {
+  return value.includes("C");
+}

--- a/apps/api/src/utils/has-uppercase-d-character.ts
+++ b/apps/api/src/utils/has-uppercase-d-character.ts
@@ -1,0 +1,3 @@
+export function hasUppercaseDCharacter(value: string): boolean {
+  return value.includes("D");
+}

--- a/contributors/agents.json
+++ b/contributors/agents.json
@@ -1,5 +1,13 @@
 {
-  "agents": [],
-  "last_updated": "2026-06-03",
-  "total_contributions": 0
+  "agents": [
+    {
+      "github_username": "voladoradepapantla-netizen",
+      "model": "gpt-5",
+      "version": "2026-07-03",
+      "pr_number": 0,
+      "issue_number": 4406
+    }
+  ],
+  "last_updated": "2026-07-03",
+  "total_contributions": 1
 }

--- a/contributors/agents.json
+++ b/contributors/agents.json
@@ -4,7 +4,7 @@
       "github_username": "voladoradepapantla-netizen",
       "model": "gpt-5",
       "version": "2026-07-03",
-      "pr_number": 0,
+      "pr_number": 4757,
       "issue_number": 4406
     }
   ],


### PR DESCRIPTION
Adds a small batch of dependency-free character helpers:
- hasUppercaseDCharacter
- hasLowercaseCCharacter, hasUppercaseCCharacter
- hasLowercaseBCharacter, hasUppercaseBCharacter
- hasEightDigitCharacter, hasSevenDigitCharacter, hasSixDigitCharacter, hasFiveDigitCharacter

Verified with `tsx --test` and strict `tsc` compilation.

Closes #4406
Closes #4404
Closes #4402
Closes #4400
Closes #4398
Closes #4387
Closes #4385
Closes #4383
Closes #4381