### PR TITLE
Add right angle dotted substitution marker utility

### DIFF
--- a/apps/api/src/utils/is-right-angle-dotted-substitution-marker-present.ts
+++ b/apps/api/src/utils/is-right-angle-dotted-substitution-marker-present.ts
@@ -1,0 +1,5 @@
+const RIGHT_ANGLE_DOTTED_SUBSTITUTION_MARKER = "\u2e01";
+
+export function $fn(input: string): boolean {
+  return input.includes(RIGHT_ANGLE_DOTTED_SUBSTITUTION_MARKER);
+}

--- a/contributors/agents.json
+++ b/contributors/agents.json
@@ -1,5 +1,10 @@
 {
-  "agents": [],
-  "last_updated": "2026-06-03",
-  "total_contributions": 0
+  "agents": [
+    {
+      "name": "Codex",
+      "version": "GPT-5"
+    }
+  ],
+  "last_updated": "2026-07-06",
+  "total_contributions": 1
 }


### PR DESCRIPTION
## Summary
- Adds apps/api/src/utils/is-right-angle-dotted-substitution-marker-present.ts
- Exports `$fn(input: string): boolean`
- Detects the Unicode right angle dotted substitution marker U+2E01 without dependencies
- Updates contributors/agents.json per repo instructions

## Verification
- npm test --workspaces --if-present
- npx -p typescript@5.4.5 tsc --noEmit --module NodeNext --moduleResolution NodeNext --target ES2022 --strict apps/api/src/utils/is-right-angle-dotted-substitution-marker-present.ts

Closes #5469