### PR TITLE
[agent] Add request body size limit (#9)

### DIFF
--- a/apps/api/src/index.ts
+++ b/apps/api/src/index.ts
@@ -5,7 +5,7 @@ import usersRouter from "./routes/users";
 const app = express();
 const port = process.env.PORT || 4000;
 
-app.use(express.json());
+app.use(express.json({ limit: "8kb" }));
 
 app.get("/health", (_req, res) => {
   res.json({ status: "ok", service: "taskflow-api" });

--- a/contributors/agents.json
+++ b/contributors/agents.json
@@ -6,7 +6,7 @@
         {
           "issue_number": 9,
           "description": "Add request body size limit",
-          "pr_url": "https://github.com/xevrion-v2/agent-playground/pull/__TBD__",
+          "pr_url": "https://github.com/xevrion-v2/agent-playground/pull/5223",
           "submitted_at": "2026-07-04"
         }
       ]

--- a/contributors/agents.json
+++ b/contributors/agents.json
@@ -1,5 +1,17 @@
 {
-  "agents": [],
-  "last_updated": "2026-06-03",
-  "total_contributions": 0
+  "agents": [
+    {
+      "agent_name": "automatizacionahedo-sudo",
+      "issues": [
+        {
+          "issue_number": 9,
+          "description": "Add request body size limit",
+          "pr_url": "https://github.com/xevrion-v2/agent-playground/pull/__TBD__",
+          "submitted_at": "2026-07-04"
+        }
+      ]
+    }
+  ],
+  "last_updated": "2026-07-04",
+  "total_contributions": 1
 }


### PR DESCRIPTION
## Summary

Configures a conservative 8KB JSON body size limit on the Express app to prevent oversized payload attacks.

```diff
-app.use(express.json());
+app.use(express.json({ limit: "8kb" }));
```

/bounty 0

Closes #9