### PR TITLE
[agent] feat(api): add low asterisk presence helper

### DIFF
--- a/apps/api/src/utils/is-low-asterisk-present-smoke.test.ts
+++ b/apps/api/src/utils/is-low-asterisk-present-smoke.test.ts
@@ -1,0 +1,12 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+
+import { isLowAsteriskPresent } from "./is-low-asterisk-present";
+
+test("isLowAsteriskPresent detects only the Unicode low asterisk character", () => {
+  assert.equal(isLowAsteriskPresent("before\u204Eafter"), true);
+  assert.equal(isLowAsteriskPresent("\u204E"), true);
+  assert.equal(isLowAsteriskPresent("regular asterisk *"), false);
+  assert.equal(isLowAsteriskPresent("plain text"), false);
+  assert.equal(isLowAsteriskPresent(""), false);
+});

--- a/apps/api/src/utils/is-low-asterisk-present.ts
+++ b/apps/api/src/utils/is-low-asterisk-present.ts
@@ -1,0 +1,3 @@
+export function isLowAsteriskPresent(input: string): boolean {
+  return input.includes("\u204E");
+}

--- a/contributors/agents.json
+++ b/contributors/agents.json
@@ -1,5 +1,13 @@
 {
-  "agents": [],
-  "last_updated": "2026-06-03",
-  "total_contributions": 0
+  "agents": [
+    {
+      "github_username": "shangguanwt",
+      "model": "GPT-5 Codex",
+      "version": "2026-07-06",
+      "pr_number": 0,
+      "issue_number": 5441
+    }
+  ],
+  "last_updated": "2026-07-06",
+  "total_contributions": 1
 }

--- a/contributors/agents.json
+++ b/contributors/agents.json
@@ -4,7 +4,7 @@
       "github_username": "shangguanwt",
       "model": "GPT-5 Codex",
       "version": "2026-07-06",
-      "pr_number": 0,
+      "pr_number": 5447,
       "issue_number": 5441
     }
   ],


### PR DESCRIPTION
## Summary
- Add dependency-free `isLowAsteriskPresent(input: string): boolean` helper for Unicode low asterisk U+204E.
- Add a focused node:test smoke test covering target, regular asterisk, plain text, and empty input.
- Update `contributors/agents.json` for the AI agent contribution.

## Claim
/claim #5441

Closes #5441

## Verification
- `npm exec --package tsx@4.7.1 -- tsx --test apps/api/src/utils/is-low-asterisk-present-smoke.test.ts`
- `npm exec --package typescript@5.4.5 -- tsc --strict --noEmit --lib es2020 apps/api/src/utils/is-low-asterisk-present.ts`
- `git diff --check`