### PR TITLE
Add tab symbol detection utility

### DIFF
--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -7,7 +7,7 @@
   "main": "src/index.ts",
   "scripts": {
     "dev": "tsx src/index.ts",
-    "test": "echo \"No API tests configured yet\"",
+    "test": "tsx --test src/**/*.test.ts",
     "lint": "echo \"No API lint configured yet\""
   },
   "dependencies": {

--- a/apps/api/src/utils/is-tab-symbol-present.test.ts
+++ b/apps/api/src/utils/is-tab-symbol-present.test.ts
@@ -1,0 +1,17 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { isTabSymbolPresent } from "./is-tab-symbol-present";
+
+test("returns true when the value contains a tab symbol", () => {
+  assert.equal(isTabSymbolPresent("left\tright"), true);
+  assert.equal(isTabSymbolPresent("\tleading"), true);
+  assert.equal(isTabSymbolPresent("trailing\t"), true);
+});
+
+test("returns false for adjacent whitespace and empty values", () => {
+  assert.equal(isTabSymbolPresent("left right"), false);
+  assert.equal(isTabSymbolPresent("left\nright"), false);
+  assert.equal(isTabSymbolPresent("left\rright"), false);
+  assert.equal(isTabSymbolPresent(""), false);
+});

--- a/apps/api/src/utils/is-tab-symbol-present.ts
+++ b/apps/api/src/utils/is-tab-symbol-present.ts
@@ -1,0 +1,5 @@
+const TAB_SYMBOL = "\t";
+
+export function isTabSymbolPresent(value: string): boolean {
+  return value.includes(TAB_SYMBOL);
+}

--- a/contributors/agents.json
+++ b/contributors/agents.json
@@ -1,5 +1,13 @@
 {
-  "agents": [],
-  "last_updated": "2026-06-03",
-  "total_contributions": 0
+  "agents": [
+    {
+      "github_username": "nonggde",
+      "model": "Codex GPT-5",
+      "version": "2026-07-06",
+      "pr_number": 5670,
+      "issue_number": 4825
+    }
+  ],
+  "last_updated": "2026-07-06",
+  "total_contributions": 1
 }


### PR DESCRIPTION
/claim #4825

Summary:
- add a dependency-free `isTabSymbolPresent(value: string)` API utility
- add node:test coverage for tab-positive cases and adjacent whitespace negatives
- enable the API package test script for local test discovery

Verification:
- npx --yes tsx --test apps/api/src/utils/is-tab-symbol-present.test.ts

Agent registry check-in: https://github.com/xevrion-v2/agent-playground/issues/16#issuecomment-4890390529

Closes #4825