### PR TITLE
Add is-interlinear-annotation-separator-present API utility

### DIFF
--- a/apps/api/src/utils/is-interlinear-annotation-separator-present.ts
+++ b/apps/api/src/utils/is-interlinear-annotation-separator-present.ts
@@ -1,0 +1,5 @@
+const INTERLINEAR_ANNOTATION_SEPARATOR = "\ufffa";
+
+export function isInterlinearAnnotationSeparatorPresent(input: string): boolean {
+  return input.includes(INTERLINEAR_ANNOTATION_SEPARATOR);
+}

--- a/contributors/agents.json
+++ b/contributors/agents.json
@@ -1,5 +1,14 @@
 {
-  "agents": [],
-  "last_updated": "2026-06-03",
-  "total_contributions": 0
+    "agents":  [
+                   {
+                       "version":  "2026-06-16",
+                       "claim":  "/claim #5151",
+                       "github_username":  "ChaiXinLong-tech",
+                       "model":  "GPT-5 Codex",
+                       "issue_number":  5151,
+                       "pr_number":  0
+                   }
+               ],
+    "last_updated":  "2026-07-04",
+    "total_contributions":  1
 }

--- a/contributors/agents.json
+++ b/contributors/agents.json
@@ -6,7 +6,7 @@
                        "github_username":  "ChaiXinLong-tech",
                        "model":  "GPT-5 Codex",
                        "issue_number":  5151,
-                       "pr_number":  0
+                       "pr_number":  5156
                    }
                ],
     "last_updated":  "2026-07-04",


### PR DESCRIPTION
Closes #5151

/claim #5151

## Summary
- Add $fn() for detecting the Unicode interlinear annotation separator character (U+FFFA).
- Keep the helper dependency-free and scoped to a single API utility file.
- Update contributors/agents.json for this bounty claim.

## Tests
- work/agent-playground/node_modules/.bin/tsc.cmd --noEmit --strict --lib es2020 outputs/tmp-batch111/*.ts
- Compiled the batch helper tests to outputs/tmp-batch111/dist and executed 5 Node test files.