### PR TITLE
Add isKangxiRadicalBowPresent utility for U+2F38 detection

### DIFF
--- a/apps/api/src/utils/is-kangxi-radical-bow-present.test.ts
+++ b/apps/api/src/utils/is-kangxi-radical-bow-present.test.ts
@@ -1,0 +1,20 @@
+import { strict as assert } from "node:assert";
+import { test } from "node:test";
+
+import { isKangxiRadicalBowPresent } from "./is-kangxi-radical-bow-present";
+
+test("returns true when kangxi radical bow char is present", () => {
+  assert.equal(isKangxiRadicalBowPresent("text ⼸"), true);
+});
+
+test("returns false when kangxi radical bow char is absent", () => {
+  assert.equal(isKangxiRadicalBowPresent("just words"), false);
+});
+
+test("returns false for empty string", () => {
+  assert.equal(isKangxiRadicalBowPresent(""), false);
+});
+
+test("returns true for string that is just the char", () => {
+  assert.equal(isKangxiRadicalBowPresent("⼸"), true);
+});

--- a/apps/api/src/utils/is-kangxi-radical-bow-present.ts
+++ b/apps/api/src/utils/is-kangxi-radical-bow-present.ts
@@ -1,0 +1,3 @@
+export function isKangxiRadicalBowPresent(input: string): boolean {
+  return input.includes("\u2F38");
+}


### PR DESCRIPTION
Adds a dependency-free TypeScript helper that checks whether a string contains the Unicode kangxi radical bow character (U+2F38).

The utility is exported from `apps/api/src/utils/is-kangxi-radical-bow-present.ts` and includes basic smoke tests.

Closes #6220