### PR TITLE
[agent] feat: add currency formatting utility Closes #5072

### DIFF
--- a/src/utils/format-currency.js
+++ b/src/utils/format-currency.js
@@ -1,0 +1,79 @@
+// Currency formatting utility
+// Bounty issue: self-created from xevrion-v2/agent-playground #33
+
+/**
+ * Formats a number as a currency string.
+ *
+ * @param {number} amount - The amount to format
+ * @param {object} [options] - Formatting options
+ * @param {string} [options.currency='USD'] - Currency code (USD, EUR, GBP, CNY, JPY)
+ * @param {number} [options.decimals] - Number of decimal places (auto-detect by default)
+ * @returns {string} Formatted currency string
+ *
+ * @example
+ * formatCurrency(1234.56)           // => '$1,234.56'
+ * formatCurrency(1000, {currency:'CNY'}) // => '楼1,000.00'
+ * formatCurrency(0)                 // => '$0.00'
+ * formatCurrency(99.9)              // => '$99.90'
+ */
+function formatCurrency(amount, options = {}) {
+  if (typeof amount !== 'number' || !Number.isFinite(amount)) {
+    throw new Error('formatCurrency(): amount must be a finite number');
+  }
+
+  const { currency = 'USD', decimals } = options;
+
+  // Currency symbols and default decimal places
+  const currencyConfig = {
+    USD: { symbol: '$', defaultDecimals: 2 },
+    EUR: { symbol: '鈧?, defaultDecimals: 2 },
+    GBP: { symbol: '拢', defaultDecimals: 2 },
+    CNY: { symbol: '楼', defaultDecimals: 2 },
+    JPY: { symbol: '楼', defaultDecimals: 0 },
+    CAD: { symbol: 'C$', defaultDecimals: 2 },
+    AUD: { symbol: 'A$', defaultDecimals: 2 },
+  };
+
+  const config = currencyConfig[currency];
+  if (!config) {
+    throw new Error('formatCurrency(): unsupported currency code: ' + currency);
+  }
+
+  const decimalPlaces = decimals !== undefined ? decimals : config.defaultDecimals;
+
+  // Handle negative amounts
+  const isNegative = amount < 0;
+  const absoluteAmount = Math.abs(amount);
+
+  // Format with locale-aware number formatting
+  const formatted = absoluteAmount.toLocaleString('en-US', {
+    minimumFractionDigits: decimalPlaces,
+    maximumFractionDigits: decimalPlaces,
+  });
+
+  return (isNegative ? '-' : '') + config.symbol + formatted;
+}
+
+/**
+ * Parses a currency string back to a number.
+ *
+ * @param {string} str - Currency string to parse
+ * @returns {number|null} Parsed amount, or null if invalid
+ *
+ * @example
+ * parseCurrency('$1,234.56')  // => 1234.56
+ * parseCurrency('楼1,000')     // => 1000
+ * parseCurrency('invalid')    // => null
+ */
+function parseCurrency(str) {
+  if (typeof str !== 'string' || str.trim() === '') return null;
+
+  // Remove currency symbols, spaces, and non-numeric chars except . and -
+  const cleaned = str.replace(/[^0-9.\-]/g, '');
+  const num = parseFloat(cleaned);
+
+  if (isNaN(num)) return null;
+  return num;
+}
+
+module.exports = { formatCurrency, parseCurrency };

--- a/src/utils/format-currency.test.js
+++ b/src/utils/format-currency.test.js
@@ -1,0 +1,100 @@
+// Tests for format-currency utility
+// Uses Node.js built-in test runner
+
+const assert = require('node:assert');
+const { test, describe } = require('node:test');
+const { formatCurrency, parseCurrency } = require('./format-currency');
+
+describe('formatCurrency', () => {
+  test('formats USD with 2 decimal places', () => {
+    assert.strictEqual(formatCurrency(1234.56), '$1,234.56');
+  });
+
+  test('formats zero', () => {
+    assert.strictEqual(formatCurrency(0), '$0.00');
+  });
+
+  test('formats integer amount', () => {
+    assert.strictEqual(formatCurrency(100), '$100.00');
+  });
+
+  test('formats with CNY symbol', () => {
+    assert.strictEqual(formatCurrency(1000, { currency: 'CNY' }), '楼1,000.00');
+  });
+
+  test('formats with EUR symbol', () => {
+    assert.strictEqual(formatCurrency(99.99, { currency: 'EUR' }), '鈧?9.99');
+  });
+
+  test('formats JPY with 0 decimal places', () => {
+    assert.strictEqual(formatCurrency(1500, { currency: 'JPY' }), '楼1,500');
+  });
+
+  test('formats GBP', () => {
+    assert.strictEqual(formatCurrency(50, { currency: 'GBP' }), '拢50.00');
+  });
+
+  test('supports custom decimal places', () => {
+    assert.strictEqual(formatCurrency(1.5, { decimals: 3 }), '$1.500');
+  });
+
+  test('rounds to specified decimals', () => {
+    assert.strictEqual(formatCurrency(1.567, { decimals: 1 }), '$1.6');
+  });
+
+  test('handles large numbers', () => {
+    assert.strictEqual(formatCurrency(1000000), '$1,000,000.00');
+  });
+
+  test('handles negative amounts', () => {
+    assert.strictEqual(formatCurrency(-50), '-$50.00');
+  });
+
+  test('throws for NaN', () => {
+    assert.throws(() => formatCurrency(NaN), /finite/);
+  });
+
+  test('throws for Infinity', () => {
+    assert.throws(() => formatCurrency(Infinity), /finite/);
+  });
+
+  test('throws for unsupported currency', () => {
+    assert.throws(() => formatCurrency(100, { currency: 'XYZ' }), /unsupported/);
+  });
+
+  test('throws for non-number', () => {
+    assert.throws(() => formatCurrency('abc'), /finite/);
+  });
+});
+
+describe('parseCurrency', () => {
+  test('parses USD format', () => {
+    assert.strictEqual(parseCurrency('$1,234.56'), 1234.56);
+  });
+
+  test('parses without commas', () => {
+    assert.strictEqual(parseCurrency('$1000.50'), 1000.50);
+  });
+
+  test('parses integer values', () => {
+    assert.strictEqual(parseCurrency('$100'), 100);
+  });
+
+  test('parses CNY format', () => {
+    assert.strictEqual(parseCurrency('楼1,000.00'), 1000.00);
+  });
+
+  test('returns null for empty string', () => {
+    assert.strictEqual(parseCurrency(''), null);
+  });
+
+  test('returns null for non-string', () => {
+    assert.strictEqual(parseCurrency(123), null);
+    assert.strictEqual(parseCurrency(null), null);
+    assert.strictEqual(parseCurrency(undefined), null);
+  });
+
+  test('returns null for invalid input', () => {
+    assert.strictEqual(parseCurrency('abc'), null);
+  });
+});


### PR DESCRIPTION
Added formatCurrency and parseCurrency utilities. Supports USD, EUR, GBP, CNY, JPY, CAD, AUD. 22 tests all passing.

Closes #5072