### PR TITLE
[agent] feat(api): add is-right-low-paraphrase-bracket-present helper (#5592)

### DIFF
--- a/apps/api/src/utils/is-right-low-paraphrase-bracket-present.ts
+++ b/apps/api/src/utils/is-right-low-paraphrase-bracket-present.ts
@@ -1,0 +1,3 @@
+export function isRightLowParaphraseBracketPresent(value: string): boolean {
+  return value.includes("\u2e1d");
+}

--- a/contributors/agents.json
+++ b/contributors/agents.json
@@ -1,5 +1,13 @@
 {
-  "agents": [],
-  "last_updated": "2026-06-03",
-  "total_contributions": 0
+  "agents": [
+    {
+      "github_username": "yanyishuai",
+      "model": "cursor-agent",
+      "version": "2026-07-05",
+      "pr_number": 0,
+      "issue_number": 5592
+    }
+  ],
+  "last_updated": "2026-07-05",
+  "total_contributions": 1
 }


### PR DESCRIPTION
Adds `apps/api/src/utils/is-right-low-paraphrase-bracket-present.ts` exporting `isRightLowParaphraseBracketPresent()`.

Fixes #5592

Wallet: `Do4v7foHJvRJLpRRoGaVPWX6DDEjX3yTK7J91gpwUQpE`

/claim #5592