### PR TITLE
[agent] Validate user creation payloads (#2207)

### DIFF
--- a/apps/api/src/__tests__/users.test.ts
+++ b/apps/api/src/__tests__/users.test.ts
@@ -1,0 +1,148 @@
+import { describe, it, expect } from "vitest";
+import express from "express";
+import request from "supertest";
+import usersRouter from "../routes/users";
+
+function buildApp() {
+  const app = express();
+  app.use(express.json());
+  app.use("/users", usersRouter);
+  return app;
+}
+
+describe("GET /users", () => {
+  it("returns 200 with a stub listing", async () => {
+    const app = buildApp();
+    const res = await request(app).get("/users");
+
+    expect(res.status).toBe(200);
+    expect(res.body).toHaveProperty("data");
+    expect(Array.isArray(res.body.data)).toBe(true);
+    expect(res.body).toHaveProperty("message");
+    expect(res.body.message).toMatch(/not implemented/i);
+  });
+});
+
+describe("POST /users", () => {
+  it("returns 201 with the created user stub", async () => {
+    const app = buildApp();
+    const newUser = { name: "Jane Doe", email: "jane@example.com" };
+
+    const res = await request(app).post("/users").send(newUser);
+
+    expect(res.status).toBe(201);
+    expect(res.body).toHaveProperty("data");
+    expect(res.body.data).toHaveProperty("id", "stub-user-id");
+    expect(res.body.data).toHaveProperty("name", "Jane Doe");
+    expect(res.body.data).toHaveProperty("email", "jane@example.com");
+    expect(res.body.message).toMatch(/not implemented/i);
+  });
+
+  it("returns 400 when name is missing", async () => {
+    const app = buildApp();
+    const res = await request(app)
+      .post("/users")
+      .send({ email: "jane@example.com" });
+
+    expect(res.status).toBe(400);
+    expect(res.body).toHaveProperty("errors");
+    expect(Array.isArray(res.body.errors)).toBe(true);
+    expect(res.body.errors.some((e: any) => e.path === "name")).toBe(true);
+  });
+
+  it("returns 400 when name is an empty string", async () => {
+    const app = buildApp();
+    const res = await request(app)
+      .post("/users")
+      .send({ name: "", email: "jane@example.com" });
+
+    expect(res.status).toBe(400);
+    expect(res.body).toHaveProperty("errors");
+    expect(res.body.errors.some((e: any) => e.path === "name")).toBe(true);
+  });
+
+  it("returns 400 when email is invalid", async () => {
+    const app = buildApp();
+    const res = await request(app)
+      .post("/users")
+      .send({ name: "Jane Doe", email: "not-an-email" });
+
+    expect(res.status).toBe(400);
+    expect(res.body).toHaveProperty("errors");
+    expect(res.body.errors.some((e: any) => e.path === "email")).toBe(true);
+  });
+
+  it("returns 400 when email is missing", async () => {
+    const app = buildApp();
+    const res = await request(app)
+      .post("/users")
+      .send({ name: "Jane Doe" });
+
+    expect(res.status).toBe(400);
+    expect(res.body).toHaveProperty("errors");
+    expect(res.body.errors.some((e: any) => e.path === "email")).toBe(true);
+  });
+
+  it("returns 400 when both name and email are missing", async () => {
+    const app = buildApp();
+    const res = await request(app).post("/users").send({});
+
+    expect(res.status).toBe(400);
+    expect(res.body).toHaveProperty("errors");
+    expect(res.body.errors.some((e: any) => e.path === "name")).toBe(true);
+    expect(res.body.errors.some((e: any) => e.path === "email")).toBe(true);
+  });
+
+  // --- Additional regression tests for #2207 ---
+
+  it("rejects non-object JSON bodies", async () => {
+    const app = buildApp();
+    const res = await request(app)
+      .post("/users")
+      .send("just a string")
+      .set("Content-Type", "application/json");
+
+    expect(res.status).toBe(400);
+    expect(res.body.errors.some((e: any) => e.path === "body")).toBe(true);
+  });
+
+  it("normalizes name with surrounding whitespace", async () => {
+    const app = buildApp();
+    const res = await request(app)
+      .post("/users")
+      .send({ name: "  Jane Doe  ", email: "jane@example.com" });
+
+    expect(res.status).toBe(201);
+    expect(res.body.data.name).toBe("Jane Doe");
+  });
+
+  it("normalizes email with surrounding whitespace", async () => {
+    const app = buildApp();
+    const res = await request(app)
+      .post("/users")
+      .send({ name: "Jane Doe", email: "  jane@example.com  " });
+
+    expect(res.status).toBe(201);
+    expect(res.body.data.email).toBe("jane@example.com");
+  });
+
+  it("ignores client-supplied id and extra fields", async () => {
+    const app = buildApp();
+    const res = await request(app)
+      .post("/users")
+      .send({
+        id: "hacker-id",
+        name: "Jane Doe",
+        email: "jane@example.com",
+        role: "admin",
+        extra: "should be ignored"
+      });
+
+    expect(res.status).toBe(201);
+    // Server-generated id, not the client-supplied one
+    expect(res.body.data.id).toBe("stub-user-id");
+    // Only name and email should appear
+    expect(res.body.data).not.toHaveProperty("role");
+    expect(res.body.data).not.toHaveProperty("extra");
+  });
+});

--- a/apps/api/src/routes/users.ts
+++ b/apps/api/src/routes/users.ts
@@ -1,19 +1,89 @@
-import { Router } from "express";
+import { Router, Request, Response } from "express";
 
 const router = Router();
 
-router.get("/", (_req, res) => {
+router.get("/", (_req: Request, res: Response) => {
   res.json({
     data: [],
     message: "User listing is not implemented yet."
   });
 });
 
-router.post("/", (req, res) => {
+interface ValidationError {
+  path: string;
+  message: string;
+}
+
+interface ValidationOk {
+  ok: true;
+  name: string;
+  email: string;
+}
+interface ValidationFail {
+  ok: false;
+  errors: ValidationError[];
+}
+
+type ValidationResult = ValidationOk | ValidationFail;
+
+const EMAIL_REGEX = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
+
+/**
+ * Validate a user creation payload.
+ *
+ * - Rejects non-object bodies entirely.
+ * - Requires a valid email and a non-empty name.
+ * - Returns trimmed / normalized values on success.
+ */
+function validateCreateUser(body: unknown): ValidationResult {
+  const errors: ValidationError[] = [];
+
+  if (!body || typeof body !== "object" || Array.isArray(body)) {
+    errors.push({ path: "body", message: "Request body must be a JSON object." });
+    return { ok: false, errors };
+  }
+
+  const data = body as Record<string, unknown>;
+
+  // --- name validation ---
+  const rawName = data.name;
+  const name = typeof rawName === "string" ? rawName.trim() : rawName;
+
+  if (!name || (typeof name === "string" && name.length === 0)) {
+    errors.push({ path: "name", message: "Name is required and must be a non-empty string." });
+  }
+
+  // --- email validation ---
+  const rawEmail = data.email;
+  const email = typeof rawEmail === "string" ? rawEmail.trim() : rawEmail;
+
+  if (!email || (typeof email === "string" && email.length === 0)) {
+    errors.push({ path: "email", message: "Email is required and must be a non-empty string." });
+  } else if (typeof email === "string" && !EMAIL_REGEX.test(email)) {
+    errors.push({ path: "email", message: "Email must be a valid email address." });
+  }
+
+  if (errors.length > 0) {
+    return { ok: false, errors };
+  }
+
+  return { ok: true, name: name as string, email: email as string };
+}
+
+router.post("/", (req: Request, res: Response) => {
+  const result = validateCreateUser(req.body);
+
+  if (!result.ok) {
+    res.status(400).json({ errors: (result as ValidationFail).errors });
+    return;
+  }
+
+  // Only return server-generated id and validated/trimmed fields
   res.status(201).json({
     data: {
       id: "stub-user-id",
-      ...req.body
+      name: (result as ValidationOk).name,
+      email: (result as ValidationOk).email
     },
     message: "User creation is not implemented yet."
   });

--- a/contributors/agents.json
+++ b/contributors/agents.json
@@ -6,7 +6,7 @@
         {
           "issue_number": 2207,
           "description": "Validate user creation payloads",
-          "pr_url": "https://github.com/xevrion-v2/agent-playground/pull/__TBD__",
+          "pr_url": "https://github.com/xevrion-v2/agent-playground/pull/5228",
           "submitted_at": "2026-07-04"
         }
       ]

--- a/contributors/agents.json
+++ b/contributors/agents.json
@@ -1,5 +1,17 @@
 {
-  "agents": [],
-  "last_updated": "2026-06-03",
-  "total_contributions": 0
+  "agents": [
+    {
+      "agent_name": "automatizacionahedo-sudo",
+      "issues": [
+        {
+          "issue_number": 2207,
+          "description": "Validate user creation payloads",
+          "pr_url": "https://github.com/xevrion-v2/agent-playground/pull/__TBD__",
+          "submitted_at": "2026-07-04"
+        }
+      ]
+    }
+  ],
+  "last_updated": "2026-07-04",
+  "total_contributions": 1
 }


### PR DESCRIPTION
## Summary

Enhances `POST /users` with proper payload validation and normalization:

### Changes

- **Reject non-object bodies**: String, array, or null bodies return 400
- **Email validation**: Required, valid format via regex
- **Name validation**: Required, non-empty string
- **Normalization**: Both name and email are trimmed of whitespace
- **Ignore extra fields**: Client-supplied `id`, `role`, or any unspecified fields are stripped from the response

### Regression tests added

- Non-object body rejection
- Whitespace normalization for name and email
- Client-supplied id and extra fields are ignored

/bounty $250

Closes #2207