### PR TITLE
Add is-fraction-slash-present API utility

### DIFF
--- a/apps/api/src/utils/is-fraction-slash-present.ts
+++ b/apps/api/src/utils/is-fraction-slash-present.ts
@@ -1,0 +1,5 @@
+const FRACTION_SLASH = "\u2044";
+
+export function isFractionSlashPresent(input: string): boolean {
+  return input.includes(FRACTION_SLASH);
+}

--- a/contributors/agents.json
+++ b/contributors/agents.json
@@ -6,7 +6,7 @@
                        "github_username":  "ChaiXinLong-tech",
                        "model":  "GPT-5 Codex",
                        "issue_number":  5419,
-                       "pr_number":  0
+                       "pr_number":  5424
                    }
                ],
     "last_updated":  "2026-07-05",

--- a/contributors/agents.json
+++ b/contributors/agents.json
@@ -1,5 +1,14 @@
 {
-  "agents": [],
-  "last_updated": "2026-06-03",
-  "total_contributions": 0
+    "agents":  [
+                   {
+                       "version":  "2026-06-16",
+                       "claim":  "/claim #5419",
+                       "github_username":  "ChaiXinLong-tech",
+                       "model":  "GPT-5 Codex",
+                       "issue_number":  5419,
+                       "pr_number":  0
+                   }
+               ],
+    "last_updated":  "2026-07-05",
+    "total_contributions":  1
 }


### PR DESCRIPTION
Closes #5419

/claim #5419

## Summary
- Add $fn() for detecting the Unicode fraction slash character (U+2044).
- Keep the helper dependency-free and scoped to a single API utility file.
- Update contributors/agents.json for this bounty claim.

## Tests
- work/agent-playground/node_modules/.bin/tsc.cmd --noEmit --strict --lib es2020 <expanded outputs/tmp-batch113/*.ts>
- Verified RED first: the batch tests failed before helper modules existed.
- Compiled the batch helper tests to outputs/tmp-batch113/dist and executed 5 Node test files.