### PR TITLE
Add is-stenographic-full-stop-present API utility

### DIFF
--- a/apps/api/src/utils/is-stenographic-full-stop-present.ts
+++ b/apps/api/src/utils/is-stenographic-full-stop-present.ts
@@ -1,0 +1,5 @@
+const STENOGRAPHIC_FULL_STOP = "\u2e3c";
+
+export function isStenographicFullStopPresent(input: string): boolean {
+  return input.includes(STENOGRAPHIC_FULL_STOP);
+}

--- a/contributors/agents.json
+++ b/contributors/agents.json
@@ -6,7 +6,7 @@
                        "github_username":  "ChaiXinLong-tech",
                        "model":  "GPT-5 Codex",
                        "issue_number":  5698,
-                       "pr_number":  0
+                       "pr_number":  5703
                    }
                ],
     "last_updated":  "2026-07-06",

--- a/contributors/agents.json
+++ b/contributors/agents.json
@@ -1,5 +1,14 @@
 {
-  "agents": [],
-  "last_updated": "2026-06-03",
-  "total_contributions": 0
+    "agents":  [
+                   {
+                       "version":  "2026-06-16",
+                       "claim":  "/claim #5698",
+                       "github_username":  "ChaiXinLong-tech",
+                       "model":  "GPT-5 Codex",
+                       "issue_number":  5698,
+                       "pr_number":  0
+                   }
+               ],
+    "last_updated":  "2026-07-06",
+    "total_contributions":  1
 }


### PR DESCRIPTION
Closes #5698

/claim #5698

## Summary
- Add $fn() for detecting the Unicode stenographic full stop character (U+2E3C).
- Keep the helper dependency-free and scoped to a single API utility file.
- Update contributors/agents.json for this bounty claim.

## Tests
- RED: work/agent-playground/node_modules/.bin/tsc.cmd --noEmit --strict --lib es2020 outputs/tmp-batch127/*.test.ts failed before helper modules existed.
- GREEN: work/agent-playground/node_modules/.bin/tsc.cmd --noEmit --strict --lib es2020 ... passed for the batch helper and test files.
- GREEN: compiled the batch helper tests to outputs/tmp-batch127/dist and executed 5 Node test files.