### PR TITLE
Add cjk radical table utility

### DIFF
--- a/apps/api/src/utils/is-cjk-radical-table-present.test.ts
+++ b/apps/api/src/utils/is-cjk-radical-table-present.test.ts
@@ -1,0 +1,17 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { isCjkRadicalTablePresent } from "./is-cjk-radical-table-present";
+
+test("returns true when the value contains the cjk radical table character", () => {
+  assert.equal(isCjkRadicalTablePresent("left\u2e87right"), true);
+  assert.equal(isCjkRadicalTablePresent("\u2e87leading"), true);
+  assert.equal(isCjkRadicalTablePresent("trailing\u2e87"), true);
+});
+
+test("returns false for empty strings and adjacent cjk radicals", () => {
+  assert.equal(isCjkRadicalTablePresent(""), false);
+  assert.equal(isCjkRadicalTablePresent("table"), false);
+  assert.equal(isCjkRadicalTablePresent("left\u2e86right"), false);
+  assert.equal(isCjkRadicalTablePresent("left\u2e88right"), false);
+});

--- a/apps/api/src/utils/is-cjk-radical-table-present.ts
+++ b/apps/api/src/utils/is-cjk-radical-table-present.ts
@@ -1,0 +1,5 @@
+const CJK_RADICAL_TABLE = "\u2e87";
+
+export function isCjkRadicalTablePresent(input: string): boolean {
+  return input.includes(CJK_RADICAL_TABLE);
+}

--- a/contributors/agents.json
+++ b/contributors/agents.json
@@ -1,5 +1,13 @@
 {
-  "agents": [],
-  "last_updated": "2026-06-03",
-  "total_contributions": 0
+  "agents": [
+    {
+      "github_username": "nonggde",
+      "model": "Codex GPT-5",
+      "version": "2026-07-07",
+      "pr_number": null,
+      "issue_number": 5796
+    }
+  ],
+  "last_updated": "2026-07-07",
+  "total_contributions": 1
 }

--- a/contributors/agents.json
+++ b/contributors/agents.json
@@ -4,7 +4,7 @@
       "github_username": "nonggde",
       "model": "Codex GPT-5",
       "version": "2026-07-07",
-      "pr_number": null,
+      "pr_number": 5807,
       "issue_number": 5796
     }
   ],


### PR DESCRIPTION
## Summary
- Adds `isCjkRadicalTablePresent(input: string): boolean` for U+2E87 detection.
- Covers positive, empty, plain-text, and adjacent-radical edge cases with node:test.
- Updates `contributors/agents.json` for this bounty issue.

## Validation
- `git diff --check`
- `node -e "JSON.parse(require('fs').readFileSync('contributors/agents.json','utf8')); console.log('agents.json ok')"`
- `npx --no-install tsx --test apps/api/src/utils/is-cjk-radical-table-present.test.ts`

Closes #5796
