### PR TITLE
Add is-halfwidth-hangul-filler-present API utility

### DIFF
--- a/apps/api/src/utils/is-halfwidth-hangul-filler-present.ts
+++ b/apps/api/src/utils/is-halfwidth-hangul-filler-present.ts
@@ -1,0 +1,5 @@
+const HALFWIDTH_HANGUL_FILLER = "\uffa0";
+
+export function isHalfwidthHangulFillerPresent(input: string): boolean {
+  return input.includes(HALFWIDTH_HANGUL_FILLER);
+}

--- a/contributors/agents.json
+++ b/contributors/agents.json
@@ -6,7 +6,7 @@
                        "github_username":  "ChaiXinLong-tech",
                        "model":  "GPT-5 Codex",
                        "issue_number":  5148,
-                       "pr_number":  0
+                       "pr_number":  5153
                    }
                ],
     "last_updated":  "2026-07-04",

--- a/contributors/agents.json
+++ b/contributors/agents.json
@@ -1,5 +1,14 @@
 {
-  "agents": [],
-  "last_updated": "2026-06-03",
-  "total_contributions": 0
+    "agents":  [
+                   {
+                       "version":  "2026-06-16",
+                       "claim":  "/claim #5148",
+                       "github_username":  "ChaiXinLong-tech",
+                       "model":  "GPT-5 Codex",
+                       "issue_number":  5148,
+                       "pr_number":  0
+                   }
+               ],
+    "last_updated":  "2026-07-04",
+    "total_contributions":  1
 }


### PR DESCRIPTION
Closes #5148

/claim #5148

## Summary
- Add $fn() for detecting the Unicode halfwidth hangul filler character (U+FFA0).
- Keep the helper dependency-free and scoped to a single API utility file.
- Update contributors/agents.json for this bounty claim.

## Tests
- work/agent-playground/node_modules/.bin/tsc.cmd --noEmit --strict --lib es2020 outputs/tmp-batch111/*.ts
- Compiled the batch helper tests to outputs/tmp-batch111/dist and executed 5 Node test files.