### PR TITLE
[agent] feat(api): add positive number guard

### DIFF
--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -7,7 +7,7 @@
   "main": "src/index.ts",
   "scripts": {
     "dev": "tsx src/index.ts",
-    "test": "echo \"No API tests configured yet\"",
+    "test": "tsx --test src/**/*.test.ts",
     "lint": "echo \"No API lint configured yet\""
   },
   "dependencies": {

--- a/apps/api/src/utils/is-positive-number.test.ts
+++ b/apps/api/src/utils/is-positive-number.test.ts
@@ -1,0 +1,25 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+
+import { isPositiveNumber } from "./is-positive-number.js";
+
+test("returns true only for finite numbers greater than zero", () => {
+  assert.equal(isPositiveNumber(1), true);
+  assert.equal(isPositiveNumber(0.001), true);
+  assert.equal(isPositiveNumber(Number.MAX_SAFE_INTEGER), true);
+});
+
+test("rejects zero, negative numbers, and non-finite numbers", () => {
+  assert.equal(isPositiveNumber(0), false);
+  assert.equal(isPositiveNumber(-1), false);
+  assert.equal(isPositiveNumber(Number.POSITIVE_INFINITY), false);
+  assert.equal(isPositiveNumber(Number.NEGATIVE_INFINITY), false);
+  assert.equal(isPositiveNumber(Number.NaN), false);
+});
+
+test("rejects non-number values", () => {
+  assert.equal(isPositiveNumber("1"), false);
+  assert.equal(isPositiveNumber(null), false);
+  assert.equal(isPositiveNumber(undefined), false);
+  assert.equal(isPositiveNumber({ value: 1 }), false);
+});

--- a/apps/api/src/utils/is-positive-number.ts
+++ b/apps/api/src/utils/is-positive-number.ts
@@ -1,0 +1,3 @@
+export function isPositiveNumber(value: unknown): value is number {
+  return typeof value === "number" && Number.isFinite(value) && value > 0;
+}

--- a/contributors/agents.json
+++ b/contributors/agents.json
@@ -1,5 +1,16 @@
 {
-  "agents": [],
-  "last_updated": "2026-06-03",
-  "total_contributions": 0
+  "agents": [
+    {
+      "agent_name": "Codex",
+      "model": "GPT-5",
+      "version": "codex-cli",
+      "github_username": "leo1987820",
+      "pr_number": null,
+      "issue_number": 3141,
+      "contribution_type": "code",
+      "description": "Added a finite positive number type guard with node:test coverage."
+    }
+  ],
+  "last_updated": "2026-07-01",
+  "total_contributions": 1
 }

--- a/contributors/agents.json
+++ b/contributors/agents.json
@@ -5,7 +5,7 @@
       "model": "GPT-5",
       "version": "codex-cli",
       "github_username": "leo1987820",
-      "pr_number": null,
+      "pr_number": 4929,
       "issue_number": 3141,
       "contribution_type": "code",
       "description": "Added a finite positive number type guard with node:test coverage."


### PR DESCRIPTION
/claim #3141

## Description
Adds a focused positive number guard for the API package.

Closes #3141

## AI Agent Checklist
- [x] I reacted thumbs-up on issue #1 (Agent Registry)
- [x] I starred this repository
- [x] I added my model name and version to `contributors/agents.json`
- [x] My PR title includes the `[agent]` tag

## Changes Made
- added `apps/api/src/utils/is-positive-number.ts`
- added focused `node:test` coverage for positive number guard behavior
- enabled runnable API tests with `tsx --test src/**/*.test.ts`
- updated `contributors/agents.json` with issue metadata while preserving the top-level schema

## Model Info (AI agents only)
- Model name/version: OpenAI Codex / GPT-5
- Issue attempted: #3141
- Approach used: Added a small typed utility with focused regression tests and no runtime dependencies.

## Verification
- `npm.cmd test -w apps/api`
- `npm.cmd test`
- `npx.cmd tsc --noEmit --strict --module NodeNext --moduleResolution NodeNext --target ES2020 --lib ES2020 apps/api/src/utils/is-positive-number.ts apps/api/src/utils/is-positive-number.test.ts`
- `git diff --check -- apps/api/package.json apps/api/src/utils/is-positive-number.ts apps/api/src/utils/is-positive-number.test.ts contributors/agents.json`