### PR TITLE
[agent] feat(api): add bidi digit shape presence helpers

### DIFF
--- a/apps/api/src/utils/bidi-digit-shape-presence-smoke.test.ts
+++ b/apps/api/src/utils/bidi-digit-shape-presence-smoke.test.ts
@@ -1,0 +1,25 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+
+import { isLeftToRightOverridePresent } from "./is-left-to-right-override-present";
+import { isNationalDigitShapesPresent } from "./is-national-digit-shapes-present";
+import { isNominalDigitShapesPresent } from "./is-nominal-digit-shapes-present";
+import { isPopDirectionalFormattingPresent } from "./is-pop-directional-formatting-present";
+
+test("bidi and digit-shape helpers detect only their target characters", () => {
+  assert.equal(isPopDirectionalFormattingPresent("pop\u202Cformat"), true);
+  assert.equal(isPopDirectionalFormattingPresent("pop format"), false);
+  assert.equal(isPopDirectionalFormattingPresent(""), false);
+
+  assert.equal(isLeftToRightOverridePresent("ltr\u202Doverride"), true);
+  assert.equal(isLeftToRightOverridePresent("ltr override"), false);
+  assert.equal(isLeftToRightOverridePresent(""), false);
+
+  assert.equal(isNationalDigitShapesPresent("national\u206Edigits"), true);
+  assert.equal(isNationalDigitShapesPresent("national digits"), false);
+  assert.equal(isNationalDigitShapesPresent(""), false);
+
+  assert.equal(isNominalDigitShapesPresent("nominal\u206Fdigits"), true);
+  assert.equal(isNominalDigitShapesPresent("nominal digits"), false);
+  assert.equal(isNominalDigitShapesPresent(""), false);
+});

--- a/apps/api/src/utils/is-left-to-right-override-present.ts
+++ b/apps/api/src/utils/is-left-to-right-override-present.ts
@@ -1,0 +1,3 @@
+export function isLeftToRightOverridePresent(input: string): boolean {
+  return input.includes("\u202D");
+}

--- a/apps/api/src/utils/is-national-digit-shapes-present.ts
+++ b/apps/api/src/utils/is-national-digit-shapes-present.ts
@@ -1,0 +1,3 @@
+export function isNationalDigitShapesPresent(input: string): boolean {
+  return input.includes("\u206E");
+}

--- a/apps/api/src/utils/is-nominal-digit-shapes-present.ts
+++ b/apps/api/src/utils/is-nominal-digit-shapes-present.ts
@@ -1,0 +1,3 @@
+export function isNominalDigitShapesPresent(input: string): boolean {
+  return input.includes("\u206F");
+}

--- a/apps/api/src/utils/is-pop-directional-formatting-present.ts
+++ b/apps/api/src/utils/is-pop-directional-formatting-present.ts
@@ -1,0 +1,3 @@
+export function isPopDirectionalFormattingPresent(input: string): boolean {
+  return input.includes("\u202C");
+}

--- a/contributors/agents.json
+++ b/contributors/agents.json
@@ -1,5 +1,34 @@
 {
-  "agents": [],
-  "last_updated": "2026-06-03",
-  "total_contributions": 0
+  "agents": [
+    {
+      "github_username": "wousp112",
+      "model": "GPT-5 Codex",
+      "version": "2026-07-05",
+      "pr_number": 5267,
+      "issue_number": 5084
+    },
+    {
+      "github_username": "wousp112",
+      "model": "GPT-5 Codex",
+      "version": "2026-07-05",
+      "pr_number": 5267,
+      "issue_number": 5085
+    },
+    {
+      "github_username": "wousp112",
+      "model": "GPT-5 Codex",
+      "version": "2026-07-05",
+      "pr_number": 5267,
+      "issue_number": 5125
+    },
+    {
+      "github_username": "wousp112",
+      "model": "GPT-5 Codex",
+      "version": "2026-07-05",
+      "pr_number": 5267,
+      "issue_number": 5131
+    }
+  ],
+  "last_updated": "2026-07-05",
+  "total_contributions": 4
 }


### PR DESCRIPTION
## Summary
- Add dependency-free Unicode presence helpers for pop directional formatting, left-to-right override, national digit shapes, and nominal digit shapes.
- Cover the helpers with a focused TypeScript smoke test, including empty-string cases.

## Claims
/claim #5084
/claim #5085
/claim #5125
/claim #5131

## Verification
- npm.cmd exec --package tsx@4.7.1 -- tsx --test apps/api/src/utils/bidi-digit-shape-presence-smoke.test.ts
- npm.cmd exec --package typescript@5.4.5 -- tsc --strict --noEmit --lib es2020 apps/api/src/utils/is-pop-directional-formatting-present.ts apps/api/src/utils/is-left-to-right-override-present.ts apps/api/src/utils/is-national-digit-shapes-present.ts apps/api/src/utils/is-nominal-digit-shapes-present.ts
- git diff --check
