### PR TITLE
Add isKangxiRadicalSnoutPresent utility for U+2F39 detection

### DIFF
--- a/apps/api/src/utils/is-kangxi-radical-snout-present.test.ts
+++ b/apps/api/src/utils/is-kangxi-radical-snout-present.test.ts
@@ -1,0 +1,20 @@
+import { strict as assert } from "node:assert";
+import { test } from "node:test";
+
+import { isKangxiRadicalSnoutPresent } from "./is-kangxi-radical-snout-present";
+
+test("returns true when kangxi radical snout char is present", () => {
+  assert.equal(isKangxiRadicalSnoutPresent("text ⼹"), true);
+});
+
+test("returns false when kangxi radical snout char is absent", () => {
+  assert.equal(isKangxiRadicalSnoutPresent("nothing here"), false);
+});
+
+test("returns false for empty string", () => {
+  assert.equal(isKangxiRadicalSnoutPresent(""), false);
+});
+
+test("returns true for string that is just the char", () => {
+  assert.equal(isKangxiRadicalSnoutPresent("⼹"), true);
+});

--- a/apps/api/src/utils/is-kangxi-radical-snout-present.ts
+++ b/apps/api/src/utils/is-kangxi-radical-snout-present.ts
@@ -1,0 +1,3 @@
+export function isKangxiRadicalSnoutPresent(input: string): boolean {
+  return input.includes("\u2F39");
+}


### PR DESCRIPTION
Adds a dependency-free TypeScript helper that checks whether a string contains the Unicode kangxi radical snout character (U+2F39).

The utility is exported from `apps/api/src/utils/is-kangxi-radical-snout-present.ts` and includes basic smoke tests.

Closes #6221