### PR TITLE
Add isForkedParagraphosPresent utility for U+2E10 detection

### DIFF
--- a/apps/api/src/utils/is-forked-paragraphos-present.test.ts
+++ b/apps/api/src/utils/is-forked-paragraphos-present.test.ts
@@ -1,0 +1,20 @@
+import { strict as assert } from "node:assert";
+import { test } from "node:test";
+
+import { isForkedParagraphosPresent } from "./is-forked-paragraphos-present";
+
+test("returns true when forked paragraphos char is present", () => {
+  assert.equal(isForkedParagraphosPresent("⸐ here"), true);
+});
+
+test("returns false when forked paragraphos char is absent", () => {
+  assert.equal(isForkedParagraphosPresent("no special chars"), false);
+});
+
+test("returns false for empty string", () => {
+  assert.equal(isForkedParagraphosPresent(""), false);
+});
+
+test("returns true for string that is just the char", () => {
+  assert.equal(isForkedParagraphosPresent("⸐"), true);
+});

--- a/apps/api/src/utils/is-forked-paragraphos-present.ts
+++ b/apps/api/src/utils/is-forked-paragraphos-present.ts
@@ -1,0 +1,3 @@
+export function isForkedParagraphosPresent(input: string): boolean {
+  return input.includes("\u2E10");
+}


### PR DESCRIPTION
Adds a dependency-free TypeScript helper that checks whether a string contains the Unicode forked paragraphos character (U+2E10).

Closes #5493