### PR TITLE
Add is-black-leftwards-bullet-present API utility

### DIFF
--- a/apps/api/src/utils/is-black-leftwards-bullet-present.ts
+++ b/apps/api/src/utils/is-black-leftwards-bullet-present.ts
@@ -1,0 +1,5 @@
+const BLACK_LEFTWARDS_BULLET = "\u204c";
+
+export function isBlackLeftwardsBulletPresent(input: string): boolean {
+  return input.includes(BLACK_LEFTWARDS_BULLET);
+}

--- a/contributors/agents.json
+++ b/contributors/agents.json
@@ -6,7 +6,7 @@
                        "github_username":  "ChaiXinLong-tech",
                        "model":  "GPT-5 Codex",
                        "issue_number":  5439,
-                       "pr_number":  0
+                       "pr_number":  5444
                    }
                ],
     "last_updated":  "2026-07-06",

--- a/contributors/agents.json
+++ b/contributors/agents.json
@@ -1,5 +1,14 @@
 {
-  "agents": [],
-  "last_updated": "2026-06-03",
-  "total_contributions": 0
+    "agents":  [
+                   {
+                       "version":  "2026-06-16",
+                       "claim":  "/claim #5439",
+                       "github_username":  "ChaiXinLong-tech",
+                       "model":  "GPT-5 Codex",
+                       "issue_number":  5439,
+                       "pr_number":  0
+                   }
+               ],
+    "last_updated":  "2026-07-06",
+    "total_contributions":  1
 }


### PR DESCRIPTION
Closes #5439

/claim #5439

## Summary
- Add $fn() for detecting the Unicode black leftwards bullet character (U+204C).
- Keep the helper dependency-free and scoped to a single API utility file.
- Update contributors/agents.json for this bounty claim.

## Tests
- work/agent-playground/node_modules/.bin/tsc.cmd --noEmit --strict --lib es2020 <expanded outputs/tmp-batch115/*.ts>
- Verified RED first: the batch tests failed before helper modules existed.
- Compiled the batch helper tests to outputs/tmp-batch115/dist and executed 5 Node test files.