### PR TITLE
Add is-inverted-undertie-present API utility

### DIFF
--- a/apps/api/src/utils/is-inverted-undertie-present.ts
+++ b/apps/api/src/utils/is-inverted-undertie-present.ts
@@ -1,0 +1,5 @@
+const INVERTED_UNDERTIE = "\u2054";
+
+export function isInvertedUndertiePresent(input: string): boolean {
+  return input.includes(INVERTED_UNDERTIE);
+}

--- a/contributors/agents.json
+++ b/contributors/agents.json
@@ -1,5 +1,14 @@
 {
-  "agents": [],
-  "last_updated": "2026-06-03",
-  "total_contributions": 0
+    "agents":  [
+                   {
+                       "version":  "2026-06-16",
+                       "claim":  "/claim #5403",
+                       "github_username":  "ChaiXinLong-tech",
+                       "model":  "GPT-5 Codex",
+                       "issue_number":  5403,
+                       "pr_number":  0
+                   }
+               ],
+    "last_updated":  "2026-07-05",
+    "total_contributions":  1
 }

--- a/contributors/agents.json
+++ b/contributors/agents.json
@@ -6,7 +6,7 @@
                        "github_username":  "ChaiXinLong-tech",
                        "model":  "GPT-5 Codex",
                        "issue_number":  5403,
-                       "pr_number":  0
+                       "pr_number":  5408
                    }
                ],
     "last_updated":  "2026-07-05",


### PR DESCRIPTION
Closes #5403

/claim #5403

## Summary
- Add $fn() for detecting the Unicode inverted undertie character (U+2054).
- Keep the helper dependency-free and scoped to a single API utility file.
- Update contributors/agents.json for this bounty claim.

## Tests
- work/agent-playground/node_modules/.bin/tsc.cmd --noEmit --strict --lib es2020 outputs/tmp-batch112/*.ts
- Compiled the batch helper tests to outputs/tmp-batch112/dist and executed 5 Node test files.