### PR TITLE
feat: Add is-vertical-tilde-present API utility (#5642)

### DIFF
--- a/apps/api/src/utils/is-vertical-tilde-present.test.ts
+++ b/apps/api/src/utils/is-vertical-tilde-present.test.ts
@@ -1,0 +1,14 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import { isVerticalTildePresent } from './is-vertical-tilde-present.js';
+
+test('isVerticalTildePresent returns true if string contains \u2E2F', () => {
+  assert.equal(isVerticalTildePresent('hello \u2E2F world'), true);
+  assert.equal(isVerticalTildePresent('\u2E2F'), true);
+});
+
+test('isVerticalTildePresent returns false if string does not contain \u2E2F', () => {
+  assert.equal(isVerticalTildePresent('hello world'), false);
+  assert.equal(isVerticalTildePresent(''), false);
+  assert.equal(isVerticalTildePresent(null as any), false);
+});

--- a/apps/api/src/utils/is-vertical-tilde-present.ts
+++ b/apps/api/src/utils/is-vertical-tilde-present.ts
@@ -1,0 +1,6 @@
+export function isVerticalTildePresent(value: string): boolean {
+  if (typeof value !== 'string') {
+    return false;
+  }
+  return value.includes('\u2E2F');
+}


### PR DESCRIPTION
Closes #5642.

Adds the `is-vertical-tilde-present` utility to `apps/api/src/utils/` along with unit tests.

Verified that all tests pass locally.

*Automatically generated and verified by Antigravity.*