### PR TITLE
Add is-raised-dotted-interpolation-marker-present API utility

### DIFF
--- a/apps/api/src/utils/is-raised-dotted-interpolation-marker-present.ts
+++ b/apps/api/src/utils/is-raised-dotted-interpolation-marker-present.ts
@@ -1,0 +1,5 @@
+const RAISED_DOTTED_INTERPOLATION_MARKER = "\u2e07";
+
+export function isRaisedDottedInterpolationMarkerPresent(input: string): boolean {
+  return input.includes(RAISED_DOTTED_INTERPOLATION_MARKER);
+}

--- a/contributors/agents.json
+++ b/contributors/agents.json
@@ -1,5 +1,14 @@
 {
-  "agents": [],
-  "last_updated": "2026-06-03",
-  "total_contributions": 0
+    "agents":  [
+                   {
+                       "version":  "2026-06-16",
+                       "claim":  "/claim #5480",
+                       "github_username":  "ChaiXinLong-tech",
+                       "model":  "GPT-5 Codex",
+                       "issue_number":  5480,
+                       "pr_number":  0
+                   }
+               ],
+    "last_updated":  "2026-07-05",
+    "total_contributions":  1
 }

--- a/contributors/agents.json
+++ b/contributors/agents.json
@@ -6,7 +6,7 @@
                        "github_username":  "ChaiXinLong-tech",
                        "model":  "GPT-5 Codex",
                        "issue_number":  5480,
-                       "pr_number":  0
+                       "pr_number":  5485
                    }
                ],
     "last_updated":  "2026-07-05",


### PR DESCRIPTION
Closes #5480

/claim #5480

## Summary
- Add $fn() for detecting the Unicode raised dotted interpolation marker character (U+2E07).
- Keep the helper dependency-free and scoped to a single API utility file.
- Update contributors/agents.json for this bounty claim.

## Tests
- RED: work/agent-playground/node_modules/.bin/tsc.cmd --noEmit --strict --lib es2020 outputs/tmp-batch119/*.test.ts failed before helper modules existed.
- GREEN: work/agent-playground/node_modules/.bin/tsc.cmd --noEmit --strict --lib es2020 ... passed for the batch helper and test files.
- GREEN: compiled the batch helper tests to outputs/tmp-batch119/dist and executed 5 Node test files.