### PR TITLE
Add slugify utility

### DIFF
--- a/contributors/agents.json
+++ b/contributors/agents.json
@@ -1,5 +1,13 @@
 {
-  "agents": [],
-  "last_updated": "2026-06-03",
-  "total_contributions": 0
+  "agents": [
+    {
+      "agent": "Codex",
+      "github": "nonggde",
+      "issue": 5065,
+      "contribution": "Added src/utils/slugify.js with Node.js built-in test coverage.",
+      "date": "2026-07-06"
+    }
+  ],
+  "last_updated": "2026-07-06",
+  "total_contributions": 1
 }

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
   ],
   "scripts": {
     "dev": "npm run dev --workspaces --if-present",
-    "test": "npm run test --workspaces --if-present",
+    "test": "node --test test/*.test.js && npm run test --workspaces --if-present",
     "lint": "npm run lint --workspaces --if-present",
     "format": "npm run format --workspaces --if-present"
   },

--- a/src/utils/slugify.js
+++ b/src/utils/slugify.js
@@ -1,0 +1,18 @@
+'use strict';
+
+function slugify(value) {
+  if (value === null || value === undefined) {
+    return '';
+  }
+
+  return String(value)
+    .trim()
+    .toLowerCase()
+    .normalize('NFKD')
+    .replace(/[\u0300-\u036f]/g, '')
+    .replace(/[^a-z0-9\s_-]/g, '')
+    .replace(/[\s_-]+/g, '-')
+    .replace(/^-+|-+$/g, '');
+}
+
+module.exports = { slugify };

--- a/test/slugify.test.js
+++ b/test/slugify.test.js
@@ -1,0 +1,27 @@
+'use strict';
+
+const assert = require('node:assert/strict');
+const test = require('node:test');
+const { slugify } = require('../src/utils/slugify');
+
+test('slugify converts plain text to url friendly slugs', () => {
+  assert.equal(slugify('Hello World'), 'hello-world');
+  assert.equal(slugify('  Multiple   Spaces  '), 'multiple-spaces');
+});
+
+test('slugify removes special characters', () => {
+  assert.equal(slugify('TaskFlow: Teams & Projects!'), 'taskflow-teams-projects');
+  assert.equal(slugify('Save 50% now'), 'save-50-now');
+});
+
+test('slugify handles accents and repeated separators', () => {
+  assert.equal(slugify('Creme brulee roadmap'), 'creme-brulee-roadmap');
+  assert.equal(slugify('alpha---beta___gamma'), 'alpha-beta-gamma');
+});
+
+test('slugify handles empty and missing values gracefully', () => {
+  assert.equal(slugify(''), '');
+  assert.equal(slugify('   '), '');
+  assert.equal(slugify(null), '');
+  assert.equal(slugify(undefined), '');
+});


### PR DESCRIPTION
## Summary
- add src/utils/slugify.js with module.exports = { slugify }
- convert strings to lowercase URL-friendly slugs, handling spaces, repeated separators, accents, special characters, and empty inputs
- add Node.js built-in test coverage and contributor metadata

## Tests
- npm test

Closes #5065