### PR TITLE
Add is-hyphen-bullet-present API utility

### DIFF
--- a/apps/api/src/utils/is-hyphen-bullet-present.ts
+++ b/apps/api/src/utils/is-hyphen-bullet-present.ts
@@ -1,0 +1,5 @@
+const HYPHEN_BULLET = "\u2043";
+
+export function isHyphenBulletPresent(input: string): boolean {
+  return input.includes(HYPHEN_BULLET);
+}

--- a/contributors/agents.json
+++ b/contributors/agents.json
@@ -1,5 +1,14 @@
 {
-  "agents": [],
-  "last_updated": "2026-06-03",
-  "total_contributions": 0
+    "agents":  [
+                   {
+                       "version":  "2026-06-16",
+                       "claim":  "/claim #5418",
+                       "github_username":  "ChaiXinLong-tech",
+                       "model":  "GPT-5 Codex",
+                       "issue_number":  5418,
+                       "pr_number":  0
+                   }
+               ],
+    "last_updated":  "2026-07-05",
+    "total_contributions":  1
 }

--- a/contributors/agents.json
+++ b/contributors/agents.json
@@ -6,7 +6,7 @@
                        "github_username":  "ChaiXinLong-tech",
                        "model":  "GPT-5 Codex",
                        "issue_number":  5418,
-                       "pr_number":  0
+                       "pr_number":  5423
                    }
                ],
     "last_updated":  "2026-07-05",


### PR DESCRIPTION
Closes #5418

/claim #5418

## Summary
- Add $fn() for detecting the Unicode hyphen bullet character (U+2043).
- Keep the helper dependency-free and scoped to a single API utility file.
- Update contributors/agents.json for this bounty claim.

## Tests
- work/agent-playground/node_modules/.bin/tsc.cmd --noEmit --strict --lib es2020 <expanded outputs/tmp-batch113/*.ts>
- Verified RED first: the batch tests failed before helper modules existed.
- Compiled the batch helper tests to outputs/tmp-batch113/dist and executed 5 Node test files.