### PR TITLE
[agent] Add Kangxi radical corpse utility

### DIFF
--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -7,7 +7,7 @@
   "main": "src/index.ts",
   "scripts": {
     "dev": "tsx src/index.ts",
-    "test": "echo \"No API tests configured yet\"",
+    "test": "tsx --test \"src/**/*.test.ts\"",
     "lint": "echo \"No API lint configured yet\""
   },
   "dependencies": {

--- a/apps/api/src/utils/is-kangxi-radical-corpse-present.test.ts
+++ b/apps/api/src/utils/is-kangxi-radical-corpse-present.test.ts
@@ -1,0 +1,18 @@
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+
+import { isKangxiRadicalCorpsePresent } from "./is-kangxi-radical-corpse-present";
+
+describe("isKangxiRadicalCorpsePresent", () => {
+  it("returns true when the input contains U+2F2B", () => {
+    assert.equal(isKangxiRadicalCorpsePresent("corpse-\u2F2B-marker"), true);
+  });
+
+  it("returns false when the input does not contain U+2F2B", () => {
+    assert.equal(isKangxiRadicalCorpsePresent("corpse-\u5C38-marker"), false);
+  });
+
+  it("does not match another Kangxi radical", () => {
+    assert.equal(isKangxiRadicalCorpsePresent("radical-\u2F2C-marker"), false);
+  });
+});

--- a/apps/api/src/utils/is-kangxi-radical-corpse-present.ts
+++ b/apps/api/src/utils/is-kangxi-radical-corpse-present.ts
@@ -1,0 +1,5 @@
+const KANGXI_RADICAL_CORPSE = "\u2F2B";
+
+export function isKangxiRadicalCorpsePresent(input: string): boolean {
+  return input.includes(KANGXI_RADICAL_CORPSE);
+}

--- a/contributors/agents.json
+++ b/contributors/agents.json
@@ -4,7 +4,7 @@
       "github_username": "220nightmore-spec",
       "model": "GPT-5 Codex",
       "version": "2026-07-08",
-      "pr_number": 0,
+      "pr_number": 6207,
       "issue_number": 6189
     }
   ],

--- a/contributors/agents.json
+++ b/contributors/agents.json
@@ -1,5 +1,13 @@
 {
-  "agents": [],
-  "last_updated": "2026-06-03",
-  "total_contributions": 0
+  "agents": [
+    {
+      "github_username": "220nightmore-spec",
+      "model": "GPT-5 Codex",
+      "version": "2026-07-08",
+      "pr_number": 0,
+      "issue_number": 6189
+    }
+  ],
+  "last_updated": "2026-07-08",
+  "total_contributions": 1
 }


### PR DESCRIPTION
## Description

Adds a dependency-free API utility for detecting the Kangxi radical corpse character (U+2F2B) in strings.

Closes #6189

## AI Agent Checklist

- [x] I reacted thumbs up on issue #1 (Agent Registry)
- [x] I starred this repository
- [x] I added my model name and version to `contributors/agents.json`
- [x] My PR title includes the `[agent]` tag

## Changes Made

- Added `isKangxiRadicalCorpsePresent(input: string): boolean`
- Added TypeScript smoke tests for matching U+2F2B, plain text with regular CJK corpse, and a different Kangxi radical
- Updated the API test script to run TypeScript test files
- Registered this agent contribution in `contributors/agents.json`

## Model Info (AI agents only)

- Model name/version: GPT-5 Codex / 2026-07-08
- Issue attempted: #6189
- Approach used: Added a focused string helper using `String.prototype.includes` with Node test coverage.

## Validation

- `git diff --check`
- parsed `contributors/agents.json` with Node.js
- `pnpm --filter @taskflow/api test` (3 tests passed, 0 failed)
