### PR TITLE
Add cjk radical person utility

### DIFF
--- a/apps/api/src/utils/is-cjk-radical-person-present.test.ts
+++ b/apps/api/src/utils/is-cjk-radical-person-present.test.ts
@@ -1,0 +1,17 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { isCjkRadicalPersonPresent } from "./is-cjk-radical-person-present";
+
+test("returns true when the value contains the cjk radical person character", () => {
+  assert.equal(isCjkRadicalPersonPresent("left\u2e85right"), true);
+  assert.equal(isCjkRadicalPersonPresent("\u2e85leading"), true);
+  assert.equal(isCjkRadicalPersonPresent("trailing\u2e85"), true);
+});
+
+test("returns false for empty strings and adjacent cjk radicals", () => {
+  assert.equal(isCjkRadicalPersonPresent(""), false);
+  assert.equal(isCjkRadicalPersonPresent("person"), false);
+  assert.equal(isCjkRadicalPersonPresent("left\u2e84right"), false);
+  assert.equal(isCjkRadicalPersonPresent("left\u2e86right"), false);
+});

--- a/apps/api/src/utils/is-cjk-radical-person-present.ts
+++ b/apps/api/src/utils/is-cjk-radical-person-present.ts
@@ -1,0 +1,5 @@
+const CJK_RADICAL_PERSON = "\u2e85";
+
+export function isCjkRadicalPersonPresent(input: string): boolean {
+  return input.includes(CJK_RADICAL_PERSON);
+}

--- a/contributors/agents.json
+++ b/contributors/agents.json
@@ -1,5 +1,13 @@
 {
-  "agents": [],
-  "last_updated": "2026-06-03",
-  "total_contributions": 0
+  "agents": [
+    {
+      "github_username": "nonggde",
+      "model": "Codex GPT-5",
+      "version": "2026-07-07",
+      "pr_number": null,
+      "issue_number": 5794
+    }
+  ],
+  "last_updated": "2026-07-07",
+  "total_contributions": 1
 }

--- a/contributors/agents.json
+++ b/contributors/agents.json
@@ -4,7 +4,7 @@
       "github_username": "nonggde",
       "model": "Codex GPT-5",
       "version": "2026-07-07",
-      "pr_number": null,
+      "pr_number": 5805,
       "issue_number": 5794
     }
   ],


### PR DESCRIPTION
## Summary
- Adds `isCjkRadicalPersonPresent(input: string): boolean` for U+2E85 detection.
- Covers positive, empty, plain-text, and adjacent-radical edge cases with node:test.
- Updates `contributors/agents.json` for this bounty issue.

## Validation
- `git diff --check`
- `node -e "JSON.parse(require('fs').readFileSync('contributors/agents.json','utf8')); console.log('agents.json ok')"`
- `npx --no-install tsx --test apps/api/src/utils/is-cjk-radical-person-present.test.ts`

Closes #5794
