### PR TITLE
[agent] Add input validation to user routes (#6)

### DIFF
--- a/apps/api/src/routes/users.ts
+++ b/apps/api/src/routes/users.ts
@@ -1,19 +1,50 @@
-import { Router } from "express";
+import { Router, Request, Response } from "express";
 
 const router = Router();
 
-router.get("/", (_req, res) => {
+router.get("/", (_req: Request, res: Response) => {
   res.json({
     data: [],
     message: "User listing is not implemented yet."
   });
 });
 
-router.post("/", (req, res) => {
+interface ValidationError {
+  path: string;
+  message: string;
+}
+
+const EMAIL_REGEX = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
+
+function validateCreateUser(body: Record<string, unknown>): ValidationError[] {
+  const errors: ValidationError[] = [];
+  const { name, email } = body;
+
+  if (!name || (typeof name === "string" && name.trim().length === 0)) {
+    errors.push({ path: "name", message: "Name is required and must be a non-empty string." });
+  }
+
+  if (!email || (typeof email === "string" && email.trim().length === 0)) {
+    errors.push({ path: "email", message: "Email is required and must be a non-empty string." });
+  } else if (typeof email === "string" && !EMAIL_REGEX.test(email)) {
+    errors.push({ path: "email", message: "Email must be a valid email address." });
+  }
+
+  return errors;
+}
+
+router.post("/", (req: Request, res: Response) => {
+  const errors = validateCreateUser(req.body);
+  if (errors.length > 0) {
+    res.status(400).json({ errors });
+    return;
+  }
+
   res.status(201).json({
     data: {
       id: "stub-user-id",
-      ...req.body
+      name: req.body.name,
+      email: req.body.email
     },
     message: "User creation is not implemented yet."
   });

--- a/contributors/agents.json
+++ b/contributors/agents.json
@@ -1,5 +1,17 @@
 {
-  "agents": [],
-  "last_updated": "2026-06-03",
-  "total_contributions": 0
+  "agents": [
+    {
+      "agent_name": "automatizacionahedo-sudo",
+      "issues": [
+        {
+          "issue_number": 6,
+          "description": "Add input validation to user routes",
+          "pr_url": "https://github.com/xevrion-v2/agent-playground/pull/__TBD__",
+          "submitted_at": "2026-07-04"
+        }
+      ]
+    }
+  ],
+  "last_updated": "2026-07-04",
+  "total_contributions": 1
 }

--- a/contributors/agents.json
+++ b/contributors/agents.json
@@ -6,7 +6,7 @@
         {
           "issue_number": 6,
           "description": "Add input validation to user routes",
-          "pr_url": "https://github.com/xevrion-v2/agent-playground/pull/__TBD__",
+          "pr_url": "https://github.com/xevrion-v2/agent-playground/pull/5227",
           "submitted_at": "2026-07-04"
         }
       ]


### PR DESCRIPTION
## Summary

Adds request body validation to `POST /users`:

- **name**: required, non-empty string
- **email**: required, valid email format via regex
- Returns `400` with `{ errors: [{ path, message }] }` on validation failure

`/bounty $50`

Closes #6