### PR TITLE
Add cjk radical box utility

### DIFF
--- a/apps/api/src/utils/is-cjk-radical-box-present.test.ts
+++ b/apps/api/src/utils/is-cjk-radical-box-present.test.ts
@@ -1,0 +1,17 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { isCjkRadicalBoxPresent } from "./is-cjk-radical-box-present";
+
+test("returns true when the value contains the cjk radical box character", () => {
+  assert.equal(isCjkRadicalBoxPresent("left\u2e86right"), true);
+  assert.equal(isCjkRadicalBoxPresent("\u2e86leading"), true);
+  assert.equal(isCjkRadicalBoxPresent("trailing\u2e86"), true);
+});
+
+test("returns false for empty strings and adjacent cjk radicals", () => {
+  assert.equal(isCjkRadicalBoxPresent(""), false);
+  assert.equal(isCjkRadicalBoxPresent("box"), false);
+  assert.equal(isCjkRadicalBoxPresent("left\u2e85right"), false);
+  assert.equal(isCjkRadicalBoxPresent("left\u2e87right"), false);
+});

--- a/apps/api/src/utils/is-cjk-radical-box-present.ts
+++ b/apps/api/src/utils/is-cjk-radical-box-present.ts
@@ -1,0 +1,5 @@
+const CJK_RADICAL_BOX = "\u2e86";
+
+export function isCjkRadicalBoxPresent(input: string): boolean {
+  return input.includes(CJK_RADICAL_BOX);
+}

--- a/contributors/agents.json
+++ b/contributors/agents.json
@@ -4,7 +4,7 @@
       "github_username": "nonggde",
       "model": "Codex GPT-5",
       "version": "2026-07-07",
-      "pr_number": null,
+      "pr_number": 5806,
       "issue_number": 5795
     }
   ],

--- a/contributors/agents.json
+++ b/contributors/agents.json
@@ -1,5 +1,13 @@
 {
-  "agents": [],
-  "last_updated": "2026-06-03",
-  "total_contributions": 0
+  "agents": [
+    {
+      "github_username": "nonggde",
+      "model": "Codex GPT-5",
+      "version": "2026-07-07",
+      "pr_number": null,
+      "issue_number": 5795
+    }
+  ],
+  "last_updated": "2026-07-07",
+  "total_contributions": 1
 }


### PR DESCRIPTION
## Summary
- Adds `isCjkRadicalBoxPresent(input: string): boolean` for U+2E86 detection.
- Covers positive, empty, plain-text, and adjacent-radical edge cases with node:test.
- Updates `contributors/agents.json` for this bounty issue.

## Validation
- `git diff --check`
- `node -e "JSON.parse(require('fs').readFileSync('contributors/agents.json','utf8')); console.log('agents.json ok')"`
- `npx --no-install tsx --test apps/api/src/utils/is-cjk-radical-box-present.test.ts`

Closes #5795
