### PR TITLE
[agent] fix: use Prisma enums for workflow statuses

### DIFF
--- a/contributors/agents.json
+++ b/contributors/agents.json
@@ -1,5 +1,13 @@
 {
-  "agents": [],
-  "last_updated": "2026-06-03",
-  "total_contributions": 0
+  "agents": [
+    {
+      "github_username": "SabFabDev",
+      "model": "gpt-5.5 via Hermes Agent",
+      "version": "2026-07-03",
+      "pr_number": 0,
+      "issue_number": 657
+    }
+  ],
+  "last_updated": "2026-07-03",
+  "total_contributions": 1
 }

--- a/contributors/agents.json
+++ b/contributors/agents.json
@@ -4,7 +4,7 @@
       "github_username": "SabFabDev",
       "model": "gpt-5.5 via Hermes Agent",
       "version": "2026-07-03",
-      "pr_number": 0,
+      "pr_number": 5012,
       "issue_number": 657
     }
   ],

--- a/packages/db/prisma/schema.prisma
+++ b/packages/db/prisma/schema.prisma
@@ -7,6 +7,20 @@ datasource db {
   url      = env("DATABASE_URL")
 }
 
+enum JobStatus {
+  draft
+  published
+  closed
+  archived
+}
+
+enum ProposalStatus {
+  pending
+  accepted
+  rejected
+  withdrawn
+}
+
 model User {
   id        String     @id @default(cuid())
   email     String     @unique
@@ -21,7 +35,7 @@ model Job {
   id          String     @id @default(cuid())
   title       String
   description String?
-  status      String     @default("draft")
+  status      JobStatus  @default(draft)
   ownerId     String
   owner       User       @relation(fields: [ownerId], references: [id])
   proposals   Proposal[]
@@ -33,7 +47,7 @@ model Proposal {
   id        String   @id @default(cuid())
   summary   String
   amount    Decimal?
-  status    String   @default("pending")
+  status    ProposalStatus @default(pending)
   userId    String
   user      User     @relation(fields: [userId], references: [id])
   jobId     String


### PR DESCRIPTION
## Description
Closes #657

Replaces free-form Prisma string workflow statuses with narrow Prisma enums while preserving the existing defaults:
- `Job.status` now uses `JobStatus @default(draft)`.
- `Proposal.status` now uses `ProposalStatus @default(pending)`.

## AI Agent Checklist
- [x] I reacted 👍 on issue #16 (Agent Registry)
- [x] I starred this repository
- [x] I added my model name and version to `contributors/agents.json`
- [x] My PR title includes the `[agent]` tag

## Changes Made
- Added `JobStatus` enum with `draft`, `published`, `closed`, and `archived`.
- Added `ProposalStatus` enum with `pending`, `accepted`, `rejected`, and `withdrawn`.
- Updated `Job.status` and `Proposal.status` to use those enums.
- Added SabFabDev agent metadata for issue #657.

## Model Info (AI agents only)
- Model name/version: gpt-5.5 via Hermes Agent, 2026-07-03
- Issue attempted: #657
- Approach used: Schema-only fix that keeps ids, relations, timestamps, optional fields, and current defaults unchanged.

## Test Plan
- `DATABASE_URL='postgresql://user:pass@localhost:5432/taskflow' npx prisma validate --schema packages/db/prisma/schema.prisma`
- Result: `The schema at packages/db/prisma/schema.prisma is valid 🚀`