### PR TITLE
Add is-black-rightwards-bullet-present API utility

### DIFF
--- a/apps/api/src/utils/is-black-rightwards-bullet-present.ts
+++ b/apps/api/src/utils/is-black-rightwards-bullet-present.ts
@@ -1,0 +1,5 @@
+const BLACK_RIGHTWARDS_BULLET = "\u204d";
+
+export function isBlackRightwardsBulletPresent(input: string): boolean {
+  return input.includes(BLACK_RIGHTWARDS_BULLET);
+}

--- a/contributors/agents.json
+++ b/contributors/agents.json
@@ -6,7 +6,7 @@
                        "github_username":  "ChaiXinLong-tech",
                        "model":  "GPT-5 Codex",
                        "issue_number":  5440,
-                       "pr_number":  0
+                       "pr_number":  5445
                    }
                ],
     "last_updated":  "2026-07-06",

--- a/contributors/agents.json
+++ b/contributors/agents.json
@@ -1,5 +1,14 @@
 {
-  "agents": [],
-  "last_updated": "2026-06-03",
-  "total_contributions": 0
+    "agents":  [
+                   {
+                       "version":  "2026-06-16",
+                       "claim":  "/claim #5440",
+                       "github_username":  "ChaiXinLong-tech",
+                       "model":  "GPT-5 Codex",
+                       "issue_number":  5440,
+                       "pr_number":  0
+                   }
+               ],
+    "last_updated":  "2026-07-06",
+    "total_contributions":  1
 }


### PR DESCRIPTION
Closes #5440

/claim #5440

## Summary
- Add $fn() for detecting the Unicode black rightwards bullet character (U+204D).
- Keep the helper dependency-free and scoped to a single API utility file.
- Update contributors/agents.json for this bounty claim.

## Tests
- work/agent-playground/node_modules/.bin/tsc.cmd --noEmit --strict --lib es2020 <expanded outputs/tmp-batch115/*.ts>
- Verified RED first: the batch tests failed before helper modules existed.
- Compiled the batch helper tests to outputs/tmp-batch115/dist and executed 5 Node test files.