### PR TITLE
Add is-open-brace-symbol-present API utility

### DIFF
--- a/apps/api/src/utils/is-open-brace-symbol-present.ts
+++ b/apps/api/src/utils/is-open-brace-symbol-present.ts
@@ -1,0 +1,3 @@
+export function isOpenBraceSymbolPresent(value: string): boolean {
+  return value.includes("{");
+}


### PR DESCRIPTION
## Summary

- add `isOpenBraceSymbolPresent`
- return whether the input string contains `{`

## Validation

- `npm test --workspace @taskflow/api`

/claim #4790

Fixes #4790