### PR TITLE
Add cjk radical knife two utility

### DIFF
--- a/apps/api/src/utils/is-cjk-radical-knife-two-present.test.ts
+++ b/apps/api/src/utils/is-cjk-radical-knife-two-present.test.ts
@@ -1,0 +1,17 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { isCjkRadicalKnifeTwoPresent } from "./is-cjk-radical-knife-two-present";
+
+test("returns true when the value contains the cjk radical knife two character", () => {
+  assert.equal(isCjkRadicalKnifeTwoPresent("left\u2e89right"), true);
+  assert.equal(isCjkRadicalKnifeTwoPresent("\u2e89leading"), true);
+  assert.equal(isCjkRadicalKnifeTwoPresent("trailing\u2e89"), true);
+});
+
+test("returns false for empty strings and adjacent cjk radicals", () => {
+  assert.equal(isCjkRadicalKnifeTwoPresent(""), false);
+  assert.equal(isCjkRadicalKnifeTwoPresent("knife"), false);
+  assert.equal(isCjkRadicalKnifeTwoPresent("left\u2e88right"), false);
+  assert.equal(isCjkRadicalKnifeTwoPresent("left\u2e8aright"), false);
+});

--- a/apps/api/src/utils/is-cjk-radical-knife-two-present.ts
+++ b/apps/api/src/utils/is-cjk-radical-knife-two-present.ts
@@ -1,0 +1,5 @@
+const CJK_RADICAL_KNIFE_TWO = "\u2e89";
+
+export function isCjkRadicalKnifeTwoPresent(input: string): boolean {
+  return input.includes(CJK_RADICAL_KNIFE_TWO);
+}

--- a/contributors/agents.json
+++ b/contributors/agents.json
@@ -1,5 +1,13 @@
 {
-  "agents": [],
-  "last_updated": "2026-06-03",
-  "total_contributions": 0
+  "agents": [
+    {
+      "github_username": "nonggde",
+      "model": "Codex GPT-5",
+      "version": "2026-07-07",
+      "pr_number": null,
+      "issue_number": 5798
+    }
+  ],
+  "last_updated": "2026-07-07",
+  "total_contributions": 1
 }

--- a/contributors/agents.json
+++ b/contributors/agents.json
@@ -4,7 +4,7 @@
       "github_username": "nonggde",
       "model": "Codex GPT-5",
       "version": "2026-07-07",
-      "pr_number": null,
+      "pr_number": 5809,
       "issue_number": 5798
     }
   ],


### PR DESCRIPTION
## Summary
- Adds `isCjkRadicalKnifeTwoPresent(input: string): boolean` for U+2E89 detection.
- Covers positive, empty, plain-text, and adjacent-radical edge cases with node:test.
- Updates `contributors/agents.json` for this bounty issue.

## Validation
- `git diff --check`
- `node -e "JSON.parse(require('fs').readFileSync('contributors/agents.json','utf8')); console.log('agents.json ok')"`
- `npx --no-install tsx --test apps/api/src/utils/is-cjk-radical-knife-two-present.test.ts`

Closes #5798
