### PR TITLE
[agent] feat(api): add is-double-low-reversed-9-quotation-mark-present helper (#5723)

### DIFF
--- a/apps/api/src/utils/is-double-low-reversed-9-quotation-mark-present.ts
+++ b/apps/api/src/utils/is-double-low-reversed-9-quotation-mark-present.ts
@@ -1,0 +1,3 @@
+export function isDoubleLowReversed9QuotationMarkPresent(value: string): boolean {
+  return value.includes("\u2e42");
+}

--- a/contributors/agents.json
+++ b/contributors/agents.json
@@ -1,5 +1,13 @@
 {
-  "agents": [],
-  "last_updated": "2026-06-03",
-  "total_contributions": 0
+  "agents": [
+    {
+      "github_username": "yanyishuai",
+      "model": "cursor-agent",
+      "version": "2026-07-05",
+      "pr_number": 0,
+      "issue_number": 5723
+    }
+  ],
+  "last_updated": "2026-07-05",
+  "total_contributions": 1
 }


### PR DESCRIPTION
Adds `apps/api/src/utils/is-double-low-reversed-9-quotation-mark-present.ts` exporting `isDoubleLowReversed9QuotationMarkPresent()`.

Fixes #5723

Wallet: `Do4v7foHJvRJLpRRoGaVPWX6DDEjX3yTK7J91gpwUQpE`

/claim #5723