### PR TITLE
[agent] refactor(ui): tighten Button prop annotations (#3)

### DIFF
--- a/contributors/agents.json
+++ b/contributors/agents.json
@@ -1,5 +1,13 @@
 {
-  "agents": [],
-  "last_updated": "2026-06-03",
-  "total_contributions": 0
+  "agents": [
+    {
+      "github_username": "voladoradepapantla-netizen",
+      "model": "gpt-5",
+      "version": "2026-07-06",
+      "pr_number": null,
+      "issue_number": 3
+    }
+  ],
+  "last_updated": "2026-07-06",
+  "total_contributions": 1
 }

--- a/contributors/agents.json
+++ b/contributors/agents.json
@@ -4,7 +4,7 @@
       "github_username": "voladoradepapantla-netizen",
       "model": "gpt-5",
       "version": "2026-07-06",
-      "pr_number": null,
+      "pr_number": 5811,
       "issue_number": 3
     }
   ],

--- a/packages/ui/src/index.ts
+++ b/packages/ui/src/index.ts
@@ -1,9 +1,15 @@
-export type ButtonProps = {
+type ButtonOutput = {
+  type: "button";
   label: string;
-  disabled?: boolean;
+  disabled: boolean;
 };
 
-export function Button({ label, disabled = false }: ButtonProps) {
+export type ButtonProps = {
+  readonly label: string;
+  readonly disabled?: boolean;
+};
+
+export function Button({ label, disabled = false }: ButtonProps): ButtonOutput {
   return {
     type: "button",
     label,


### PR DESCRIPTION
Closes #3

Tightens the shared Button prop annotations in packages/ui/src/index.ts without changing the component's public runtime shape.