### PR TITLE
Add is-two-em-dash-present API utility

### DIFF
--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -7,7 +7,7 @@
   "main": "src/index.ts",
   "scripts": {
     "dev": "tsx src/index.ts",
-    "test": "echo \"No API tests configured yet\"",
+    "test": "tsx --test src/**/*.test.ts",
     "lint": "echo \"No API lint configured yet\""
   },
   "dependencies": {

--- a/apps/api/src/utils/is-two-em-dash-present.test.ts
+++ b/apps/api/src/utils/is-two-em-dash-present.test.ts
@@ -1,0 +1,17 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { isTwoEmDashPresent } from "./is-two-em-dash-present";
+
+test("returns true when the value contains a two-em dash", () => {
+  assert.equal(isTwoEmDashPresent("left\u2e3aright"), true);
+  assert.equal(isTwoEmDashPresent("\u2e3aleading"), true);
+  assert.equal(isTwoEmDashPresent("trailing\u2e3a"), true);
+});
+
+test("returns false for regular and adjacent dash values", () => {
+  assert.equal(isTwoEmDashPresent("left-right"), false);
+  assert.equal(isTwoEmDashPresent("left\u2014right"), false);
+  assert.equal(isTwoEmDashPresent("left\u2e3bright"), false);
+  assert.equal(isTwoEmDashPresent(""), false);
+});

--- a/apps/api/src/utils/is-two-em-dash-present.ts
+++ b/apps/api/src/utils/is-two-em-dash-present.ts
@@ -1,0 +1,5 @@
+const TWO_EM_DASH = "\u2e3a";
+
+export function isTwoEmDashPresent(input: string): boolean {
+  return input.includes(TWO_EM_DASH);
+}

--- a/contributors/agents.json
+++ b/contributors/agents.json
@@ -1,5 +1,13 @@
 {
-  "agents": [],
-  "last_updated": "2026-06-03",
-  "total_contributions": 0
+  "agents": [
+    {
+      "github_username": "nonggde",
+      "model": "Codex GPT-5",
+      "version": "2026-07-06",
+      "pr_number": null,
+      "issue_number": 5696
+    }
+  ],
+  "last_updated": "2026-07-06",
+  "total_contributions": 1
 }

--- a/contributors/agents.json
+++ b/contributors/agents.json
@@ -4,7 +4,7 @@
       "github_username": "nonggde",
       "model": "Codex GPT-5",
       "version": "2026-07-06",
-      "pr_number": null,
+      "pr_number": 5753,
       "issue_number": 5696
     }
   ],


### PR DESCRIPTION
/claim #5696

## Summary
- add isTwoEmDashPresent for detecting U+2E3A two-em dash characters
- add focused node:test coverage for positive, adjacent dash, regular dash, em dash, and empty string cases
- enable the API TypeScript smoke test command

## Validation
- npx --yes tsx --test apps/api/src/utils/is-two-em-dash-present.test.ts
- contributors/agents.json parses as JSON
- git diff --check