### PR TITLE
Add is-low-kavyka-with-dot-present API utility

### DIFF
--- a/apps/api/src/utils/is-low-kavyka-with-dot-present.ts
+++ b/apps/api/src/utils/is-low-kavyka-with-dot-present.ts
@@ -1,0 +1,5 @@
+const LOW_KAVYKA_WITH_DOT = "\u2e48";
+
+export function isLowKavykaWithDotPresent(input: string): boolean {
+  return input.includes(LOW_KAVYKA_WITH_DOT);
+}

--- a/contributors/agents.json
+++ b/contributors/agents.json
@@ -6,7 +6,7 @@
                        "github_username":  "ChaiXinLong-tech",
                        "model":  "GPT-5 Codex",
                        "issue_number":  5738,
-                       "pr_number":  0
+                       "pr_number":  5743
                    }
                ],
     "last_updated":  "2026-07-06",

--- a/contributors/agents.json
+++ b/contributors/agents.json
@@ -1,5 +1,14 @@
 {
-  "agents": [],
-  "last_updated": "2026-06-03",
-  "total_contributions": 0
+    "agents":  [
+                   {
+                       "version":  "2026-06-16",
+                       "claim":  "/claim #5738",
+                       "github_username":  "ChaiXinLong-tech",
+                       "model":  "GPT-5 Codex",
+                       "issue_number":  5738,
+                       "pr_number":  0
+                   }
+               ],
+    "last_updated":  "2026-07-06",
+    "total_contributions":  1
 }


### PR DESCRIPTION
Closes #5738

/claim #5738

## Summary
- Add $fn() for detecting the Unicode low kavyka with dot character (U+2E48).
- Keep the helper dependency-free and scoped to a single API utility file.
- Update contributors/agents.json for this bounty claim.

## Tests
- RED: work/agent-playground/node_modules/.bin/tsc.cmd --noEmit --strict --lib es2020 outputs/tmp-batch129/*.test.ts failed before helper modules existed.
- GREEN: work/agent-playground/node_modules/.bin/tsc.cmd --noEmit --strict --lib es2020 ... passed for the batch helper and test files.
- GREEN: compiled the batch helper tests to outputs/tmp-batch129/dist and executed 5 Node test files.