### PR TITLE
Add is-dagger-with-left-guard-present API utility

### DIFF
--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -7,7 +7,7 @@
   "main": "src/index.ts",
   "scripts": {
     "dev": "tsx src/index.ts",
-    "test": "echo \"No API tests configured yet\"",
+    "test": "tsx --test src/**/*.test.ts",
     "lint": "echo \"No API lint configured yet\""
   },
   "dependencies": {

--- a/apps/api/src/utils/is-dagger-with-left-guard-present.test.ts
+++ b/apps/api/src/utils/is-dagger-with-left-guard-present.test.ts
@@ -1,0 +1,17 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { isDaggerWithLeftGuardPresent } from "./is-dagger-with-left-guard-present";
+
+test("returns true when the value contains a dagger with left guard", () => {
+  assert.equal(isDaggerWithLeftGuardPresent("left\u2e36right"), true);
+  assert.equal(isDaggerWithLeftGuardPresent("\u2e36leading"), true);
+  assert.equal(isDaggerWithLeftGuardPresent("trailing\u2e36"), true);
+});
+
+test("returns false for regular and adjacent dagger-like values", () => {
+  assert.equal(isDaggerWithLeftGuardPresent("left\u2020right"), false);
+  assert.equal(isDaggerWithLeftGuardPresent("left\u2e37right"), false);
+  assert.equal(isDaggerWithLeftGuardPresent("left\u2e35right"), false);
+  assert.equal(isDaggerWithLeftGuardPresent(""), false);
+});

--- a/apps/api/src/utils/is-dagger-with-left-guard-present.ts
+++ b/apps/api/src/utils/is-dagger-with-left-guard-present.ts
@@ -1,0 +1,5 @@
+const DAGGER_WITH_LEFT_GUARD = "\u2e36";
+
+export function isDaggerWithLeftGuardPresent(input: string): boolean {
+  return input.includes(DAGGER_WITH_LEFT_GUARD);
+}

--- a/contributors/agents.json
+++ b/contributors/agents.json
@@ -1,5 +1,13 @@
 {
-  "agents": [],
-  "last_updated": "2026-06-03",
-  "total_contributions": 0
+  "agents": [
+    {
+      "github_username": "nonggde",
+      "model": "Codex GPT-5",
+      "version": "2026-07-06",
+      "pr_number": null,
+      "issue_number": 5682
+    }
+  ],
+  "last_updated": "2026-07-06",
+  "total_contributions": 1
 }

--- a/contributors/agents.json
+++ b/contributors/agents.json
@@ -4,7 +4,7 @@
       "github_username": "nonggde",
       "model": "Codex GPT-5",
       "version": "2026-07-06",
-      "pr_number": null,
+      "pr_number": 5692,
       "issue_number": 5682
     }
   ],


### PR DESCRIPTION
/claim #5682

## Summary
- add isDaggerWithLeftGuardPresent for detecting U+2E36 dagger-with-left-guard characters
- add focused node:test coverage for positive, adjacent dagger-like, regular dagger, and empty string cases
- enable the API TypeScript smoke test command

## Validation
- npx --yes tsx --test apps/api/src/utils/is-dagger-with-left-guard-present.test.ts
- contributors/agents.json parses as JSON
- git diff --check