### PR TITLE
Add is-forward-slash-symbol-present API utility

### DIFF
--- a/apps/api/src/utils/is-forward-slash-symbol-present.ts
+++ b/apps/api/src/utils/is-forward-slash-symbol-present.ts
@@ -1,0 +1,3 @@
+export function isForwardSlashSymbolPresent(value: string): boolean {
+  return value.includes("/");
+}


### PR DESCRIPTION
## Summary

- add `isForwardSlashSymbolPresent`
- return whether the input string contains `/`

## Validation

- `npm test --workspace @taskflow/api`

/claim #4744

Fixes #4744