### PR TITLE
Add API environment helper

### DIFF
--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -7,7 +7,7 @@
   "main": "src/index.ts",
   "scripts": {
     "dev": "tsx src/index.ts",
-    "test": "echo \"No API tests configured yet\"",
+    "test": "tsx --test src/**/*.test.ts",
     "lint": "echo \"No API lint configured yet\""
   },
   "dependencies": {

--- a/apps/api/src/config/env.test.ts
+++ b/apps/api/src/config/env.test.ts
@@ -1,0 +1,28 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { getApiPort, getOptionalEnv, getRequiredEnv } from "./env";
+
+test("getOptionalEnv returns trimmed values", () => {
+  assert.equal(getOptionalEnv("API_URL", undefined, { API_URL: "  http://api.test  " }), "http://api.test");
+});
+
+test("getOptionalEnv falls back for missing or blank values", () => {
+  assert.equal(getOptionalEnv("API_URL", "http://localhost", {}), "http://localhost");
+  assert.equal(getOptionalEnv("API_URL", "http://localhost", { API_URL: "   " }), "http://localhost");
+});
+
+test("getRequiredEnv returns values and throws for missing settings", () => {
+  assert.equal(getRequiredEnv("JWT_SECRET", { JWT_SECRET: " secret " }), "secret");
+  assert.throws(
+    () => getRequiredEnv("JWT_SECRET", {}),
+    /Missing required environment variable: JWT_SECRET/,
+  );
+});
+
+test("getApiPort parses the optional PORT setting", () => {
+  assert.equal(getApiPort({}), 4000);
+  assert.equal(getApiPort({ PORT: "5000" }), 5000);
+  assert.throws(() => getApiPort({ PORT: "0" }), /PORT must be a positive integer/);
+  assert.throws(() => getApiPort({ PORT: "abc" }), /PORT must be a positive integer/);
+});

--- a/apps/api/src/config/env.ts
+++ b/apps/api/src/config/env.ts
@@ -1,0 +1,38 @@
+export type EnvSource = Record<string, string | undefined>;
+
+function normalizeEnvValue(value: string | undefined): string | undefined {
+  const trimmed = value?.trim();
+  return trimmed ? trimmed : undefined;
+}
+
+export function getOptionalEnv(
+  name: string,
+  fallback?: string,
+  source: EnvSource = process.env,
+): string | undefined {
+  return normalizeEnvValue(source[name]) ?? fallback;
+}
+
+export function getRequiredEnv(
+  name: string,
+  source: EnvSource = process.env,
+): string {
+  const value = getOptionalEnv(name, undefined, source);
+
+  if (!value) {
+    throw new Error(`Missing required environment variable: ${name}`);
+  }
+
+  return value;
+}
+
+export function getApiPort(source: EnvSource = process.env): number {
+  const rawPort = getOptionalEnv("PORT", "4000", source) ?? "4000";
+  const port = Number.parseInt(rawPort, 10);
+
+  if (!Number.isInteger(port) || port <= 0) {
+    throw new Error(`PORT must be a positive integer, received: ${rawPort}`);
+  }
+
+  return port;
+}

--- a/apps/api/src/index.ts
+++ b/apps/api/src/index.ts
@@ -1,9 +1,10 @@
 import express from "express";
 
+import { getApiPort } from "./config/env";
 import usersRouter from "./routes/users";
 
 const app = express();
-const port = process.env.PORT || 4000;
+const port = getApiPort();
 
 app.use(express.json());
 

--- a/contributors/agents.json
+++ b/contributors/agents.json
@@ -1,5 +1,13 @@
 {
-  "agents": [],
-  "last_updated": "2026-06-03",
-  "total_contributions": 0
+  "agents": [
+    {
+      "github_username": "nonggde",
+      "model": "Codex GPT-5",
+      "version": "2026-07-06",
+      "pr_number": 5669,
+      "issue_number": 2821
+    }
+  ],
+  "last_updated": "2026-07-06",
+  "total_contributions": 1
 }


### PR DESCRIPTION
/claim #2821

Summary:
- add a dependency-free API env helper for optional, required, and PORT settings
- read the API entrypoint PORT through the shared helper
- add focused node:test coverage and enable the API test script

Verification:
- npx --yes tsx --test apps/api/src/config/env.test.ts
- npx --yes tsx --test apps/api/src/**/*.test.ts

Note:
- npm test for the API workspace could not run in this local checkout because workspace dependencies are not installed and tsx is not on the local PATH; the same tests pass through npx.

Agent registry check-in: https://github.com/xevrion-v2/agent-playground/issues/16#issuecomment-4890326441

Closes #2821