### PR TITLE
Add is-left-double-parenthesis-present API utility

### DIFF
--- a/apps/api/src/utils/is-left-double-parenthesis-present.ts
+++ b/apps/api/src/utils/is-left-double-parenthesis-present.ts
@@ -1,0 +1,5 @@
+const LEFT_DOUBLE_PARENTHESIS = "\u2e28";
+
+export function isLeftDoubleParenthesisPresent(input: string): boolean {
+  return input.includes(LEFT_DOUBLE_PARENTHESIS);
+}

--- a/contributors/agents.json
+++ b/contributors/agents.json
@@ -1,5 +1,14 @@
 {
-  "agents": [],
-  "last_updated": "2026-06-03",
-  "total_contributions": 0
+    "agents":  [
+                   {
+                       "version":  "2026-06-16",
+                       "claim":  "/claim #5631",
+                       "github_username":  "ChaiXinLong-tech",
+                       "model":  "GPT-5 Codex",
+                       "issue_number":  5631,
+                       "pr_number":  0
+                   }
+               ],
+    "last_updated":  "2026-07-06",
+    "total_contributions":  1
 }

--- a/contributors/agents.json
+++ b/contributors/agents.json
@@ -6,7 +6,7 @@
                        "github_username":  "ChaiXinLong-tech",
                        "model":  "GPT-5 Codex",
                        "issue_number":  5631,
-                       "pr_number":  0
+                       "pr_number":  5636
                    }
                ],
     "last_updated":  "2026-07-06",


### PR DESCRIPTION
Closes #5631

/claim #5631

## Summary
- Add $fn() for detecting the Unicode left double parenthesis character (U+2E28).
- Keep the helper dependency-free and scoped to a single API utility file.
- Update contributors/agents.json for this bounty claim.

## Tests
- RED: work/agent-playground/node_modules/.bin/tsc.cmd --noEmit --strict --lib es2020 outputs/tmp-batch124/*.test.ts failed before helper modules existed.
- GREEN: work/agent-playground/node_modules/.bin/tsc.cmd --noEmit --strict --lib es2020 ... passed for the batch helper and test files.
- GREEN: compiled the batch helper tests to outputs/tmp-batch124/dist and executed 5 Node test files.