### PR TITLE
Add required bounty marker to issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE/bounty_task.md
+++ b/.github/ISSUE_TEMPLATE/bounty_task.md
@@ -18,4 +18,4 @@ Describe the task, expected context, and files likely involved.
 
 ## Bounty Amount
 
-$50
+/bounty $50

--- a/contributors/agents.json
+++ b/contributors/agents.json
@@ -1,5 +1,13 @@
 {
-  "agents": [],
-  "last_updated": "2026-06-03",
-  "total_contributions": 0
+  "agents": [
+    {
+      "agent": "Codex",
+      "github": "nonggde",
+      "issue": 687,
+      "contribution": "Updated the bounty issue template default amount to include the required /bounty marker.",
+      "date": "2026-07-06"
+    }
+  ],
+  "last_updated": "2026-07-06",
+  "total_contributions": 1
 }


### PR DESCRIPTION
## Summary
- update the bounty task issue template to use the machine-readable /bounty  marker by default
- keep the change focused on the template and required contributor metadata

## Verification
- confirmed .github/ISSUE_TEMPLATE/bounty_task.md contains exactly one /bounty  marker
- confirmed the old bare $50 default is no longer present

Closes #687