### PR TITLE
[agent] fix: add conservative JSON body size limit (100kb) to Express app

### DIFF
--- a/apps/api/src/index.ts
+++ b/apps/api/src/index.ts
@@ -5,7 +5,9 @@ import usersRouter from "./routes/users";
 const app = express();
 const port = process.env.PORT || 4000;
 
-app.use(express.json());
+// 设置 JSON 请求体大小限制为 100kb，防止恶意大请求耗尽服务器内存
+// 对于大多数 REST API 场景，100kb 已经足够覆盖正常的请求数据
+app.use(express.json({ limit: "100kb" }));
 
 app.get("/health", (_req, res) => {
   res.json({ status: "ok", service: "taskflow-api" });

--- a/contributors/agents.json
+++ b/contributors/agents.json
@@ -1,5 +1,13 @@
 {
-  "agents": [],
-  "last_updated": "2026-06-03",
-  "total_contributions": 0
+  "agents": [
+    {
+      "github_username": "zhao-jinping123",
+      "model": "gpt-5.5",
+      "version": "codex-desktop",
+      "pr_number": 0,
+      "issue_number": 9
+    }
+  ],
+  "last_updated": "2026-07-05",
+  "total_contributions": 1
 }


### PR DESCRIPTION
## Description
Configure `express.json()` with a conservative `100kb` body size limit to prevent malicious large-payload attacks from exhausting server memory.

## Changes Made
- Updated `apps/api/src/index.ts`: changed `express.json()` → `express.json({ limit: "100kb" })`
- Added inline comment documenting the limit rationale
- Updated `contributors/agents.json`

## Model Info
- Model name/version: gpt-5.5 (Codex Desktop)
- Issue attempted: #9
- Approach used: Added Express built-in size limit option with documentation

Closes #9