### PR TITLE
[agent] feat(api): add round number helper

### DIFF
--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -7,7 +7,7 @@
   "main": "src/index.ts",
   "scripts": {
     "dev": "tsx src/index.ts",
-    "test": "echo \"No API tests configured yet\"",
+    "test": "tsx --test src/**/*.test.ts",
     "lint": "echo \"No API lint configured yet\""
   },
   "dependencies": {

--- a/apps/api/src/utils/round-number.test.ts
+++ b/apps/api/src/utils/round-number.test.ts
@@ -1,0 +1,29 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { roundNumber } from "./round-number.js";
+
+test("roundNumber rounds to the nearest integer by default", () => {
+  assert.equal(roundNumber(12.5), 13);
+  assert.equal(roundNumber(-12.5), -12);
+});
+
+test("roundNumber supports positive decimal precision", () => {
+  assert.equal(roundNumber(1.2345, 2), 1.23);
+  assert.equal(roundNumber(1.2355, 2), 1.24);
+});
+
+test("roundNumber supports negative precision for coarse rounding", () => {
+  assert.equal(roundNumber(1234, -2), 1200);
+  assert.equal(roundNumber(1275, -2), 1300);
+});
+
+test("roundNumber truncates fractional precision values", () => {
+  assert.equal(roundNumber(1.2345, 2.9), 1.23);
+});
+
+test("roundNumber leaves non-finite values unchanged", () => {
+  assert.equal(roundNumber(Number.POSITIVE_INFINITY), Number.POSITIVE_INFINITY);
+  assert.ok(Number.isNaN(roundNumber(Number.NaN)));
+  assert.equal(roundNumber(12.34, Number.POSITIVE_INFINITY), 12.34);
+});

--- a/apps/api/src/utils/round-number.ts
+++ b/apps/api/src/utils/round-number.ts
@@ -1,0 +1,12 @@
+export function roundNumber(value: number, precision = 0): number {
+  if (!Number.isFinite(value)) {
+    return value;
+  }
+
+  if (!Number.isFinite(precision)) {
+    return value;
+  }
+
+  const factor = 10 ** Math.trunc(precision);
+  return Math.round(value * factor) / factor;
+}

--- a/contributors/agents.json
+++ b/contributors/agents.json
@@ -4,7 +4,7 @@
       "github_username": "leo1987820",
       "model": "GPT-5 Codex",
       "version": "2026-07-01",
-      "pr_number": null,
+      "pr_number": 5079,
       "issue_number": 3143
     }
   ],

--- a/contributors/agents.json
+++ b/contributors/agents.json
@@ -1,5 +1,13 @@
 {
-  "agents": [],
-  "last_updated": "2026-06-03",
-  "total_contributions": 0
+  "agents": [
+    {
+      "github_username": "leo1987820",
+      "model": "GPT-5 Codex",
+      "version": "2026-07-01",
+      "pr_number": null,
+      "issue_number": 3143
+    }
+  ],
+  "last_updated": "2026-07-01",
+  "total_contributions": 1
 }


### PR DESCRIPTION
Closes #3143
/claim #3143

## Summary
- add `apps/api/src/utils/round-number.ts` with a dependency-free `roundNumber` helper
- add focused `node:test` coverage for default, decimal, negative precision, fractional precision, and non-finite values
- wire the API workspace test script to `tsx --test src/**/*.test.ts`

## Why this version is different
- uses the required `apps/api` path
- includes runnable tests instead of only adding the helper
- avoids lockfile or dependency noise
- updates `contributors/agents.json`; the PR number will be filled in after this PR is created

## Verification
- `npm.cmd test -w apps/api`
- `npm.cmd test`
- `npx.cmd tsc --noEmit --strict --module NodeNext --moduleResolution NodeNext --target ES2020 --lib ES2020 apps/api/src/utils/round-number.ts apps/api/src/utils/round-number.test.ts`
- `git diff --check -- apps/api/package.json apps/api/src/utils/round-number.ts apps/api/src/utils/round-number.test.ts contributors/agents.json`