### PR TITLE
Add is-turned-semicolon-present API utility

### DIFF
--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -7,7 +7,7 @@
   "main": "src/index.ts",
   "scripts": {
     "dev": "tsx src/index.ts",
-    "test": "echo \"No API tests configured yet\"",
+    "test": "tsx --test src/**/*.test.ts",
     "lint": "echo \"No API lint configured yet\""
   },
   "dependencies": {

--- a/apps/api/src/utils/is-turned-semicolon-present.test.ts
+++ b/apps/api/src/utils/is-turned-semicolon-present.test.ts
@@ -1,0 +1,17 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { isTurnedSemicolonPresent } from "./is-turned-semicolon-present";
+
+test("returns true when the value contains a turned semicolon", () => {
+  assert.equal(isTurnedSemicolonPresent("left\u2e35right"), true);
+  assert.equal(isTurnedSemicolonPresent("\u2e35leading"), true);
+  assert.equal(isTurnedSemicolonPresent("trailing\u2e35"), true);
+});
+
+test("returns false for regular and adjacent semicolon-like values", () => {
+  assert.equal(isTurnedSemicolonPresent("left;right"), false);
+  assert.equal(isTurnedSemicolonPresent("left\u2e34right"), false);
+  assert.equal(isTurnedSemicolonPresent("left,right"), false);
+  assert.equal(isTurnedSemicolonPresent(""), false);
+});

--- a/apps/api/src/utils/is-turned-semicolon-present.ts
+++ b/apps/api/src/utils/is-turned-semicolon-present.ts
@@ -1,0 +1,5 @@
+const TURNED_SEMICOLON = "\u2e35";
+
+export function isTurnedSemicolonPresent(input: string): boolean {
+  return input.includes(TURNED_SEMICOLON);
+}

--- a/contributors/agents.json
+++ b/contributors/agents.json
@@ -1,5 +1,13 @@
 {
-  "agents": [],
-  "last_updated": "2026-06-03",
-  "total_contributions": 0
+  "agents": [
+    {
+      "github_username": "nonggde",
+      "model": "Codex GPT-5",
+      "version": "2026-07-06",
+      "pr_number": null,
+      "issue_number": 5681
+    }
+  ],
+  "last_updated": "2026-07-06",
+  "total_contributions": 1
 }

--- a/contributors/agents.json
+++ b/contributors/agents.json
@@ -4,7 +4,7 @@
       "github_username": "nonggde",
       "model": "Codex GPT-5",
       "version": "2026-07-06",
-      "pr_number": null,
+      "pr_number": 5691,
       "issue_number": 5681
     }
   ],


### PR DESCRIPTION
/claim #5681

## Summary
- add isTurnedSemicolonPresent for detecting U+2E35 turned semicolon characters
- add focused node:test coverage for positive, adjacent punctuation, regular semicolon, and empty string cases
- enable the API TypeScript smoke test command

## Validation
- npx --yes tsx --test apps/api/src/utils/is-turned-semicolon-present.test.ts
- contributors/agents.json parses as JSON
- git diff --check