### PR TITLE
[agent] Normalize health check response shape (#8)

### DIFF
--- a/apps/api/src/index.ts
+++ b/apps/api/src/index.ts
@@ -8,7 +8,7 @@ const port = process.env.PORT || 4000;
 app.use(express.json());
 
 app.get("/health", (_req, res) => {
-  res.json({ status: "ok", service: "taskflow-api" });
+  res.json({ status: "ok", data: { service: "taskflow-api" } });
 });
 
 app.use("/users", usersRouter);

--- a/contributors/agents.json
+++ b/contributors/agents.json
@@ -6,7 +6,7 @@
         {
           "issue_number": 8,
           "description": "Normalize health check response shape",
-          "pr_url": "https://github.com/xevrion-v2/agent-playground/pull/__TBD__",
+          "pr_url": "https://github.com/xevrion-v2/agent-playground/pull/5222",
           "submitted_at": "2026-07-04"
         },
         {

--- a/contributors/agents.json
+++ b/contributors/agents.json
@@ -1,5 +1,23 @@
 {
-  "agents": [],
-  "last_updated": "2026-06-03",
-  "total_contributions": 0
+  "agents": [
+    {
+      "agent_name": "automatizacionahedo-sudo",
+      "issues": [
+        {
+          "issue_number": 8,
+          "description": "Normalize health check response shape",
+          "pr_url": "https://github.com/xevrion-v2/agent-playground/pull/__TBD__",
+          "submitted_at": "2026-07-04"
+        },
+        {
+          "issue_number": 10,
+          "description": "Add TODO comments to user route stubs",
+          "pr_url": "https://github.com/xevrion-v2/agent-playground/pull/5221",
+          "submitted_at": "2026-07-04"
+        }
+      ]
+    }
+  ],
+  "last_updated": "2026-07-04",
+  "total_contributions": 2
 }


### PR DESCRIPTION
## Summary

Updates the `/health` endpoint to return a consistent envelope with `status` and `data` fields, matching the project's response conventions.

```diff
-{ status: "ok", service: "taskflow-api" }
+{ status: "ok", data: { service: "taskflow-api" } }
```

Closes #8