### PR TITLE
Add isReversedForkedParagraphosPresent utility for U+2E11 detection

### DIFF
--- a/apps/api/src/utils/is-reversed-forked-paragraphos-present.test.ts
+++ b/apps/api/src/utils/is-reversed-forked-paragraphos-present.test.ts
@@ -1,0 +1,20 @@
+import { strict as assert } from "node:assert";
+import { test } from "node:test";
+
+import { isReversedForkedParagraphosPresent } from "./is-reversed-forked-paragraphos-present";
+
+test("returns true when reversed forked paragraphos char is present", () => {
+  assert.equal(isReversedForkedParagraphosPresent("⸑ text"), true);
+});
+
+test("returns false when reversed forked paragraphos char is absent", () => {
+  assert.equal(isReversedForkedParagraphosPresent("plain text"), false);
+});
+
+test("returns false for empty string", () => {
+  assert.equal(isReversedForkedParagraphosPresent(""), false);
+});
+
+test("returns true for string that is just the char", () => {
+  assert.equal(isReversedForkedParagraphosPresent("⸑"), true);
+});

--- a/apps/api/src/utils/is-reversed-forked-paragraphos-present.ts
+++ b/apps/api/src/utils/is-reversed-forked-paragraphos-present.ts
@@ -1,0 +1,3 @@
+export function isReversedForkedParagraphosPresent(input: string): boolean {
+  return input.includes("\u2E11");
+}


### PR DESCRIPTION
Adds a dependency-free TypeScript helper that checks whether a string contains the Unicode reversed forked paragraphos character (U+2E11).

Closes #5494