### PR TITLE
Add isKangxiRadicalBristlePresent utility for U+2F3A detection

### DIFF
--- a/apps/api/src/utils/is-kangxi-radical-bristle-present.test.ts
+++ b/apps/api/src/utils/is-kangxi-radical-bristle-present.test.ts
@@ -1,0 +1,20 @@
+import { strict as assert } from "node:assert";
+import { test } from "node:test";
+
+import { isKangxiRadicalBristlePresent } from "./is-kangxi-radical-bristle-present";
+
+test("returns true when kangxi radical bristle char is present", () => {
+  assert.equal(isKangxiRadicalBristlePresent("text ⼺"), true);
+});
+
+test("returns false when kangxi radical bristle char is absent", () => {
+  assert.equal(isKangxiRadicalBristlePresent("plain text"), false);
+});
+
+test("returns false for empty string", () => {
+  assert.equal(isKangxiRadicalBristlePresent(""), false);
+});
+
+test("returns true for string that is just the char", () => {
+  assert.equal(isKangxiRadicalBristlePresent("⼺"), true);
+});

--- a/apps/api/src/utils/is-kangxi-radical-bristle-present.ts
+++ b/apps/api/src/utils/is-kangxi-radical-bristle-present.ts
@@ -1,0 +1,3 @@
+export function isKangxiRadicalBristlePresent(input: string): boolean {
+  return input.includes("\u2F3A");
+}


### PR DESCRIPTION
Adds a dependency-free TypeScript helper that checks whether a string contains the Unicode kangxi radical bristle character (U+2F3A).

The utility is exported from `apps/api/src/utils/is-kangxi-radical-bristle-present.ts` and includes basic smoke tests.

Closes #6222