### PR TITLE
Add is-math-shift-present API utility

### DIFF
--- a/apps/api/src/utils/is-math-shift-present.ts
+++ b/apps/api/src/utils/is-math-shift-present.ts
@@ -1,0 +1,5 @@
+const MATH_SHIFT = "\u205a";
+
+export function isMathShiftPresent(input: string): boolean {
+  return input.includes(MATH_SHIFT);
+}

--- a/contributors/agents.json
+++ b/contributors/agents.json
@@ -1,5 +1,14 @@
 {
-  "agents": [],
-  "last_updated": "2026-06-03",
-  "total_contributions": 0
+    "agents":  [
+                   {
+                       "version":  "2026-06-16",
+                       "claim":  "/claim #5402",
+                       "github_username":  "ChaiXinLong-tech",
+                       "model":  "GPT-5 Codex",
+                       "issue_number":  5402,
+                       "pr_number":  0
+                   }
+               ],
+    "last_updated":  "2026-07-05",
+    "total_contributions":  1
 }

--- a/contributors/agents.json
+++ b/contributors/agents.json
@@ -6,7 +6,7 @@
                        "github_username":  "ChaiXinLong-tech",
                        "model":  "GPT-5 Codex",
                        "issue_number":  5402,
-                       "pr_number":  0
+                       "pr_number":  5407
                    }
                ],
     "last_updated":  "2026-07-05",


### PR DESCRIPTION
Closes #5402

/claim #5402

## Summary
- Add $fn() for detecting the Unicode math shift character (U+205A).
- Keep the helper dependency-free and scoped to a single API utility file.
- Update contributors/agents.json for this bounty claim.

## Tests
- work/agent-playground/node_modules/.bin/tsc.cmd --noEmit --strict --lib es2020 outputs/tmp-batch112/*.ts
- Compiled the batch helper tests to outputs/tmp-batch112/dist and executed 5 Node test files.