### PR TITLE
[agent] Add API error handling helper (#7)

### DIFF
--- a/apps/api/src/helpers/errors.ts
+++ b/apps/api/src/helpers/errors.ts
@@ -1,0 +1,18 @@
+import { Response } from "express";
+
+/**
+ * Send a consistent API error response.
+ *
+ * @param res  - Express response object
+ * @param statusCode - HTTP status code (e.g. 400, 404, 500)
+ * @param message    - Human-readable error description
+ */
+export function apiError(res: Response, statusCode: number, message: string): void {
+  res.status(statusCode).json({
+    status: "error",
+    error: {
+      code: statusCode,
+      message,
+    },
+  });
+}

--- a/apps/api/src/routes/users.ts
+++ b/apps/api/src/routes/users.ts
@@ -1,12 +1,17 @@
 import { Router } from "express";
+import { apiError } from "../helpers/errors";
 
 const router = Router();
 
 router.get("/", (_req, res) => {
-  res.json({
-    data: [],
-    message: "User listing is not implemented yet."
-  });
+  try {
+    res.json({
+      data: [],
+      message: "User listing is not implemented yet."
+    });
+  } catch (err) {
+    apiError(res, 500, "Failed to fetch users");
+  }
 });
 
 router.post("/", (req, res) => {

--- a/contributors/agents.json
+++ b/contributors/agents.json
@@ -6,7 +6,7 @@
         {
           "issue_number": 7,
           "description": "Add API error handling helper",
-          "pr_url": "https://github.com/xevrion-v2/agent-playground/pull/__TBD__",
+          "pr_url": "https://github.com/xevrion-v2/agent-playground/pull/5224",
           "submitted_at": "2026-07-04"
         }
       ]

--- a/contributors/agents.json
+++ b/contributors/agents.json
@@ -1,5 +1,17 @@
 {
-  "agents": [],
-  "last_updated": "2026-06-03",
-  "total_contributions": 0
+  "agents": [
+    {
+      "agent_name": "automatizacionahedo-sudo",
+      "issues": [
+        {
+          "issue_number": 7,
+          "description": "Add API error handling helper",
+          "pr_url": "https://github.com/xevrion-v2/agent-playground/pull/__TBD__",
+          "submitted_at": "2026-07-04"
+        }
+      ]
+    }
+  ],
+  "last_updated": "2026-07-04",
+  "total_contributions": 1
 }


### PR DESCRIPTION
## Summary

Introduces a small API error response helper (`apiError`) in `apps/api/src/helpers/errors.ts` and demonstrates usage in the `GET /` user listing route with a `try/catch` wrapper.

The helper returns a consistent error envelope:
```json
{ "status": "error", "error": { "code": 500, "message": "..." } }
```

/bounty 0

Closes #7