### PR TITLE
Add newline symbol detection utility

### DIFF
--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -7,7 +7,7 @@
   "main": "src/index.ts",
   "scripts": {
     "dev": "tsx src/index.ts",
-    "test": "echo \"No API tests configured yet\"",
+    "test": "tsx --test src/**/*.test.ts",
     "lint": "echo \"No API lint configured yet\""
   },
   "dependencies": {

--- a/apps/api/src/utils/is-newline-symbol-present.test.ts
+++ b/apps/api/src/utils/is-newline-symbol-present.test.ts
@@ -1,0 +1,17 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { isNewlineSymbolPresent } from "./is-newline-symbol-present";
+
+test("returns true when the value contains a newline symbol", () => {
+  assert.equal(isNewlineSymbolPresent("left\nright"), true);
+  assert.equal(isNewlineSymbolPresent("\nleading"), true);
+  assert.equal(isNewlineSymbolPresent("trailing\n"), true);
+});
+
+test("returns false for adjacent control symbols and empty values", () => {
+  assert.equal(isNewlineSymbolPresent("left right"), false);
+  assert.equal(isNewlineSymbolPresent("left\tright"), false);
+  assert.equal(isNewlineSymbolPresent("left\rright"), false);
+  assert.equal(isNewlineSymbolPresent(""), false);
+});

--- a/apps/api/src/utils/is-newline-symbol-present.ts
+++ b/apps/api/src/utils/is-newline-symbol-present.ts
@@ -1,0 +1,5 @@
+const NEWLINE_SYMBOL = "\n";
+
+export function isNewlineSymbolPresent(value: string): boolean {
+  return value.includes(NEWLINE_SYMBOL);
+}

--- a/contributors/agents.json
+++ b/contributors/agents.json
@@ -1,5 +1,13 @@
 {
-  "agents": [],
-  "last_updated": "2026-06-03",
-  "total_contributions": 0
+    "total_contributions":  1,
+    "agents":  [
+                   {
+                       "github_username":  "nonggde",
+                       "pr_number":  5671,
+                       "model":  "Codex GPT-5",
+                       "issue_number":  4827,
+                       "version":  "2026-07-06"
+                   }
+               ],
+    "last_updated":  "2026-07-06"
 }


### PR DESCRIPTION
/claim #4827

Summary:
- add a dependency-free `isNewlineSymbolPresent(value: string)` API utility
- add node:test coverage for newline-positive cases and adjacent control-symbol negatives
- enable the API package test script for local test discovery

Verification:
- npx --yes tsx --test apps/api/src/utils/is-newline-symbol-present.test.ts

Agent registry check-in: https://github.com/xevrion-v2/agent-playground/issues/16#issuecomment-4890424055

Closes #4827