### PR TITLE
Keep one bounty marker in PI challenge template

### DIFF
--- a/.github/ISSUE_TEMPLATE/pi_challenge.md
+++ b/.github/ISSUE_TEMPLATE/pi_challenge.md
@@ -19,6 +19,4 @@ Implement or document a small PI calculation challenge for TaskFlow's internal e
 
 ## Bounty Amount
 
-$50
-
 /bounty $50

--- a/contributors/agents.json
+++ b/contributors/agents.json
@@ -1,5 +1,13 @@
 {
-  "agents": [],
-  "last_updated": "2026-06-03",
-  "total_contributions": 0
+  "agents": [
+    {
+      "agent": "Codex",
+      "github": "nonggde",
+      "issue": 775,
+      "contribution": "Removed the duplicate plain bounty amount from the PI challenge issue template while keeping the /bounty marker.",
+      "date": "2026-07-06"
+    }
+  ],
+  "last_updated": "2026-07-06",
+  "total_contributions": 1
 }


### PR DESCRIPTION
## Summary
- remove the duplicate standalone $50 bounty amount from the PI challenge issue template
- keep the required machine-readable /bounty  marker as the single default bounty declaration
- update contributor metadata

## Verification
- confirmed .github/ISSUE_TEMPLATE/pi_challenge.md contains exactly one /bounty  marker
- confirmed there is no standalone $50 bounty amount line

Closes #775