### PR TITLE
[agent] feat(api): add format shaping presence helpers

### DIFF
--- a/apps/api/src/utils/format-shaping-presence-smoke.test.ts
+++ b/apps/api/src/utils/format-shaping-presence-smoke.test.ts
@@ -1,0 +1,21 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+
+import { isActivateArabicFormShapingPresent } from "./is-activate-arabic-form-shaping-present";
+import { isActivateSymmetricSwappingPresent } from "./is-activate-symmetric-swapping-present";
+import { isInhibitArabicFormShapingPresent } from "./is-inhibit-arabic-form-shaping-present";
+import { isInhibitSymmetricSwappingPresent } from "./is-inhibit-symmetric-swapping-present";
+
+test("format shaping helpers detect only their target characters", () => {
+  assert.equal(isInhibitSymmetricSwappingPresent("swap\u206Aoff"), true);
+  assert.equal(isInhibitSymmetricSwappingPresent("swap off"), false);
+
+  assert.equal(isActivateSymmetricSwappingPresent("swap\u206Bon"), true);
+  assert.equal(isActivateSymmetricSwappingPresent("swap on"), false);
+
+  assert.equal(isInhibitArabicFormShapingPresent("shape\u206Coff"), true);
+  assert.equal(isInhibitArabicFormShapingPresent("shape off"), false);
+
+  assert.equal(isActivateArabicFormShapingPresent("shape\u206Don"), true);
+  assert.equal(isActivateArabicFormShapingPresent("shape on"), false);
+});

--- a/apps/api/src/utils/is-activate-arabic-form-shaping-present.ts
+++ b/apps/api/src/utils/is-activate-arabic-form-shaping-present.ts
@@ -1,0 +1,3 @@
+export function isActivateArabicFormShapingPresent(input: string): boolean {
+  return input.includes("\u206D");
+}

--- a/apps/api/src/utils/is-activate-symmetric-swapping-present.ts
+++ b/apps/api/src/utils/is-activate-symmetric-swapping-present.ts
@@ -1,0 +1,3 @@
+export function isActivateSymmetricSwappingPresent(input: string): boolean {
+  return input.includes("\u206B");
+}

--- a/apps/api/src/utils/is-inhibit-arabic-form-shaping-present.ts
+++ b/apps/api/src/utils/is-inhibit-arabic-form-shaping-present.ts
@@ -1,0 +1,3 @@
+export function isInhibitArabicFormShapingPresent(input: string): boolean {
+  return input.includes("\u206C");
+}

--- a/apps/api/src/utils/is-inhibit-symmetric-swapping-present.ts
+++ b/apps/api/src/utils/is-inhibit-symmetric-swapping-present.ts
@@ -1,0 +1,3 @@
+export function isInhibitSymmetricSwappingPresent(input: string): boolean {
+  return input.includes("\u206A");
+}

--- a/contributors/agents.json
+++ b/contributors/agents.json
@@ -1,5 +1,34 @@
 {
-  "agents": [],
-  "last_updated": "2026-06-03",
-  "total_contributions": 0
+  "agents": [
+    {
+      "github_username": "wousp112",
+      "model": "GPT-5 Codex",
+      "version": "2026-07-04",
+      "pr_number": 5265,
+      "issue_number": 5121
+    },
+    {
+      "github_username": "wousp112",
+      "model": "GPT-5 Codex",
+      "version": "2026-07-04",
+      "pr_number": 5265,
+      "issue_number": 5122
+    },
+    {
+      "github_username": "wousp112",
+      "model": "GPT-5 Codex",
+      "version": "2026-07-04",
+      "pr_number": 5265,
+      "issue_number": 5123
+    },
+    {
+      "github_username": "wousp112",
+      "model": "GPT-5 Codex",
+      "version": "2026-07-04",
+      "pr_number": 5265,
+      "issue_number": 5124
+    }
+  ],
+  "last_updated": "2026-07-04",
+  "total_contributions": 4
 }


### PR DESCRIPTION
## Summary
- Add dependency-free Unicode format-character presence helpers for inhibit/activate symmetric swapping and inhibit/activate Arabic form shaping.
- Cover the helpers with a focused TypeScript smoke test.

## Claims
/claim #5121
/claim #5122
/claim #5123
/claim #5124

## Verification
- npm.cmd exec --package tsx@4.7.1 -- tsx --test apps/api/src/utils/format-shaping-presence-smoke.test.ts
- npm.cmd exec --package typescript@5.4.5 -- tsc --strict --noEmit --lib es2020 apps/api/src/utils/is-inhibit-symmetric-swapping-present.ts apps/api/src/utils/is-activate-symmetric-swapping-present.ts apps/api/src/utils/is-inhibit-arabic-form-shaping-present.ts apps/api/src/utils/is-activate-arabic-form-shaping-present.ts
- git diff --check
