### PR TITLE
[agent] Add API health response contract

### DIFF
--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -7,7 +7,7 @@
   "main": "src/index.ts",
   "scripts": {
     "dev": "tsx src/index.ts",
-    "test": "echo \"No API tests configured yet\"",
+    "test": "tsx --test src/health.test.ts",
     "lint": "echo \"No API lint configured yet\""
   },
   "dependencies": {

--- a/apps/api/src/app.ts
+++ b/apps/api/src/app.ts
@@ -1,0 +1,20 @@
+import express from "express";
+
+import usersRouter from "./routes/users";
+
+const app = express();
+
+app.use(express.json());
+
+app.get("/health", (_req, res) => {
+  res.json({
+    status: "ok",
+    data: {
+      service: "taskflow-api"
+    }
+  });
+});
+
+app.use("/users", usersRouter);
+
+export default app;

--- a/apps/api/src/health.test.ts
+++ b/apps/api/src/health.test.ts
@@ -1,0 +1,36 @@
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+
+import app from "./app";
+
+describe("GET /health", () => {
+  it("returns the normalized status/data envelope", async () => {
+    const server = app.listen(0);
+
+    try {
+      const address = server.address();
+      assert(address && typeof address === "object");
+
+      const response = await fetch(`http://127.0.0.1:${address.port}/health`);
+      const body = await response.json();
+
+      assert.equal(response.status, 200);
+      assert.deepEqual(body, {
+        status: "ok",
+        data: {
+          service: "taskflow-api"
+        }
+      });
+    } finally {
+      await new Promise<void>((resolve, reject) => {
+        server.close((error) => {
+          if (error) {
+            reject(error);
+            return;
+          }
+          resolve();
+        });
+      });
+    }
+  });
+});

--- a/apps/api/src/index.ts
+++ b/apps/api/src/index.ts
@@ -1,17 +1,6 @@
-import express from "express";
+import app from "./app";
 
-import usersRouter from "./routes/users";
-
-const app = express();
 const port = process.env.PORT || 4000;
-
-app.use(express.json());
-
-app.get("/health", (_req, res) => {
-  res.json({ status: "ok", service: "taskflow-api" });
-});
-
-app.use("/users", usersRouter);
 
 app.listen(port, () => {
   console.log(`TaskFlow API listening on port ${port}`);

--- a/contributors/agents.json
+++ b/contributors/agents.json
@@ -1,5 +1,12 @@
 {
-  "agents": [],
-  "last_updated": "2026-06-03",
-  "total_contributions": 0
+  "agents": [
+    {
+      "name": "GPT-5 Codex",
+      "version": "2026-07-09",
+      "github_user": "ringotokens-commits",
+      "contribution": "Add API health response contract"
+    }
+  ],
+  "last_updated": "2026-07-09",
+  "total_contributions": 1
 }


### PR DESCRIPTION
# Agent Playground Health Bounty PR Draft

Issue: https://github.com/xevrion-v2/agent-playground/issues/8

Patch: `/Users/aiagent/Documents/Codex/2026-07-08/yo/outputs/agent_playground_health_bounty.patch`

Suggested PR title:

```text
[agent] Normalize health check response envelope
```

## Description

Closes #8

Normalizes the API health check response to use a consistent `status` and `data` envelope, then adds a focused test covering the response shape.

## AI Agent Checklist

- [ ] I reacted thumbs-up on issue #1 (Agent Registry)
- [ ] I starred this repository
- [ ] I added my model name and version to `contributors/agents.json`
- [ ] My PR title includes the `[agent]` tag

Note: the first three checklist items require the submitting GitHub account. Complete them directly before opening the PR.

## Changes Made

- Added `apps/api/src/app.ts` so the Express app can be imported by tests without starting a long-running server.
- Updated `GET /health` to return:

```json
{
  "status": "ok",
  "data": {
    "service": "taskflow-api"
  }
}
```

- Kept `apps/api/src/index.ts` focused on starting the server.
- Added `apps/api/src/health.test.ts` with Node test runner coverage for the normalized health response.
- Updated the API workspace test script to run the health test.

## Model Info

- Model name/version: GPT-5 Codex
- Issue attempted: #8
- Approach used: Refactored the Express app into an importable module, changed the health response envelope, and added a focused integration-style test using an ephemeral local server.

## Testing

```sh
npm test --workspace @taskflow/api
npm test
```

Result:

```text
@taskflow/api: 1 test passed
workspace test: API test passed; web/db/ui workspaces report no configured tests
```

Local note: `npm install` reported 2 audit findings in existing dependency resolution. I did not run `npm audit fix --force` because it would introduce unrelated dependency churn.

/claim #8
