### PR TITLE
test(users): add comprehensive unit tests for user routes (#12)

### DIFF
--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -7,7 +7,7 @@
   "main": "src/index.ts",
   "scripts": {
     "dev": "tsx src/index.ts",
-    "test": "echo \"No API tests configured yet\"",
+    "test": "vitest run",
     "lint": "echo \"No API lint configured yet\""
   },
   "dependencies": {
@@ -15,7 +15,10 @@
   },
   "devDependencies": {
     "@types/express": "^4.17.21",
+    "@types/supertest": "^7.2.0",
+    "supertest": "^7.2.2",
     "tsx": "^4.7.1",
-    "typescript": "^5.4.5"
+    "typescript": "^5.4.5",
+    "vitest": "^4.1.9"
   }
 }

--- a/apps/api/src/__tests__/users.test.ts
+++ b/apps/api/src/__tests__/users.test.ts
@@ -1,0 +1,139 @@
+import { describe, it, expect } from "vitest";
+import request from "supertest";
+import express from "express";
+import usersRouter from "../routes/users";
+
+/**
+ * Build a minimal Express app that mounts the users router at /users
+ * so we can test via supertest without starting the full API server.
+ */
+function buildApp() {
+  const app = express();
+  app.use(express.json());
+  app.use("/users", usersRouter);
+  return app;
+}
+
+describe("GET /users", () => {
+  it("should return 200 OK with a data array and message", async () => {
+    const app = buildApp();
+    const res = await request(app).get("/users");
+
+    expect(res.status).toBe(200);
+    expect(res.body).toHaveProperty("data");
+    expect(Array.isArray(res.body.data)).toBe(true);
+    expect(res.body.data).toHaveLength(0);
+    expect(res.body).toHaveProperty("message");
+    expect(typeof res.body.message).toBe("string");
+    expect(res.body.message).toBe("User listing is not implemented yet.");
+  });
+
+  it("should not return nested errors or unexpected fields", async () => {
+    const app = buildApp();
+    const res = await request(app).get("/users");
+
+    expect(res.body).not.toHaveProperty("error");
+    expect(res.body).not.toHaveProperty("errors");
+    expect(res.body).not.toHaveProperty("stack");
+  });
+
+  it("should set Content-Type application/json", async () => {
+    const app = buildApp();
+    const res = await request(app).get("/users");
+
+    expect(res.headers["content-type"]).toMatch(/application\/json/);
+  });
+});
+
+describe("POST /users", () => {
+  it("should return 201 Created with a stub user and message", async () => {
+    const app = buildApp();
+    const payload = { name: "Alice", email: "alice@example.com" };
+    const res = await request(app).post("/users").send(payload);
+
+    expect(res.status).toBe(201);
+    expect(res.body).toHaveProperty("data");
+    expect(res.body.data).toHaveProperty("id", "stub-user-id");
+    expect(res.body.data).toMatchObject(payload);
+    expect(res.body).toHaveProperty("message");
+    expect(res.body.message).toBe("User creation is not implemented yet.");
+  });
+
+  it("should accept and echo back an empty request body", async () => {
+    const app = buildApp();
+    const res = await request(app).post("/users").send({});
+
+    expect(res.status).toBe(201);
+    expect(res.body.data).toHaveProperty("id", "stub-user-id");
+    // With an empty body, req.body is {} so spread yields an empty object
+    expect(res.body.data).not.toHaveProperty("name");
+    expect(res.body.data).not.toHaveProperty("email");
+  });
+
+  it("should echo back any additional fields sent in the body", async () => {
+    const app = buildApp();
+    const payload = {
+      name: "Bob",
+      email: "bob@example.com",
+      role: "admin",
+      age: 30,
+      tags: ["dev", "ops"],
+    };
+    const res = await request(app).post("/users").send(payload);
+
+    expect(res.status).toBe(201);
+    expect(res.body.data).toHaveProperty("id", "stub-user-id");
+    expect(res.body.data).toMatchObject(payload);
+  });
+
+  it("should not return errors for unexpected fields", async () => {
+    const app = buildApp();
+    const payload = { someUnknownField: "should-be-allowed" };
+    const res = await request(app).post("/users").send(payload);
+
+    expect(res.status).toBe(201);
+    expect(res.body.data).toHaveProperty("id", "stub-user-id");
+    expect(res.body.data).toHaveProperty("someUnknownField", "should-be-allowed");
+    expect(res.body).not.toHaveProperty("error");
+    expect(res.body).not.toHaveProperty("errors");
+  });
+
+  it("should set Content-Type application/json on response", async () => {
+    const app = buildApp();
+    const res = await request(app).post("/users").send({ name: "Test" });
+
+    expect(res.headers["content-type"]).toMatch(/application\/json/);
+  });
+
+  it("should handle request with no body gracefully", async () => {
+    const app = buildApp();
+    // Send without explicitly setting a body
+    const res = await request(app).post("/users");
+
+    expect(res.status).toBe(201);
+    expect(res.body.data).toHaveProperty("id", "stub-user-id");
+  });
+});
+
+describe("unknown methods on /users", () => {
+  it("should return 404 for PUT /users", async () => {
+    const app = buildApp();
+    const res = await request(app).put("/users");
+
+    expect(res.status).toBe(404);
+  });
+
+  it("should return 404 for DELETE /users", async () => {
+    const app = buildApp();
+    const res = await request(app).delete("/users");
+
+    expect(res.status).toBe(404);
+  });
+
+  it("should return 404 for PATCH /users", async () => {
+    const app = buildApp();
+    const res = await request(app).patch("/users");
+
+    expect(res.status).toBe(404);
+  });
+});

--- a/contributors/agents.json
+++ b/contributors/agents.json
@@ -18,7 +18,7 @@
         {
           "issue_number": 12,
           "description": "Write unit tests for user routes",
-          "pr_url": "https://github.com/xevrion-v2/agent-playground/pull/__TBD__",
+          "pr_url": "https://github.com/xevrion-v2/agent-playground/pull/5231",
           "submitted_at": "2026-07-04"
         }
       ]

--- a/contributors/agents.json
+++ b/contributors/agents.json
@@ -1,5 +1,29 @@
 {
-  "agents": [],
-  "last_updated": "2026-06-03",
-  "total_contributions": 0
+  "agents": [
+    {
+      "agent_name": "automatizacionahedo-sudo",
+      "issues": [
+        {
+          "issue_number": 2207,
+          "description": "Validate user creation payloads",
+          "pr_url": "https://github.com/xevrion-v2/agent-playground/pull/5228",
+          "submitted_at": "2026-07-04"
+        },
+        {
+          "issue_number": 11,
+          "description": "Write unit tests for leaderboard updates",
+          "pr_url": "https://github.com/xevrion-v2/agent-playground/pull/5230",
+          "submitted_at": "2026-07-04"
+        },
+        {
+          "issue_number": 12,
+          "description": "Write unit tests for user routes",
+          "pr_url": "https://github.com/xevrion-v2/agent-playground/pull/__TBD__",
+          "submitted_at": "2026-07-04"
+        }
+      ]
+    }
+  ],
+  "last_updated": "2026-07-04",
+  "total_contributions": 3
 }


### PR DESCRIPTION
/closes #12
/claim #12

[agent]

## Summary
Add comprehensive unit tests for user routes

### Changes
- Created `apps/api/src/__tests__/users.test.ts` with 12 test cases covering GET and POST /users endpoints
- Updated `apps/api/package.json` to use vitest for running tests
- Updated `contributors/agents.json` with issue #12 entry

### Test Coverage
- **GET /users**: 200 status, JSON structure, empty data array, message verification, no unexpected error fields
- **POST /users**: 201 status, stub user ID, body echo-back, empty body handling, additional fields, no-body request
- **HTTP methods**: 404 for unsupported methods (PUT, DELETE, PATCH)
- **Content-Type**: Proper application/json headers on all responses