### PR TITLE
Add is-word-separator-middle-dot-present API utility

### DIFF
--- a/apps/api/src/utils/is-word-separator-middle-dot-present.ts
+++ b/apps/api/src/utils/is-word-separator-middle-dot-present.ts
@@ -1,0 +1,5 @@
+const WORD_SEPARATOR_MIDDLE_DOT = "\u2e31";
+
+export function isWordSeparatorMiddleDotPresent(input: string): boolean {
+  return input.includes(WORD_SEPARATOR_MIDDLE_DOT);
+}

--- a/contributors/agents.json
+++ b/contributors/agents.json
@@ -1,5 +1,14 @@
 {
-  "agents": [],
-  "last_updated": "2026-06-03",
-  "total_contributions": 0
+    "agents":  [
+                   {
+                       "version":  "2026-06-16",
+                       "claim":  "/claim #5643",
+                       "github_username":  "ChaiXinLong-tech",
+                       "model":  "GPT-5 Codex",
+                       "issue_number":  5643,
+                       "pr_number":  0
+                   }
+               ],
+    "last_updated":  "2026-07-06",
+    "total_contributions":  1
 }

--- a/contributors/agents.json
+++ b/contributors/agents.json
@@ -6,7 +6,7 @@
                        "github_username":  "ChaiXinLong-tech",
                        "model":  "GPT-5 Codex",
                        "issue_number":  5643,
-                       "pr_number":  0
+                       "pr_number":  5648
                    }
                ],
     "last_updated":  "2026-07-06",


### PR DESCRIPTION
Closes #5643

/claim #5643

## Summary
- Add $fn() for detecting the Unicode word separator middle dot character (U+2E31).
- Keep the helper dependency-free and scoped to a single API utility file.
- Update contributors/agents.json for this bounty claim.

## Tests
- RED: work/agent-playground/node_modules/.bin/tsc.cmd --noEmit --strict --lib es2020 outputs/tmp-batch125/*.test.ts failed before helper modules existed.
- GREEN: work/agent-playground/node_modules/.bin/tsc.cmd --noEmit --strict --lib es2020 ... passed for the batch helper and test files.
- GREEN: compiled the batch helper tests to outputs/tmp-batch125/dist and executed 5 Node test files.