### PR TITLE
Add cjk radical knife one utility

### DIFF
--- a/apps/api/src/utils/is-cjk-radical-knife-one-present.test.ts
+++ b/apps/api/src/utils/is-cjk-radical-knife-one-present.test.ts
@@ -1,0 +1,17 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { isCjkRadicalKnifeOnePresent } from "./is-cjk-radical-knife-one-present";
+
+test("returns true when the value contains the cjk radical knife one character", () => {
+  assert.equal(isCjkRadicalKnifeOnePresent("left\u2e88right"), true);
+  assert.equal(isCjkRadicalKnifeOnePresent("\u2e88leading"), true);
+  assert.equal(isCjkRadicalKnifeOnePresent("trailing\u2e88"), true);
+});
+
+test("returns false for empty strings and adjacent cjk radicals", () => {
+  assert.equal(isCjkRadicalKnifeOnePresent(""), false);
+  assert.equal(isCjkRadicalKnifeOnePresent("knife"), false);
+  assert.equal(isCjkRadicalKnifeOnePresent("left\u2e87right"), false);
+  assert.equal(isCjkRadicalKnifeOnePresent("left\u2e89right"), false);
+});

--- a/apps/api/src/utils/is-cjk-radical-knife-one-present.ts
+++ b/apps/api/src/utils/is-cjk-radical-knife-one-present.ts
@@ -1,0 +1,5 @@
+const CJK_RADICAL_KNIFE_ONE = "\u2e88";
+
+export function isCjkRadicalKnifeOnePresent(input: string): boolean {
+  return input.includes(CJK_RADICAL_KNIFE_ONE);
+}

--- a/contributors/agents.json
+++ b/contributors/agents.json
@@ -1,5 +1,13 @@
 {
-  "agents": [],
-  "last_updated": "2026-06-03",
-  "total_contributions": 0
+  "agents": [
+    {
+      "github_username": "nonggde",
+      "model": "Codex GPT-5",
+      "version": "2026-07-07",
+      "pr_number": null,
+      "issue_number": 5797
+    }
+  ],
+  "last_updated": "2026-07-07",
+  "total_contributions": 1
 }

--- a/contributors/agents.json
+++ b/contributors/agents.json
@@ -4,7 +4,7 @@
       "github_username": "nonggde",
       "model": "Codex GPT-5",
       "version": "2026-07-07",
-      "pr_number": null,
+      "pr_number": 5808,
       "issue_number": 5797
     }
   ],


### PR DESCRIPTION
## Summary
- Adds `isCjkRadicalKnifeOnePresent(input: string): boolean` for U+2E88 detection.
- Covers positive, empty, plain-text, and adjacent-radical edge cases with node:test.
- Updates `contributors/agents.json` for this bounty issue.

## Validation
- `git diff --check`
- `node -e "JSON.parse(require('fs').readFileSync('contributors/agents.json','utf8')); console.log('agents.json ok')"`
- `npx --no-install tsx --test apps/api/src/utils/is-cjk-radical-knife-one-present.test.ts`

Closes #5797
