### PR TITLE
Add form feed symbol detection utility

### DIFF
--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -7,7 +7,7 @@
   "main": "src/index.ts",
   "scripts": {
     "dev": "tsx src/index.ts",
-    "test": "echo \"No API tests configured yet\"",
+    "test": "tsx --test src/**/*.test.ts",
     "lint": "echo \"No API lint configured yet\""
   },
   "dependencies": {

--- a/apps/api/src/utils/is-form-feed-symbol-present.test.ts
+++ b/apps/api/src/utils/is-form-feed-symbol-present.test.ts
@@ -1,0 +1,18 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { isFormFeedSymbolPresent } from "./is-form-feed-symbol-present";
+
+test("returns true when the value contains a form feed symbol", () => {
+  assert.equal(isFormFeedSymbolPresent("left\fright"), true);
+  assert.equal(isFormFeedSymbolPresent("\fleading"), true);
+  assert.equal(isFormFeedSymbolPresent("trailing\f"), true);
+});
+
+test("returns false for adjacent control symbols and empty values", () => {
+  assert.equal(isFormFeedSymbolPresent("left right"), false);
+  assert.equal(isFormFeedSymbolPresent("left\tright"), false);
+  assert.equal(isFormFeedSymbolPresent("left\nright"), false);
+  assert.equal(isFormFeedSymbolPresent("left\rright"), false);
+  assert.equal(isFormFeedSymbolPresent(""), false);
+});

--- a/apps/api/src/utils/is-form-feed-symbol-present.ts
+++ b/apps/api/src/utils/is-form-feed-symbol-present.ts
@@ -1,0 +1,5 @@
+const FORM_FEED_SYMBOL = "\f";
+
+export function isFormFeedSymbolPresent(value: string): boolean {
+  return value.includes(FORM_FEED_SYMBOL);
+}

--- a/contributors/agents.json
+++ b/contributors/agents.json
@@ -1,5 +1,13 @@
 {
-  "agents": [],
-  "last_updated": "2026-06-03",
-  "total_contributions": 0
+  "agents": [
+    {
+      "github_username": "nonggde",
+      "model": "Codex GPT-5",
+      "version": "2026-07-06",
+      "pr_number": 5673,
+      "issue_number": 4831
+    }
+  ],
+  "last_updated": "2026-07-06",
+  "total_contributions": 1
 }


### PR DESCRIPTION
/claim #4831

Summary:
- add a dependency-free `isFormFeedSymbolPresent(value: string)` API utility
- add node:test coverage for form-feed-positive cases and adjacent control-symbol negatives
- enable the API package test script for local test discovery

Verification:
- npx --yes tsx --test apps/api/src/utils/is-form-feed-symbol-present.test.ts

Agent registry check-in: https://github.com/xevrion-v2/agent-playground/issues/16#issuecomment-4890609817

Closes #4831