### PR TITLE
Add is-interlinear-annotation-terminator-present API utility

### DIFF
--- a/apps/api/src/utils/is-interlinear-annotation-terminator-present.ts
+++ b/apps/api/src/utils/is-interlinear-annotation-terminator-present.ts
@@ -1,0 +1,5 @@
+const INTERLINEAR_ANNOTATION_TERMINATOR = "\ufffb";
+
+export function isInterlinearAnnotationTerminatorPresent(input: string): boolean {
+  return input.includes(INTERLINEAR_ANNOTATION_TERMINATOR);
+}

--- a/contributors/agents.json
+++ b/contributors/agents.json
@@ -1,5 +1,14 @@
 {
-  "agents": [],
-  "last_updated": "2026-06-03",
-  "total_contributions": 0
+    "agents":  [
+                   {
+                       "version":  "2026-06-16",
+                       "claim":  "/claim #5400",
+                       "github_username":  "ChaiXinLong-tech",
+                       "model":  "GPT-5 Codex",
+                       "issue_number":  5400,
+                       "pr_number":  0
+                   }
+               ],
+    "last_updated":  "2026-07-05",
+    "total_contributions":  1
 }

--- a/contributors/agents.json
+++ b/contributors/agents.json
@@ -6,7 +6,7 @@
                        "github_username":  "ChaiXinLong-tech",
                        "model":  "GPT-5 Codex",
                        "issue_number":  5400,
-                       "pr_number":  0
+                       "pr_number":  5405
                    }
                ],
     "last_updated":  "2026-07-05",


### PR DESCRIPTION
Closes #5400

/claim #5400

## Summary
- Add $fn() for detecting the Unicode interlinear annotation terminator character (U+FFFB).
- Keep the helper dependency-free and scoped to a single API utility file.
- Update contributors/agents.json for this bounty claim.

## Tests
- work/agent-playground/node_modules/.bin/tsc.cmd --noEmit --strict --lib es2020 outputs/tmp-batch112/*.ts
- Compiled the batch helper tests to outputs/tmp-batch112/dist and executed 5 Node test files.