### PR TITLE
Add isKangxiRadicalShootPresent utility for U+2F37 detection

### DIFF
--- a/apps/api/src/utils/is-kangxi-radical-shoot-present.test.ts
+++ b/apps/api/src/utils/is-kangxi-radical-shoot-present.test.ts
@@ -1,0 +1,20 @@
+import { strict as assert } from "node:assert";
+import { test } from "node:test";
+
+import { isKangxiRadicalShootPresent } from "./is-kangxi-radical-shoot-present";
+
+test("returns true when kangxi radical shoot char is present", () => {
+  assert.equal(isKangxiRadicalShootPresent("text ⼷"), true);
+});
+
+test("returns false when kangxi radical shoot char is absent", () => {
+  assert.equal(isKangxiRadicalShootPresent("normal text"), false);
+});
+
+test("returns false for empty string", () => {
+  assert.equal(isKangxiRadicalShootPresent(""), false);
+});
+
+test("returns true for string that is just the char", () => {
+  assert.equal(isKangxiRadicalShootPresent("⼷"), true);
+});

--- a/apps/api/src/utils/is-kangxi-radical-shoot-present.ts
+++ b/apps/api/src/utils/is-kangxi-radical-shoot-present.ts
@@ -1,0 +1,3 @@
+export function isKangxiRadicalShootPresent(input: string): boolean {
+  return input.includes("\u2F37");
+}


### PR DESCRIPTION
Adds a dependency-free TypeScript helper that checks whether a string contains the Unicode kangxi radical shoot character (U+2F37).

The utility is exported from `apps/api/src/utils/is-kangxi-radical-shoot-present.ts` and includes basic smoke tests.

Closes #6219