### PR TITLE
[agent] Validate user creation payloads

### DIFF
--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -7,7 +7,7 @@
   "main": "src/index.ts",
   "scripts": {
     "dev": "tsx src/index.ts",
-    "test": "echo \"No API tests configured yet\"",
+    "test": "tsx --test src/users.test.ts",
     "lint": "echo \"No API lint configured yet\""
   },
   "dependencies": {

--- a/apps/api/src/app.ts
+++ b/apps/api/src/app.ts
@@ -1,0 +1,15 @@
+import express from "express";
+
+import usersRouter from "./routes/users";
+
+const app = express();
+
+app.use(express.json({ strict: false }));
+
+app.get("/health", (_req, res) => {
+  res.json({ status: "ok", service: "taskflow-api" });
+});
+
+app.use("/users", usersRouter);
+
+export default app;

--- a/apps/api/src/index.ts
+++ b/apps/api/src/index.ts
@@ -1,17 +1,6 @@
-import express from "express";
+import app from "./app";
 
-import usersRouter from "./routes/users";
-
-const app = express();
 const port = process.env.PORT || 4000;
-
-app.use(express.json());
-
-app.get("/health", (_req, res) => {
-  res.json({ status: "ok", service: "taskflow-api" });
-});
-
-app.use("/users", usersRouter);
 
 app.listen(port, () => {
   console.log(`TaskFlow API listening on port ${port}`);

--- a/apps/api/src/routes/users.ts
+++ b/apps/api/src/routes/users.ts
@@ -1,6 +1,47 @@
 import { Router } from "express";
+import { randomUUID } from "node:crypto";
 
 const router = Router();
+
+type CreateUserPayload = {
+  email: string;
+  name?: string;
+};
+
+const emailPattern = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
+
+function isPlainObject(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function normalizeWhitespace(value: string): string {
+  return value.trim().replace(/\s+/g, " ");
+}
+
+function parseCreateUserPayload(body: unknown): CreateUserPayload | { error: string } {
+  if (!isPlainObject(body)) {
+    return { error: "Request body must be a JSON object." };
+  }
+
+  const rawEmail = body.email;
+  if (typeof rawEmail !== "string") {
+    return { error: "A valid email is required." };
+  }
+
+  const email = rawEmail.trim().toLowerCase();
+  if (!emailPattern.test(email)) {
+    return { error: "A valid email is required." };
+  }
+
+  const rawName = body.name;
+  if (rawName !== undefined && typeof rawName !== "string") {
+    return { error: "Name must be a string when provided." };
+  }
+
+  const name = rawName === undefined ? undefined : normalizeWhitespace(rawName);
+
+  return name ? { email, name } : { email };
+}
 
 router.get("/", (_req, res) => {
   res.json({
@@ -10,10 +51,19 @@ router.get("/", (_req, res) => {
 });
 
 router.post("/", (req, res) => {
+  const parsed = parseCreateUserPayload(req.body);
+
+  if ("error" in parsed) {
+    res.status(400).json({
+      error: parsed.error
+    });
+    return;
+  }
+
   res.status(201).json({
     data: {
-      id: "stub-user-id",
-      ...req.body
+      id: randomUUID(),
+      ...parsed
     },
     message: "User creation is not implemented yet."
   });

--- a/apps/api/src/users.test.ts
+++ b/apps/api/src/users.test.ts
@@ -1,0 +1,97 @@
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+
+import app from "./app";
+
+async function withApi<T>(callback: (baseUrl: string) => Promise<T>): Promise<T> {
+  const server = app.listen(0);
+
+  try {
+    const address = server.address();
+    assert(address && typeof address === "object");
+    return await callback(`http://127.0.0.1:${address.port}`);
+  } finally {
+    await new Promise<void>((resolve, reject) => {
+      server.close((error) => {
+        if (error) {
+          reject(error);
+          return;
+        }
+        resolve();
+      });
+    });
+  }
+}
+
+async function postUser(baseUrl: string, body: unknown) {
+  const response = await fetch(`${baseUrl}/users`, {
+    method: "POST",
+    headers: {
+      "content-type": "application/json"
+    },
+    body: JSON.stringify(body)
+  });
+
+  return {
+    response,
+    body: await response.json()
+  };
+}
+
+describe("POST /users", () => {
+  it("rejects non-object JSON bodies", async () => {
+    await withApi(async (baseUrl) => {
+      for (const payload of [null, [], "hello"]) {
+        const { response, body } = await postUser(baseUrl, payload);
+
+        assert.equal(response.status, 400);
+        assert.deepEqual(body, {
+          error: "Request body must be a JSON object."
+        });
+      }
+    });
+  });
+
+  it("requires a valid email", async () => {
+    await withApi(async (baseUrl) => {
+      for (const payload of [{}, { email: "" }, { email: "not-an-email" }, { email: 123 }]) {
+        const { response, body } = await postUser(baseUrl, payload);
+
+        assert.equal(response.status, 400);
+        assert.deepEqual(body, {
+          error: "A valid email is required."
+        });
+      }
+    });
+  });
+
+  it("normalizes email and optional name values", async () => {
+    await withApi(async (baseUrl) => {
+      const { response, body } = await postUser(baseUrl, {
+        email: "  USER@Example.COM ",
+        name: "  Ada   Lovelace  "
+      });
+
+      assert.equal(response.status, 201);
+      assert.equal(body.data.email, "user@example.com");
+      assert.equal(body.data.name, "Ada Lovelace");
+      assert.match(body.data.id, /^[0-9a-f-]{36}$/);
+    });
+  });
+
+  it("ignores client-controlled ids and unrelated fields", async () => {
+    await withApi(async (baseUrl) => {
+      const { response, body } = await postUser(baseUrl, {
+        id: "client-id",
+        email: "person@example.com",
+        role: "admin",
+        createdAt: "yesterday"
+      });
+
+      assert.equal(response.status, 201);
+      assert.notEqual(body.data.id, "client-id");
+      assert.deepEqual(Object.keys(body.data).sort(), ["email", "id"]);
+      assert.equal(body.data.email, "person@example.com");
+    });
+  });
+});

--- a/contributors/agents.json
+++ b/contributors/agents.json
@@ -1,5 +1,12 @@
 {
-  "agents": [],
-  "last_updated": "2026-06-03",
-  "total_contributions": 0
+  "agents": [
+    {
+      "name": "GPT-5 Codex",
+      "version": "2026-07-09",
+      "github_user": "ringotokens-commits",
+      "contribution": "Validate user creation payloads"
+    }
+  ],
+  "last_updated": "2026-07-09",
+  "total_contributions": 1
 }


### PR DESCRIPTION
# Agent Playground User Validation Bounty PR Draft

Issue: https://github.com/xevrion-v2/agent-playground/issues/2207

Patch: `/Users/aiagent/Documents/Codex/2026-07-08/yo/outputs/agent_playground_user_validation_bounty.patch`

Suggested PR title:

```text
[agent] Validate user creation payloads
```

## Description

Closes #2207

Adds focused validation for `POST /users` so user creation no longer trusts arbitrary request bodies. The route now requires a valid email, normalizes accepted fields, ignores client-controlled IDs and unrelated fields, and returns clear `400` responses for invalid JSON shapes.

## AI Agent Checklist

- [ ] I reacted thumbs-up on issue #1 (Agent Registry)
- [ ] I starred this repository
- [ ] I added my model name and version to `contributors/agents.json`
- [ ] My PR title includes the `[agent]` tag

Note: the first three checklist items require the submitting GitHub account. Complete them directly before opening the PR.

## Changes Made

- Added `apps/api/src/app.ts` so the Express app can be imported in tests without starting the production listener.
- Updated JSON parsing to allow valid JSON primitives through to route validation.
- Added `POST /users` validation for:
  - non-object JSON bodies;
  - missing or invalid email values;
  - optional string-only `name` values.
- Normalizes accepted emails to lowercase and trims/collapses optional names.
- Generates user IDs server-side with `randomUUID()`.
- Ignores client-supplied `id` and unrelated request fields.
- Added regression tests covering all issue acceptance criteria.
- Updated the API workspace test script to run the new user-route tests.

## Model Info

- Model name/version: GPT-5 Codex
- Issue attempted: #2207
- Approach used: Added explicit payload parsing/normalization in the user route and integration-style regression tests against an ephemeral Express server.

## Testing

```sh
npm test --workspace @taskflow/api
npm test
```

Result:

```text
@taskflow/api: 4 tests passed
workspace test: API tests passed; web/db/ui workspaces report no configured tests
```

Local note: `npm install` reported 2 audit findings in the existing dependency set. I did not run `npm audit fix --force` because it would introduce unrelated dependency churn.

/claim #2207

Also addresses the lightweight user-route validation requirements from #6.

/claim #6
