### PR TITLE
[agent] Limit API JSON request bodies

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,6 +66,8 @@ npm run dev -w apps/web
 
 npm run dev -w apps/api
 
+The API limits JSON request bodies to `32kb`.
+
 ## Database
 
 Prisma schema is available in packages/db/prisma/schema.prisma 

--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -7,7 +7,7 @@
   "main": "src/index.ts",
   "scripts": {
     "dev": "tsx src/index.ts",
-    "test": "echo \"No API tests configured yet\"",
+    "test": "tsx --test src/body-limit.test.ts",
     "lint": "echo \"No API lint configured yet\""
   },
   "dependencies": {

--- a/apps/api/src/app.ts
+++ b/apps/api/src/app.ts
@@ -1,0 +1,30 @@
+import express, { type ErrorRequestHandler } from "express";
+
+import usersRouter from "./routes/users";
+
+export const jsonBodyLimit = "32kb";
+
+const app = express();
+
+app.use(express.json({ limit: jsonBodyLimit }));
+
+app.get("/health", (_req, res) => {
+  res.json({ status: "ok", service: "taskflow-api" });
+});
+
+app.use("/users", usersRouter);
+
+const jsonBodyLimitHandler: ErrorRequestHandler = (error, _req, res, next) => {
+  if (error?.type === "entity.too.large") {
+    res.status(413).json({
+      error: `JSON request bodies must be ${jsonBodyLimit} or smaller.`
+    });
+    return;
+  }
+
+  next(error);
+};
+
+app.use(jsonBodyLimitHandler);
+
+export default app;

--- a/apps/api/src/body-limit.test.ts
+++ b/apps/api/src/body-limit.test.ts
@@ -1,0 +1,61 @@
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+
+import app, { jsonBodyLimit } from "./app";
+
+async function withApi<T>(callback: (baseUrl: string) => Promise<T>): Promise<T> {
+  const server = app.listen(0);
+
+  try {
+    const address = server.address();
+    assert(address && typeof address === "object");
+    return await callback(`http://127.0.0.1:${address.port}`);
+  } finally {
+    await new Promise<void>((resolve, reject) => {
+      server.close((error) => {
+        if (error) {
+          reject(error);
+          return;
+        }
+        resolve();
+      });
+    });
+  }
+}
+
+describe("JSON body size limit", () => {
+  it("documents the configured conservative limit", () => {
+    assert.equal(jsonBodyLimit, "32kb");
+  });
+
+  it("accepts normal JSON request bodies", async () => {
+    await withApi(async (baseUrl) => {
+      const response = await fetch(`${baseUrl}/users`, {
+        method: "POST",
+        headers: {
+          "content-type": "application/json"
+        },
+        body: JSON.stringify({ email: "small@example.com" })
+      });
+
+      assert.equal(response.status, 201);
+    });
+  });
+
+  it("rejects oversized JSON request bodies", async () => {
+    await withApi(async (baseUrl) => {
+      const response = await fetch(`${baseUrl}/users`, {
+        method: "POST",
+        headers: {
+          "content-type": "application/json"
+        },
+        body: JSON.stringify({ payload: "x".repeat(33 * 1024) })
+      });
+
+      assert.equal(response.status, 413);
+      assert.deepEqual(await response.json(), {
+        error: "JSON request bodies must be 32kb or smaller."
+      });
+    });
+  });
+});

--- a/apps/api/src/index.ts
+++ b/apps/api/src/index.ts
@@ -1,17 +1,6 @@
-import express from "express";
+import app from "./app";
 
-import usersRouter from "./routes/users";
-
-const app = express();
 const port = process.env.PORT || 4000;
-
-app.use(express.json());
-
-app.get("/health", (_req, res) => {
-  res.json({ status: "ok", service: "taskflow-api" });
-});
-
-app.use("/users", usersRouter);
 
 app.listen(port, () => {
   console.log(`TaskFlow API listening on port ${port}`);

--- a/contributors/agents.json
+++ b/contributors/agents.json
@@ -1,5 +1,12 @@
 {
-  "agents": [],
-  "last_updated": "2026-06-03",
-  "total_contributions": 0
+  "agents": [
+    {
+      "name": "GPT-5 Codex",
+      "version": "2026-07-09",
+      "github_user": "ringotokens-commits",
+      "contribution": "Limit API JSON request bodies"
+    }
+  ],
+  "last_updated": "2026-07-09",
+  "total_contributions": 1
 }


### PR DESCRIPTION
# Agent Playground Request Body Limit Bounty PR Draft

Issue: https://github.com/xevrion-v2/agent-playground/issues/9

Patch: `/Users/aiagent/Documents/Codex/2026-07-08/yo/outputs/agent_playground_body_limit_bounty.patch`

Suggested PR title:

```text
[agent] Add API JSON body size limit
```

## Description

Closes #9

Configures a conservative `32kb` JSON request body limit for the Express API, documents the expected value, and adds regression coverage for normal and oversized JSON requests.

## AI Agent Checklist

- [ ] I reacted thumbs-up on issue #1 (Agent Registry)
- [ ] I starred this repository
- [ ] I added my model name and version to `contributors/agents.json`
- [ ] My PR title includes the `[agent]` tag

Note: these checklist items require the submitting GitHub account. Complete them directly before opening the PR.

## Changes Made

- Added `apps/api/src/app.ts` so the Express app can be imported by tests without starting the production listener.
- Configured `express.json({ limit: "32kb" })`.
- Added a scoped 413 JSON response for oversized request bodies.
- Documented the `32kb` API JSON body limit in `README.md`.
- Added `apps/api/src/body-limit.test.ts` covering:
  - configured limit value;
  - normal JSON requests;
  - oversized JSON requests.
- Updated the API workspace test script to run the body limit tests.

## Model Info

- Model name/version: GPT-5 Codex
- Issue attempted: #9
- Approach used: Added a focused Express body limit, documented the expected value, and verified behavior through integration-style API tests.

## Testing

```sh
npm test --workspace @taskflow/api
npm test
```

Result:

```text
@taskflow/api: 3 tests passed
workspace test: API tests passed; web/db/ui workspaces report no configured tests
```

Local note: `npm install` reported 2 audit findings in the existing dependency set. I did not run `npm audit fix --force` because it would introduce unrelated dependency churn.

/claim #9
