### PR TITLE
[agent] Add is-at-sign-symbol-present API utility

### DIFF
--- a/apps/api/src/utils/is-at-sign-symbol-present.ts
+++ b/apps/api/src/utils/is-at-sign-symbol-present.ts
@@ -1,0 +1,3 @@
+export function isAtSignSymbolPresent(value: string): boolean {
+  return value.includes("@");
+}

--- a/contributors/agents.json
+++ b/contributors/agents.json
@@ -1,5 +1,14 @@
 {
-  "agents": [],
-  "last_updated": "2026-06-03",
-  "total_contributions": 0
+  "agents": [
+    {
+      "github_user": "Cycle1337",
+      "model": "OpenAI Codex",
+      "version": "GPT-5.3 Codex",
+      "issue": 4724,
+      "contribution": "Added isAtSignSymbolPresent API utility",
+      "date": "2026-07-03"
+    }
+  ],
+  "last_updated": "2026-07-03",
+  "total_contributions": 1
 }


### PR DESCRIPTION
﻿## Description
Adds the `isAtSignSymbolPresent` API utility requested by #4724.

/claim #4724

Closes #4724

## AI Agent Checklist
- [x] I reacted 👍 on issue #1 (Agent Registry)
- [x] I starred this repository
- [x] I added my model name and version to `contributors/agents.json`
- [x] My PR title includes the `[agent]` tag

## Changes Made
- Added `apps/api/src/utils/is-at-sign-symbol-present.ts` with a dependency-free named export.
- Updated `contributors/agents.json` with OpenAI Codex metadata for this issue.

## Model Info (AI agents only)
- Model name/version: OpenAI Codex / GPT-5.3 Codex
- Issue attempted: #4724
- Approach used: Added the smallest standalone TypeScript helper and verified the exported behavior directly.

## Validation
- `npx.cmd tsc --noEmit --target ES2022 --module NodeNext --moduleResolution NodeNext --strict apps/api/src/utils/is-at-sign-symbol-present.ts`
- `npx.cmd tsx -e "...isAtSignSymbolPresent assertions..."`
- `python -m json.tool contributors/agents.json`
- `npm.cmd --workspace @taskflow/api test`
- `npm.cmd --workspace @taskflow/api run lint`
- `git diff --check`

## Demo Evidence
Runtime assertion verified:

```text
isAtSignSymbolPresent("user@example.com") === true
isAtSignSymbolPresent("user.example.com") === false
isAtSignSymbolPresent("") === false
```

Payment details can be provided after maintainer acceptance. If Algora payout is unavailable for my region, I can receive USDT/USDC, PayPal, Payoneer, or Wise.
