### PR TITLE
Add isEditorialCoronisPresent utility for U+2E0E detection

### DIFF
--- a/apps/api/src/utils/is-editorial-coronis-present.test.ts
+++ b/apps/api/src/utils/is-editorial-coronis-present.test.ts
@@ -1,0 +1,20 @@
+import { strict as assert } from "node:assert";
+import { test } from "node:test";
+
+import { isEditorialCoronisPresent } from "./is-editorial-coronis-present";
+
+test("returns true when editorial coronis char is present", () => {
+  assert.equal(isEditorialCoronisPresent("⸎ ending"), true);
+});
+
+test("returns false when editorial coronis char is absent", () => {
+  assert.equal(isEditorialCoronisPresent("nothing special"), false);
+});
+
+test("returns false for empty string", () => {
+  assert.equal(isEditorialCoronisPresent(""), false);
+});
+
+test("returns true for string that is just the char", () => {
+  assert.equal(isEditorialCoronisPresent("⸎"), true);
+});

--- a/apps/api/src/utils/is-editorial-coronis-present.ts
+++ b/apps/api/src/utils/is-editorial-coronis-present.ts
@@ -1,0 +1,3 @@
+export function isEditorialCoronisPresent(input: string): boolean {
+  return input.includes("\u2E0E");
+}


### PR DESCRIPTION
Adds a dependency-free TypeScript helper that checks whether a string contains the Unicode editorial coronis character (U+2E0E).

Closes #5491