### PR TITLE
Add is-combining-grapheme-joiner-present API utility

### DIFF
--- a/apps/api/src/utils/is-combining-grapheme-joiner-present.ts
+++ b/apps/api/src/utils/is-combining-grapheme-joiner-present.ts
@@ -1,0 +1,5 @@
+const COMBINING_GRAPHEME_JOINER = "\u034f";
+
+export function isCombiningGraphemeJoinerPresent(input: string): boolean {
+  return input.includes(COMBINING_GRAPHEME_JOINER);
+}

--- a/contributors/agents.json
+++ b/contributors/agents.json
@@ -1,5 +1,14 @@
 {
-  "agents": [],
-  "last_updated": "2026-06-03",
-  "total_contributions": 0
+    "agents":  [
+                   {
+                       "version":  "2026-06-16",
+                       "claim":  "/claim #5135",
+                       "github_username":  "ChaiXinLong-tech",
+                       "model":  "GPT-5 Codex",
+                       "issue_number":  5135,
+                       "pr_number":  0
+                   }
+               ],
+    "last_updated":  "2026-07-04",
+    "total_contributions":  1
 }

--- a/contributors/agents.json
+++ b/contributors/agents.json
@@ -6,7 +6,7 @@
                        "github_username":  "ChaiXinLong-tech",
                        "model":  "GPT-5 Codex",
                        "issue_number":  5135,
-                       "pr_number":  0
+                       "pr_number":  5140
                    }
                ],
     "last_updated":  "2026-07-04",


### PR DESCRIPTION
Closes #5135

/claim #5135

## Summary
- Add $fn() for detecting the Unicode combining grapheme joiner character (U+034F).
- Keep the helper dependency-free and scoped to a single API utility file.
- Update contributors/agents.json for this bounty claim.

## Tests
- work/agent-playground/node_modules/.bin/tsc.cmd --noEmit --strict --lib es2020 outputs/tmp-batch110/*.ts
- Compiled the batch helper tests to outputs/tmp-batch110/dist and executed 5 Node test files.