### PR TITLE
feat: Add is-reversed-question-mark-present API utility (#5641)

### DIFF
--- a/apps/api/src/utils/is-reversed-question-mark-present.test.ts
+++ b/apps/api/src/utils/is-reversed-question-mark-present.test.ts
@@ -1,0 +1,14 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import { isReversedQuestionMarkPresent } from './is-reversed-question-mark-present.js';
+
+test('isReversedQuestionMarkPresent returns true if string contains \u2E2E', () => {
+  assert.equal(isReversedQuestionMarkPresent('hello \u2E2E world'), true);
+  assert.equal(isReversedQuestionMarkPresent('\u2E2E'), true);
+});
+
+test('isReversedQuestionMarkPresent returns false if string does not contain \u2E2E', () => {
+  assert.equal(isReversedQuestionMarkPresent('hello world'), false);
+  assert.equal(isReversedQuestionMarkPresent(''), false);
+  assert.equal(isReversedQuestionMarkPresent(null as any), false);
+});

--- a/apps/api/src/utils/is-reversed-question-mark-present.ts
+++ b/apps/api/src/utils/is-reversed-question-mark-present.ts
@@ -1,0 +1,6 @@
+export function isReversedQuestionMarkPresent(value: string): boolean {
+  if (typeof value !== 'string') {
+    return false;
+  }
+  return value.includes('\u2E2E');
+}


### PR DESCRIPTION
Closes #5641.

Adds the `is-reversed-question-mark-present` utility to `apps/api/src/utils/` along with unit tests.

Verified that all tests pass locally.

*Automatically generated and verified by Antigravity.*