### PR TITLE
test(ui): add unit tests for Button component stub

### DIFF
--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -5,7 +5,7 @@
   "description": "Shared UI components for TaskFlow.",
   "main": "src/index.ts",
   "scripts": {
-    "test": "echo \"No UI tests configured yet\"",
+    "test": "npx --yes tsx --test src/index.test.ts",
     "lint": "echo \"No UI lint configured yet\""
   },
   "devDependencies": {

--- a/packages/ui/src/index.test.ts
+++ b/packages/ui/src/index.test.ts
@@ -1,0 +1,34 @@
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+import { Button } from "./index.js";
+
+describe("Button component stub", () => {
+  it("should return correct label when passed in props", () => {
+    const props = { label: "Submit" };
+    const result = Button(props);
+    
+    assert.equal(result.type, "button");
+    assert.equal(result.label, "Submit");
+  });
+
+  it("should default disabled to false when not provided", () => {
+    const props = { label: "Click Me" };
+    const result = Button(props);
+    
+    assert.equal(result.disabled, false);
+  });
+
+  it("should set disabled to true when passed as true in props", () => {
+    const props = { label: "Save", disabled: true };
+    const result = Button(props);
+    
+    assert.equal(result.disabled, true);
+  });
+
+  it("should set disabled to false when explicitly passed as false in props", () => {
+    const props = { label: "Cancel", disabled: false };
+    const result = Button(props);
+    
+    assert.equal(result.disabled, false);
+  });
+});


### PR DESCRIPTION
## Summary

Adds unit tests for the shared `Button` component stub and configures the workspace test command.

## Changes
- **New file**: `packages/ui/src/index.test.ts` with 4 unit tests covering label and disabled fields.
- **Updated**: `packages/ui/package.json` test script updated to use `tsx --test`.

Closes #13