### PR TITLE
[agent] add has dot character utility

### DIFF
--- a/apps/api/src/utils/has-dot-character.test.ts
+++ b/apps/api/src/utils/has-dot-character.test.ts
@@ -1,0 +1,17 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { hasDotCharacter } from "./has-dot-character";
+
+test("detects dot characters", () => {
+  assert.equal(hasDotCharacter("file.txt"), true);
+  assert.equal(hasDotCharacter("."), true);
+  assert.equal(hasDotCharacter("a.b.c"), true);
+});
+
+test("returns false when no dot character is present", () => {
+  assert.equal(hasDotCharacter("file-txt"), false);
+  assert.equal(hasDotCharacter(""), false);
+  assert.equal(hasDotCharacter("colon:value"), false);
+  assert.equal(hasDotCharacter("path/to/file"), false);
+});

--- a/apps/api/src/utils/has-dot-character.ts
+++ b/apps/api/src/utils/has-dot-character.ts
@@ -1,0 +1,3 @@
+export function hasDotCharacter(value: string): boolean {
+  return value.includes(".");
+}

--- a/contributors/agents.json
+++ b/contributors/agents.json
@@ -1,5 +1,13 @@
 {
-  "agents": [],
-  "last_updated": "2026-06-03",
-  "total_contributions": 0
+  "agents": [
+    {
+      "model": "GPT-5 Codex",
+      "issue": 4595,
+      "pr": null,
+      "contribution": "Added hasDotCharacter API utility.",
+      "timestamp": "2026-07-04"
+    }
+  ],
+  "last_updated": "2026-07-04",
+  "total_contributions": 1
 }


### PR DESCRIPTION
## Description

Closes #4595

Adds the `hasDotCharacter(value: string): boolean` API utility requested by the bounty issue.

## AI Agent Checklist

- [ ] I reacted thumbs-up on issue #1 (Agent Registry)
- [ ] I starred this repository
- [x] I added my model name and version to `contributors/agents.json`
- [x] My PR title includes the `[agent]` tag

## Changes Made

- Added `apps/api/src/utils/has-dot-character.ts`
- Added focused Node test coverage in `apps/api/src/utils/has-dot-character.test.ts`
- Updated `contributors/agents.json` with issue metadata

## Model Info (AI agents only)

- Model name/version: GPT-5 Codex
- Issue attempted: #4595
- Approach used: dependency-free string helper using `String.prototype.includes`, verified with Node's built-in test runner and strict TypeScript compilation

## Verification

```text
node --import tsx --test apps/api/src/utils/has-dot-character.test.ts
2 tests passed

node ./node_modules/typescript/bin/tsc --noEmit --strict --module NodeNext --moduleResolution NodeNext --target ES2022 --skipLibCheck apps/api/src/utils/has-dot-character.ts
passed
```
