### PR TITLE
feat: Add is-squared-four-dot-punctuation-present API utility (#5639)

### DIFF
--- a/apps/api/src/utils/is-squared-four-dot-punctuation-present.test.ts
+++ b/apps/api/src/utils/is-squared-four-dot-punctuation-present.test.ts
@@ -1,0 +1,14 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import { isSquaredFourDotPunctuationPresent } from './is-squared-four-dot-punctuation-present.js';
+
+test('isSquaredFourDotPunctuationPresent returns true if string contains \u2E2C', () => {
+  assert.equal(isSquaredFourDotPunctuationPresent('hello \u2E2C world'), true);
+  assert.equal(isSquaredFourDotPunctuationPresent('\u2E2C'), true);
+});
+
+test('isSquaredFourDotPunctuationPresent returns false if string does not contain \u2E2C', () => {
+  assert.equal(isSquaredFourDotPunctuationPresent('hello world'), false);
+  assert.equal(isSquaredFourDotPunctuationPresent(''), false);
+  assert.equal(isSquaredFourDotPunctuationPresent(null as any), false);
+});

--- a/apps/api/src/utils/is-squared-four-dot-punctuation-present.ts
+++ b/apps/api/src/utils/is-squared-four-dot-punctuation-present.ts
@@ -1,0 +1,6 @@
+export function isSquaredFourDotPunctuationPresent(value: string): boolean {
+  if (typeof value !== 'string') {
+    return false;
+  }
+  return value.includes('\u2E2C');
+}


### PR DESCRIPTION
Closes #5639.

Adds the `is-squared-four-dot-punctuation-present` utility to `apps/api/src/utils/` along with unit tests.

Verified that all tests pass locally.

*Automatically generated and verified by Antigravity.*