### PR TITLE
Add isParagraphosPresent utility for U+2E0F detection

### DIFF
--- a/apps/api/src/utils/is-paragraphos-present.test.ts
+++ b/apps/api/src/utils/is-paragraphos-present.test.ts
@@ -1,0 +1,20 @@
+import { strict as assert } from "node:assert";
+import { test } from "node:test";
+
+import { isParagraphosPresent } from "./is-paragraphos-present";
+
+test("returns true when paragraphos char is present", () => {
+  assert.equal(isParagraphosPresent("⸏ text"), true);
+});
+
+test("returns false when paragraphos char is absent", () => {
+  assert.equal(isParagraphosPresent("regular text"), false);
+});
+
+test("returns false for empty string", () => {
+  assert.equal(isParagraphosPresent(""), false);
+});
+
+test("returns true for string that is just the char", () => {
+  assert.equal(isParagraphosPresent("⸏"), true);
+});

--- a/apps/api/src/utils/is-paragraphos-present.ts
+++ b/apps/api/src/utils/is-paragraphos-present.ts
@@ -1,0 +1,3 @@
+export function isParagraphosPresent(input: string): boolean {
+  return input.includes("\u2E0F");
+}


### PR DESCRIPTION
Adds a dependency-free TypeScript helper that checks whether a string contains the Unicode paragraphos character (U+2E0F).

Closes #5492