### PR TITLE
feat(utils): implement infinite sequence iterator (#15)

### DIFF
--- a/contributors/agents.json
+++ b/contributors/agents.json
@@ -3,7 +3,7 @@
     {
       "issue_number": 15,
       "description": "Implement infinite sequence iterator",
-      "pr_url": "https://github.com/xevrion-v2/agent-playground/pull/__TBD__"
+      "pr_url": "https://github.com/xevrion-v2/agent-playground/pull/5233"
     }
   ],
   "last_updated": "2026-07-04",

--- a/contributors/agents.json
+++ b/contributors/agents.json
@@ -1,5 +1,11 @@
 {
-  "agents": [],
-  "last_updated": "2026-06-03",
-  "total_contributions": 0
+  "agents": [
+    {
+      "issue_number": 15,
+      "description": "Implement infinite sequence iterator",
+      "pr_url": "https://github.com/xevrion-v2/agent-playground/pull/__TBD__"
+    }
+  ],
+  "last_updated": "2026-07-04",
+  "total_contributions": 1
 }

--- a/packages/utils/src/__tests__/sequence.test.ts
+++ b/packages/utils/src/__tests__/sequence.test.ts
@@ -1,0 +1,182 @@
+import { describe, it, expect } from "vitest";
+import {
+  createInfiniteSequence,
+  naturalNumbers,
+  evenNumbers,
+  fibonacciSequence,
+  Sequence,
+  seq,
+  take,
+} from "../sequence";
+
+describe("createInfiniteSequence", () => {
+  it("produces an infinite sequence of natural numbers", () => {
+    const naturals = createInfiniteSequence((i) => i + 1);
+    expect(naturals.next().value).toBe(1);
+    expect(naturals.next().value).toBe(2);
+    expect(naturals.next().value).toBe(3);
+  });
+
+  it("can be used with for...of with a break condition", () => {
+    const squares = createInfiniteSequence((i) => i * i);
+    const results: number[] = [];
+    for (const val of squares) {
+      if (val > 25) break;
+      results.push(val);
+    }
+    expect(results).toEqual([0, 1, 4, 9, 16, 25]);
+  });
+
+  it("supports Symbol.iterator for spread (finite take)", () => {
+    const seq = createInfiniteSequence((i) => i * 10);
+    // Manual finite consumption
+    const first4 = take(seq, 4);
+    expect(first4).toEqual([0, 10, 20, 30]);
+  });
+
+  it("throws on non-function generator", () => {
+    expect(() =>
+      (createInfiniteSequence as unknown as (g: unknown) => void)(42),
+    ).toThrow(TypeError);
+    expect(() =>
+      (createInfiniteSequence as unknown as (g: unknown) => void)("foo"),
+    ).toThrow(TypeError);
+  });
+});
+
+describe("take", () => {
+  it("takes the first N elements from an iterable", () => {
+    const naturals = createInfiniteSequence((i) => i + 1);
+    expect(take(naturals, 5)).toEqual([1, 2, 3, 4, 5]);
+  });
+
+  it("returns an empty array for count 0", () => {
+    const naturals = createInfiniteSequence((i) => i + 1);
+    expect(take(naturals, 0)).toEqual([]);
+  });
+
+  it("throws on negative count", () => {
+    const naturals = createInfiniteSequence((i) => i + 1);
+    expect(() => take(naturals, -1)).toThrow(RangeError);
+  });
+
+  it("handles finite iterables gracefully (defensive)", () => {
+    const finite = [10, 20, 30];
+    expect(take(finite, 10)).toEqual([10, 20, 30]);
+  });
+});
+
+describe("naturalNumbers", () => {
+  it("generates natural numbers starting from 1 by default", () => {
+    expect(take(naturalNumbers(), 5)).toEqual([1, 2, 3, 4, 5]);
+  });
+
+  it("starts from a custom start value", () => {
+    expect(take(naturalNumbers(10), 3)).toEqual([10, 11, 12]);
+  });
+
+  it("throws on non-integer start", () => {
+    expect(() => naturalNumbers(1.5)).toThrow(RangeError);
+  });
+
+  it("throws on NaN start", () => {
+    expect(() => naturalNumbers(NaN)).toThrow(RangeError);
+  });
+
+  it("works with 0 start", () => {
+    expect(take(naturalNumbers(0), 3)).toEqual([0, 1, 2]);
+  });
+});
+
+describe("evenNumbers", () => {
+  it("generates even numbers starting from 0 by default", () => {
+    expect(take(evenNumbers(), 5)).toEqual([0, 2, 4, 6, 8]);
+  });
+
+  it("starts from a custom even value", () => {
+    expect(take(evenNumbers(10), 4)).toEqual([10, 12, 14, 16]);
+  });
+
+  it("throws on odd start", () => {
+    expect(() => evenNumbers(1)).toThrow(RangeError);
+  });
+
+  it("throws on non-finite start", () => {
+    expect(() => evenNumbers(Infinity)).toThrow(RangeError);
+  });
+});
+
+describe("fibonacciSequence", () => {
+  it("generates the classic Fibonacci sequence", () => {
+    expect(take(fibonacciSequence(), 10)).toEqual([0, 1, 1, 2, 3, 5, 8, 13, 21, 34]);
+  });
+
+  it("supports custom start values (Lucas-like)", () => {
+    expect(take(fibonacciSequence(2, 1), 6)).toEqual([2, 1, 3, 4, 7, 11]);
+  });
+
+  it("handles [1, 1] start (alternate Fibonacci)", () => {
+    expect(take(fibonacciSequence(1, 1), 6)).toEqual([1, 1, 2, 3, 5, 8]);
+  });
+
+  it("throws on non-finite start", () => {
+    expect(() => fibonacciSequence(Infinity, 1)).toThrow(RangeError);
+    expect(() => fibonacciSequence(0, NaN)).toThrow(RangeError);
+  });
+});
+
+describe("Sequence class", () => {
+  it("implements IterableIterator correctly", () => {
+    const s = new Sequence(createInfiniteSequence((i) => i + 1));
+    expect(s.next().value).toBe(1);
+    expect(s.next().value).toBe(2);
+    expect(s.next().value).toBe(3);
+  });
+
+  it("take() works as a method", () => {
+    const s = new Sequence(createInfiniteSequence((i) => i + 1));
+    expect(s.take(5)).toEqual([1, 2, 3, 4, 5]);
+  });
+
+  it("map() transforms elements", () => {
+    const s = new Sequence(createInfiniteSequence((i) => i + 1));
+    const doubled = s.map((x) => x * 2);
+    expect(doubled.take(5)).toEqual([2, 4, 6, 8, 10]);
+  });
+
+  it("filter() skips non-matching elements", () => {
+    const s = new Sequence(createInfiniteSequence((i) => i + 1));
+    const evens = s.filter((x) => x % 2 === 0);
+    expect(evens.take(4)).toEqual([2, 4, 6, 8]);
+  });
+
+  it("skip() advances past elements", () => {
+    const s = new Sequence(createInfiniteSequence((i) => i + 1));
+    s.skip(3);
+    expect(s.take(3)).toEqual([4, 5, 6]);
+  });
+
+  it("supports chaining: map -> filter -> take", () => {
+    const naturals = new Sequence(createInfiniteSequence((i) => i + 1));
+    const result = naturals
+      .map((x) => x * 2)
+      .filter((x) => x % 4 === 0)
+      .take(5);
+    expect(result).toEqual([4, 8, 12, 16, 20]);
+  });
+});
+
+describe("seq() convenience factory", () => {
+  it("creates a Sequence from a generator", () => {
+    const naturals = seq((i) => i + 1);
+    expect(naturals.take(3)).toEqual([1, 2, 3]);
+  });
+
+  it("supports chaining", () => {
+    const result = seq((i) => i + 1)
+      .filter((x) => x % 2 === 0)
+      .map((x) => x * 10)
+      .take(4);
+    expect(result).toEqual([20, 40, 60, 80]);
+  });
+});

--- a/packages/utils/src/sequence.ts
+++ b/packages/utils/src/sequence.ts
@@ -1,0 +1,344 @@
+/**
+ * Infinite Sequence Iterator
+ *
+ * A utility for creating iterable iterators that generate values from
+ * a sequence indefinitely. Supports lazy evaluation — values are computed
+ * on demand via a generator callback indexed by position.
+ *
+ * @example
+ * ```ts
+ * const naturals = createInfiniteSequence(i => i + 1);
+ * const it = naturals[Symbol.iterator]();
+ * it.next().value; // 1
+ * it.next().value; // 2
+ * it.next().value; // 3
+ *
+ * // Or spread into an array (with a finite bound):
+ * const first5 = [...(function*(){ for (let i=0; i<5; i++) yield i+1; })()];
+ * ```
+ */
+
+// ---------------------------------------------------------------------------
+// Core factory
+// ---------------------------------------------------------------------------
+
+/**
+ * Creates an infinite sequence iterator that produces values by calling
+ * `generator(index)` for each successive index, starting at 0.
+ *
+ * The returned object is both an `Iterable<T>` (has `[Symbol.iterator]`)
+ * and an `Iterator<T>` (has `next()`), so it can be used directly in
+ * `for...of` loops, spread syntax, or manual `.next()` calls.
+ *
+ * Since the sequence is **infinite**, consuming it with a `for...of` loop
+ * or spreading into an array without an explicit bound will never terminate.
+ * Always use a finite consumer such as:
+ *   - `take(n)` — see {@link take}
+ *   - A `for...of` loop with a `break` condition
+ *   - Destructuring a known number of elements via `Array.from({ length: n }, ...)`
+ *
+ * @typeParam T - The element type produced by the sequence.
+ * @param generator - A callback `(index: number) => T` that computes the
+ *   value at position `index` (0-based). The index is monotonically
+ *   increasing with each call.
+ * @returns An `IterableIterator<T>` that lazily yields values forever.
+ *
+ * @example <caption>Natural numbers (1, 2, 3, …)</caption>
+ * ```ts
+ * const naturals = createInfiniteSequence(i => i + 1);
+ * ```
+ *
+ * @example <caption>Even numbers (0, 2, 4, …)</caption>
+ * ```ts
+ * const evens = createInfiniteSequence(i => i * 2);
+ * ```
+ *
+ * @example <caption>Fibonacci sequence (0, 1, 1, 2, 3, 5, …)</caption>
+ * ```ts
+ * const fib = createInfiniteSequence((i, a = 0, b = 1) => ([a, b] = [b, a + b], a));
+ * ```
+ *
+ * @example <caption>Constant value</caption>
+ * ```ts
+ * const forever42 = createInfiniteSequence(() => 42);
+ * ```
+ *
+ * @example <caption>Using with take() utility</caption>
+ * ```ts
+ * const first10 = [...take(createInfiniteSequence(i => i + 1), 10)];
+ * // [1, 2, 3, 4, 5, 6, 7, 8, 9, 10]
+ * ```
+ */
+export function createInfiniteSequence<T>(
+  generator: (index: number) => T,
+): IterableIterator<T> {
+  if (typeof generator !== "function") {
+    throw new TypeError(
+      `Expected a function as generator, got ${typeof generator}`,
+    );
+  }
+
+  let index = 0;
+
+  const iterator: Iterator<T> = {
+    next(): IteratorResult<T> {
+      return { value: generator(index++), done: false };
+    },
+  };
+
+  const self: IterableIterator<T> = {
+    next: iterator.next.bind(iterator),
+    [Symbol.iterator](): IterableIterator<T> {
+      return self;
+    },
+  };
+
+  return self;
+}
+
+// ---------------------------------------------------------------------------
+// Utility: take
+// ---------------------------------------------------------------------------
+
+/**
+ * Takes the first `n` values from an iterable and returns them as an array.
+ *
+ * This is the safe way to inspect infinite sequences without hanging.
+ *
+ * @param iterable - Any iterable (finite or infinite).
+ * @param n - Number of elements to take.
+ * @returns An array of the first `n` values.
+ *
+ * @example
+ * ```ts
+ * const naturals = createInfiniteSequence(i => i + 1);
+ * take(naturals, 3); // [1, 2, 3]
+ * ```
+ */
+export function take<T>(iterable: Iterable<T>, n: number): T[] {
+  if (n < 0) {
+    throw new RangeError(`take() requires a non-negative count, got ${n}`);
+  }
+
+  const result: T[] = [];
+  const iterator = iterable[Symbol.iterator]();
+  for (let i = 0; i < n; i++) {
+    const next = iterator.next();
+    if (next.done) break; // defensive: handle finite iterables too
+    result.push(next.value);
+  }
+  return result;
+}
+
+// ---------------------------------------------------------------------------
+// Common sequence generators
+// ---------------------------------------------------------------------------
+
+/**
+ * Creates an infinite sequence of natural numbers: 1, 2, 3, 4, …
+ *
+ * @param start - The first number (default 1).
+ * @returns An infinite iterable iterator of natural numbers.
+ *
+ * @example
+ * ```ts
+ * const naturals = naturalNumbers();
+ * take(naturals, 5); // [1, 2, 3, 4, 5]
+ * ```
+ */
+export function naturalNumbers(start: number = 1): IterableIterator<number> {
+  if (!Number.isFinite(start) || !Number.isInteger(start)) {
+    throw new RangeError(
+      `naturalNumbers() requires a finite integer start, got ${start}`,
+    );
+  }
+  return createInfiniteSequence((i) => start + i);
+}
+
+/**
+ * Creates an infinite sequence of even numbers: 0, 2, 4, 6, …
+ *
+ * @param startFrom - The first even number in the sequence (default 0).
+ *   Must be an even integer.
+ * @returns An infinite iterable iterator of even numbers.
+ *
+ * @example
+ * ```ts
+ * const evens = evenNumbers();
+ * take(evens, 4); // [0, 2, 4, 6]
+ * ```
+ */
+export function evenNumbers(startFrom: number = 0): IterableIterator<number> {
+  if (!Number.isFinite(startFrom) || startFrom % 2 !== 0) {
+    throw new RangeError(
+      `evenNumbers() requires a finite even start value, got ${startFrom}`,
+    );
+  }
+  return createInfiniteSequence((i) => startFrom + i * 2);
+}
+
+/**
+ * Creates an infinite Fibonacci sequence: 0, 1, 1, 2, 3, 5, 8, 13, …
+ *
+ * The sequence starts with `f0` and `f1` (default 0 and 1), and each
+ * subsequent term is the sum of the two preceding terms.
+ *
+ * @param f0 - The first Fibonacci term (default 0).
+ * @param f1 - The second Fibonacci term (default 1).
+ * @returns An infinite iterable iterator of Fibonacci numbers.
+ *
+ * @example
+ * ```ts
+ * const fib = fibonacciSequence();
+ * take(fib, 8); // [0, 1, 1, 2, 3, 5, 8, 13]
+ * ```
+ *
+ * @example <caption>Custom start values (Lucas-like)</caption>
+ * ```ts
+ * const lucas = fibonacciSequence(2, 1);
+ * take(lucas, 6); // [2, 1, 3, 4, 7, 11]
+ * ```
+ */
+export function fibonacciSequence(
+  f0: number = 0,
+  f1: number = 1,
+): IterableIterator<number> {
+  if (!Number.isFinite(f0) || !Number.isFinite(f1)) {
+    throw new RangeError(
+      `fibonacciSequence() requires finite start values, got ${f0}, ${f1}`,
+    );
+  }
+
+  let a = f0;
+  let b = f1;
+  let doneFirst = false;
+
+  const generator = (): number => {
+    if (!doneFirst) {
+      doneFirst = true;
+      return a;
+    }
+    const next = b;
+    b = a + b;
+    a = next;
+    return next;
+  };
+
+  // Hand-craft the iterator because we need mutable closure state
+  const iterator: Iterator<number> = {
+    next(): IteratorResult<number> {
+      return { value: generator(), done: false };
+    },
+  };
+
+  const fibIterator: IterableIterator<number> = {
+    next: iterator.next.bind(iterator),
+    [Symbol.iterator](): IterableIterator<number> {
+      return fibIterator;
+    },
+  };
+
+  return fibIterator;
+}
+
+// ---------------------------------------------------------------------------
+// Utility: sequence — chainable sequence builder
+// ---------------------------------------------------------------------------
+
+/**
+ * A chainable sequence builder that wraps an infinite sequence and
+ * provides convenience methods like `take`, `map`, `filter`, and `skip`.
+ *
+ * @typeParam T - Element type.
+ */
+export class Sequence<T> implements IterableIterator<T> {
+  private inner: IterableIterator<T>;
+
+  /**
+   * @param source - The source iterable iterator to wrap.
+   */
+  constructor(source: IterableIterator<T>) {
+    this.inner = source;
+  }
+
+  /** @internal */
+  next(...args: [] | [undefined]): IteratorResult<T> {
+    return this.inner.next(...args);
+  }
+
+  /** @internal */
+  [Symbol.iterator](): IterableIterator<T> {
+    return this;
+  }
+
+  /**
+   * Take the first `n` elements and return them as an array.
+   */
+  take(n: number): T[] {
+    return take(this, n);
+  }
+
+  /**
+   * Transform each element via a mapper function.
+   */
+  map<U>(fn: (value: T, index: number) => U): Sequence<U> {
+    let index = 0;
+    const mapped = createInfiniteSequence<U>(() => {
+      const next = this.inner.next();
+      if (next.done) {
+        throw new Error("Unexpected end of infinite sequence");
+      }
+      return fn(next.value, index++);
+    });
+    return new Sequence(mapped);
+  }
+
+  /**
+   * Filter elements by a predicate.
+   *
+   * Note: Since the source is infinite, the filtered sequence is also
+   * infinite but may skip elements that don't match.
+   */
+  filter(predicate: (value: T, index: number) => boolean): Sequence<T> {
+    let index = 0;
+    const filtered = createInfiniteSequence<T>(() => {
+      // eslint-disable-next-line no-constant-condition
+      while (true) {
+        const next = this.inner.next();
+        if (next.done) {
+          throw new Error("Unexpected end of infinite sequence");
+        }
+        if (predicate(next.value, index++)) {
+          return next.value;
+        }
+      }
+    });
+    return new Sequence(filtered);
+  }
+
+  /**
+   * Skip the first `n` elements.
+   */
+  skip(n: number): Sequence<T> {
+    for (let i = 0; i < n; i++) {
+      this.inner.next();
+    }
+    return this;
+  }
+}
+
+/**
+ * Create a chainable sequence from a generator function.
+ *
+ * @example
+ * ```ts
+ * const first10Evens = seq(i => i * 2).take(10);
+ * // [0, 2, 4, 6, 8, 10, 12, 14, 16, 18]
+ *
+ * seq(i => i + 1).filter(x => x % 2 === 0).take(5);
+ * // [2, 4, 6, 8, 10]
+ * ```
+ */
+export function seq<T>(generator: (index: number) => T): Sequence<T> {
+  return new Sequence(createInfiniteSequence(generator));
+}


### PR DESCRIPTION
/closes #15 /claim #15 [agent]

## Summary

Implements an infinite sequence iterator utility for the utils package, addressing Issue #15.

## What's included

### Core API
- `createInfiniteSequence<T>(generator)` — creates an infinite lazy iterable iterator from a generator function
- `take(iterable, n)` — safely consumes the first N elements of an infinite sequence

### Common sequence generators
- `naturalNumbers(start?)` — infinite natural numbers (1, 2, 3, ...)
- `evenNumbers(startFrom?)` — infinite even numbers (0, 2, 4, ...)
- `fibonacciSequence(f0?, f1?)` — infinite Fibonacci numbers (0, 1, 1, 2, ...)

### Chainable Sequence class
- `Sequence<T>` — wraps an IterableIterator with chainable .map(), .filter(), .skip(), .take() methods
- `seq(generator)` — convenience factory for creating sequences

### Quality
- ✅ Full TypeScript typings with JSDoc documentation
- ✅ 29 unit tests covering all functions, edge cases, and chainable API
- ✅ All pre-existing tests continue to pass (46 total)
- ✅ Proper error handling for invalid inputs (negative count, non-finite numbers, etc.)
- ✅ Lazy evaluation — values computed only on demand