### PR TITLE
Add is-commercial-minus-sign-present API utility

### DIFF
--- a/apps/api/src/utils/is-commercial-minus-sign-present.ts
+++ b/apps/api/src/utils/is-commercial-minus-sign-present.ts
@@ -1,0 +1,5 @@
+const COMMERCIAL_MINUS_SIGN = "\u2052";
+
+export function isCommercialMinusSignPresent(input: string): boolean {
+  return input.includes(COMMERCIAL_MINUS_SIGN);
+}

--- a/contributors/agents.json
+++ b/contributors/agents.json
@@ -6,7 +6,7 @@
                        "github_username":  "ChaiXinLong-tech",
                        "model":  "GPT-5 Codex",
                        "issue_number":  5449,
-                       "pr_number":  0
+                       "pr_number":  5454
                    }
                ],
     "last_updated":  "2026-07-05",

--- a/contributors/agents.json
+++ b/contributors/agents.json
@@ -1,5 +1,14 @@
 {
-  "agents": [],
-  "last_updated": "2026-06-03",
-  "total_contributions": 0
+    "agents":  [
+                   {
+                       "version":  "2026-06-16",
+                       "claim":  "/claim #5449",
+                       "github_username":  "ChaiXinLong-tech",
+                       "model":  "GPT-5 Codex",
+                       "issue_number":  5449,
+                       "pr_number":  0
+                   }
+               ],
+    "last_updated":  "2026-07-05",
+    "total_contributions":  1
 }


### PR DESCRIPTION
Closes #5449

/claim #5449

## Summary
- Add $fn() for detecting the Unicode commercial minus sign character (U+2052).
- Keep the helper dependency-free and scoped to a single API utility file.
- Update contributors/agents.json for this bounty claim.

## Tests
- RED: work/agent-playground/node_modules/.bin/tsc.cmd --noEmit --strict --lib es2020 outputs/tmp-batch116/*.test.ts failed before helper modules existed.
- GREEN: work/agent-playground/node_modules/.bin/tsc.cmd --noEmit --strict --lib es2020 ... passed for the batch helper and test files.
- GREEN: compiled the batch helper tests to outputs/tmp-batch116/dist and executed 5 Node test files.