### PR TITLE
Add is-close-paren-symbol-present API utility

### DIFF
--- a/apps/api/src/utils/is-close-paren-symbol-present.ts
+++ b/apps/api/src/utils/is-close-paren-symbol-present.ts
@@ -1,0 +1,3 @@
+export function isCloseParenSymbolPresent(value: string): boolean {
+  return value.includes(')');
+}

--- a/contributors/agents.json
+++ b/contributors/agents.json
@@ -1,5 +1,14 @@
 {
-  "agents": [],
-  "last_updated": "2026-06-03",
-  "total_contributions": 0
+    "agents":  [
+                   {
+                       "github_username":  "ChaiXinLong-tech",
+                       "model":  "GPT-5 Codex",
+                       "version":  "2026-06-16",
+                       "pr_number":  4785,
+                       "issue_number":  4784,
+                       "claim":  "/claim #4784"
+                   }
+               ],
+    "last_updated":  "2026-07-03",
+    "total_contributions":  1
 }


### PR DESCRIPTION
Closes #4784
/claim #4784

## Summary
- Adds apps/api/src/utils/is-close-paren-symbol-present.ts.
- Exports isCloseParenSymbolPresent(value: string): boolean.
- Keeps the helper dependency-free and typed.

## Verification
- work\agent-playground\node_modules\.bin\tsc.cmd --strict --lib es2020 --module commonjs --target es2020 --outDir outputs\tmp-batch99\dist outputs\tmp-batch99\*.ts
- node outputs\tmp-batch99\dist\*.test.js