### PR TITLE
Add CJK radical c-simplified bird utility

### DIFF
--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -7,7 +7,7 @@
   "main": "src/index.ts",
   "scripts": {
     "dev": "tsx src/index.ts",
-    "test": "echo \"No API tests configured yet\"",
+    "test": "tsx src/utils/batch-smoke-test.ts",
     "lint": "echo \"No API lint configured yet\""
   },
   "dependencies": {

--- a/apps/api/src/utils/batch-smoke-test.ts
+++ b/apps/api/src/utils/batch-smoke-test.ts
@@ -1,0 +1,12 @@
+import assert from "node:assert/strict";
+
+import { $fn as isCjkRadicalCSimplifiedBirdPresent } from "./is-cjk-radical-c-simplified-bird-present";
+
+assert.equal(isCjkRadicalCSimplifiedBirdPresent(""), false);
+assert.equal(isCjkRadicalCSimplifiedBirdPresent("plain ascii text"), false);
+assert.equal(isCjkRadicalCSimplifiedBirdPresent("contains \u2ee6 radical"), true);
+assert.equal(isCjkRadicalCSimplifiedBirdPresent("\u2ee6"), true);
+assert.equal(isCjkRadicalCSimplifiedBirdPresent("nearby radical \u2ee5"), false);
+
+console.log("API utils smoke tests passed");
+

--- a/apps/api/src/utils/is-cjk-radical-c-simplified-bird-present.ts
+++ b/apps/api/src/utils/is-cjk-radical-c-simplified-bird-present.ts
@@ -1,0 +1,6 @@
+const CJK_RADICAL_C_SIMPLIFIED_BIRD = "\u2ee6";
+
+export function $fn(input: string): boolean {
+  return input.includes(CJK_RADICAL_C_SIMPLIFIED_BIRD);
+}
+


### PR DESCRIPTION
## Summary

/claim #6051

Adds the dependency-free API utility requested by #6051 for detecting the CJK radical c-simplified bird character (`U+2EE6`).

## Changes

- Added `apps/api/src/utils/is-cjk-radical-c-simplified-bird-present.ts`.
- Exported `$fn(input: string): boolean`.
- Added a batch TypeScript smoke test covering positive, negative, empty, and nearby-character cases.
- Updated the API package test script to run the smoke test.

## Verification

```bash
npm install
npm test --workspace apps/api
```

Result:

```text
API utils smoke tests passed
```

Payment/contact if accepted: `https://paypal.me/nhatminh122004` or `nhatminh122004@gmail.com`.

