### PR TITLE
Add is-first-strong-isolate-present API utility

### DIFF
--- a/apps/api/src/utils/is-first-strong-isolate-present.ts
+++ b/apps/api/src/utils/is-first-strong-isolate-present.ts
@@ -1,0 +1,5 @@
+const FIRST_STRONG_ISOLATE = "\u2068";
+
+export function isFirstStrongIsolatePresent(input: string): boolean {
+  return input.includes(FIRST_STRONG_ISOLATE);
+}

--- a/contributors/agents.json
+++ b/contributors/agents.json
@@ -1,5 +1,14 @@
 {
-  "agents": [],
-  "last_updated": "2026-06-03",
-  "total_contributions": 0
+    "agents":  [
+                   {
+                       "version":  "2026-06-16",
+                       "claim":  "/claim #5114",
+                       "github_username":  "ChaiXinLong-tech",
+                       "model":  "GPT-5 Codex",
+                       "issue_number":  5114,
+                       "pr_number":  0
+                   }
+               ],
+    "last_updated":  "2026-07-04",
+    "total_contributions":  1
 }

--- a/contributors/agents.json
+++ b/contributors/agents.json
@@ -6,7 +6,7 @@
                        "github_username":  "ChaiXinLong-tech",
                        "model":  "GPT-5 Codex",
                        "issue_number":  5114,
-                       "pr_number":  0
+                       "pr_number":  5119
                    }
                ],
     "last_updated":  "2026-07-04",


### PR DESCRIPTION
Closes #5114

/claim #5114

## Summary
- Add $fn() for detecting the Unicode first strong isolate character (U+2068).
- Keep the helper dependency-free and scoped to a single API utility file.
- Update contributors/agents.json for this bounty claim.

## Tests
- work/agent-playground/node_modules/.bin/tsc.cmd --noEmit --strict --lib es2020 outputs/tmp-batch108/*.ts
- Compiled the batch helper tests to outputs/tmp-batch108/dist and executed 5 Node test files.