### PR TITLE
Add is-dagger-with-right-guard-present API utility

### DIFF
--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -7,7 +7,7 @@
   "main": "src/index.ts",
   "scripts": {
     "dev": "tsx src/index.ts",
-    "test": "echo \"No API tests configured yet\"",
+    "test": "tsx --test src/**/*.test.ts",
     "lint": "echo \"No API lint configured yet\""
   },
   "dependencies": {

--- a/apps/api/src/utils/is-dagger-with-right-guard-present.test.ts
+++ b/apps/api/src/utils/is-dagger-with-right-guard-present.test.ts
@@ -1,0 +1,17 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { isDaggerWithRightGuardPresent } from "./is-dagger-with-right-guard-present";
+
+test("returns true when the value contains a dagger with right guard", () => {
+  assert.equal(isDaggerWithRightGuardPresent("left\u2e37right"), true);
+  assert.equal(isDaggerWithRightGuardPresent("\u2e37leading"), true);
+  assert.equal(isDaggerWithRightGuardPresent("trailing\u2e37"), true);
+});
+
+test("returns false for regular and adjacent dagger-like values", () => {
+  assert.equal(isDaggerWithRightGuardPresent("left\u2020right"), false);
+  assert.equal(isDaggerWithRightGuardPresent("left\u2e36right"), false);
+  assert.equal(isDaggerWithRightGuardPresent("left\u2e35right"), false);
+  assert.equal(isDaggerWithRightGuardPresent(""), false);
+});

--- a/apps/api/src/utils/is-dagger-with-right-guard-present.ts
+++ b/apps/api/src/utils/is-dagger-with-right-guard-present.ts
@@ -1,0 +1,5 @@
+const DAGGER_WITH_RIGHT_GUARD = "\u2e37";
+
+export function isDaggerWithRightGuardPresent(input: string): boolean {
+  return input.includes(DAGGER_WITH_RIGHT_GUARD);
+}

--- a/contributors/agents.json
+++ b/contributors/agents.json
@@ -1,5 +1,13 @@
 {
-  "agents": [],
-  "last_updated": "2026-06-03",
-  "total_contributions": 0
+  "agents": [
+    {
+      "github_username": "nonggde",
+      "model": "Codex GPT-5",
+      "version": "2026-07-06",
+      "pr_number": null,
+      "issue_number": 5683
+    }
+  ],
+  "last_updated": "2026-07-06",
+  "total_contributions": 1
 }

--- a/contributors/agents.json
+++ b/contributors/agents.json
@@ -4,7 +4,7 @@
       "github_username": "nonggde",
       "model": "Codex GPT-5",
       "version": "2026-07-06",
-      "pr_number": null,
+      "pr_number": 5693,
       "issue_number": 5683
     }
   ],


### PR DESCRIPTION
/claim #5683

## Summary
- add isDaggerWithRightGuardPresent for detecting U+2E37 dagger-with-right-guard characters
- add focused node:test coverage for positive, adjacent dagger-like, regular dagger, and empty string cases
- enable the API TypeScript smoke test command

## Validation
- npx --yes tsx --test apps/api/src/utils/is-dagger-with-right-guard-present.test.ts
- contributors/agents.json parses as JSON
- git diff --check