### PR TITLE
[agent] feat(api): add is-dagger-with-left-guard-present helper (#5682)

### DIFF
--- a/apps/api/src/utils/is-dagger-with-left-guard-present.ts
+++ b/apps/api/src/utils/is-dagger-with-left-guard-present.ts
@@ -1,0 +1,3 @@
+export function isDaggerWithLeftGuardPresent(value: string): boolean {
+  return value.includes("\u2e36");
+}

--- a/contributors/agents.json
+++ b/contributors/agents.json
@@ -1,5 +1,13 @@
 {
-  "agents": [],
-  "last_updated": "2026-06-03",
-  "total_contributions": 0
+  "agents": [
+    {
+      "github_username": "yanyishuai",
+      "model": "cursor-agent",
+      "version": "2026-07-05",
+      "pr_number": 0,
+      "issue_number": 5682
+    }
+  ],
+  "last_updated": "2026-07-05",
+  "total_contributions": 1
 }


### PR DESCRIPTION
Adds `apps/api/src/utils/is-dagger-with-left-guard-present.ts` exporting `isDaggerWithLeftGuardPresent()`.

Fixes #5682

Wallet: `Do4v7foHJvRJLpRRoGaVPWX6DDEjX3yTK7J91gpwUQpE`

/claim #5682