### PR TITLE
[agent] tests(leaderboard): add unit tests for leaderboard updates (#11)

### DIFF
--- a/contributors/agents.json
+++ b/contributors/agents.json
@@ -1,5 +1,23 @@
 {
-  "agents": [],
-  "last_updated": "2026-06-03",
-  "total_contributions": 0
+  "agents": [
+    {
+      "agent_name": "automatizacionahedo-sudo",
+      "issues": [
+        {
+          "issue_number": 2207,
+          "description": "Validate user creation payloads",
+          "pr_url": "https://github.com/xevrion-v2/agent-playground/pull/5228",
+          "submitted_at": "2026-07-04"
+        },
+        {
+          "issue_number": 11,
+          "description": "Write unit tests for leaderboard updates",
+          "pr_url": "https://github.com/xevrion-v2/agent-playground/pull/__TBD__",
+          "submitted_at": "2026-07-04"
+        }
+      ]
+    }
+  ],
+  "last_updated": "2026-07-04",
+  "total_contributions": 2
 }

--- a/contributors/agents.json
+++ b/contributors/agents.json
@@ -12,7 +12,7 @@
         {
           "issue_number": 11,
           "description": "Write unit tests for leaderboard updates",
-          "pr_url": "https://github.com/xevrion-v2/agent-playground/pull/__TBD__",
+          "pr_url": "https://github.com/xevrion-v2/agent-playground/pull/5230",
           "submitted_at": "2026-07-04"
         }
       ]

--- a/package.json
+++ b/package.json
@@ -9,7 +9,8 @@
   ],
   "scripts": {
     "dev": "npm run dev --workspaces --if-present",
-    "test": "npm run test --workspaces --if-present",
+    "test": "npm run test:leaderboard && npm run test --workspaces --if-present",
+    "test:leaderboard": "node --test scripts/*.test.mjs",
     "lint": "npm run lint --workspaces --if-present",
     "format": "npm run format --workspaces --if-present"
   },

--- a/scripts/update-leaderboard.mjs
+++ b/scripts/update-leaderboard.mjs
@@ -1,0 +1,51 @@
+import { existsSync, readFileSync, writeFileSync } from "node:fs";
+
+/**
+ * Increment a contributor's count on the leaderboard.
+ * Returns a new leaderboard object without mutating the original.
+ *
+ * @param {Record<string, number>} leaderboard - Current leaderboard map
+ * @param {string} contributor - Contributor username
+ * @returns {Record<string, number>} New leaderboard with the contributor incremented
+ */
+export function incrementLeaderboard(leaderboard, contributor) {
+  if (!contributor || typeof contributor !== "string") {
+    throw new Error("Contributor must be a non-empty string");
+  }
+
+  const currentCount = Number(leaderboard[contributor] ?? 0);
+
+  return {
+    ...leaderboard,
+    [contributor]: currentCount + 1,
+  };
+}
+
+/**
+ * Update a leaderboard JSON file by incrementing a contributor.
+ * Creates the file if it doesn't exist.
+ *
+ * @param {string} filePath - Path to the JSON leaderboard file
+ * @param {string} contributor - Contributor username to increment
+ */
+export function updateLeaderboardFile(filePath, contributor) {
+  const leaderboard = existsSync(filePath)
+    ? JSON.parse(readFileSync(filePath, "utf8"))
+    : {};
+
+  const updated = incrementLeaderboard(leaderboard, contributor);
+
+  writeFileSync(filePath, JSON.stringify(updated, null, 2) + "\n");
+}
+
+// CLI usage
+if (process.argv[1] && import.meta.url === new URL(process.argv[1], "file:").href) {
+  const [, , filePath, contributor] = process.argv;
+
+  if (!filePath || !contributor) {
+    console.error("Usage: node scripts/update-leaderboard.mjs <file> <contributor>");
+    process.exit(1);
+  }
+
+  updateLeaderboardFile(filePath, contributor);
+}

--- a/scripts/update-leaderboard.test.mjs
+++ b/scripts/update-leaderboard.test.mjs
@@ -1,0 +1,98 @@
+import assert from "node:assert/strict";
+import { mkdtemp, readFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { test, describe } from "node:test";
+
+import {
+  incrementLeaderboard,
+  updateLeaderboardFile,
+} from "./update-leaderboard.mjs";
+
+describe("incrementLeaderboard", () => {
+  test("adds a new contributor with count 1", () => {
+    const result = incrementLeaderboard({}, "new-contributor");
+    assert.deepEqual(result, { "new-contributor": 1 });
+  });
+
+  test("does not mutate the original leaderboard (immutability)", () => {
+    const original = { alice: 2 };
+    const result = incrementLeaderboard(original, "alice");
+    assert.deepEqual(original, { alice: 2 }); // unchanged
+    assert.deepEqual(result, { alice: 3 });
+  });
+
+  test("increments an existing contributor by 1", () => {
+    const leaderboard = { alice: 2, bob: 1 };
+    const result = incrementLeaderboard(leaderboard, "alice");
+    assert.deepEqual(result, { alice: 3, bob: 1 });
+  });
+
+  test("increments a contributor with zero count", () => {
+    const leaderboard = { alice: 0 };
+    const result = incrementLeaderboard(leaderboard, "alice");
+    assert.deepEqual(result, { alice: 1 });
+  });
+
+  test("treats missing contributor as 0 and creates entry", () => {
+    const leaderboard = { bob: 5 };
+    const result = incrementLeaderboard(leaderboard, "carol");
+    assert.deepEqual(result, { bob: 5, carol: 1 });
+  });
+
+  test("preserves other entries when incrementing", () => {
+    const leaderboard = { alice: 1, bob: 2, charlie: 3 };
+    const result = incrementLeaderboard(leaderboard, "bob");
+    assert.deepEqual(result, { alice: 1, bob: 3, charlie: 3 });
+  });
+
+  test("throws for empty string contributor", () => {
+    assert.throws(
+      () => incrementLeaderboard({}, ""),
+      /Contributor must be a non-empty string/,
+    );
+  });
+
+  test("throws for non-string contributor", () => {
+    assert.throws(
+      () => incrementLeaderboard({}, 123),
+      /Contributor must be a non-empty string/,
+    );
+  });
+
+  test("throws for null contributor", () => {
+    assert.throws(
+      () => incrementLeaderboard({}, null),
+      /Contributor must be a non-empty string/,
+    );
+  });
+});
+
+describe("updateLeaderboardFile", () => {
+  test("creates a new leaderboard file with the contributor", async () => {
+    const directory = await mkdtemp(join(tmpdir(), "leaderboard-"));
+    const filePath = join(directory, "leaderboard.json");
+
+    updateLeaderboardFile(filePath, "alice");
+
+    const content = await readFile(filePath, "utf8");
+    assert.equal(content, JSON.stringify({ alice: 1 }, null, 2) + "\n");
+  });
+
+  test("updates an existing leaderboard file", async () => {
+    const directory = await mkdtemp(join(tmpdir(), "leaderboard-"));
+    const filePath = join(directory, "leaderboard.json");
+
+    // Write initial data
+    const initial = { alice: 2, bob: 1 };
+    await import("node:fs/promises").then((fs) =>
+      fs.writeFile(filePath, JSON.stringify(initial, null, 2) + "\n"),
+    );
+
+    // Update
+    updateLeaderboardFile(filePath, "alice");
+
+    const content = await readFile(filePath, "utf8");
+    assert.equal(content, JSON.stringify({ alice: 3, bob: 1 }, null, 2) + "\n");
+  });
+});


### PR DESCRIPTION
/closes #11
/claim #11

[agent]

## Summary
Add unit tests covering leaderboard update logic

### Changes
- `scripts/update-leaderboard.mjs` — Extracted leaderboard increment helper with immutability and validation
- `scripts/update-leaderboard.test.mjs` — 11 unit tests covering new contributors, existing contributors, edge cases, and file I/O
- `package.json` — Added `test:leaderboard` script and wired into `npm test`
- `contributors/agents.json` — Registered agent contribution for issue #11