### PR TITLE
Add is-top-half-section-sign-present API utility

### DIFF
--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -7,7 +7,7 @@
   "main": "src/index.ts",
   "scripts": {
     "dev": "tsx src/index.ts",
-    "test": "echo \"No API tests configured yet\"",
+    "test": "tsx --test src/**/*.test.ts",
     "lint": "echo \"No API lint configured yet\""
   },
   "dependencies": {

--- a/apps/api/src/utils/is-top-half-section-sign-present.test.ts
+++ b/apps/api/src/utils/is-top-half-section-sign-present.test.ts
@@ -1,0 +1,17 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { isTopHalfSectionSignPresent } from "./is-top-half-section-sign-present";
+
+test("returns true when the value contains a top half section sign", () => {
+  assert.equal(isTopHalfSectionSignPresent("left\u2e39right"), true);
+  assert.equal(isTopHalfSectionSignPresent("\u2e39leading"), true);
+  assert.equal(isTopHalfSectionSignPresent("trailing\u2e39"), true);
+});
+
+test("returns false for regular and adjacent section-like values", () => {
+  assert.equal(isTopHalfSectionSignPresent("left\u00a7right"), false);
+  assert.equal(isTopHalfSectionSignPresent("left\u2e36right"), false);
+  assert.equal(isTopHalfSectionSignPresent("left\u2e37right"), false);
+  assert.equal(isTopHalfSectionSignPresent(""), false);
+});

--- a/apps/api/src/utils/is-top-half-section-sign-present.ts
+++ b/apps/api/src/utils/is-top-half-section-sign-present.ts
@@ -1,0 +1,5 @@
+const TOP_HALF_SECTION_SIGN = "\u2e39";
+
+export function isTopHalfSectionSignPresent(input: string): boolean {
+  return input.includes(TOP_HALF_SECTION_SIGN);
+}

--- a/contributors/agents.json
+++ b/contributors/agents.json
@@ -4,7 +4,7 @@
       "github_username": "nonggde",
       "model": "Codex GPT-5",
       "version": "2026-07-06",
-      "pr_number": null,
+      "pr_number": 5707,
       "issue_number": 5695
     }
   ],

--- a/contributors/agents.json
+++ b/contributors/agents.json
@@ -1,5 +1,13 @@
 {
-  "agents": [],
-  "last_updated": "2026-06-03",
-  "total_contributions": 0
+  "agents": [
+    {
+      "github_username": "nonggde",
+      "model": "Codex GPT-5",
+      "version": "2026-07-06",
+      "pr_number": null,
+      "issue_number": 5695
+    }
+  ],
+  "last_updated": "2026-07-06",
+  "total_contributions": 1
 }


### PR DESCRIPTION
/claim #5695

## Summary
- add isTopHalfSectionSignPresent for detecting U+2E39 top-half-section-sign characters
- add focused node:test coverage for positive, adjacent section-like, and empty string cases
- enable the API TypeScript smoke test command

## Validation
- npx --yes tsx --test apps/api/src/utils/is-top-half-section-sign-present.test.ts
- contributors/agents.json parses as JSON
- git diff --check