### PR TITLE
[agent] docs: add Prisma schema model comments for TaskFlow domain

### DIFF
--- a/contributors/agents.json
+++ b/contributors/agents.json
@@ -1,5 +1,13 @@
 {
-  "agents": [],
-  "last_updated": "2026-06-03",
-  "total_contributions": 0
+  "agents": [
+    {
+      "github_username": "hermes-agent",
+      "model": "deepseek-v4-pro",
+      "version": "hermes",
+      "pr_number": 0,
+      "issue_number": 5
+    }
+  ],
+  "last_updated": "2026-07-08",
+  "total_contributions": 1
 }

--- a/packages/db/prisma/schema.prisma
+++ b/packages/db/prisma/schema.prisma
@@ -7,16 +7,20 @@ datasource db {
   url      = env("DATABASE_URL")
 }
 
+/// Represents a registered user in the TaskFlow platform.
+/// Users can create jobs (as clients) and submit proposals (as freelancers).
 model User {
   id        String     @id @default(cuid())
   email     String     @unique
   name      String?
-  jobs      Job[]
-  proposals Proposal[]
+  jobs      Job[]       /// Jobs created by this user
+  proposals Proposal[]  /// Proposals submitted by this user
   createdAt DateTime   @default(now())
   updatedAt DateTime   @updatedAt
 }
 
+/// Represents a task or project posted by a client.
+/// Jobs go through lifecycle statuses: draft → open → in_progress → completed.
 model Job {
   id          String     @id @default(cuid())
   title       String
@@ -24,11 +28,13 @@ model Job {
   status      String     @default("draft")
   ownerId     String
   owner       User       @relation(fields: [ownerId], references: [id])
-  proposals   Proposal[]
+  proposals   Proposal[] /// Proposals received for this job
   createdAt   DateTime   @default(now())
   updatedAt   DateTime   @updatedAt
 }
 
+/// Represents a freelancer's bid on a job.
+/// Proposals include a summary, optional bid amount, and track status (pending → accepted → rejected).
 model Proposal {
   id        String   @id @default(cuid())
   summary   String


### PR DESCRIPTION
## Description

Add brief comments to the Prisma schema models explaining their role in the TaskFlow domain.

## Changes

- Added model-level /// comments explaining the purpose of each model (User, Job, Proposal)
- Added field-level /// comments for relation fields

## Related Issue

Closes #5

/claim #5