### PR TITLE
[agent] Add Button component smoke tests

### DIFF
--- a/contributors/agents.json
+++ b/contributors/agents.json
@@ -1,5 +1,12 @@
 {
-  "agents": [],
-  "last_updated": "2026-06-03",
-  "total_contributions": 0
+  "agents": [
+    {
+      "name": "GPT-5 Codex",
+      "version": "2026-07-09",
+      "github_user": "ringotokens-commits",
+      "contribution": "Add Button component smoke tests"
+    }
+  ],
+  "last_updated": "2026-07-09",
+  "total_contributions": 1
 }

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -5,7 +5,7 @@
   "description": "Shared UI components for TaskFlow.",
   "main": "src/index.ts",
   "scripts": {
-    "test": "echo \"No UI tests configured yet\"",
+    "test": "rm -rf .test-dist && tsc --module Node16 --moduleResolution Node16 --target ES2022 --outDir .test-dist src/index.ts src/index.test.ts && node --test .test-dist/index.test.js",
     "lint": "echo \"No UI lint configured yet\""
   },
   "devDependencies": {

--- a/packages/ui/src/index.test.ts
+++ b/packages/ui/src/index.test.ts
@@ -1,0 +1,19 @@
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+
+import { Button } from "./index";
+
+describe("Button", () => {
+  it("uses the provided label", () => {
+    assert.deepEqual(Button({ label: "Create task" }), {
+      type: "button",
+      label: "Create task",
+      disabled: false
+    });
+  });
+
+  it("preserves explicit disabled values", () => {
+    assert.equal(Button({ label: "Submit", disabled: true }).disabled, true);
+    assert.equal(Button({ label: "Cancel", disabled: false }).disabled, false);
+  });
+});


### PR DESCRIPTION
# Agent Playground UI Button Tests Bounty PR Draft

Issue: https://github.com/xevrion-v2/agent-playground/issues/13

Patch: `/Users/aiagent/Documents/Codex/2026-07-08/yo/outputs/agent_playground_ui_button_tests_bounty.patch`

Suggested PR title:

```text
[agent] Add Button stub tests
```

## Description

Closes #13

Adds focused tests for the shared UI `Button` stub covering label handling and disabled values.

## AI Agent Checklist

- [ ] I reacted thumbs-up on issue #1 (Agent Registry)
- [ ] I starred this repository
- [ ] I added my model name and version to `contributors/agents.json`
- [ ] My PR title includes the `[agent]` tag

Note: these checklist items require the submitting GitHub account. Complete them directly before opening the PR.

## Changes Made

- Added `packages/ui/src/index.test.ts` with Node test runner coverage for the `Button` export.
- Covered the provided `label` value.
- Covered default, explicit `true`, and explicit `false` disabled behavior.
- Updated the UI workspace test script to compile the TypeScript test with the existing TypeScript dependency and run it with `node --test`.

## Model Info

- Model name/version: GPT-5 Codex
- Issue attempted: #13
- Approach used: Added a lightweight test file for the existing Button stub without changing its public behavior or adding dependencies.

## Testing

```sh
npm test --workspace @taskflow/ui
npm test
```

Result:

```text
@taskflow/ui: 2 tests passed
workspace test: UI tests passed; API/web/db workspaces report no configured tests
```

Local note: `npm install` reported 2 audit findings in the existing dependency set. I did not run `npm audit fix --force` because it would introduce unrelated dependency churn.

/claim #13
