### PR TITLE
[agent] docs: add environment variables documentation and .env.example

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,20 @@
+# =============================================================================
+# TaskFlow — Environment Variables
+# =============================================================================
+# Copy this file to .env and fill in your local values.
+# Each app/package may also have its own .env file for app-specific settings.
+# =============================================================================
+
+# --- Database (used by packages/db) ---
+DATABASE_URL="postgresql://user:password@localhost:5432/taskflow"
+
+# --- API Server (apps/api) ---
+PORT=4000
+JWT_SECRET="your-jwt-secret-here"
+
+# --- Web Frontend (apps/web) ---
+NEXT_PUBLIC_API_URL="http://localhost:4000"
+
+# --- Optional Integrations ---
+# STRIPE_SECRET_KEY="sk_test_..."
+# STRIPE_WEBHOOK_SECRET="whsec_..."

--- a/README.md
+++ b/README.md
@@ -81,5 +81,16 @@ with models for:
 
 ## Environment Variables
 
-Each app/package expects its own .env values for DB, auth, 
+Each app/package expects its own .env values for DB, auth,
 and integrations.
+
+Copy `.env.example` to `.env` at the project root and adjust the values:
+
+| Variable              | Used By     | Description                              |
+|-----------------------|-------------|------------------------------------------|
+| `DATABASE_URL`        | packages/db | PostgreSQL connection string             |
+| `PORT`                | apps/api    | API server port (default: 4000)          |
+| `JWT_SECRET`          | apps/api    | Secret key for JWT token signing         |
+| `NEXT_PUBLIC_API_URL` | apps/web    | Base URL for the API from the frontend   |
+| `STRIPE_SECRET_KEY`   | apps/api    | (Optional) Stripe secret key for payments|
+| `STRIPE_WEBHOOK_SECRET`| apps/api   | (Optional) Stripe webhook signing secret |


### PR DESCRIPTION
## Description

Add a short section describing expected local environment variables for the web and API apps.

## Changes
- Added `.env.example` at project root with all required and optional environment variables
- Updated README.md Environment Variables section with a table of variables, their usage, and descriptions

## Related Issue
Closes #4

/claim #4