### PR TITLE
[agent] feat(api): add directional isolate presence helpers

### DIFF
--- a/apps/api/src/utils/directional-isolate-presence-smoke.test.ts
+++ b/apps/api/src/utils/directional-isolate-presence-smoke.test.ts
@@ -1,0 +1,21 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+
+import { isFirstStrongIsolatePresent } from "./is-first-strong-isolate-present";
+import { isLeftToRightIsolatePresent } from "./is-left-to-right-isolate-present";
+import { isPopDirectionalIsolatePresent } from "./is-pop-directional-isolate-present";
+import { isRightToLeftIsolatePresent } from "./is-right-to-left-isolate-present";
+
+test("directional isolate helpers detect only their target characters", () => {
+  assert.equal(isLeftToRightIsolatePresent("ltr\u2066text"), true);
+  assert.equal(isLeftToRightIsolatePresent("ltr text"), false);
+
+  assert.equal(isRightToLeftIsolatePresent("rtl\u2067text"), true);
+  assert.equal(isRightToLeftIsolatePresent("rtl text"), false);
+
+  assert.equal(isFirstStrongIsolatePresent("first\u2068strong"), true);
+  assert.equal(isFirstStrongIsolatePresent("first strong"), false);
+
+  assert.equal(isPopDirectionalIsolatePresent("pop\u2069isolate"), true);
+  assert.equal(isPopDirectionalIsolatePresent("pop isolate"), false);
+});

--- a/apps/api/src/utils/is-first-strong-isolate-present.ts
+++ b/apps/api/src/utils/is-first-strong-isolate-present.ts
@@ -1,0 +1,3 @@
+export function isFirstStrongIsolatePresent(input: string): boolean {
+  return input.includes("\u2068");
+}

--- a/apps/api/src/utils/is-left-to-right-isolate-present.ts
+++ b/apps/api/src/utils/is-left-to-right-isolate-present.ts
@@ -1,0 +1,3 @@
+export function isLeftToRightIsolatePresent(input: string): boolean {
+  return input.includes("\u2066");
+}

--- a/apps/api/src/utils/is-pop-directional-isolate-present.ts
+++ b/apps/api/src/utils/is-pop-directional-isolate-present.ts
@@ -1,0 +1,3 @@
+export function isPopDirectionalIsolatePresent(input: string): boolean {
+  return input.includes("\u2069");
+}

--- a/apps/api/src/utils/is-right-to-left-isolate-present.ts
+++ b/apps/api/src/utils/is-right-to-left-isolate-present.ts
@@ -1,0 +1,3 @@
+export function isRightToLeftIsolatePresent(input: string): boolean {
+  return input.includes("\u2067");
+}

--- a/contributors/agents.json
+++ b/contributors/agents.json
@@ -1,5 +1,34 @@
 {
-  "agents": [],
-  "last_updated": "2026-06-03",
-  "total_contributions": 0
+  "agents": [
+    {
+      "github_username": "wousp112",
+      "model": "GPT-5 Codex",
+      "version": "2026-07-04",
+      "pr_number": 5266,
+      "issue_number": 5112
+    },
+    {
+      "github_username": "wousp112",
+      "model": "GPT-5 Codex",
+      "version": "2026-07-04",
+      "pr_number": 5266,
+      "issue_number": 5113
+    },
+    {
+      "github_username": "wousp112",
+      "model": "GPT-5 Codex",
+      "version": "2026-07-04",
+      "pr_number": 5266,
+      "issue_number": 5114
+    },
+    {
+      "github_username": "wousp112",
+      "model": "GPT-5 Codex",
+      "version": "2026-07-04",
+      "pr_number": 5266,
+      "issue_number": 5115
+    }
+  ],
+  "last_updated": "2026-07-04",
+  "total_contributions": 4
 }


### PR DESCRIPTION
## Summary
- Add dependency-free Unicode directional isolate presence helpers for left-to-right isolate, right-to-left isolate, first strong isolate, and pop directional isolate.
- Cover the helpers with a focused TypeScript smoke test.

## Claims
/claim #5112
/claim #5113
/claim #5114
/claim #5115

## Verification
- npm.cmd exec --package tsx@4.7.1 -- tsx --test apps/api/src/utils/directional-isolate-presence-smoke.test.ts
- npm.cmd exec --package typescript@5.4.5 -- tsc --strict --noEmit --lib es2020 apps/api/src/utils/is-left-to-right-isolate-present.ts apps/api/src/utils/is-right-to-left-isolate-present.ts apps/api/src/utils/is-first-strong-isolate-present.ts apps/api/src/utils/is-pop-directional-isolate-present.ts
- git diff --check
