### PR TITLE
Add is-left-low-paraphrase-bracket-present API utility

### DIFF
--- a/apps/api/src/utils/is-left-low-paraphrase-bracket-present.ts
+++ b/apps/api/src/utils/is-left-low-paraphrase-bracket-present.ts
@@ -1,0 +1,5 @@
+const LEFT_LOW_PARAPHRASE_BRACKET = "\u2e1c";
+
+export function isLeftLowParaphraseBracketPresent(input: string): boolean {
+  return input.includes(LEFT_LOW_PARAPHRASE_BRACKET);
+}

--- a/contributors/agents.json
+++ b/contributors/agents.json
@@ -1,5 +1,14 @@
 {
-  "agents": [],
-  "last_updated": "2026-06-03",
-  "total_contributions": 0
+    "agents":  [
+                   {
+                       "version":  "2026-06-16",
+                       "claim":  "/claim #5591",
+                       "github_username":  "ChaiXinLong-tech",
+                       "model":  "GPT-5 Codex",
+                       "issue_number":  5591,
+                       "pr_number":  0
+                   }
+               ],
+    "last_updated":  "2026-07-06",
+    "total_contributions":  1
 }

--- a/contributors/agents.json
+++ b/contributors/agents.json
@@ -6,7 +6,7 @@
                        "github_username":  "ChaiXinLong-tech",
                        "model":  "GPT-5 Codex",
                        "issue_number":  5591,
-                       "pr_number":  0
+                       "pr_number":  5596
                    }
                ],
     "last_updated":  "2026-07-06",


### PR DESCRIPTION
Closes #5591

/claim #5591

## Summary
- Add $fn() for detecting the Unicode left low paraphrase bracket character (U+2E1C).
- Keep the helper dependency-free and scoped to a single API utility file.
- Update contributors/agents.json for this bounty claim.

## Tests
- RED: work/agent-playground/node_modules/.bin/tsc.cmd --noEmit --strict --lib es2020 outputs/tmp-batch122/*.test.ts failed before helper modules existed.
- GREEN: work/agent-playground/node_modules/.bin/tsc.cmd --noEmit --strict --lib es2020 ... passed for the batch helper and test files.
- GREEN: compiled the batch helper tests to outputs/tmp-batch122/dist and executed 5 Node test files.