### PR TITLE
Add is-three-em-dash-present API utility

### DIFF
--- a/apps/api/src/utils/is-three-em-dash-present.ts
+++ b/apps/api/src/utils/is-three-em-dash-present.ts
@@ -1,0 +1,5 @@
+const THREE_EM_DASH = "\u2e3b";
+
+export function isThreeEmDashPresent(input: string): boolean {
+  return input.includes(THREE_EM_DASH);
+}

--- a/contributors/agents.json
+++ b/contributors/agents.json
@@ -1,5 +1,14 @@
 {
-  "agents": [],
-  "last_updated": "2026-06-03",
-  "total_contributions": 0
+    "agents":  [
+                   {
+                       "version":  "2026-06-16",
+                       "claim":  "/claim #5697",
+                       "github_username":  "ChaiXinLong-tech",
+                       "model":  "GPT-5 Codex",
+                       "issue_number":  5697,
+                       "pr_number":  0
+                   }
+               ],
+    "last_updated":  "2026-07-06",
+    "total_contributions":  1
 }

--- a/contributors/agents.json
+++ b/contributors/agents.json
@@ -6,7 +6,7 @@
                        "github_username":  "ChaiXinLong-tech",
                        "model":  "GPT-5 Codex",
                        "issue_number":  5697,
-                       "pr_number":  0
+                       "pr_number":  5702
                    }
                ],
     "last_updated":  "2026-07-06",


### PR DESCRIPTION
Closes #5697

/claim #5697

## Summary
- Add $fn() for detecting the Unicode three-em dash character (U+2E3B).
- Keep the helper dependency-free and scoped to a single API utility file.
- Update contributors/agents.json for this bounty claim.

## Tests
- RED: work/agent-playground/node_modules/.bin/tsc.cmd --noEmit --strict --lib es2020 outputs/tmp-batch127/*.test.ts failed before helper modules existed.
- GREEN: work/agent-playground/node_modules/.bin/tsc.cmd --noEmit --strict --lib es2020 ... passed for the batch helper and test files.
- GREEN: compiled the batch helper tests to outputs/tmp-batch127/dist and executed 5 Node test files.