### PR TITLE
Add is-close-bracket-symbol-present API utility

### DIFF
--- a/apps/api/src/utils/is-close-bracket-symbol-present.ts
+++ b/apps/api/src/utils/is-close-bracket-symbol-present.ts
@@ -1,0 +1,3 @@
+export function isCloseBracketSymbolPresent(value: string): boolean {
+  return value.includes("]");
+}


### PR DESCRIPTION
## Summary

- add `isCloseBracketSymbolPresent`
- return whether the input string contains `]`

## Validation

- `npm test --workspace @taskflow/api`

/claim #4788

Fixes #4788