### PR TITLE
[agent] Validate user creation payloads

### DIFF
--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -7,7 +7,7 @@
   "main": "src/index.ts",
   "scripts": {
     "dev": "tsx src/index.ts",
-    "test": "echo \"No API tests configured yet\"",
+    "test": "node --import tsx --test src/services/userService.test.ts src/routes/users.test.ts",
     "lint": "echo \"No API lint configured yet\""
   },
   "dependencies": {

--- a/apps/api/src/routes/users.test.ts
+++ b/apps/api/src/routes/users.test.ts
@@ -1,0 +1,152 @@
+import assert from "node:assert/strict";
+import { once } from "node:events";
+import http, { type Server } from "node:http";
+import { type AddressInfo } from "node:net";
+import { describe, it } from "node:test";
+
+import express from "express";
+
+import usersRouter from "./users.js";
+
+interface JsonResponse {
+  status: number;
+  body: unknown;
+}
+
+interface UserCreateResponse {
+  data: {
+    id?: unknown;
+    email?: unknown;
+    name?: unknown;
+    role?: unknown;
+  };
+  message?: unknown;
+}
+
+describe("users routes", () => {
+  it("returns 400 for invalid create-user payloads", async () => {
+    await withUsersServer(async (baseUrl) => {
+      const response = await postJson(baseUrl, "/users", ["not", "object"]);
+
+      assert.equal(response.status, 400);
+      assert.deepEqual(response.body, {
+        error: {
+          message: "Invalid user payload.",
+          details: ["Request body must be a JSON object."]
+        }
+      });
+    });
+  });
+
+  it("returns 400 when email is missing or invalid", async () => {
+    await withUsersServer(async (baseUrl) => {
+      const response = await postJson(baseUrl, "/users", {
+        name: "No Email"
+      });
+
+      assert.equal(response.status, 400);
+      assert.deepEqual(response.body, {
+        error: {
+          message: "Invalid user payload.",
+          details: ["email is required and must be a string."]
+        }
+      });
+    });
+  });
+
+  it("normalizes accepted fields and ignores client-controlled fields", async () => {
+    await withUsersServer(async (baseUrl) => {
+      const response = await postJson(baseUrl, "/users", {
+        id: "client-id",
+        email: "  PERSON@Example.COM ",
+        name: "  Ada   Lovelace  ",
+        role: "admin"
+      });
+
+      assert.equal(response.status, 201);
+      const body = response.body as UserCreateResponse;
+      assert.equal(typeof body.data.id, "string");
+      assert.notEqual(body.data.id, "client-id");
+      assert.equal(body.data.email, "person@example.com");
+      assert.equal(body.data.name, "Ada Lovelace");
+      assert.equal(body.data.role, undefined);
+      assert.equal(body.message, "User creation is not implemented yet.");
+    });
+  });
+});
+
+async function withUsersServer(
+  run: (baseUrl: string) => Promise<void>
+): Promise<void> {
+  const app = express();
+  app.use(express.json());
+  app.use("/users", usersRouter);
+
+  const server = app.listen(0, "127.0.0.1");
+  await once(server, "listening");
+
+  try {
+    const address = server.address();
+    if (!address || typeof address === "string") {
+      throw new Error("Expected test server to listen on a TCP port.");
+    }
+
+    await run(`http://127.0.0.1:${address.port}`);
+  } finally {
+    await closeServer(server);
+  }
+}
+
+async function postJson(
+  baseUrl: string,
+  path: string,
+  payload: unknown
+): Promise<JsonResponse> {
+  const url = new URL(path, baseUrl);
+  const requestBody = JSON.stringify(payload);
+
+  return new Promise<JsonResponse>((resolve, reject) => {
+    const request = http.request(
+      {
+        hostname: url.hostname,
+        port: url.port,
+        path: url.pathname,
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+          "Content-Length": Buffer.byteLength(requestBody)
+        }
+      },
+      (response) => {
+        let body = "";
+        response.setEncoding("utf8");
+        response.on("data", (chunk) => {
+          body += chunk;
+        });
+        response.on("end", () => {
+          resolve({
+            status: response.statusCode ?? 0,
+            body: JSON.parse(body)
+          });
+        });
+      }
+    );
+
+    request.on("error", reject);
+    request.write(requestBody);
+    request.end();
+  });
+}
+
+async function closeServer(server: Server): Promise<void> {
+  await new Promise<void>((resolve, reject) => {
+    server.close((error) => {
+      if (error) {
+        reject(error);
+        return;
+      }
+
+      resolve();
+    });
+  });
+}

--- a/apps/api/src/routes/users.ts
+++ b/apps/api/src/routes/users.ts
@@ -1,22 +1,39 @@
 import { Router } from "express";
 
+import {
+  UserValidationError,
+  createUser,
+  listUsers
+} from "../services/userService.js";
+
 const router = Router();
 
 router.get("/", (_req, res) => {
   res.json({
-    data: [],
+    data: listUsers(),
     message: "User listing is not implemented yet."
   });
 });
 
 router.post("/", (req, res) => {
-  res.status(201).json({
-    data: {
-      id: "stub-user-id",
-      ...req.body
-    },
-    message: "User creation is not implemented yet."
-  });
+  try {
+    res.status(201).json({
+      data: createUser(req.body),
+      message: "User creation is not implemented yet."
+    });
+  } catch (error) {
+    if (error instanceof UserValidationError) {
+      res.status(400).json({
+        error: {
+          message: error.message,
+          details: error.details
+        }
+      });
+      return;
+    }
+
+    throw error;
+  }
 });
 
 export default router;

--- a/apps/api/src/services/userService.test.ts
+++ b/apps/api/src/services/userService.test.ts
@@ -1,0 +1,59 @@
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+
+import { UserValidationError, createUser } from "./userService.js";
+
+describe("createUser", () => {
+  it("rejects non-object JSON bodies", () => {
+    assert.throws(() => createUser(null), UserValidationError);
+    assert.throws(() => createUser([]), UserValidationError);
+    assert.throws(() => createUser("not an object"), UserValidationError);
+  });
+
+  it("requires a valid email", () => {
+    assert.throws(() => createUser({ name: "Ana" }), UserValidationError);
+    assert.throws(
+      () => createUser({ email: "not-an-email" }),
+      UserValidationError
+    );
+  });
+
+  it("normalizes email and name values", () => {
+    const user = createUser(
+      { email: "  TEST@Example.COM ", name: "  Test   User  " },
+      () => "server-id"
+    );
+
+    assert.deepEqual(user, {
+      id: "server-id",
+      email: "test@example.com",
+      name: "Test User"
+    });
+  });
+
+  it("ignores client-controlled ids and unrelated fields", () => {
+    const user = createUser(
+      {
+        id: "client-id",
+        email: "person@example.com",
+        name: "Person",
+        role: "admin",
+        createdAt: "2026-01-01"
+      },
+      () => "server-id"
+    );
+
+    assert.deepEqual(user, {
+      id: "server-id",
+      email: "person@example.com",
+      name: "Person"
+    });
+  });
+
+  it("rejects non-string name values", () => {
+    assert.throws(
+      () => createUser({ email: "person@example.com", name: 123 }),
+      UserValidationError
+    );
+  });
+});

--- a/apps/api/src/services/userService.ts
+++ b/apps/api/src/services/userService.ts
@@ -1,0 +1,84 @@
+import { randomUUID } from "node:crypto";
+
+export interface UserRecord {
+  id: string;
+  email: string;
+  name?: string;
+}
+
+export class UserValidationError extends Error {
+  constructor(
+    message: string,
+    public readonly details: string[]
+  ) {
+    super(message);
+    this.name = "UserValidationError";
+  }
+}
+
+type IdGenerator = () => string;
+
+const EMAIL_PATTERN = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
+
+export function listUsers(): UserRecord[] {
+  return [];
+}
+
+export function createUser(
+  input: unknown,
+  generateId: IdGenerator = randomUUID
+): UserRecord {
+  if (!isPlainObject(input)) {
+    throw new UserValidationError("Invalid user payload.", [
+      "Request body must be a JSON object."
+    ]);
+  }
+
+  const errors: string[] = [];
+  const email = normalizeEmail(input.email, errors);
+  const name = normalizeName(input.name, errors);
+
+  if (errors.length > 0 || email === undefined) {
+    throw new UserValidationError("Invalid user payload.", errors);
+  }
+
+  return {
+    id: generateId(),
+    email,
+    ...(name === undefined ? {} : { name })
+  };
+}
+
+function isPlainObject(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function normalizeEmail(value: unknown, errors: string[]): string | undefined {
+  if (typeof value !== "string") {
+    errors.push("email is required and must be a string.");
+    return undefined;
+  }
+
+  const email = value.trim().toLowerCase();
+
+  if (!EMAIL_PATTERN.test(email)) {
+    errors.push("email must be a valid email address.");
+    return undefined;
+  }
+
+  return email;
+}
+
+function normalizeName(value: unknown, errors: string[]): string | undefined {
+  if (value === undefined || value === null) {
+    return undefined;
+  }
+
+  if (typeof value !== "string") {
+    errors.push("name must be a string when provided.");
+    return undefined;
+  }
+
+  const name = value.trim().replace(/\s+/g, " ");
+  return name.length === 0 ? undefined : name;
+}

--- a/contributors/agents.json
+++ b/contributors/agents.json
@@ -4,7 +4,7 @@
       "github_username": "bsou911",
       "model": "GPT-5 Codex",
       "version": "2026-07-05",
-      "pr_number": null,
+      "pr_number": 5280,
       "issue_number": 2207
     }
   ],

--- a/contributors/agents.json
+++ b/contributors/agents.json
@@ -1,5 +1,13 @@
 {
-  "agents": [],
-  "last_updated": "2026-06-03",
-  "total_contributions": 0
+  "agents": [
+    {
+      "github_username": "bsou911",
+      "model": "GPT-5 Codex",
+      "version": "2026-07-05",
+      "pr_number": null,
+      "issue_number": 2207
+    }
+  ],
+  "last_updated": "2026-07-05",
+  "total_contributions": 1
 }


### PR DESCRIPTION
## Description

Closes #2207

Adds a focused user creation service so `POST /users` no longer trusts arbitrary request bodies. The route now validates the payload shape, requires a valid email, normalizes accepted fields, ignores client-controlled ids and unrelated fields, and returns a 400 response for invalid payloads.

/claim #2207

## AI Agent Checklist

- [x] I reacted :+1: on issue #16 (Agent Registry)
- [x] I starred this repository
- [x] I added my model name and version to `contributors/agents.json`
- [x] My PR title includes the `[agent]` tag

## Changes Made

- Added `apps/api/src/services/userService.ts` with user payload validation, normalization, and server-side id generation.
- Updated `apps/api/src/routes/users.ts` to call the service and return structured validation errors.
- Added `apps/api/src/services/userService.test.ts` with regression coverage for the acceptance criteria.
- Added `apps/api/src/routes/users.test.ts` to verify the route-level 400 and 201 behavior.
- Updated the API test script to run both service and route tests through Node's built-in test runner.
- Added the required AI agent metadata entry for issue #2207.

## Model Info (AI agents only)

- Model name/version: GPT-5 Codex, 2026-07-05
- Issue attempted: #2207
- Approach used: Kept the change scoped to user creation validation, preserving the placeholder API response while preventing client-controlled ids and unrelated fields from being echoed back.

## Validation

- `pnpm -C apps/api test` - 8 tests passed, 0 failures.
- `pnpm -C apps/api exec tsc --noEmit --module NodeNext --moduleResolution NodeNext --target ES2022 --strict src/routes/users.ts src/services/userService.ts src/services/userService.test.ts src/routes/users.test.ts --skipLibCheck`
