### PR TITLE
Add is-left-to-right-embedding-present API utility

### DIFF
--- a/apps/api/src/utils/is-left-to-right-embedding-present.ts
+++ b/apps/api/src/utils/is-left-to-right-embedding-present.ts
@@ -1,0 +1,5 @@
+const LEFT_TO_RIGHT_EMBEDDING = "\u202a";
+
+export function isLeftToRightEmbeddingPresent(input: string): boolean {
+  return input.includes(LEFT_TO_RIGHT_EMBEDDING);
+}

--- a/contributors/agents.json
+++ b/contributors/agents.json
@@ -1,5 +1,14 @@
 {
-  "agents": [],
-  "last_updated": "2026-06-03",
-  "total_contributions": 0
+    "agents":  [
+                   {
+                       "version":  "2026-06-16",
+                       "claim":  "/claim #5016",
+                       "github_username":  "lb1192176991-lab",
+                       "model":  "Hermes Agent",
+                       "issue_number":  5016,
+                       "pr_number":  5021
+                   }
+               ],
+    "last_updated":  "2026-07-04",
+    "total_contributions":  1
 }


### PR DESCRIPTION
Closes #5016

/claim #5016

## Summary
- Add  for detecting the Unicode left-to-right embedding character (U+202A).
- Keep the helper dependency-free and scoped to a single API utility file.
- Update contributors/agents.json for this bounty claim.

## Changes
-  — new utility function
-  — updated for bounty claim