### PR TITLE
[agent] fix: drain API server on shutdown signals

### DIFF
--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -8,7 +8,8 @@
   "scripts": {
     "dev": "tsx src/index.ts",
     "test": "echo \"No API tests configured yet\"",
-    "lint": "echo \"No API lint configured yet\""
+    "lint": "echo \"No API lint configured yet\"",
+    "validate:shutdown": "node scripts/validate-graceful-shutdown.mjs"
   },
   "dependencies": {
     "express": "^4.18.3"

--- a/apps/api/scripts/validate-graceful-shutdown.mjs
+++ b/apps/api/scripts/validate-graceful-shutdown.mjs
@@ -1,0 +1,28 @@
+import { readFile } from "node:fs/promises";
+import { fileURLToPath } from "node:url";
+import { dirname, join } from "node:path";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const indexPath = join(__dirname, "..", "src", "index.ts");
+const source = await readFile(indexPath, "utf8");
+
+const requiredSnippets = [
+  "const server: Server = app.listen",
+  "server.close((error) =>",
+  'process.on("SIGTERM", shutdown)',
+  'process.on("SIGINT", shutdown)',
+  "setTimeout(() =>",
+  "process.exit(0)",
+];
+
+const missing = requiredSnippets.filter((snippet) => !source.includes(snippet));
+
+if (missing.length > 0) {
+  console.error("Graceful shutdown validation failed. Missing snippets:");
+  for (const snippet of missing) {
+    console.error(`- ${snippet}`);
+  }
+  process.exit(1);
+}
+
+console.log("Graceful shutdown validation passed.");

--- a/apps/api/src/index.ts
+++ b/apps/api/src/index.ts
@@ -1,9 +1,11 @@
 import express from "express";
+import type { Server } from "node:http";
 
 import usersRouter from "./routes/users";
 
 const app = express();
 const port = process.env.PORT || 4000;
+const shutdownTimeoutMs = Number(process.env.SHUTDOWN_TIMEOUT_MS || 10000);
 
 app.use(express.json());
 
@@ -13,6 +15,38 @@ app.get("/health", (_req, res) => {
 
 app.use("/users", usersRouter);
 
-app.listen(port, () => {
+const server: Server = app.listen(port, () => {
   console.log(`TaskFlow API listening on port ${port}`);
 });
+
+let shuttingDown = false;
+
+const shutdown = (signal: NodeJS.Signals) => {
+  if (shuttingDown) {
+    return;
+  }
+
+  shuttingDown = true;
+  console.log(`${signal} received. Draining TaskFlow API server...`);
+
+  const timer = setTimeout(() => {
+    console.error(`Graceful shutdown timed out after ${shutdownTimeoutMs}ms.`);
+    process.exit(1);
+  }, shutdownTimeoutMs);
+  timer.unref();
+
+  server.close((error) => {
+    clearTimeout(timer);
+
+    if (error) {
+      console.error("Error while closing TaskFlow API server:", error);
+      process.exit(1);
+    }
+
+    console.log("TaskFlow API server closed cleanly.");
+    process.exit(0);
+  });
+};
+
+process.on("SIGTERM", shutdown);
+process.on("SIGINT", shutdown);

--- a/contributors/agents.json
+++ b/contributors/agents.json
@@ -1,5 +1,13 @@
 {
-  "agents": [],
-  "last_updated": "2026-06-03",
-  "total_contributions": 0
+  "agents": [
+    {
+      "github_username": "SabFabDev",
+      "model": "gpt-5.5 via Hermes Agent",
+      "version": "2026-07-03",
+      "pr_number": 0,
+      "issue_number": 1437
+    }
+  ],
+  "last_updated": "2026-07-03",
+  "total_contributions": 1
 }

--- a/contributors/agents.json
+++ b/contributors/agents.json
@@ -4,7 +4,7 @@
       "github_username": "SabFabDev",
       "model": "gpt-5.5 via Hermes Agent",
       "version": "2026-07-03",
-      "pr_number": 0,
+      "pr_number": 5023,
       "issue_number": 1437
     }
   ],


### PR DESCRIPTION
## Description
Closes #1437

Adds graceful shutdown handling to the API entrypoint so `SIGTERM` and `SIGINT` stop accepting new connections, drain the HTTP server via `server.close()`, and force-exit if shutdown hangs.

## AI Agent Checklist
- [x] I reacted 👍 on issue #16 (Agent Registry)
- [x] I starred this repository
- [x] I added my model name and version to `contributors/agents.json`
- [x] My PR title includes the `[agent]` tag

## Changes Made
- Scoped runtime change to `apps/api/src/index.ts`.
- Keeps a reference to the HTTP `Server` returned by `app.listen()`.
- Adds idempotent shutdown handling for `SIGTERM` and `SIGINT`.
- Adds a forced timeout using `SHUTDOWN_TIMEOUT_MS` with a 10s default.
- Adds `apps/api/scripts/validate-graceful-shutdown.mjs` and `validate:shutdown` script.
- Adds SabFabDev agent metadata for issue #1437.

## Model Info (AI agents only)
- Model name/version: gpt-5.5 via Hermes Agent, 2026-07-03
- Issue attempted: #1437
- Approach used: Focused API entrypoint shutdown fix with lightweight validation script.

## Test Plan
- `npm install --ignore-scripts`
- `npm --workspace @taskflow/api run validate:shutdown` → `Graceful shutdown validation passed.`
- `npm --workspace @taskflow/api run test` → `No API tests configured yet`