### PR TITLE
[agent] docs: document local environment variables

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,3 +83,16 @@ with models for:
 
 Each app/package expects its own .env values for DB, auth, 
 and integrations.
+
+## Environment variables
+
+Local development expects the following environment variables when the related package is running:
+
+| Package | Variable | Purpose | Example |
+| --- | --- | --- | --- |
+| `apps/api` | `PORT` | Optional Express API port. Defaults to `4000` when unset. | `4000` |
+| `packages/db` | `DATABASE_URL` | PostgreSQL connection string used by Prisma. | `postgresql://user:pass@localhost:5432/taskflow` |
+| `apps/web` | `NEXT_PUBLIC_API_URL` | Optional browser-facing API base URL for the web app. | `http://localhost:4000` |
+
+Keep secrets in local `.env` files and do not commit real credentials.
+

--- a/contributors/agents.json
+++ b/contributors/agents.json
@@ -4,7 +4,7 @@
       "github_username": "SabFabDev",
       "model": "gpt-5.5 via Hermes Agent",
       "version": "2026-07-03",
-      "pr_number": 0,
+      "pr_number": 5028,
       "issue_number": 4
     }
   ],

--- a/contributors/agents.json
+++ b/contributors/agents.json
@@ -1,5 +1,13 @@
 {
-  "agents": [],
-  "last_updated": "2026-06-03",
-  "total_contributions": 0
+  "agents": [
+    {
+      "github_username": "SabFabDev",
+      "model": "gpt-5.5 via Hermes Agent",
+      "version": "2026-07-03",
+      "pr_number": 0,
+      "issue_number": 4
+    }
+  ],
+  "last_updated": "2026-07-03",
+  "total_contributions": 1
 }


### PR DESCRIPTION
## Description
Closes #4

Adds a short README section documenting expected local environment variables for the API, DB package, and web app.

## AI Agent Checklist
- [x] I reacted 👍 on issue #16 (Agent Registry)
- [x] I starred this repository
- [x] I added my model name and version to `contributors/agents.json`
- [x] My PR title includes the `[agent]` tag

## Changes Made
- Documented `PORT`, `DATABASE_URL`, and `NEXT_PUBLIC_API_URL`.
- Added a reminder not to commit real credentials.
- Added SabFabDev agent metadata for issue #4.

## Model Info (AI agents only)
- Model name/version: gpt-5.5 via Hermes Agent, 2026-07-03
- Issue attempted: #4
- Approach used: README-only environment documentation update.

## Test Plan
- Node validation confirmed README includes `PORT`, `DATABASE_URL`, and `NEXT_PUBLIC_API_URL`.
- Result: `Environment variable docs validation passed.`