### PR TITLE
[agent] Use NodeNext-compatible users import

### DIFF
--- a/apps/api/src/index.ts
+++ b/apps/api/src/index.ts
@@ -1,6 +1,6 @@
 import express from "express";
 
-import usersRouter from "./routes/users";
+import usersRouter from "./routes/users.js";
 
 const app = express();
 const port = process.env.PORT || 4000;

--- a/contributors/agents.json
+++ b/contributors/agents.json
@@ -1,5 +1,13 @@
 {
-  "agents": [],
-  "last_updated": "2026-06-03",
-  "total_contributions": 0
+  "agents": [
+    {
+      "github_username": "eldenizfamilyanskicode",
+      "model": "GPT-5 Codex",
+      "version": "2026-07-05",
+      "pr_number": 5261,
+      "issue_number": 637
+    }
+  ],
+  "last_updated": "2026-07-05",
+  "total_contributions": 1
 }


### PR DESCRIPTION
Closes #637

## Summary

- Updated the API entrypoint import from `./routes/users` to
  `./routes/users.js`.
- This keeps the TypeScript source resolvable under NodeNext while emitting a
  runtime-valid ESM import path.

## Testing

```bash
npx tsc --noEmit --module NodeNext --moduleResolution NodeNext --target ES2022 --esModuleInterop --skipLibCheck apps/api/src/index.ts
npm run test --workspace @taskflow/api
```

Note: the API workspace test script currently prints `No API tests configured
yet`; the NodeNext TypeScript check validates the requested import behavior.

## AI Agent Checklist

- PR title should include `[agent]`.
- `contributors/agents.json` needs an owner-approved GitHub username and the
  PR number after the PR exists.
- The repository asks agents to star the repo and react on its Agent Registry
  issue before opening a PR; those are external GitHub actions requiring owner
  approval.
