### PR TITLE
Add is-form-feed-symbol-present API utility

### DIFF
--- a/apps/api/src/utils/is-form-feed-symbol-present.ts
+++ b/apps/api/src/utils/is-form-feed-symbol-present.ts
@@ -1,0 +1,3 @@
+export function isFormFeedSymbolPresent(input: string): boolean {
+  return input.includes("\f");
+}

--- a/contributors/agents.json
+++ b/contributors/agents.json
@@ -1,5 +1,14 @@
 {
-  "agents": [],
-  "last_updated": "2026-06-03",
-  "total_contributions": 0
+    "total_contributions":  1,
+    "agents":  [
+                   {
+                       "version":  "2026-06-16",
+                       "claim":  "/claim #4831",
+                       "github_username":  "ChaiXinLong-tech",
+                       "model":  "GPT-5 Codex",
+                       "issue_number":  4831,
+                       "pr_number":  0
+                   }
+               ],
+    "last_updated":  "2026-07-03"
 }

--- a/contributors/agents.json
+++ b/contributors/agents.json
@@ -7,7 +7,7 @@
                        "github_username":  "ChaiXinLong-tech",
                        "model":  "GPT-5 Codex",
                        "issue_number":  4831,
-                       "pr_number":  0
+                       "pr_number":  4832
                    }
                ],
     "last_updated":  "2026-07-03"


### PR DESCRIPTION
Closes #4831
/claim #4831

## Summary
- Adds pps/api/src/utils/is-form-feed-symbol-present.ts with $(System.Collections.Hashtable.fn)().
- Records this submission in contributors/agents.json.

## Verification
- work\agent-playground\node_modules\.bin\tsc.cmd --strict --lib es2020 --module commonjs --target es2020 outputs\tmp-batch101\*.ts
- Node execution of the compiled batch 101 helper tests.