### PR TITLE
Add isKangxiRadicalStepPresent utility for U+2F3B detection

### DIFF
--- a/apps/api/src/utils/is-kangxi-radical-step-present.test.ts
+++ b/apps/api/src/utils/is-kangxi-radical-step-present.test.ts
@@ -1,0 +1,20 @@
+import { strict as assert } from "node:assert";
+import { test } from "node:test";
+
+import { isKangxiRadicalStepPresent } from "./is-kangxi-radical-step-present";
+
+test("returns true when kangxi radical step char is present", () => {
+  assert.equal(isKangxiRadicalStepPresent("text ⼻"), true);
+});
+
+test("returns false when kangxi radical step char is absent", () => {
+  assert.equal(isKangxiRadicalStepPresent("no special chars"), false);
+});
+
+test("returns false for empty string", () => {
+  assert.equal(isKangxiRadicalStepPresent(""), false);
+});
+
+test("returns true for string that is just the char", () => {
+  assert.equal(isKangxiRadicalStepPresent("⼻"), true);
+});

--- a/apps/api/src/utils/is-kangxi-radical-step-present.ts
+++ b/apps/api/src/utils/is-kangxi-radical-step-present.ts
@@ -1,0 +1,3 @@
+export function isKangxiRadicalStepPresent(input: string): boolean {
+  return input.includes("\u2F3B");
+}


### PR DESCRIPTION
Adds a dependency-free TypeScript helper that checks whether a string contains the Unicode kangxi radical step character (U+2F3B).

The utility is exported from `apps/api/src/utils/is-kangxi-radical-step-present.ts` and includes basic smoke tests.

Closes #6223