### PR TITLE
feat: add thenable helper

### DIFF
--- a/apps/api/src/utils/is-thenable.test.ts
+++ b/apps/api/src/utils/is-thenable.test.ts
@@ -1,0 +1,25 @@
+import { strict as assert } from "node:assert";
+import { test } from "node:test";
+
+import { isThenable } from "./is-thenable";
+
+test("detects thenables", () => {
+  assert.equal(isThenable(Promise.resolve("ok")), true);
+  assert.equal(isThenable({ then() {} }), true);
+  assert.equal(isThenable(async () => {}), false);
+  assert.equal(isThenable(null), false);
+  assert.equal(isThenable(undefined), false);
+  assert.equal(isThenable({ then: 1 }), false);
+  assert.equal(isThenable("ok"), false);
+});
+
+test("narrows to PromiseLike", () => {
+  const value: unknown = { then(onFulfilled: (value: string) => void) { onFulfilled("ok"); } };
+
+  if (isThenable(value)) {
+    const narrowed: PromiseLike<unknown> = value;
+    assert.equal(typeof narrowed.then, "function");
+  } else {
+    assert.fail("Expected narrowing");
+  }
+});

--- a/apps/api/src/utils/is-thenable.ts
+++ b/apps/api/src/utils/is-thenable.ts
@@ -1,0 +1,11 @@
+export function isThenable(value: unknown): value is PromiseLike<unknown> {
+  if (typeof value !== "object" && typeof value !== "function") {
+    return false;
+  }
+
+  if (value === null) {
+    return false;
+  }
+
+  return typeof (value as { then?: unknown }).then === "function";
+}

--- a/contributors/agents.json
+++ b/contributors/agents.json
@@ -4,7 +4,7 @@
       "github_username": "voladoradepapantla-netizen",
       "model": "gpt-5",
       "version": "2026-07-03",
-      "pr_number": 0,
+      "pr_number": 4870,
       "issue_number": 3628
     }
   ],

--- a/contributors/agents.json
+++ b/contributors/agents.json
@@ -1,5 +1,13 @@
 {
-  "agents": [],
-  "last_updated": "2026-06-03",
-  "total_contributions": 0
+  "agents": [
+    {
+      "github_username": "voladoradepapantla-netizen",
+      "model": "gpt-5",
+      "version": "2026-07-03",
+      "pr_number": 0,
+      "issue_number": 3628
+    }
+  ],
+  "last_updated": "2026-07-03",
+  "total_contributions": 1
 }


### PR DESCRIPTION
Adds a standalone thenable type guard and test coverage for API input handling.