### PR TITLE
Add is-right-raised-omission-bracket-present API utility

### DIFF
--- a/apps/api/src/utils/is-right-raised-omission-bracket-present.ts
+++ b/apps/api/src/utils/is-right-raised-omission-bracket-present.ts
@@ -1,0 +1,5 @@
+const RIGHT_RAISED_OMISSION_BRACKET = "\u2e0d";
+
+export function isRightRaisedOmissionBracketPresent(input: string): boolean {
+  return input.includes(RIGHT_RAISED_OMISSION_BRACKET);
+}

--- a/contributors/agents.json
+++ b/contributors/agents.json
@@ -6,7 +6,7 @@
                        "github_username":  "ChaiXinLong-tech",
                        "model":  "GPT-5 Codex",
                        "issue_number":  5490,
-                       "pr_number":  0
+                       "pr_number":  5495
                    }
                ],
     "last_updated":  "2026-07-05",

--- a/contributors/agents.json
+++ b/contributors/agents.json
@@ -1,5 +1,14 @@
 {
-  "agents": [],
-  "last_updated": "2026-06-03",
-  "total_contributions": 0
+    "agents":  [
+                   {
+                       "version":  "2026-06-16",
+                       "claim":  "/claim #5490",
+                       "github_username":  "ChaiXinLong-tech",
+                       "model":  "GPT-5 Codex",
+                       "issue_number":  5490,
+                       "pr_number":  0
+                   }
+               ],
+    "last_updated":  "2026-07-05",
+    "total_contributions":  1
 }


### PR DESCRIPTION
Closes #5490

/claim #5490

## Summary
- Add $fn() for detecting the Unicode right raised omission bracket character (U+2E0D).
- Keep the helper dependency-free and scoped to a single API utility file.
- Update contributors/agents.json for this bounty claim.

## Tests
- RED: work/agent-playground/node_modules/.bin/tsc.cmd --noEmit --strict --lib es2020 outputs/tmp-batch120/*.test.ts failed before helper modules existed.
- GREEN: work/agent-playground/node_modules/.bin/tsc.cmd --noEmit --strict --lib es2020 ... passed for the batch helper and test files.
- GREEN: compiled the batch helper tests to outputs/tmp-batch120/dist and executed 5 Node test files.