### PR TITLE
feat: Add is-word-separator-middle-dot-present API utility (#5643)

### DIFF
--- a/apps/api/src/utils/is-word-separator-middle-dot-present.test.ts
+++ b/apps/api/src/utils/is-word-separator-middle-dot-present.test.ts
@@ -1,0 +1,14 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import { isWordSeparatorMiddleDotPresent } from './is-word-separator-middle-dot-present.js';
+
+test('isWordSeparatorMiddleDotPresent returns true if string contains \u2E31', () => {
+  assert.equal(isWordSeparatorMiddleDotPresent('hello \u2E31 world'), true);
+  assert.equal(isWordSeparatorMiddleDotPresent('\u2E31'), true);
+});
+
+test('isWordSeparatorMiddleDotPresent returns false if string does not contain \u2E31', () => {
+  assert.equal(isWordSeparatorMiddleDotPresent('hello world'), false);
+  assert.equal(isWordSeparatorMiddleDotPresent(''), false);
+  assert.equal(isWordSeparatorMiddleDotPresent(null as any), false);
+});

--- a/apps/api/src/utils/is-word-separator-middle-dot-present.ts
+++ b/apps/api/src/utils/is-word-separator-middle-dot-present.ts
@@ -1,0 +1,6 @@
+export function isWordSeparatorMiddleDotPresent(value: string): boolean {
+  if (typeof value !== 'string') {
+    return false;
+  }
+  return value.includes('\u2E31');
+}


### PR DESCRIPTION
Closes #5643.

Adds the `is-word-separator-middle-dot-present` utility to `apps/api/src/utils/` along with unit tests.

Verified that all tests pass locally.

*Automatically generated and verified by Antigravity.*