### PR TITLE
[agent] feat: add random currency and case utilities

### DIFF
--- a/contributors/agents.json
+++ b/contributors/agents.json
@@ -1,5 +1,27 @@
 {
-  "agents": [],
-  "last_updated": "2026-06-03",
-  "total_contributions": 0
+  "agents": [
+    {
+      "github_username": "wousp112",
+      "model": "GPT-5 Codex",
+      "version": "2026-07-05",
+      "pr_number": 5272,
+      "issue_number": 5068
+    },
+    {
+      "github_username": "wousp112",
+      "model": "GPT-5 Codex",
+      "version": "2026-07-05",
+      "pr_number": 5272,
+      "issue_number": 5072
+    },
+    {
+      "github_username": "wousp112",
+      "model": "GPT-5 Codex",
+      "version": "2026-07-05",
+      "pr_number": 5272,
+      "issue_number": 5077
+    }
+  ],
+  "last_updated": "2026-07-05",
+  "total_contributions": 3
 }

--- a/src/utils/case-converter.js
+++ b/src/utils/case-converter.js
@@ -1,0 +1,49 @@
+function splitWords(value) {
+  if (value === null || value === undefined) {
+    return [];
+  }
+
+  const normalized = String(value)
+    .replace(/([A-Z]+)([A-Z][a-z])/g, '$1 $2')
+    .replace(/([a-z0-9])([A-Z])/g, '$1 $2')
+    .replace(/[^A-Za-z0-9]+/g, ' ')
+    .trim();
+
+  if (normalized === '') {
+    return [];
+  }
+
+  return normalized.split(/\s+/).map((word) => word.toLowerCase());
+}
+
+function capitalize(word) {
+  return word.charAt(0).toUpperCase() + word.slice(1);
+}
+
+function toCamelCase(value) {
+  const words = splitWords(value);
+  if (words.length === 0) {
+    return '';
+  }
+
+  return words[0] + words.slice(1).map(capitalize).join('');
+}
+
+function toSnakeCase(value) {
+  return splitWords(value).join('_');
+}
+
+function toKebabCase(value) {
+  return splitWords(value).join('-');
+}
+
+function toPascalCase(value) {
+  return splitWords(value).map(capitalize).join('');
+}
+
+module.exports = {
+  toCamelCase,
+  toSnakeCase,
+  toKebabCase,
+  toPascalCase,
+};

--- a/src/utils/case-converter.test.js
+++ b/src/utils/case-converter.test.js
@@ -1,0 +1,104 @@
+const assert = require('node:assert/strict');
+const test = require('node:test');
+
+const { toCamelCase, toKebabCase, toPascalCase, toSnakeCase } = require('./case-converter');
+
+test('toCamelCase converts a simple sentence', () => {
+  assert.equal(toCamelCase('hello world'), 'helloWorld');
+});
+
+test('toCamelCase converts snake case', () => {
+  assert.equal(toCamelCase('hello_world'), 'helloWorld');
+});
+
+test('toCamelCase converts kebab case', () => {
+  assert.equal(toCamelCase('hello-world'), 'helloWorld');
+});
+
+test('toCamelCase converts pascal case', () => {
+  assert.equal(toCamelCase('HelloWorld'), 'helloWorld');
+});
+
+test('toCamelCase lowercases acronyms', () => {
+  assert.equal(toCamelCase('API response'), 'apiResponse');
+});
+
+test('toCamelCase returns empty string for null', () => {
+  assert.equal(toCamelCase(null), '');
+});
+
+test('toCamelCase returns empty string for empty input', () => {
+  assert.equal(toCamelCase(''), '');
+});
+
+test('toSnakeCase converts a simple sentence', () => {
+  assert.equal(toSnakeCase('hello world'), 'hello_world');
+});
+
+test('toSnakeCase converts camel case', () => {
+  assert.equal(toSnakeCase('helloWorld'), 'hello_world');
+});
+
+test('toSnakeCase converts pascal case', () => {
+  assert.equal(toSnakeCase('HelloWorld'), 'hello_world');
+});
+
+test('toSnakeCase collapses repeated whitespace', () => {
+  assert.equal(toSnakeCase('hello   world'), 'hello_world');
+});
+
+test('toSnakeCase trims surrounding separators', () => {
+  assert.equal(toSnakeCase('__hello-world__'), 'hello_world');
+});
+
+test('toSnakeCase returns empty string for null', () => {
+  assert.equal(toSnakeCase(null), '');
+});
+
+test('toKebabCase converts a simple sentence', () => {
+  assert.equal(toKebabCase('hello world'), 'hello-world');
+});
+
+test('toKebabCase converts snake case', () => {
+  assert.equal(toKebabCase('hello_world'), 'hello-world');
+});
+
+test('toKebabCase converts camel case', () => {
+  assert.equal(toKebabCase('helloWorld'), 'hello-world');
+});
+
+test('toKebabCase converts mixed separators', () => {
+  assert.equal(toKebabCase('hello_world again'), 'hello-world-again');
+});
+
+test('toKebabCase returns empty string for empty input', () => {
+  assert.equal(toKebabCase(''), '');
+});
+
+test('toPascalCase converts a simple sentence', () => {
+  assert.equal(toPascalCase('hello world'), 'HelloWorld');
+});
+
+test('toPascalCase converts snake case', () => {
+  assert.equal(toPascalCase('hello_world'), 'HelloWorld');
+});
+
+test('toPascalCase converts camel case', () => {
+  assert.equal(toPascalCase('helloWorld'), 'HelloWorld');
+});
+
+test('toPascalCase converts kebab case', () => {
+  assert.equal(toPascalCase('hello-world'), 'HelloWorld');
+});
+
+test('toPascalCase returns empty string for null', () => {
+  assert.equal(toPascalCase(null), '');
+});
+
+test('case converters preserve numbers', () => {
+  assert.equal(toSnakeCase('version 2 value'), 'version_2_value');
+});
+
+test('case converters ignore punctuation', () => {
+  assert.equal(toCamelCase('hello, world!'), 'helloWorld');
+});

--- a/src/utils/format-currency.js
+++ b/src/utils/format-currency.js
@@ -1,0 +1,104 @@
+const SYMBOLS = Object.freeze({
+  USD: '$',
+  EUR: '\u20ac',
+  GBP: '\u00a3',
+  CNY: '\u00a5',
+  JPY: '\u00a5',
+  CAD: 'C$',
+  AUD: 'A$',
+});
+
+const DEFAULT_DECIMALS = Object.freeze({
+  USD: 2,
+  EUR: 2,
+  GBP: 2,
+  CNY: 2,
+  JPY: 0,
+  CAD: 2,
+  AUD: 2,
+});
+
+function toFiniteNumber(value) {
+  if (typeof value === 'string' && value.trim() === '') {
+    return undefined;
+  }
+
+  const number = Number(value);
+  return Number.isFinite(number) ? number : undefined;
+}
+
+function normalizeCurrency(currency) {
+  const normalized = String(currency || 'USD').toUpperCase();
+  return Object.hasOwn(SYMBOLS, normalized) ? normalized : undefined;
+}
+
+function normalizeDecimals(currency, options) {
+  const configured = options && options.decimals;
+  if (configured === undefined || configured === null) {
+    return DEFAULT_DECIMALS[currency];
+  }
+
+  const decimals = Number(configured);
+  if (!Number.isFinite(decimals) || decimals < 0) {
+    return DEFAULT_DECIMALS[currency];
+  }
+
+  return Math.trunc(decimals);
+}
+
+function addThousandsSeparators(value) {
+  return value.replace(/\B(?=(\d{3})+(?!\d))/g, ',');
+}
+
+function formatCurrency(amount, currency = 'USD', options = {}) {
+  const value = toFiniteNumber(amount);
+  const normalizedCurrency = normalizeCurrency(currency);
+
+  if (value === undefined || normalizedCurrency === undefined) {
+    return '';
+  }
+
+  const decimals = normalizeDecimals(normalizedCurrency, options);
+  const fixed = Math.abs(value).toFixed(decimals);
+  const [integerPart, decimalPart] = fixed.split('.');
+  const formatted = `${SYMBOLS[normalizedCurrency]}${addThousandsSeparators(integerPart)}`;
+  const sign = value < 0 ? '-' : '';
+
+  return decimalPart ? `${sign}${formatted}.${decimalPart}` : `${sign}${formatted}`;
+}
+
+function parseCurrency(value) {
+  if (typeof value === 'number') {
+    return Number.isFinite(value) ? value : undefined;
+  }
+
+  if (typeof value !== 'string') {
+    return undefined;
+  }
+
+  let text = value.trim();
+  if (text === '') {
+    return undefined;
+  }
+
+  const parenthesizedNegative = text.startsWith('(') && text.endsWith(')');
+  text = text.replace(/[()]/g, '').trim();
+  const signedNegative = text.startsWith('-');
+  text = text.replace(/^[+-]/, '').replace(/,/g, '').replace(/[^\d.]/g, '');
+
+  if (!/\d/.test(text) || text.split('.').length > 2) {
+    return undefined;
+  }
+
+  const number = Number(text);
+  if (!Number.isFinite(number)) {
+    return undefined;
+  }
+
+  return parenthesizedNegative || signedNegative ? -number : number;
+}
+
+module.exports = {
+  formatCurrency,
+  parseCurrency,
+};

--- a/src/utils/format-currency.test.js
+++ b/src/utils/format-currency.test.js
@@ -1,0 +1,92 @@
+const assert = require('node:assert/strict');
+const test = require('node:test');
+
+const { formatCurrency, parseCurrency } = require('./format-currency');
+
+test('formatCurrency formats USD by default', () => {
+  assert.equal(formatCurrency(1234.56), '$1,234.56');
+});
+
+test('formatCurrency formats EUR', () => {
+  assert.equal(formatCurrency(1234.56, 'EUR'), '\u20ac1,234.56');
+});
+
+test('formatCurrency formats GBP', () => {
+  assert.equal(formatCurrency(1234.56, 'GBP'), '\u00a31,234.56');
+});
+
+test('formatCurrency formats CNY', () => {
+  assert.equal(formatCurrency(1234.56, 'CNY'), '\u00a51,234.56');
+});
+
+test('formatCurrency formats JPY with zero decimals by default', () => {
+  assert.equal(formatCurrency(1234.56, 'JPY'), '\u00a51,235');
+});
+
+test('formatCurrency formats CAD', () => {
+  assert.equal(formatCurrency(1234.56, 'CAD'), 'C$1,234.56');
+});
+
+test('formatCurrency formats AUD', () => {
+  assert.equal(formatCurrency(1234.56, 'AUD'), 'A$1,234.56');
+});
+
+test('formatCurrency formats zero', () => {
+  assert.equal(formatCurrency(0), '$0.00');
+});
+
+test('formatCurrency formats negative amounts', () => {
+  assert.equal(formatCurrency(-42.5), '-$42.50');
+});
+
+test('formatCurrency formats large numbers', () => {
+  assert.equal(formatCurrency(1234567890.12), '$1,234,567,890.12');
+});
+
+test('formatCurrency supports zero custom decimals', () => {
+  assert.equal(formatCurrency(12.34, 'USD', { decimals: 0 }), '$12');
+});
+
+test('formatCurrency supports three custom decimals', () => {
+  assert.equal(formatCurrency(12.3456, 'USD', { decimals: 3 }), '$12.346');
+});
+
+test('formatCurrency accepts numeric strings', () => {
+  assert.equal(formatCurrency('19.9', 'GBP'), '\u00a319.90');
+});
+
+test('formatCurrency returns empty string for invalid amounts', () => {
+  assert.equal(formatCurrency('abc'), '');
+});
+
+test('formatCurrency returns empty string for unsupported currencies', () => {
+  assert.equal(formatCurrency(10, 'CHF'), '');
+});
+
+test('parseCurrency parses USD strings', () => {
+  assert.equal(parseCurrency('$1,234.56'), 1234.56);
+});
+
+test('parseCurrency parses EUR strings', () => {
+  assert.equal(parseCurrency('\u20ac99.50'), 99.5);
+});
+
+test('parseCurrency parses negative values with a leading minus', () => {
+  assert.equal(parseCurrency('-$42.50'), -42.5);
+});
+
+test('parseCurrency parses negative values with parentheses', () => {
+  assert.equal(parseCurrency('($42.50)'), -42.5);
+});
+
+test('parseCurrency parses large values with commas', () => {
+  assert.equal(parseCurrency('A$1,234,567.89'), 1234567.89);
+});
+
+test('parseCurrency returns finite numeric input unchanged', () => {
+  assert.equal(parseCurrency(12.5), 12.5);
+});
+
+test('parseCurrency returns undefined for invalid input', () => {
+  assert.equal(parseCurrency('not money'), undefined);
+});

--- a/src/utils/random.js
+++ b/src/utils/random.js
@@ -1,0 +1,60 @@
+const { randomInt: cryptoRandomInt, randomUUID: cryptoRandomUUID } = require('node:crypto');
+
+const DEFAULT_ALPHABET = 'ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789';
+
+function toInteger(value) {
+  const number = Number(value);
+  return Number.isFinite(number) ? Math.trunc(number) : undefined;
+}
+
+function randomString(length = 16, alphabet = DEFAULT_ALPHABET) {
+  const size = toInteger(length);
+  const characters = typeof alphabet === 'string' ? alphabet : '';
+
+  if (size === undefined || size <= 0 || characters.length === 0) {
+    return '';
+  }
+
+  let value = '';
+  for (let index = 0; index < size; index += 1) {
+    value += characters[cryptoRandomInt(0, characters.length)];
+  }
+
+  return value;
+}
+
+function randomInt(min, max) {
+  const lowerInput = max === undefined ? 0 : min;
+  const upperInput = max === undefined ? min : max;
+  let lower = toInteger(lowerInput);
+  let upper = toInteger(upperInput);
+
+  if (lower === undefined || upper === undefined) {
+    return undefined;
+  }
+
+  if (lower > upper) {
+    [lower, upper] = [upper, lower];
+  }
+
+  return cryptoRandomInt(lower, upper + 1);
+}
+
+function randomUUID() {
+  return cryptoRandomUUID();
+}
+
+function randomPick(values, fallback) {
+  if (!Array.isArray(values) || values.length === 0) {
+    return fallback;
+  }
+
+  return values[randomInt(0, values.length - 1)];
+}
+
+module.exports = {
+  randomString,
+  randomInt,
+  randomUUID,
+  randomPick,
+};

--- a/src/utils/random.test.js
+++ b/src/utils/random.test.js
@@ -1,0 +1,93 @@
+const assert = require('node:assert/strict');
+const test = require('node:test');
+
+const { randomInt, randomPick, randomString, randomUUID } = require('./random');
+
+test('randomString defaults to 16 characters', () => {
+  assert.equal(randomString().length, 16);
+});
+
+test('randomString uses alphanumeric characters by default', () => {
+  assert.match(randomString(64), /^[A-Za-z0-9]+$/);
+});
+
+test('randomString uses the requested length', () => {
+  assert.equal(randomString(24).length, 24);
+});
+
+test('randomString returns empty string for zero length', () => {
+  assert.equal(randomString(0), '');
+});
+
+test('randomString returns empty string for negative length', () => {
+  assert.equal(randomString(-4), '');
+});
+
+test('randomString truncates fractional lengths', () => {
+  assert.equal(randomString(4.9, 'a'), 'aaaa');
+});
+
+test('randomString returns empty string for invalid lengths', () => {
+  assert.equal(randomString(Number.NaN), '');
+});
+
+test('randomString uses a custom alphabet', () => {
+  assert.equal(randomString(6, 'z'), 'zzzzzz');
+});
+
+test('randomString returns empty string for an empty alphabet', () => {
+  assert.equal(randomString(6, ''), '');
+});
+
+test('randomInt returns an integer within an inclusive range', () => {
+  const value = randomInt(3, 7);
+  assert.equal(Number.isInteger(value), true);
+  assert.equal(value >= 3 && value <= 7, true);
+});
+
+test('randomInt returns the only value in a single-value range', () => {
+  assert.equal(randomInt(5, 5), 5);
+});
+
+test('randomInt supports one argument as the maximum', () => {
+  const value = randomInt(4);
+  assert.equal(value >= 0 && value <= 4, true);
+});
+
+test('randomInt swaps reversed bounds', () => {
+  const value = randomInt(10, 8);
+  assert.equal(value >= 8 && value <= 10, true);
+});
+
+test('randomInt truncates fractional bounds', () => {
+  assert.equal(randomInt(2.8, 2.9), 2);
+});
+
+test('randomInt supports negative ranges', () => {
+  const value = randomInt(-5, -2);
+  assert.equal(value >= -5 && value <= -2, true);
+});
+
+test('randomInt returns undefined for an invalid minimum', () => {
+  assert.equal(randomInt('x', 4), undefined);
+});
+
+test('randomInt returns undefined for an invalid maximum', () => {
+  assert.equal(randomInt(1, Infinity), undefined);
+});
+
+test('randomUUID returns an RFC 4122 version 4 UUID', () => {
+  assert.match(randomUUID(), /^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/);
+});
+
+test('randomPick returns one value from the array', () => {
+  assert.equal(['red'].includes(randomPick(['red'])), true);
+});
+
+test('randomPick returns undefined for an empty array', () => {
+  assert.equal(randomPick([]), undefined);
+});
+
+test('randomPick returns the fallback for invalid input', () => {
+  assert.equal(randomPick(null, 'fallback'), 'fallback');
+});


### PR DESCRIPTION
Refs #33
Closes #5068
Closes #5072
Closes #5077

/claim #5068
/claim #5072
/claim #5077

## Summary
- Add `src/utils/random.js` with `randomString`, `randomInt`, `randomUUID`, and `randomPick`.
- Add `src/utils/format-currency.js` with `formatCurrency` and `parseCurrency`.
- Add `src/utils/case-converter.js` with camel, snake, kebab, and pascal case converters.
- Cover the requested edge cases with Node built-in test files.

## Verification
- `node --test .\src\utils\random.test.js`
- `node --test .\src\utils\format-currency.test.js`
- `node --test .\src\utils\case-converter.test.js`

## Bounty note
The three linked issues include `Parent bounty: #33`, but their individual `/bounty` amount fields are blank. This PR claims the linked bounty tasks for maintainer review without assuming a specific dollar value.
