### PR TITLE
Add hasPercentSign API utility

### DIFF
--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -7,7 +7,7 @@
   "main": "src/index.ts",
   "scripts": {
     "dev": "tsx src/index.ts",
-    "test": "echo \"No API tests configured yet\"",
+    "test": "tsx --test src/**/*.test.ts",
     "lint": "echo \"No API lint configured yet\""
   },
   "dependencies": {

--- a/apps/api/src/utils/has-percent-sign.test.ts
+++ b/apps/api/src/utils/has-percent-sign.test.ts
@@ -1,0 +1,17 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { hasPercentSign } from "./has-percent-sign";
+
+test("returns true when the value contains a percent sign", () => {
+  assert.equal(hasPercentSign("50%"), true);
+  assert.equal(hasPercentSign("% complete"), true);
+  assert.equal(hasPercentSign("discount: 10% off"), true);
+});
+
+test("returns false for adjacent non-matching cases", () => {
+  assert.equal(hasPercentSign("50 pct"), false);
+  assert.equal(hasPercentSign("50 percent"), false);
+  assert.equal(hasPercentSign("50／100"), false);
+  assert.equal(hasPercentSign(""), false);
+});

--- a/apps/api/src/utils/has-percent-sign.ts
+++ b/apps/api/src/utils/has-percent-sign.ts
@@ -1,0 +1,3 @@
+export function hasPercentSign(value: string): boolean {
+  return value.includes("%");
+}

--- a/contributors/agents.json
+++ b/contributors/agents.json
@@ -1,5 +1,13 @@
 {
-  "agents": [],
-  "last_updated": "2026-06-03",
-  "total_contributions": 0
+  "agents": [
+    {
+      "agent": "Codex",
+      "github": "nonggde",
+      "issue": 3785,
+      "contribution": "Added the API hasPercentSign utility with focused Node.js test coverage.",
+      "date": "2026-07-06"
+    }
+  ],
+  "last_updated": "2026-07-06",
+  "total_contributions": 1
 }


### PR DESCRIPTION
## Summary
- add pps/api/src/utils/has-percent-sign.ts with a dependency-free hasPercentSign(value: string): boolean export
- add focused Node.js test coverage for matching and adjacent non-matching cases
- wire the API package test script to run TS tests with 	sx --test
- update contributor metadata

## Tests
- npx --yes tsx --test apps/api/src/utils/has-percent-sign.test.ts

Closes #3785