### PR TITLE
[agent] add has slash character utility

### DIFF
--- a/apps/api/src/utils/has-slash-character.test.ts
+++ b/apps/api/src/utils/has-slash-character.test.ts
@@ -1,0 +1,18 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { hasSlashCharacter } from "./has-slash-character";
+
+test("detects slash characters", () => {
+  assert.equal(hasSlashCharacter("path/to"), true);
+  assert.equal(hasSlashCharacter("/"), true);
+  assert.equal(hasSlashCharacter("https://example.com"), true);
+});
+
+test("returns false when no slash character is present", () => {
+  assert.equal(hasSlashCharacter("path-to"), false);
+  assert.equal(hasSlashCharacter(""), false);
+  assert.equal(hasSlashCharacter("file.txt"), false);
+  assert.equal(hasSlashCharacter("key:value"), false);
+  assert.equal(hasSlashCharacter("path\\to"), false);
+});

--- a/apps/api/src/utils/has-slash-character.ts
+++ b/apps/api/src/utils/has-slash-character.ts
@@ -1,0 +1,3 @@
+export function hasSlashCharacter(value: string): boolean {
+  return value.includes("/");
+}

--- a/contributors/agents.json
+++ b/contributors/agents.json
@@ -1,5 +1,13 @@
 {
-  "agents": [],
-  "last_updated": "2026-06-03",
-  "total_contributions": 0
+  "agents": [
+    {
+      "model": "GPT-5 Codex",
+      "issue": 4140,
+      "pr": null,
+      "contribution": "Added hasSlashCharacter API utility.",
+      "timestamp": "2026-07-04"
+    }
+  ],
+  "last_updated": "2026-07-04",
+  "total_contributions": 1
 }


### PR DESCRIPTION
## Summary

- Add `hasSlashCharacter` utility for API-side string checks.
- Cover positive and negative cases with Node test runner tests.
- Register this agent's contribution in `contributors/agents.json`.

## Verification

- `node --import file:///C:/Users/deski/Desktop/work/xevrion-agent-playground-4595/node_modules/tsx/dist/loader.mjs --test apps/api/src/utils/has-slash-character.test.ts`
- `node C:\Users\deski\Desktop\work\xevrion-agent-playground-4595\node_modules\typescript\bin\tsc --noEmit --strict --module NodeNext --moduleResolution NodeNext --target ES2022 --skipLibCheck apps/api/src/utils/has-slash-character.ts`

Closes #4140
