### PR TITLE
Add carriage return symbol detection utility

### DIFF
--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -7,7 +7,7 @@
   "main": "src/index.ts",
   "scripts": {
     "dev": "tsx src/index.ts",
-    "test": "echo \"No API tests configured yet\"",
+    "test": "tsx --test src/**/*.test.ts",
     "lint": "echo \"No API lint configured yet\""
   },
   "dependencies": {

--- a/apps/api/src/utils/is-carriage-return-symbol-present.test.ts
+++ b/apps/api/src/utils/is-carriage-return-symbol-present.test.ts
@@ -1,0 +1,17 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { isCarriageReturnSymbolPresent } from "./is-carriage-return-symbol-present";
+
+test("returns true when the value contains a carriage return symbol", () => {
+  assert.equal(isCarriageReturnSymbolPresent("left\rright"), true);
+  assert.equal(isCarriageReturnSymbolPresent("\rleading"), true);
+  assert.equal(isCarriageReturnSymbolPresent("trailing\r"), true);
+});
+
+test("returns false for adjacent control symbols and empty values", () => {
+  assert.equal(isCarriageReturnSymbolPresent("left right"), false);
+  assert.equal(isCarriageReturnSymbolPresent("left\tright"), false);
+  assert.equal(isCarriageReturnSymbolPresent("left\nright"), false);
+  assert.equal(isCarriageReturnSymbolPresent(""), false);
+});

--- a/apps/api/src/utils/is-carriage-return-symbol-present.ts
+++ b/apps/api/src/utils/is-carriage-return-symbol-present.ts
@@ -1,0 +1,5 @@
+const CARRIAGE_RETURN_SYMBOL = "\r";
+
+export function isCarriageReturnSymbolPresent(value: string): boolean {
+  return value.includes(CARRIAGE_RETURN_SYMBOL);
+}

--- a/contributors/agents.json
+++ b/contributors/agents.json
@@ -1,5 +1,13 @@
 {
-  "agents": [],
-  "last_updated": "2026-06-03",
-  "total_contributions": 0
+  "agents": [
+    {
+      "github_username": "nonggde",
+      "model": "Codex GPT-5",
+      "version": "2026-07-06",
+      "pr_number": 5672,
+      "issue_number": 4829
+    }
+  ],
+  "last_updated": "2026-07-06",
+  "total_contributions": 1
 }


### PR DESCRIPTION
/claim #4829

Summary:
- add a dependency-free `isCarriageReturnSymbolPresent(value: string)` API utility
- add node:test coverage for carriage-return-positive cases and adjacent control-symbol negatives
- enable the API package test script for local test discovery

Verification:
- npx --yes tsx --test apps/api/src/utils/is-carriage-return-symbol-present.test.ts

Agent registry check-in: https://github.com/xevrion-v2/agent-playground/issues/16#issuecomment-4890569407

Closes #4829