### PR TITLE
tests(ui): add unit tests for Button component (#13)

### DIFF
--- a/contributors/agents.json
+++ b/contributors/agents.json
@@ -1,5 +1,16 @@
 {
-  "agents": [],
-  "last_updated": "2026-06-03",
-  "total_contributions": 0
+  "agents": [
+    {
+      "agent_name": "automatizacionahedo-sudo",
+      "issues": [
+        {
+          "issue_number": 13,
+          "description": "Write unit tests for UI Button stub",
+          "pr_url": "https://github.com/xevrion-v2/agent-playground/pull/__TBD__"
+        }
+      ]
+    }
+  ],
+  "last_updated": "2026-07-04",
+  "total_contributions": 1
 }

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -5,10 +5,12 @@
   "description": "Shared UI components for TaskFlow.",
   "main": "src/index.ts",
   "scripts": {
-    "test": "echo \"No UI tests configured yet\"",
+    "test": "vitest run",
+    "test:watch": "vitest",
     "lint": "echo \"No UI lint configured yet\""
   },
   "devDependencies": {
-    "typescript": "^5.4.5"
+    "typescript": "^5.4.5",
+    "vitest": "^4.1.9"
   }
 }

--- a/packages/ui/src/__tests__/Button.test.ts
+++ b/packages/ui/src/__tests__/Button.test.ts
@@ -1,0 +1,67 @@
+import { describe, it, expect } from "vitest";
+import { Button } from "../index";
+
+describe("Button", () => {
+  it("should return an object with type 'button'", () => {
+    const result = Button({ label: "Click me" });
+    expect(result).toBeDefined();
+    expect(result.type).toBe("button");
+  });
+
+  it("should return an object with the provided label", () => {
+    const result = Button({ label: "Submit" });
+    expect(result.label).toBe("Submit");
+  });
+
+  it("should default disabled to false when not provided", () => {
+    const result = Button({ label: "Click me" });
+    expect(result.disabled).toBe(false);
+  });
+
+  it("should set disabled to true when explicitly passed", () => {
+    const result = Button({ label: "Click me", disabled: true });
+    expect(result.disabled).toBe(true);
+  });
+
+  it("should set disabled to false when explicitly passed as false", () => {
+    const result = Button({ label: "Click me", disabled: false });
+    expect(result.disabled).toBe(false);
+  });
+
+  it("should handle empty string label", () => {
+    const result = Button({ label: "" });
+    expect(result.label).toBe("");
+    expect(result.type).toBe("button");
+    expect(result.disabled).toBe(false);
+  });
+
+  it("should handle label with special characters", () => {
+    const result = Button({ label: "Save & Continue" });
+    expect(result.label).toBe("Save & Continue");
+  });
+
+  it("should not mutate the input props", () => {
+    const props = { label: "Delete", disabled: true };
+    const result = Button(props);
+    expect(result.label).toBe("Delete");
+    expect(result.disabled).toBe(true);
+    // Verify original object is unchanged
+    expect(props).toEqual({ label: "Delete", disabled: true });
+  });
+
+  it("should return a new object each time it is called", () => {
+    const result1 = Button({ label: "A" });
+    const result2 = Button({ label: "A" });
+    expect(result1).not.toBe(result2);
+    expect(result1).toEqual(result2);
+  });
+
+  it("should only have type, label, and disabled properties", () => {
+    const result = Button({ label: "test" });
+    const keys = Object.keys(result);
+    expect(keys).toHaveLength(3);
+    expect(keys).toContain("type");
+    expect(keys).toContain("label");
+    expect(keys).toContain("disabled");
+  });
+});

--- a/packages/ui/vitest.config.ts
+++ b/packages/ui/vitest.config.ts
@@ -1,0 +1,8 @@
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+  test: {
+    globals: true,
+    environment: "node",
+  },
+});


### PR DESCRIPTION
## Summary

This PR adds unit tests for the UI Button stub component to address Issue #13.

## Changes

- **packages/ui/package.json**: Added  as a devDependency and configured  /  scripts.
- **packages/ui/vitest.config.ts**: Created vitest configuration for the UI package.
- **packages/ui/src/__tests__/Button.test.ts**: Unit tests covering:
  - Returns correct type (`button`)
  - Returns provided label
  - `disabled` defaults to `false`
  - `disabled` can be set to `true` or `false`
  - Handles empty string labels
  - Handles special characters in labels
  - Does not mutate input props
  - Returns a new object on each call (immutability)
  - Only exposes `type`, `label`, and `disabled` properties
- **contributors/agents.json**: Added entry for issue #13.

## Testing

All 10 tests pass:

```
 ✓ src/__tests__/Button.test.ts (10 tests) 14ms
```

Closes #13