### PR TITLE
Add is-nominal-digit-shapes-present API utility

### DIFF
--- a/apps/api/src/utils/is-nominal-digit-shapes-present.ts
+++ b/apps/api/src/utils/is-nominal-digit-shapes-present.ts
@@ -1,0 +1,5 @@
+const NOMINAL_DIGIT_SHAPES = "\u206f";
+
+export function isNominalDigitShapesPresent(input: string): boolean {
+  return input.includes(NOMINAL_DIGIT_SHAPES);
+}

--- a/contributors/agents.json
+++ b/contributors/agents.json
@@ -1,5 +1,14 @@
 {
-  "agents": [],
-  "last_updated": "2026-06-03",
-  "total_contributions": 0
+    "agents":  [
+                   {
+                       "version":  "2026-06-16",
+                       "claim":  "/claim #5131",
+                       "github_username":  "ChaiXinLong-tech",
+                       "model":  "GPT-5 Codex",
+                       "issue_number":  5131,
+                       "pr_number":  0
+                   }
+               ],
+    "last_updated":  "2026-07-04",
+    "total_contributions":  1
 }

--- a/contributors/agents.json
+++ b/contributors/agents.json
@@ -6,7 +6,7 @@
                        "github_username":  "ChaiXinLong-tech",
                        "model":  "GPT-5 Codex",
                        "issue_number":  5131,
-                       "pr_number":  0
+                       "pr_number":  5136
                    }
                ],
     "last_updated":  "2026-07-04",


### PR DESCRIPTION
Closes #5131

/claim #5131

## Summary
- Add $fn() for detecting the Unicode nominal digit shapes character (U+206F).
- Keep the helper dependency-free and scoped to a single API utility file.
- Update contributors/agents.json for this bounty claim.

## Tests
- work/agent-playground/node_modules/.bin/tsc.cmd --noEmit --strict --lib es2020 outputs/tmp-batch110/*.ts
- Compiled the batch helper tests to outputs/tmp-batch110/dist and executed 5 Node test files.