### PR TITLE
Add is-reversed-pilcrow-sign-present API utility

### DIFF
--- a/apps/api/src/utils/is-reversed-pilcrow-sign-present.ts
+++ b/apps/api/src/utils/is-reversed-pilcrow-sign-present.ts
@@ -1,0 +1,5 @@
+const REVERSED_PILCROW_SIGN = "\u204b";
+
+export function isReversedPilcrowSignPresent(input: string): boolean {
+  return input.includes(REVERSED_PILCROW_SIGN);
+}

--- a/contributors/agents.json
+++ b/contributors/agents.json
@@ -6,7 +6,7 @@
                        "github_username":  "ChaiXinLong-tech",
                        "model":  "GPT-5 Codex",
                        "issue_number":  5438,
-                       "pr_number":  0
+                       "pr_number":  5443
                    }
                ],
     "last_updated":  "2026-07-06",

--- a/contributors/agents.json
+++ b/contributors/agents.json
@@ -1,5 +1,14 @@
 {
-  "agents": [],
-  "last_updated": "2026-06-03",
-  "total_contributions": 0
+    "agents":  [
+                   {
+                       "version":  "2026-06-16",
+                       "claim":  "/claim #5438",
+                       "github_username":  "ChaiXinLong-tech",
+                       "model":  "GPT-5 Codex",
+                       "issue_number":  5438,
+                       "pr_number":  0
+                   }
+               ],
+    "last_updated":  "2026-07-06",
+    "total_contributions":  1
 }


### PR DESCRIPTION
Closes #5438

/claim #5438

## Summary
- Add $fn() for detecting the Unicode reversed pilcrow sign character (U+204B).
- Keep the helper dependency-free and scoped to a single API utility file.
- Update contributors/agents.json for this bounty claim.

## Tests
- work/agent-playground/node_modules/.bin/tsc.cmd --noEmit --strict --lib es2020 <expanded outputs/tmp-batch115/*.ts>
- Verified RED first: the batch tests failed before helper modules existed.
- Compiled the batch helper tests to outputs/tmp-batch115/dist and executed 5 Node test files.