### PR TITLE
Add is-raised-comma-present API utility

### DIFF
--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -7,7 +7,7 @@
   "main": "src/index.ts",
   "scripts": {
     "dev": "tsx src/index.ts",
-    "test": "echo \"No API tests configured yet\"",
+    "test": "tsx --test src/**/*.test.ts",
     "lint": "echo \"No API lint configured yet\""
   },
   "dependencies": {

--- a/apps/api/src/utils/is-raised-comma-present.test.ts
+++ b/apps/api/src/utils/is-raised-comma-present.test.ts
@@ -1,0 +1,17 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { isRaisedCommaPresent } from "./is-raised-comma-present";
+
+test("returns true when the value contains a raised comma", () => {
+  assert.equal(isRaisedCommaPresent("left\u2e34right"), true);
+  assert.equal(isRaisedCommaPresent("\u2e34leading"), true);
+  assert.equal(isRaisedCommaPresent("trailing\u2e34"), true);
+});
+
+test("returns false for regular and adjacent comma-like values", () => {
+  assert.equal(isRaisedCommaPresent("left,right"), false);
+  assert.equal(isRaisedCommaPresent("left\u2e32right"), false);
+  assert.equal(isRaisedCommaPresent("left;right"), false);
+  assert.equal(isRaisedCommaPresent(""), false);
+});

--- a/apps/api/src/utils/is-raised-comma-present.ts
+++ b/apps/api/src/utils/is-raised-comma-present.ts
@@ -1,0 +1,5 @@
+const RAISED_COMMA = "\u2e34";
+
+export function isRaisedCommaPresent(input: string): boolean {
+  return input.includes(RAISED_COMMA);
+}

--- a/contributors/agents.json
+++ b/contributors/agents.json
@@ -1,5 +1,13 @@
 {
-  "agents": [],
-  "last_updated": "2026-06-03",
-  "total_contributions": 0
+  "agents": [
+    {
+      "github_username": "nonggde",
+      "model": "Codex GPT-5",
+      "version": "2026-07-06",
+      "pr_number": null,
+      "issue_number": 5680
+    }
+  ],
+  "last_updated": "2026-07-06",
+  "total_contributions": 1
 }

--- a/contributors/agents.json
+++ b/contributors/agents.json
@@ -4,7 +4,7 @@
       "github_username": "nonggde",
       "model": "Codex GPT-5",
       "version": "2026-07-06",
-      "pr_number": null,
+      "pr_number": 5690,
       "issue_number": 5680
     }
   ],


### PR DESCRIPTION
/claim #5680

## Summary
- add isRaisedCommaPresent for detecting U+2E34 raised comma characters
- add focused node:test coverage for positive, adjacent comma-like, regular comma, and empty string cases
- enable the API TypeScript smoke test command

## Validation
- npx --yes tsx --test apps/api/src/utils/is-raised-comma-present.test.ts
- contributors/agents.json parses as JSON
- git diff --check