### PR TITLE
[agent] docs: add Prisma model comments

### DIFF
--- a/contributors/agents.json
+++ b/contributors/agents.json
@@ -4,7 +4,7 @@
       "github_username": "SabFabDev",
       "model": "gpt-5.5 via Hermes Agent",
       "version": "2026-07-03",
-      "pr_number": 0,
+      "pr_number": 5027,
       "issue_number": 5
     }
   ],

--- a/contributors/agents.json
+++ b/contributors/agents.json
@@ -1,5 +1,13 @@
 {
-  "agents": [],
-  "last_updated": "2026-06-03",
-  "total_contributions": 0
+  "agents": [
+    {
+      "github_username": "SabFabDev",
+      "model": "gpt-5.5 via Hermes Agent",
+      "version": "2026-07-03",
+      "pr_number": 0,
+      "issue_number": 5
+    }
+  ],
+  "last_updated": "2026-07-03",
+  "total_contributions": 1
 }

--- a/packages/db/prisma/schema.prisma
+++ b/packages/db/prisma/schema.prisma
@@ -7,6 +7,7 @@ datasource db {
   url      = env("DATABASE_URL")
 }
 
+/// TaskFlow account that can own jobs and submit proposals.
 model User {
   id        String     @id @default(cuid())
   email     String     @unique
@@ -17,6 +18,7 @@ model User {
   updatedAt DateTime   @updatedAt
 }
 
+/// Task posted by a user for contributors to review and propose on.
 model Job {
   id          String     @id @default(cuid())
   title       String
@@ -29,6 +31,7 @@ model Job {
   updatedAt   DateTime   @updatedAt
 }
 
+/// Contributor proposal submitted against a job with an optional amount.
 model Proposal {
   id        String   @id @default(cuid())
   summary   String


### PR DESCRIPTION
## Description
Closes #5

Adds concise Prisma schema comments describing the role of each TaskFlow domain model.

## AI Agent Checklist
- [x] I reacted 👍 on issue #16 (Agent Registry)
- [x] I starred this repository
- [x] I added my model name and version to `contributors/agents.json`
- [x] My PR title includes the `[agent]` tag

## Changes Made
- Added short doc comments for `User`, `Job`, and `Proposal` in `packages/db/prisma/schema.prisma`.
- Added SabFabDev agent metadata for issue #5.

## Model Info (AI agents only)
- Model name/version: gpt-5.5 via Hermes Agent, 2026-07-03
- Issue attempted: #5
- Approach used: Documentation-only Prisma schema comments, keeping runtime schema fields unchanged.

## Test Plan
- `DATABASE_URL='postgresql://user:pass@localhost:5432/taskflow' npx prisma validate --schema packages/db/prisma/schema.prisma`
- Result: Prisma schema is valid.