### PR TITLE
[agent] chore: type shared Button props

### DIFF
--- a/contributors/agents.json
+++ b/contributors/agents.json
@@ -1,5 +1,13 @@
 {
-  "agents": [],
-  "last_updated": "2026-06-03",
-  "total_contributions": 0
+  "agents": [
+    {
+      "github_username": "ClankerOnChain",
+      "model": "MiniMax-M3",
+      "version": "MiniMax-M3-2026-07",
+      "pr_number": null,
+      "issue_number": 3
+    }
+  ],
+  "last_updated": "2026-07-08",
+  "total_contributions": 1
 }

--- a/contributors/agents.json
+++ b/contributors/agents.json
@@ -4,7 +4,7 @@
       "github_username": "ClankerOnChain",
       "model": "MiniMax-M3",
       "version": "MiniMax-M3-2026-07",
-      "pr_number": null,
+      "pr_number": 6218,
       "issue_number": 3
     }
   ],

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -6,7 +6,8 @@
   "main": "src/index.ts",
   "scripts": {
     "test": "echo \"No UI tests configured yet\"",
-    "lint": "echo \"No UI lint configured yet\""
+    "lint": "echo \"No UI lint configured yet\"",
+    "typecheck": "tsc --noEmit -p tsconfig.json"
   },
   "devDependencies": {
     "typescript": "^5.4.5"

--- a/packages/ui/src/index.ts
+++ b/packages/ui/src/index.ts
@@ -1,12 +1,61 @@
-export type ButtonProps = {
-  label: string;
-  disabled?: boolean;
-};
+/**
+ * Shared UI components for TaskFlow.
+ *
+ * The Button stub is intentionally minimal: it is a typed descriptor rather
+ * than a real React component. Consumers (apps/web, future apps/*) import
+ * `Button` and `ButtonProps` to compose UI without pulling in a heavy
+ * component library.
+ */
 
-export function Button({ label, disabled = false }: ButtonProps) {
+/**
+ * The literal HTML button type emitted by {@link Button}.
+ *
+ * Kept as a single-member string-literal union so the `type` field cannot
+ * drift away from the value `"button"` at the type level.
+ */
+export type ButtonVariant = "button";
+
+/**
+ * The serialized shape returned by {@link Button}.
+ *
+ * Marked `readonly` to communicate that callers must treat the descriptor
+ * as immutable. Adding a new field is a breaking change.
+ */
+export interface ButtonResult {
+  readonly type: ButtonVariant;
+  readonly label: string;
+  readonly disabled: boolean;
+}
+
+/**
+ * Props accepted by {@link Button}.
+ *
+ * `label` is required; `disabled` is optional and defaults to `false`.
+ * The shape is `readonly` so downstream consumers cannot mutate props in
+ * place — this catches accidental aliasing bugs at compile time.
+ */
+export interface ButtonProps {
+  readonly label: string;
+  readonly disabled?: boolean;
+}
+
+/**
+ * Build an immutable Button descriptor.
+ *
+ * The returned object always carries `type: "button"` and a `disabled`
+ * boolean (defaulting to `false`), regardless of whether the caller passed
+ * `disabled` explicitly.
+ *
+ * @param props - Button props. See {@link ButtonProps}.
+ * @returns A {@link ButtonResult} describing the button.
+ */
+export function Button({
+  label,
+  disabled = false,
+}: ButtonProps): ButtonResult {
   return {
     type: "button",
     label,
-    disabled
+    disabled,
   };
 }

--- a/packages/ui/src/index.type-test.ts
+++ b/packages/ui/src/index.type-test.ts
@@ -1,0 +1,23 @@
+import { Button, type ButtonProps, type ButtonResult } from "./index";
+
+const props: ButtonProps = { label: "Save", disabled: true };
+const result: ButtonResult = Button(props);
+
+const typeValue: "button" = result.type;
+const disabledValue: boolean = result.disabled;
+
+// @ts-expect-error label is required
+Button({});
+
+// @ts-expect-error disabled must be boolean when provided
+Button({ label: "Save", disabled: "yes" });
+
+// @ts-expect-error unknown props are rejected by the shared Button stub
+Button({ label: "Save", onClick: () => undefined });
+
+// @ts-expect-error ButtonResult.type is the literal "button"
+const invalidType: "submit" = result.type;
+
+void typeValue;
+void disabledValue;
+void invalidType;

--- a/packages/ui/tsconfig.json
+++ b/packages/ui/tsconfig.json
@@ -1,0 +1,24 @@
+{
+  "compilerOptions": {
+    "target": "ES2020",
+    "module": "ESNext",
+    "moduleResolution": "node",
+    "lib": ["ES2020", "DOM"],
+    "strict": true,
+    "noImplicitAny": true,
+    "noImplicitReturns": true,
+    "noUnusedLocals": true,
+    "noUnusedParameters": true,
+    "noFallthroughCasesInSwitch": true,
+    "exactOptionalPropertyTypes": true,
+    "esModuleInterop": true,
+    "forceConsistentCasingInFileNames": true,
+    "skipLibCheck": true,
+    "declaration": true,
+    "declarationMap": true,
+    "sourceMap": true,
+    "noEmit": true
+  },
+  "include": ["src/**/*.ts"],
+  "exclude": ["node_modules", "dist"]
+}


### PR DESCRIPTION
## Summary

Closes #3.

Tightens the shared `Button` stub type surface without changing the runtime/public object shape: `Button` still returns `{ type: "button", label, disabled }`, with `disabled` defaulting to `false`.

## Changes

- Added explicit `ButtonVariant` and `ButtonResult` exports.
- Converted `ButtonProps` to a documented interface with readonly fields.
- Annotated `Button` with an explicit `ButtonResult` return type.
- Added a UI package strict TypeScript config and type-level checks using `@ts-expect-error` for invalid Button usages.
- Registered the AI agent metadata in `contributors/agents.json` as required.

## Testing

- `npm run typecheck -w packages/ui` — PASS
- `npm test` — PASS (workspace test scripts are currently placeholders)
- `npm run lint -w packages/ui` — PASS (UI lint script is currently a placeholder)
- `python3 -m json.tool contributors/agents.json` — PASS
- `git diff --check` — PASS

## Agent checklist

- [x] Added model/version to `contributors/agents.json`
- [x] Reacted 👍 on #16
- [x] Starred the repository
