### PR TITLE
feat: add between number helper

### DIFF
--- a/apps/api/src/utils/is-between-number.test.ts
+++ b/apps/api/src/utils/is-between-number.test.ts
@@ -1,0 +1,27 @@
+import { strict as assert } from "node:assert";
+import { test } from "node:test";
+
+import { isBetweenNumber } from "./is-between-number";
+
+test("detects numbers between bounds", () => {
+  assert.equal(isBetweenNumber(5, 1, 10), true);
+  assert.equal(isBetweenNumber(1, 1, 10), true);
+  assert.equal(isBetweenNumber(10, 1, 10), true);
+  assert.equal(isBetweenNumber(0, 1, 10), false);
+  assert.equal(isBetweenNumber(11, 1, 10), false);
+  assert.equal(isBetweenNumber(1.5, 1, 2), true);
+  assert.equal(isBetweenNumber(Number.NaN, 1, 10), false);
+  assert.equal(isBetweenNumber(Number.POSITIVE_INFINITY, 1, 10), false);
+  assert.equal(isBetweenNumber("5", 1, 10), false);
+});
+
+test("narrows to number", () => {
+  const value: unknown = 7;
+
+  if (isBetweenNumber(value, 1, 10)) {
+    const narrowed: number = value;
+    assert.equal(narrowed, 7);
+  } else {
+    assert.fail("Expected narrowing");
+  }
+});

--- a/apps/api/src/utils/is-between-number.ts
+++ b/apps/api/src/utils/is-between-number.ts
@@ -1,0 +1,11 @@
+export function isBetweenNumber(value: unknown, min: number, max: number): value is number {
+  return (
+    typeof value === "number" &&
+    Number.isFinite(value) &&
+    Number.isFinite(min) &&
+    Number.isFinite(max) &&
+    min <= max &&
+    value >= min &&
+    value <= max
+  );
+}

--- a/contributors/agents.json
+++ b/contributors/agents.json
@@ -1,5 +1,13 @@
 {
-  "agents": [],
-  "last_updated": "2026-06-03",
-  "total_contributions": 0
+  "agents": [
+    {
+      "github_username": "voladoradepapantla-netizen",
+      "model": "gpt-5",
+      "version": "2026-07-03",
+      "pr_number": 0,
+      "issue_number": 3632
+    }
+  ],
+  "last_updated": "2026-07-03",
+  "total_contributions": 1
 }

--- a/contributors/agents.json
+++ b/contributors/agents.json
@@ -4,7 +4,7 @@
       "github_username": "voladoradepapantla-netizen",
       "model": "gpt-5",
       "version": "2026-07-03",
-      "pr_number": 0,
+      "pr_number": 4872,
       "issue_number": 3632
     }
   ],


### PR DESCRIPTION
Adds a standalone between-number helper and test coverage for range checks.