### PR TITLE
Add currency formatting utility

### DIFF
--- a/contributors/agents.json
+++ b/contributors/agents.json
@@ -1,5 +1,12 @@
 {
-  "agents": [],
-  "last_updated": "2026-06-03",
-  "total_contributions": 0
+  "agents": [
+    {
+      "github": "taherdhanera",
+      "contribution": "Added currency formatting and parsing utility for issue #5072",
+      "issue": 5072,
+      "date": "2026-07-04"
+    }
+  ],
+  "last_updated": "2026-07-04",
+  "total_contributions": 1
 }

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
   ],
   "scripts": {
     "dev": "npm run dev --workspaces --if-present",
-    "test": "npm run test --workspaces --if-present",
+    "test": "node --test && npm run test --workspaces --if-present",
     "lint": "npm run lint --workspaces --if-present",
     "format": "npm run format --workspaces --if-present"
   },

--- a/src/utils/format-currency.js
+++ b/src/utils/format-currency.js
@@ -1,0 +1,113 @@
+const SUPPORTED_CURRENCIES = new Set(["USD", "EUR", "GBP", "CNY", "JPY", "CAD", "AUD"]);
+
+function normalizeCurrency(currency = "USD") {
+  const normalized = String(currency).trim().toUpperCase();
+
+  if (!SUPPORTED_CURRENCIES.has(normalized)) {
+    throw new RangeError(`Unsupported currency: ${currency}`);
+  }
+
+  return normalized;
+}
+
+function normalizeDecimalPlaces(decimalPlaces, currency) {
+  if (decimalPlaces === undefined) {
+    return currency === "JPY" ? 0 : 2;
+  }
+
+  if (!Number.isInteger(decimalPlaces) || decimalPlaces < 0 || decimalPlaces > 20) {
+    throw new RangeError("decimalPlaces must be an integer between 0 and 20");
+  }
+
+  return decimalPlaces;
+}
+
+function formatCurrency(amount, options = {}) {
+  const normalizedOptions = typeof options === "string" ? { currency: options } : options;
+  const currency = normalizeCurrency(normalizedOptions.currency);
+  const decimalPlaces = normalizeDecimalPlaces(normalizedOptions.decimalPlaces, currency);
+  const locale = normalizedOptions.locale || "en-US";
+  const value = typeof amount === "string" && amount.trim() !== "" ? Number(amount) : amount;
+
+  if (typeof value !== "number" || !Number.isFinite(value)) {
+    throw new TypeError("amount must be a finite number");
+  }
+
+  return new Intl.NumberFormat(locale, {
+    style: "currency",
+    currency,
+    minimumFractionDigits: decimalPlaces,
+    maximumFractionDigits: decimalPlaces,
+  }).format(Object.is(value, -0) ? 0 : value);
+}
+
+function parseCurrency(value) {
+  if (typeof value === "number") {
+    if (!Number.isFinite(value)) {
+      throw new TypeError("value must be finite");
+    }
+
+    return value;
+  }
+
+  if (typeof value !== "string") {
+    throw new TypeError("value must be a string or number");
+  }
+
+  const trimmed = value.trim();
+
+  if (!trimmed) {
+    throw new TypeError("value cannot be empty");
+  }
+
+  const isParenthesizedNegative = /^\(.*\)$/.test(trimmed);
+  const hasMinus = /-/.test(trimmed);
+  let numeric = trimmed
+    .replace(/[A-Z]{3}/gi, "")
+    .replace(/[^\d.,-]/g, "")
+    .replace(/-/g, "");
+
+  if (!numeric || !/\d/.test(numeric)) {
+    throw new TypeError("value does not contain a currency amount");
+  }
+
+  numeric = normalizeNumberSeparators(numeric);
+
+  const parsed = Number(numeric);
+
+  if (!Number.isFinite(parsed)) {
+    throw new TypeError("value does not contain a valid currency amount");
+  }
+
+  return isParenthesizedNegative || hasMinus ? -parsed : parsed;
+}
+
+function normalizeNumberSeparators(value) {
+  const lastComma = value.lastIndexOf(",");
+  const lastDot = value.lastIndexOf(".");
+
+  if (lastComma !== -1 && lastDot !== -1) {
+    const decimalSeparator = lastComma > lastDot ? "," : ".";
+    const groupSeparator = decimalSeparator === "," ? "." : ",";
+
+    return value.split(groupSeparator).join("").replace(decimalSeparator, ".");
+  }
+
+  if (lastComma !== -1) {
+    const parts = value.split(",");
+    const lastPart = parts[parts.length - 1];
+
+    if (parts.length > 1 && lastPart.length > 0 && lastPart.length <= 2) {
+      return `${parts.slice(0, -1).join("")}.${lastPart}`;
+    }
+
+    return parts.join("");
+  }
+
+  return value;
+}
+
+module.exports = {
+  formatCurrency,
+  parseCurrency,
+};

--- a/test/format-currency.test.js
+++ b/test/format-currency.test.js
@@ -1,0 +1,92 @@
+const assert = require("node:assert/strict");
+const test = require("node:test");
+
+const { formatCurrency, parseCurrency } = require("../src/utils/format-currency");
+
+test("formats USD with default cents", () => {
+  assert.equal(formatCurrency(1234.5, "USD"), "$1,234.50");
+});
+
+test("formats EUR", () => {
+  assert.equal(formatCurrency(1234.5, "EUR"), "€1,234.50");
+});
+
+test("formats GBP", () => {
+  assert.equal(formatCurrency(1234.5, "GBP"), "£1,234.50");
+});
+
+test("formats CNY", () => {
+  assert.equal(formatCurrency(1234.5, "CNY"), "CN¥1,234.50");
+});
+
+test("formats JPY without default decimals", () => {
+  assert.equal(formatCurrency(1234.5, "JPY"), "¥1,235");
+});
+
+test("formats CAD", () => {
+  assert.equal(formatCurrency(1234.5, "CAD"), "CA$1,234.50");
+});
+
+test("formats AUD", () => {
+  assert.equal(formatCurrency(1234.5, "AUD"), "A$1,234.50");
+});
+
+test("formats negative amounts", () => {
+  assert.equal(formatCurrency(-987.65, "USD"), "-$987.65");
+});
+
+test("formats zero without negative zero output", () => {
+  assert.equal(formatCurrency(-0, "USD"), "$0.00");
+});
+
+test("formats large numbers", () => {
+  assert.equal(formatCurrency(1234567890.12, "USD"), "$1,234,567,890.12");
+});
+
+test("supports custom decimal places", () => {
+  assert.equal(formatCurrency(12.3456, { currency: "USD", decimalPlaces: 3 }), "$12.346");
+});
+
+test("supports custom locale", () => {
+  assert.equal(formatCurrency(1234.5, { currency: "EUR", locale: "de-DE" }), "1.234,50 €");
+});
+
+test("rejects unsupported currencies", () => {
+  assert.throws(() => formatCurrency(12, "INR"), RangeError);
+});
+
+test("rejects non-finite amounts", () => {
+  assert.throws(() => formatCurrency(Number.NaN, "USD"), TypeError);
+});
+
+test("parses USD formatted strings", () => {
+  assert.equal(parseCurrency("$1,234.50"), 1234.5);
+});
+
+test("parses currency codes", () => {
+  assert.equal(parseCurrency("EUR 1,234.50"), 1234.5);
+});
+
+test("parses negative strings", () => {
+  assert.equal(parseCurrency("-£987.65"), -987.65);
+});
+
+test("parses parenthesized negatives", () => {
+  assert.equal(parseCurrency("($987.65)"), -987.65);
+});
+
+test("parses zero", () => {
+  assert.equal(parseCurrency("$0.00"), 0);
+});
+
+test("parses European separators", () => {
+  assert.equal(parseCurrency("1.234,56 €"), 1234.56);
+});
+
+test("parses numbers directly", () => {
+  assert.equal(parseCurrency(42.25), 42.25);
+});
+
+test("rejects invalid currency strings", () => {
+  assert.throws(() => parseCurrency("not money"), TypeError);
+});


### PR DESCRIPTION
## Summary
- add src/utils/format-currency.js with formatCurrency and parseCurrency exports
- support USD, EUR, GBP, CNY, JPY, CAD, AUD, negatives, zero, large values, custom decimal places, and locale-aware formatting
- add 22 Node test cases and include them in the root test command
- update contributors/agents.json

/claim #5072
Closes #5072

## Tests
- npm test