### PR TITLE
feat: Add is-five-dot-mark-present API utility (#5640)

### DIFF
--- a/apps/api/src/utils/is-five-dot-mark-present.test.ts
+++ b/apps/api/src/utils/is-five-dot-mark-present.test.ts
@@ -1,0 +1,14 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import { isFiveDotMarkPresent } from './is-five-dot-mark-present.js';
+
+test('isFiveDotMarkPresent returns true if string contains \u2E2D', () => {
+  assert.equal(isFiveDotMarkPresent('hello \u2E2D world'), true);
+  assert.equal(isFiveDotMarkPresent('\u2E2D'), true);
+});
+
+test('isFiveDotMarkPresent returns false if string does not contain \u2E2D', () => {
+  assert.equal(isFiveDotMarkPresent('hello world'), false);
+  assert.equal(isFiveDotMarkPresent(''), false);
+  assert.equal(isFiveDotMarkPresent(null as any), false);
+});

--- a/apps/api/src/utils/is-five-dot-mark-present.ts
+++ b/apps/api/src/utils/is-five-dot-mark-present.ts
@@ -1,0 +1,6 @@
+export function isFiveDotMarkPresent(value: string): boolean {
+  if (typeof value !== 'string') {
+    return false;
+  }
+  return value.includes('\u2E2D');
+}


### PR DESCRIPTION
Closes #5640.

Adds the `is-five-dot-mark-present` utility to `apps/api/src/utils/` along with unit tests.

Verified that all tests pass locally.

*Automatically generated and verified by Antigravity.*