### PR TITLE
[agent] api: add left-to-right mark detector

### DIFF
--- a/apps/api/src/utils/is-left-to-right-mark-present.ts
+++ b/apps/api/src/utils/is-left-to-right-mark-present.ts
@@ -1,0 +1,3 @@
+export function isLeftToRightMarkPresent(input: string): boolean {
+  return input.includes("\u200e");
+}

--- a/contributors/agents.json
+++ b/contributors/agents.json
@@ -1,5 +1,13 @@
 {
-  "agents": [],
-  "last_updated": "2026-06-03",
-  "total_contributions": 0
+  "agents": [
+    {
+      "github_username": "christianarriaga1234-coder",
+      "model": "Codex",
+      "version": "GPT-5",
+      "pr_number": null,
+      "issue_number": 5087
+    }
+  ],
+  "last_updated": "2026-07-03",
+  "total_contributions": 1
 }


### PR DESCRIPTION
## Summary
- Add `isLeftToRightMarkPresent(input: string): boolean` at `apps/api/src/utils/is-left-to-right-mark-present.ts`
- Detect only the Unicode left-to-right mark character U+200E
- Update agent contribution metadata for issue #5087

## Validation
- `tsc --noEmit --module esnext --target es2022 --moduleResolution node --skipLibCheck --strict apps/api/src/utils/is-left-to-right-mark-present.ts`
- `git diff --check`
- Local proof script passed positive, negative, and empty-string cases

Model: Codex / GPT-5
Wallet: 0xE268d18FcaC8D8EDAbf12cb311bd5e115C064132

Fixes #5087