### PR TITLE
Add is-byte-order-mark-present API utility

### DIFF
--- a/apps/api/src/utils/is-byte-order-mark-present.ts
+++ b/apps/api/src/utils/is-byte-order-mark-present.ts
@@ -1,0 +1,3 @@
+export function isByteOrderMarkPresent(value: string): boolean {
+  return value.includes("\uFEFF");
+}


### PR DESCRIPTION
## Summary

- add `isByteOrderMarkPresent`
- return whether the input string contains byte order mark (`U+FEFF`)

## Validation

- `npm test --workspace @taskflow/api`

/claim #4859

Fixes #4859