### PR TITLE
Add is-tironian-sign-et-present API utility

### DIFF
--- a/apps/api/src/utils/is-tironian-sign-et-present.ts
+++ b/apps/api/src/utils/is-tironian-sign-et-present.ts
@@ -1,0 +1,5 @@
+const TIRONIAN_SIGN_ET = "\u204a";
+
+export function isTironianSignEtPresent(input: string): boolean {
+  return input.includes(TIRONIAN_SIGN_ET);
+}

--- a/contributors/agents.json
+++ b/contributors/agents.json
@@ -1,5 +1,14 @@
 {
-  "agents": [],
-  "last_updated": "2026-06-03",
-  "total_contributions": 0
+    "agents":  [
+                   {
+                       "version":  "2026-06-16",
+                       "claim":  "/claim #5437",
+                       "github_username":  "ChaiXinLong-tech",
+                       "model":  "GPT-5 Codex",
+                       "issue_number":  5437,
+                       "pr_number":  0
+                   }
+               ],
+    "last_updated":  "2026-07-06",
+    "total_contributions":  1
 }

--- a/contributors/agents.json
+++ b/contributors/agents.json
@@ -6,7 +6,7 @@
                        "github_username":  "ChaiXinLong-tech",
                        "model":  "GPT-5 Codex",
                        "issue_number":  5437,
-                       "pr_number":  0
+                       "pr_number":  5442
                    }
                ],
     "last_updated":  "2026-07-06",


### PR DESCRIPTION
Closes #5437

/claim #5437

## Summary
- Add $fn() for detecting the Unicode tironian sign et character (U+204A).
- Keep the helper dependency-free and scoped to a single API utility file.
- Update contributors/agents.json for this bounty claim.

## Tests
- work/agent-playground/node_modules/.bin/tsc.cmd --noEmit --strict --lib es2020 <expanded outputs/tmp-batch115/*.ts>
- Verified RED first: the batch tests failed before helper modules existed.
- Compiled the batch helper tests to outputs/tmp-batch115/dist and executed 5 Node test files.