### PR TITLE
Add en space detection utility

### DIFF
--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -7,7 +7,7 @@
   "main": "src/index.ts",
   "scripts": {
     "dev": "tsx src/index.ts",
-    "test": "echo \"No API tests configured yet\"",
+    "test": "tsx --test src/**/*.test.ts",
     "lint": "echo \"No API lint configured yet\""
   },
   "dependencies": {

--- a/apps/api/src/utils/is-en-space-present.test.ts
+++ b/apps/api/src/utils/is-en-space-present.test.ts
@@ -1,0 +1,17 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { isEnSpacePresent } from "./is-en-space-present";
+
+test("returns true when the value contains an en space", () => {
+  assert.equal(isEnSpacePresent("left\u2002right"), true);
+  assert.equal(isEnSpacePresent("\u2002leading"), true);
+  assert.equal(isEnSpacePresent("trailing\u2002"), true);
+});
+
+test("returns false for adjacent spacing characters", () => {
+  assert.equal(isEnSpacePresent("left right"), false);
+  assert.equal(isEnSpacePresent("left\u2003right"), false);
+  assert.equal(isEnSpacePresent("left\u2009right"), false);
+  assert.equal(isEnSpacePresent(""), false);
+});

--- a/apps/api/src/utils/is-en-space-present.ts
+++ b/apps/api/src/utils/is-en-space-present.ts
@@ -1,0 +1,5 @@
+const EN_SPACE = "\u2002";
+
+export function isEnSpacePresent(value: string): boolean {
+  return value.includes(EN_SPACE);
+}


### PR DESCRIPTION
## Summary
- add pps/api/src/utils/is-en-space-present.ts with a dependency-free isEnSpacePresent(value: string): boolean export
- add focused Node.js test coverage for U+2002 en space matches and adjacent non-matching spacing characters
- wire the API package test script to run TS tests with 	sx --test

## Tests
- npx --yes tsx --test apps/api/src/utils/is-en-space-present.test.ts

Closes #4864