### PR TITLE
Add is-right-square-bracket-with-quill-present API utility

### DIFF
--- a/apps/api/src/utils/is-right-square-bracket-with-quill-present.ts
+++ b/apps/api/src/utils/is-right-square-bracket-with-quill-present.ts
@@ -1,0 +1,5 @@
+const RIGHT_SQUARE_BRACKET_WITH_QUILL = "\u2046";
+
+export function isRightSquareBracketWithQuillPresent(input: string): boolean {
+  return input.includes(RIGHT_SQUARE_BRACKET_WITH_QUILL);
+}

--- a/contributors/agents.json
+++ b/contributors/agents.json
@@ -6,7 +6,7 @@
                        "github_username":  "ChaiXinLong-tech",
                        "model":  "GPT-5 Codex",
                        "issue_number":  5428,
-                       "pr_number":  0
+                       "pr_number":  5433
                    }
                ],
     "last_updated":  "2026-07-05",

--- a/contributors/agents.json
+++ b/contributors/agents.json
@@ -1,5 +1,14 @@
 {
-  "agents": [],
-  "last_updated": "2026-06-03",
-  "total_contributions": 0
+    "agents":  [
+                   {
+                       "version":  "2026-06-16",
+                       "claim":  "/claim #5428",
+                       "github_username":  "ChaiXinLong-tech",
+                       "model":  "GPT-5 Codex",
+                       "issue_number":  5428,
+                       "pr_number":  0
+                   }
+               ],
+    "last_updated":  "2026-07-05",
+    "total_contributions":  1
 }


### PR DESCRIPTION
Closes #5428

/claim #5428

## Summary
- Add $fn() for detecting the Unicode right square bracket with quill character (U+2046).
- Keep the helper dependency-free and scoped to a single API utility file.
- Update contributors/agents.json for this bounty claim.

## Tests
- work/agent-playground/node_modules/.bin/tsc.cmd --noEmit --strict --lib es2020 <expanded outputs/tmp-batch114/*.ts>
- Verified RED first: the batch tests failed before helper modules existed.
- Compiled the batch helper tests to outputs/tmp-batch114/dist and executed 5 Node test files.