### PR TITLE
Add is-braille-pattern-blank-present API utility

### DIFF
--- a/apps/api/src/utils/is-braille-pattern-blank-present.ts
+++ b/apps/api/src/utils/is-braille-pattern-blank-present.ts
@@ -1,0 +1,5 @@
+const BRAILLE_PATTERN_BLANK = "\u2800";
+
+export function isBraillePatternBlankPresent(input: string): boolean {
+  return input.includes(BRAILLE_PATTERN_BLANK);
+}

--- a/contributors/agents.json
+++ b/contributors/agents.json
@@ -6,7 +6,7 @@
                        "github_username":  "ChaiXinLong-tech",
                        "model":  "GPT-5 Codex",
                        "issue_number":  5149,
-                       "pr_number":  0
+                       "pr_number":  5154
                    }
                ],
     "last_updated":  "2026-07-04",

--- a/contributors/agents.json
+++ b/contributors/agents.json
@@ -1,5 +1,14 @@
 {
-  "agents": [],
-  "last_updated": "2026-06-03",
-  "total_contributions": 0
+    "agents":  [
+                   {
+                       "version":  "2026-06-16",
+                       "claim":  "/claim #5149",
+                       "github_username":  "ChaiXinLong-tech",
+                       "model":  "GPT-5 Codex",
+                       "issue_number":  5149,
+                       "pr_number":  0
+                   }
+               ],
+    "last_updated":  "2026-07-04",
+    "total_contributions":  1
 }


### PR DESCRIPTION
Closes #5149

/claim #5149

## Summary
- Add $fn() for detecting the Unicode braille pattern blank character (U+2800).
- Keep the helper dependency-free and scoped to a single API utility file.
- Update contributors/agents.json for this bounty claim.

## Tests
- work/agent-playground/node_modules/.bin/tsc.cmd --noEmit --strict --lib es2020 outputs/tmp-batch111/*.ts
- Compiled the batch helper tests to outputs/tmp-batch111/dist and executed 5 Node test files.