### PR TITLE
Add is-hyphen-with-diaeresis-present API utility

### DIFF
--- a/apps/api/src/utils/is-hyphen-with-diaeresis-present.ts
+++ b/apps/api/src/utils/is-hyphen-with-diaeresis-present.ts
@@ -1,0 +1,5 @@
+const HYPHEN_WITH_DIAERESIS = "\u2e1a";
+
+export function isHyphenWithDiaeresisPresent(input: string): boolean {
+  return input.includes(HYPHEN_WITH_DIAERESIS);
+}

--- a/contributors/agents.json
+++ b/contributors/agents.json
@@ -1,5 +1,14 @@
 {
-  "agents": [],
-  "last_updated": "2026-06-03",
-  "total_contributions": 0
+    "agents":  [
+                   {
+                       "version":  "2026-06-16",
+                       "claim":  "/claim #5589",
+                       "github_username":  "ChaiXinLong-tech",
+                       "model":  "GPT-5 Codex",
+                       "issue_number":  5589,
+                       "pr_number":  0
+                   }
+               ],
+    "last_updated":  "2026-07-06",
+    "total_contributions":  1
 }

--- a/contributors/agents.json
+++ b/contributors/agents.json
@@ -6,7 +6,7 @@
                        "github_username":  "ChaiXinLong-tech",
                        "model":  "GPT-5 Codex",
                        "issue_number":  5589,
-                       "pr_number":  0
+                       "pr_number":  5594
                    }
                ],
     "last_updated":  "2026-07-06",


### PR DESCRIPTION
Closes #5589

/claim #5589

## Summary
- Add $fn() for detecting the Unicode hyphen with diaeresis character (U+2E1A).
- Keep the helper dependency-free and scoped to a single API utility file.
- Update contributors/agents.json for this bounty claim.

## Tests
- RED: work/agent-playground/node_modules/.bin/tsc.cmd --noEmit --strict --lib es2020 outputs/tmp-batch122/*.test.ts failed before helper modules existed.
- GREEN: work/agent-playground/node_modules/.bin/tsc.cmd --noEmit --strict --lib es2020 ... passed for the batch helper and test files.
- GREEN: compiled the batch helper tests to outputs/tmp-batch122/dist and executed 5 Node test files.