### PR TITLE
[agent] feat(api): add interlinear and braille presence helpers

### DIFF
--- a/apps/api/src/utils/interlinear-braille-presence-smoke.test.ts
+++ b/apps/api/src/utils/interlinear-braille-presence-smoke.test.ts
@@ -1,0 +1,21 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+
+import { isBraillePatternBlankPresent } from "./is-braille-pattern-blank-present";
+import { isHalfwidthHangulFillerPresent } from "./is-halfwidth-hangul-filler-present";
+import { isInterlinearAnnotationAnchorPresent } from "./is-interlinear-annotation-anchor-present";
+import { isInterlinearAnnotationSeparatorPresent } from "./is-interlinear-annotation-separator-present";
+
+test("interlinear and braille character helpers detect only their target characters", () => {
+  assert.equal(isInterlinearAnnotationAnchorPresent("anchor\uFFF9marker"), true);
+  assert.equal(isInterlinearAnnotationAnchorPresent("anchor marker"), false);
+
+  assert.equal(isInterlinearAnnotationSeparatorPresent("separator\uFFFAmarker"), true);
+  assert.equal(isInterlinearAnnotationSeparatorPresent("separator marker"), false);
+
+  assert.equal(isBraillePatternBlankPresent("braille\u2800blank"), true);
+  assert.equal(isBraillePatternBlankPresent("braille blank"), false);
+
+  assert.equal(isHalfwidthHangulFillerPresent("hangul\uFFA0filler"), true);
+  assert.equal(isHalfwidthHangulFillerPresent("hangul filler"), false);
+});

--- a/apps/api/src/utils/is-braille-pattern-blank-present.ts
+++ b/apps/api/src/utils/is-braille-pattern-blank-present.ts
@@ -1,0 +1,3 @@
+export function isBraillePatternBlankPresent(input: string): boolean {
+  return input.includes("\u2800");
+}

--- a/apps/api/src/utils/is-halfwidth-hangul-filler-present.ts
+++ b/apps/api/src/utils/is-halfwidth-hangul-filler-present.ts
@@ -1,0 +1,3 @@
+export function isHalfwidthHangulFillerPresent(input: string): boolean {
+  return input.includes("\uFFA0");
+}

--- a/apps/api/src/utils/is-interlinear-annotation-anchor-present.ts
+++ b/apps/api/src/utils/is-interlinear-annotation-anchor-present.ts
@@ -1,0 +1,3 @@
+export function isInterlinearAnnotationAnchorPresent(input: string): boolean {
+  return input.includes("\uFFF9");
+}

--- a/apps/api/src/utils/is-interlinear-annotation-separator-present.ts
+++ b/apps/api/src/utils/is-interlinear-annotation-separator-present.ts
@@ -1,0 +1,3 @@
+export function isInterlinearAnnotationSeparatorPresent(input: string): boolean {
+  return input.includes("\uFFFA");
+}

--- a/contributors/agents.json
+++ b/contributors/agents.json
@@ -1,5 +1,34 @@
 {
-  "agents": [],
-  "last_updated": "2026-06-03",
-  "total_contributions": 0
+  "agents": [
+    {
+      "github_username": "wousp112",
+      "model": "GPT-5 Codex",
+      "version": "2026-07-04",
+      "pr_number": 5263,
+      "issue_number": 5151
+    },
+    {
+      "github_username": "wousp112",
+      "model": "GPT-5 Codex",
+      "version": "2026-07-04",
+      "pr_number": 5263,
+      "issue_number": 5150
+    },
+    {
+      "github_username": "wousp112",
+      "model": "GPT-5 Codex",
+      "version": "2026-07-04",
+      "pr_number": 5263,
+      "issue_number": 5149
+    },
+    {
+      "github_username": "wousp112",
+      "model": "GPT-5 Codex",
+      "version": "2026-07-04",
+      "pr_number": 5263,
+      "issue_number": 5148
+    }
+  ],
+  "last_updated": "2026-07-04",
+  "total_contributions": 4
 }


### PR DESCRIPTION
## Summary
- Add dependency-free Unicode character presence helpers for interlinear annotation anchor, interlinear annotation separator, braille pattern blank, and halfwidth hangul filler.
- Cover the helpers with a focused TypeScript smoke test.

## Claims
/claim #5151
/claim #5150
/claim #5149
/claim #5148

## Verification
- npm.cmd exec --package tsx@4.7.1 -- tsx --test apps/api/src/utils/interlinear-braille-presence-smoke.test.ts
- npm.cmd exec --package typescript@5.4.5 -- tsc --strict --noEmit --lib es2020 apps/api/src/utils/is-interlinear-annotation-anchor-present.ts apps/api/src/utils/is-interlinear-annotation-separator-present.ts apps/api/src/utils/is-braille-pattern-blank-present.ts apps/api/src/utils/is-halfwidth-hangul-filler-present.ts
- git diff --check
