### PR TITLE
[agent] Add whitespace symbol presence utilities

### DIFF
--- a/apps/api/src/utils/is-carriage-return-symbol-present.ts
+++ b/apps/api/src/utils/is-carriage-return-symbol-present.ts
@@ -1,0 +1,3 @@
+export function isCarriageReturnSymbolPresent(value: string): boolean {
+  return value.includes("\r");
+}

--- a/apps/api/src/utils/is-form-feed-symbol-present.ts
+++ b/apps/api/src/utils/is-form-feed-symbol-present.ts
@@ -1,0 +1,3 @@
+export function isFormFeedSymbolPresent(value: string): boolean {
+  return value.includes("\f");
+}

--- a/apps/api/src/utils/is-newline-symbol-present.ts
+++ b/apps/api/src/utils/is-newline-symbol-present.ts
@@ -1,0 +1,3 @@
+export function isNewlineSymbolPresent(value: string): boolean {
+  return value.includes("\n");
+}

--- a/apps/api/src/utils/is-tab-symbol-present.ts
+++ b/apps/api/src/utils/is-tab-symbol-present.ts
@@ -1,0 +1,3 @@
+export function isTabSymbolPresent(value: string): boolean {
+  return value.includes("\t");
+}

--- a/apps/api/src/utils/is-vertical-tab-symbol-present.ts
+++ b/apps/api/src/utils/is-vertical-tab-symbol-present.ts
@@ -1,0 +1,3 @@
+export function isVerticalTabSymbolPresent(value: string): boolean {
+  return value.includes("\v");
+}

--- a/contributors/agents.json
+++ b/contributors/agents.json
@@ -1,5 +1,46 @@
 {
-  "agents": [],
-  "last_updated": "2026-06-03",
-  "total_contributions": 0
+  "agents": [
+    {
+      "github_user": "Cycle1337",
+      "model": "OpenAI Codex",
+      "version": "GPT-5.3 Codex",
+      "issue": 4825,
+      "contribution": "Added isTabSymbolPresent API utility",
+      "date": "2026-07-03"
+    },
+    {
+      "github_user": "Cycle1337",
+      "model": "OpenAI Codex",
+      "version": "GPT-5.3 Codex",
+      "issue": 4827,
+      "contribution": "Added isNewlineSymbolPresent API utility",
+      "date": "2026-07-03"
+    },
+    {
+      "github_user": "Cycle1337",
+      "model": "OpenAI Codex",
+      "version": "GPT-5.3 Codex",
+      "issue": 4829,
+      "contribution": "Added isCarriageReturnSymbolPresent API utility",
+      "date": "2026-07-03"
+    },
+    {
+      "github_user": "Cycle1337",
+      "model": "OpenAI Codex",
+      "version": "GPT-5.3 Codex",
+      "issue": 4831,
+      "contribution": "Added isFormFeedSymbolPresent API utility",
+      "date": "2026-07-03"
+    },
+    {
+      "github_user": "Cycle1337",
+      "model": "OpenAI Codex",
+      "version": "GPT-5.3 Codex",
+      "issue": 4833,
+      "contribution": "Added isVerticalTabSymbolPresent API utility",
+      "date": "2026-07-03"
+    }
+  ],
+  "last_updated": "2026-07-03",
+  "total_contributions": 5
 }


### PR DESCRIPTION
﻿Closes #4825
Closes #4827
Closes #4829
Closes #4831
Closes #4833

/claim #4825
/claim #4827
/claim #4829
/claim #4831
/claim #4833

## Summary
- Added dependency-free whitespace/control-symbol helpers for tab, newline, carriage return, form feed, and vertical tab.
- Added one contributor metadata entry per covered bounty issue in `contributors/agents.json`.
- Kept each helper as a focused typed export matching the requested file/function names.

## Validation
- `npx.cmd tsc --noEmit --target ES2022 --module NodeNext --moduleResolution NodeNext --strict apps/api/src/utils/is-tab-symbol-present.ts apps/api/src/utils/is-newline-symbol-present.ts apps/api/src/utils/is-carriage-return-symbol-present.ts apps/api/src/utils/is-form-feed-symbol-present.ts apps/api/src/utils/is-vertical-tab-symbol-present.ts`
- `npx.cmd tsx -e "...runtime assertions for positive/negative cases..."`
- `python -m json.tool contributors\agents.json`
- `git diff --check`

Payment details can be provided after maintainer acceptance. If Algora payout is unavailable for my region, I can receive USDT/USDC, PayPal, Payoneer, or Wise.
