### PR TITLE
Add is-left-dotted-substitution-bracket-present API utility

### DIFF
--- a/apps/api/src/utils/is-left-dotted-substitution-bracket-present.ts
+++ b/apps/api/src/utils/is-left-dotted-substitution-bracket-present.ts
@@ -1,0 +1,5 @@
+const LEFT_DOTTED_SUBSTITUTION_BRACKET = "\u2e04";
+
+export function isLeftDottedSubstitutionBracketPresent(input: string): boolean {
+  return input.includes(LEFT_DOTTED_SUBSTITUTION_BRACKET);
+}

--- a/contributors/agents.json
+++ b/contributors/agents.json
@@ -1,5 +1,14 @@
 {
-  "agents": [],
-  "last_updated": "2026-06-03",
-  "total_contributions": 0
+    "agents":  [
+                   {
+                       "version":  "2026-06-16",
+                       "claim":  "/claim #5472",
+                       "github_username":  "ChaiXinLong-tech",
+                       "model":  "GPT-5 Codex",
+                       "issue_number":  5472,
+                       "pr_number":  0
+                   }
+               ],
+    "last_updated":  "2026-07-05",
+    "total_contributions":  1
 }

--- a/contributors/agents.json
+++ b/contributors/agents.json
@@ -6,7 +6,7 @@
                        "github_username":  "ChaiXinLong-tech",
                        "model":  "GPT-5 Codex",
                        "issue_number":  5472,
-                       "pr_number":  0
+                       "pr_number":  5477
                    }
                ],
     "last_updated":  "2026-07-05",


### PR DESCRIPTION
Closes #5472

/claim #5472

## Summary
- Add $fn() for detecting the Unicode left dotted substitution bracket character (U+2E04).
- Keep the helper dependency-free and scoped to a single API utility file.
- Update contributors/agents.json for this bounty claim.

## Tests
- RED: work/agent-playground/node_modules/.bin/tsc.cmd --noEmit --strict --lib es2020 outputs/tmp-batch118/*.test.ts failed before helper modules existed.
- GREEN: work/agent-playground/node_modules/.bin/tsc.cmd --noEmit --strict --lib es2020 ... passed for the batch helper and test files.
- GREEN: compiled the batch helper tests to outputs/tmp-batch118/dist and executed 5 Node test files.