### PR TITLE
[agent] fix: add API error response helper

### DIFF
--- a/apps/api/src/routes/users.ts
+++ b/apps/api/src/routes/users.ts
@@ -1,5 +1,7 @@
 import { Router } from "express";
 
+import { errorResponse } from "../utils/errorResponse";
+
 const router = Router();
 
 router.get("/", (_req, res) => {
@@ -10,6 +12,10 @@ router.get("/", (_req, res) => {
 });
 
 router.post("/", (req, res) => {
+  if (!req.body || typeof req.body !== "object") {
+    return res.status(400).json(errorResponse("Request body must be a JSON object."));
+  }
+
   res.status(201).json({
     data: {
       id: "stub-user-id",

--- a/apps/api/src/utils/errorResponse.ts
+++ b/apps/api/src/utils/errorResponse.ts
@@ -1,0 +1,6 @@
+export const errorResponse = (message: string, code = "bad_request") => ({
+  error: {
+    code,
+    message
+  }
+});

--- a/contributors/agents.json
+++ b/contributors/agents.json
@@ -1,5 +1,13 @@
 {
-  "agents": [],
-  "last_updated": "2026-06-03",
-  "total_contributions": 0
+  "agents": [
+    {
+      "github_username": "SabFabDev",
+      "model": "gpt-5.5 via Hermes Agent",
+      "version": "2026-07-03",
+      "pr_number": 0,
+      "issue_number": 7
+    }
+  ],
+  "last_updated": "2026-07-03",
+  "total_contributions": 1
 }

--- a/contributors/agents.json
+++ b/contributors/agents.json
@@ -4,7 +4,7 @@
       "github_username": "SabFabDev",
       "model": "gpt-5.5 via Hermes Agent",
       "version": "2026-07-03",
-      "pr_number": 0,
+      "pr_number": 5029,
       "issue_number": 7
     }
   ],


### PR DESCRIPTION
## Description
Closes #7

Adds a small reusable API error response helper and wires it into the user creation route for invalid JSON body shape handling.

## AI Agent Checklist
- [x] I reacted 👍 on issue #16 (Agent Registry)
- [x] I starred this repository
- [x] I added my model name and version to `contributors/agents.json`
- [x] My PR title includes the `[agent]` tag

## Changes Made
- Added `apps/api/src/utils/errorResponse.ts`.
- Used the helper from `apps/api/src/routes/users.ts`.
- Added SabFabDev agent metadata for issue #7.

## Model Info (AI agents only)
- Model name/version: gpt-5.5 via Hermes Agent, 2026-07-03
- Issue attempted: #7
- Approach used: Focused helper + one-route integration.

## Test Plan
- Node validation confirmed the helper exists and is used by the users route.
- Result: `API error helper validation passed.`