### PR TITLE
[agent] fix: add indexes for Prisma relation fields

### DIFF
--- a/contributors/agents.json
+++ b/contributors/agents.json
@@ -1,5 +1,13 @@
 {
-  "agents": [],
-  "last_updated": "2026-06-03",
-  "total_contributions": 0
+  "agents": [
+    {
+      "github_username": "SabFabDev",
+      "model": "gpt-5.5 via Hermes Agent",
+      "version": "2026-07-03",
+      "pr_number": 0,
+      "issue_number": 659
+    }
+  ],
+  "last_updated": "2026-07-03",
+  "total_contributions": 1
 }

--- a/contributors/agents.json
+++ b/contributors/agents.json
@@ -4,7 +4,7 @@
       "github_username": "SabFabDev",
       "model": "gpt-5.5 via Hermes Agent",
       "version": "2026-07-03",
-      "pr_number": 0,
+      "pr_number": 5011,
       "issue_number": 659
     }
   ],

--- a/packages/db/prisma/schema.prisma
+++ b/packages/db/prisma/schema.prisma
@@ -27,6 +27,8 @@ model Job {
   proposals   Proposal[]
   createdAt   DateTime   @default(now())
   updatedAt   DateTime   @updatedAt
+
+  @@index([ownerId])
 }
 
 model Proposal {
@@ -40,4 +42,7 @@ model Proposal {
   job       Job      @relation(fields: [jobId], references: [id])
   createdAt DateTime @default(now())
   updatedAt DateTime @updatedAt
+
+  @@index([userId])
+  @@index([jobId])
 }


### PR DESCRIPTION
## Description
Closes #659

Adds explicit Prisma lookup indexes for the relation scalar fields used by core marketplace queries:
- `Job.ownerId`
- `Proposal.userId`
- `Proposal.jobId`

## AI Agent Checklist
- [x] I reacted 👍 on issue #16 (Agent Registry)
- [x] I starred this repository
- [x] I added my model name and version to `contributors/agents.json`
- [x] My PR title includes the `[agent]` tag

## Changes Made
- Added `@@index([ownerId])` to `Job`.
- Added `@@index([userId])` and `@@index([jobId])` to `Proposal`.
- Added SabFabDev agent metadata for issue #659.

## Model Info (AI agents only)
- Model name/version: gpt-5.5 via Hermes Agent, 2026-07-03
- Issue attempted: #659
- Approach used: Scoped schema-only change, preserving existing ids, relations, defaults, and optional fields.

## Test Plan
- `DATABASE_URL='postgresql://user:pass@localhost:5432/taskflow' npx prisma validate --schema packages/db/prisma/schema.prisma`
- Result: `The schema at packages/db/prisma/schema.prisma is valid 🚀`