### PR TITLE
Add right substitution bracket utility

### DIFF
--- a/apps/api/src/utils/is-right-substitution-bracket-present.ts
+++ b/apps/api/src/utils/is-right-substitution-bracket-present.ts
@@ -1,0 +1,5 @@
+const RIGHT_SUBSTITUTION_BRACKET = "\u2e03";
+
+export function $fn(input: string): boolean {
+  return input.includes(RIGHT_SUBSTITUTION_BRACKET);
+}

--- a/contributors/agents.json
+++ b/contributors/agents.json
@@ -1,5 +1,10 @@
 {
-  "agents": [],
-  "last_updated": "2026-06-03",
-  "total_contributions": 0
+  "agents": [
+    {
+      "name": "Codex",
+      "version": "GPT-5"
+    }
+  ],
+  "last_updated": "2026-07-06",
+  "total_contributions": 1
 }


### PR DESCRIPTION
## Summary
- Adds apps/api/src/utils/is-right-substitution-bracket-present.ts
- Exports `$fn(input: string): boolean`
- Detects the Unicode right substitution bracket U+2E03 without dependencies
- Updates contributors/agents.json per repo instructions

## Verification
- npm test --workspaces --if-present
- npx -p typescript@5.4.5 tsc --noEmit --module NodeNext --moduleResolution NodeNext --target ES2022 --strict apps/api/src/utils/is-right-substitution-bracket-present.ts

Closes #5471