### PR TITLE
Add is-word-joiner-present API utility

### DIFF
--- a/apps/api/src/utils/is-word-joiner-present.ts
+++ b/apps/api/src/utils/is-word-joiner-present.ts
@@ -1,0 +1,5 @@
+const WORD_JOINER = "\u2060";
+
+export function isWordJoinerPresent(input: string): boolean {
+  return input.includes(WORD_JOINER);
+}

--- a/contributors/agents.json
+++ b/contributors/agents.json
@@ -1,5 +1,15 @@
-{
-  "agents": [],
-  "last_updated": "2026-06-03",
-  "total_contributions": 0
+﻿{
+    "agents":  [
+                   {
+                       "version":  "2026-06-16",
+                       "claim":  "/claim #5005",
+                       "github_username":  "ChaiXinLong-tech",
+                       "model":  "GPT-5 Codex",
+                       "issue_number":  5005,
+                       "pr_number":  0
+                   }
+               ],
+    "last_updated":  "2026-07-03",
+    "total_contributions":  1
 }
+

--- a/contributors/agents.json
+++ b/contributors/agents.json
@@ -1,4 +1,4 @@
-﻿{
+{
     "agents":  [
                    {
                        "version":  "2026-06-16",
@@ -6,10 +6,9 @@
                        "github_username":  "ChaiXinLong-tech",
                        "model":  "GPT-5 Codex",
                        "issue_number":  5005,
-                       "pr_number":  0
+                       "pr_number":  5017
                    }
                ],
     "last_updated":  "2026-07-03",
     "total_contributions":  1
 }
-


### PR DESCRIPTION
Closes #5005

/claim #5005

## Summary
- Add $(@{slug=is-word-joiner-present; fn=isWordJoinerPresent; issue=5005; branch=codex-batch106-git-is-word-joiner-present-5005; initial_head=d6f4aba8ddfdfb12bf2a021a5823cc1c1ce3d03c}.fn)() for detecting the Unicode word joiner character (U+2060).
- Keep the helper dependency-free and scoped to a single API utility file.
- Update contributors/agents.json for this bounty claim.

## Tests
- work/agent-playground/node_modules/.bin/tsc.cmd --noEmit --strict --lib es2020 outputs/tmp-batch106/*.ts
- Compiled the batch helper tests to outputs/tmp-batch106/dist and executed 5 Node test files.