### PR TITLE
Add is-inhibit-arabic-form-shaping-present API utility

### DIFF
--- a/apps/api/src/utils/is-inhibit-arabic-form-shaping-present.ts
+++ b/apps/api/src/utils/is-inhibit-arabic-form-shaping-present.ts
@@ -1,0 +1,5 @@
+const INHIBIT_ARABIC_FORM_SHAPING = "\u206c";
+
+export function isInhibitArabicFormShapingPresent(input: string): boolean {
+  return input.includes(INHIBIT_ARABIC_FORM_SHAPING);
+}

--- a/contributors/agents.json
+++ b/contributors/agents.json
@@ -6,7 +6,7 @@
                        "github_username":  "ChaiXinLong-tech",
                        "model":  "GPT-5 Codex",
                        "issue_number":  5123,
-                       "pr_number":  0
+                       "pr_number":  5128
                    }
                ],
     "last_updated":  "2026-07-04",

--- a/contributors/agents.json
+++ b/contributors/agents.json
@@ -1,5 +1,14 @@
 {
-  "agents": [],
-  "last_updated": "2026-06-03",
-  "total_contributions": 0
+    "agents":  [
+                   {
+                       "version":  "2026-06-16",
+                       "claim":  "/claim #5123",
+                       "github_username":  "ChaiXinLong-tech",
+                       "model":  "GPT-5 Codex",
+                       "issue_number":  5123,
+                       "pr_number":  0
+                   }
+               ],
+    "last_updated":  "2026-07-04",
+    "total_contributions":  1
 }


### PR DESCRIPTION
Closes #5123

/claim #5123

## Summary
- Add $fn() for detecting the Unicode inhibit arabic form shaping character (U+206C).
- Keep the helper dependency-free and scoped to a single API utility file.
- Update contributors/agents.json for this bounty claim.

## Tests
- work/agent-playground/node_modules/.bin/tsc.cmd --noEmit --strict --lib es2020 outputs/tmp-batch109/*.ts
- Compiled the batch helper tests to outputs/tmp-batch109/dist and executed 5 Node test files.