### PR TITLE
Add em space detection utility

### DIFF
--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -7,7 +7,7 @@
   "main": "src/index.ts",
   "scripts": {
     "dev": "tsx src/index.ts",
-    "test": "echo \"No API tests configured yet\"",
+    "test": "tsx --test src/**/*.test.ts",
     "lint": "echo \"No API lint configured yet\""
   },
   "dependencies": {

--- a/apps/api/src/utils/is-em-space-present.test.ts
+++ b/apps/api/src/utils/is-em-space-present.test.ts
@@ -1,0 +1,17 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { isEmSpacePresent } from "./is-em-space-present";
+
+test("returns true when the value contains an em space", () => {
+  assert.equal(isEmSpacePresent("left\u2003right"), true);
+  assert.equal(isEmSpacePresent("\u2003leading"), true);
+  assert.equal(isEmSpacePresent("trailing\u2003"), true);
+});
+
+test("returns false for adjacent spacing characters", () => {
+  assert.equal(isEmSpacePresent("left right"), false);
+  assert.equal(isEmSpacePresent("left\u2002right"), false);
+  assert.equal(isEmSpacePresent("left\u2009right"), false);
+  assert.equal(isEmSpacePresent(""), false);
+});

--- a/apps/api/src/utils/is-em-space-present.ts
+++ b/apps/api/src/utils/is-em-space-present.ts
@@ -1,0 +1,5 @@
+const EM_SPACE = "\u2003";
+
+export function isEmSpacePresent(value: string): boolean {
+  return value.includes(EM_SPACE);
+}


### PR DESCRIPTION
## Summary
- add pps/api/src/utils/is-em-space-present.ts with a dependency-free isEmSpacePresent(value: string): boolean export
- add focused Node.js test coverage for U+2003 em space matches and adjacent non-matching spacing characters
- wire the API package test script to run TS tests with 	sx --test

## Tests
- npx --yes tsx --test apps/api/src/utils/is-em-space-present.test.ts

Closes #4862