### PR TITLE
[agent] feat: Add pagination helper Closes #2817

### DIFF
--- a/apps/api/src/utils/pagination.test.ts
+++ b/apps/api/src/utils/pagination.test.ts
@@ -1,0 +1,85 @@
+import test from "node:test";
+import assert from "node:assert";
+import { normalizePagination } from "./pagination";
+
+test("pagination helper tests", async (t) => {
+  await t.test("returns defaults when no input is provided", () => {
+    const result = normalizePagination();
+    assert.deepStrictEqual(result, {
+      page: 1,
+      pageSize: 20,
+      limit: 20,
+      offset: 0,
+    });
+  });
+
+  await t.test("returns defaults when empty input object is provided", () => {
+    const result = normalizePagination({});
+    assert.deepStrictEqual(result, {
+      page: 1,
+      pageSize: 20,
+      limit: 20,
+      offset: 0,
+    });
+  });
+
+  await t.test("parses numeric values correctly", () => {
+    const result = normalizePagination({ page: 2, pageSize: 15 });
+    assert.deepStrictEqual(result, {
+      page: 2,
+      pageSize: 15,
+      limit: 15,
+      offset: 15,
+    });
+  });
+
+  await t.test("parses string values correctly", () => {
+    const result = normalizePagination({ page: "3", pageSize: "10" });
+    assert.deepStrictEqual(result, {
+      page: 3,
+      pageSize: 10,
+      limit: 10,
+      offset: 20,
+    });
+  });
+
+  await t.test("uses defaults for invalid non-integer inputs", () => {
+    const result = normalizePagination({ page: "abc", pageSize: 2.5 });
+    assert.deepStrictEqual(result, {
+      page: 1,
+      pageSize: 20,
+      limit: 20,
+      offset: 0,
+    });
+  });
+
+  await t.test("enforces minimum page of 1", () => {
+    const result = normalizePagination({ page: -5, pageSize: 10 });
+    assert.deepStrictEqual(result, {
+      page: 1,
+      pageSize: 10,
+      limit: 10,
+      offset: 0,
+    });
+  });
+
+  await t.test("enforces minimum page size of 1", () => {
+    const result = normalizePagination({ page: 1, pageSize: 0 });
+    assert.deepStrictEqual(result, {
+      page: 1,
+      pageSize: 20,
+      limit: 20,
+      offset: 0,
+    });
+  });
+
+  await t.test("clamps page size to maximum of 100", () => {
+    const result = normalizePagination({ page: 1, pageSize: 500 });
+    assert.deepStrictEqual(result, {
+      page: 1,
+      pageSize: 100,
+      limit: 100,
+      offset: 0,
+    });
+  });
+});

--- a/apps/api/src/utils/pagination.ts
+++ b/apps/api/src/utils/pagination.ts
@@ -1,0 +1,48 @@
+export type PaginationInput = {
+  page?: string | number;
+  pageSize?: string | number;
+};
+
+export type Pagination = {
+  page: number;
+  pageSize: number;
+  limit: number;
+  offset: number;
+};
+
+const DEFAULT_PAGE = 1;
+const DEFAULT_PAGE_SIZE = 20;
+const MAX_PAGE_SIZE = 100;
+
+function toPositiveInteger(value: string | number | undefined, fallback: number): number {
+  if (value === undefined || value === null) {
+    return fallback;
+  }
+  const parsed = Number(value);
+  if (!Number.isInteger(parsed) || parsed < 1) {
+    return fallback;
+  }
+  return parsed;
+}
+
+/**
+ * Normalizes page and pageSize input parameters to return a validated
+ * page, pageSize, limit, and offset object.
+ *
+ * @param {PaginationInput} [input={}] - The pagination input.
+ * @returns {Pagination} The normalized pagination parameters.
+ */
+export function normalizePagination(input: PaginationInput = {}): Pagination {
+  const page = toPositiveInteger(input.page, DEFAULT_PAGE);
+  const pageSize = Math.min(
+    toPositiveInteger(input.pageSize, DEFAULT_PAGE_SIZE),
+    MAX_PAGE_SIZE,
+  );
+
+  return {
+    page,
+    pageSize,
+    limit: pageSize,
+    offset: (page - 1) * pageSize,
+  };
+}

--- a/contributors/agents.json
+++ b/contributors/agents.json
@@ -1,5 +1,20 @@
 {
-  "agents": [],
-  "last_updated": "2026-06-03",
-  "total_contributions": 0
+  "agents": [
+    {
+      "github_username": "OVS-Intelligence-LLC",
+      "model": "Gemini 3.5 Pro (Backend Architect)",
+      "version": "v1.0",
+      "pr_number": 5066,
+      "issue_number": 5065
+    },
+    {
+      "github_username": "OVS-Intelligence-LLC",
+      "model": "Gemini 3.5 Pro (Backend Architect)",
+      "version": "v1.0",
+      "pr_number": 5286,
+      "issue_number": 2817
+    }
+  ],
+  "last_updated": "2026-07-05",
+  "total_contributions": 2
 }


### PR DESCRIPTION
Closes #2817. This PR adds the reusable pagination parser utility normalizePagination in TypeScript under apps/api.