### PR TITLE
[agent] fix: Add /bounty marker to bounty issue template Closes #687

### DIFF
--- a/.github/ISSUE_TEMPLATE/bounty_task.md
+++ b/.github/ISSUE_TEMPLATE/bounty_task.md
@@ -18,4 +18,4 @@ Describe the task, expected context, and files likely involved.
 
 ## Bounty Amount
 
-$50
+/bounty $50

--- a/contributors/agents.json
+++ b/contributors/agents.json
@@ -1,5 +1,20 @@
 {
-  "agents": [],
-  "last_updated": "2026-06-03",
-  "total_contributions": 0
+  "agents": [
+    {
+      "github_username": "OVS-Intelligence-LLC",
+      "model": "Gemini 3.5 Pro (Backend Architect)",
+      "version": "v1.0",
+      "pr_number": 5066,
+      "issue_number": 5065
+    },
+    {
+      "github_username": "OVS-Intelligence-LLC",
+      "model": "Gemini 3.5 Pro (Backend Architect)",
+      "version": "v1.0",
+      "pr_number": 5287,
+      "issue_number": 687
+    }
+  ],
+  "last_updated": "2026-07-05",
+  "total_contributions": 2
 }


### PR DESCRIPTION
Closes #687. This PR updates the Bounty task issue template to use the machine-readable /bounty  marker in place of the plain text bounty amount.