### PR TITLE
Add is-reversed-forked-paragraphos-present API utility

### DIFF
--- a/apps/api/src/utils/is-reversed-forked-paragraphos-present.ts
+++ b/apps/api/src/utils/is-reversed-forked-paragraphos-present.ts
@@ -1,0 +1,5 @@
+const REVERSED_FORKED_PARAGRAPHOS = "\u2e11";
+
+export function isReversedForkedParagraphosPresent(input: string): boolean {
+  return input.includes(REVERSED_FORKED_PARAGRAPHOS);
+}

--- a/contributors/agents.json
+++ b/contributors/agents.json
@@ -1,5 +1,14 @@
 {
-  "agents": [],
-  "last_updated": "2026-06-03",
-  "total_contributions": 0
+    "agents":  [
+                   {
+                       "version":  "2026-06-16",
+                       "claim":  "/claim #5494",
+                       "github_username":  "ChaiXinLong-tech",
+                       "model":  "GPT-5 Codex",
+                       "issue_number":  5494,
+                       "pr_number":  0
+                   }
+               ],
+    "last_updated":  "2026-07-05",
+    "total_contributions":  1
 }

--- a/contributors/agents.json
+++ b/contributors/agents.json
@@ -6,7 +6,7 @@
                        "github_username":  "ChaiXinLong-tech",
                        "model":  "GPT-5 Codex",
                        "issue_number":  5494,
-                       "pr_number":  0
+                       "pr_number":  5499
                    }
                ],
     "last_updated":  "2026-07-05",


### PR DESCRIPTION
Closes #5494

/claim #5494

## Summary
- Add $fn() for detecting the Unicode reversed forked paragraphos character (U+2E11).
- Keep the helper dependency-free and scoped to a single API utility file.
- Update contributors/agents.json for this bounty claim.

## Tests
- RED: work/agent-playground/node_modules/.bin/tsc.cmd --noEmit --strict --lib es2020 outputs/tmp-batch120/*.test.ts failed before helper modules existed.
- GREEN: work/agent-playground/node_modules/.bin/tsc.cmd --noEmit --strict --lib es2020 ... passed for the batch helper and test files.
- GREEN: compiled the batch helper tests to outputs/tmp-batch120/dist and executed 5 Node test files.