### PR TITLE
[agent] Add shared API error helper

### DIFF
--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -7,7 +7,7 @@
   "main": "src/index.ts",
   "scripts": {
     "dev": "tsx src/index.ts",
-    "test": "echo \"No API tests configured yet\"",
+    "test": "tsx --test src/api-error.test.ts",
     "lint": "echo \"No API lint configured yet\""
   },
   "dependencies": {

--- a/apps/api/src/api-error.test.ts
+++ b/apps/api/src/api-error.test.ts
@@ -1,0 +1,46 @@
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+
+import app from "./app";
+
+async function withApi<T>(callback: (baseUrl: string) => Promise<T>): Promise<T> {
+  const server = app.listen(0);
+
+  try {
+    const address = server.address();
+    assert(address && typeof address === "object");
+    return await callback(`http://127.0.0.1:${address.port}`);
+  } finally {
+    await new Promise<void>((resolve, reject) => {
+      server.close((error) => {
+        if (error) {
+          reject(error);
+          return;
+        }
+        resolve();
+      });
+    });
+  }
+}
+
+describe("API error helper", () => {
+  it("returns a consistent error envelope from a route", async () => {
+    await withApi(async (baseUrl) => {
+      const response = await fetch(`${baseUrl}/users`, {
+        method: "POST",
+        headers: {
+          "content-type": "application/json"
+        },
+        body: JSON.stringify(null)
+      });
+
+      assert.equal(response.status, 400);
+      assert.deepEqual(await response.json(), {
+        error: {
+          code: "invalid_request_body",
+          message: "Request body must be a JSON object."
+        }
+      });
+    });
+  });
+});

--- a/apps/api/src/app.ts
+++ b/apps/api/src/app.ts
@@ -1,0 +1,15 @@
+import express from "express";
+
+import usersRouter from "./routes/users";
+
+const app = express();
+
+app.use(express.json({ strict: false }));
+
+app.get("/health", (_req, res) => {
+  res.json({ status: "ok", service: "taskflow-api" });
+});
+
+app.use("/users", usersRouter);
+
+export default app;

--- a/apps/api/src/index.ts
+++ b/apps/api/src/index.ts
@@ -1,17 +1,6 @@
-import express from "express";
+import app from "./app";
 
-import usersRouter from "./routes/users";
-
-const app = express();
 const port = process.env.PORT || 4000;
-
-app.use(express.json());
-
-app.get("/health", (_req, res) => {
-  res.json({ status: "ok", service: "taskflow-api" });
-});
-
-app.use("/users", usersRouter);
 
 app.listen(port, () => {
   console.log(`TaskFlow API listening on port ${port}`);

--- a/apps/api/src/routes/users.ts
+++ b/apps/api/src/routes/users.ts
@@ -1,6 +1,12 @@
 import { Router } from "express";
 
+import { sendApiError } from "../utils/api-error";
+
 const router = Router();
+
+function isJsonObject(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
 
 router.get("/", (_req, res) => {
   res.json({
@@ -10,6 +16,16 @@ router.get("/", (_req, res) => {
 });
 
 router.post("/", (req, res) => {
+  if (!isJsonObject(req.body)) {
+    sendApiError(
+      res,
+      400,
+      "invalid_request_body",
+      "Request body must be a JSON object."
+    );
+    return;
+  }
+
   res.status(201).json({
     data: {
       id: "stub-user-id",

--- a/apps/api/src/utils/api-error.ts
+++ b/apps/api/src/utils/api-error.ts
@@ -1,0 +1,22 @@
+import type { Response } from "express";
+
+type ApiErrorPayload = {
+  error: {
+    code: string;
+    message: string;
+  };
+};
+
+export function sendApiError(
+  res: Response,
+  status: number,
+  code: string,
+  message: string
+): Response<ApiErrorPayload> {
+  return res.status(status).json({
+    error: {
+      code,
+      message
+    }
+  });
+}

--- a/contributors/agents.json
+++ b/contributors/agents.json
@@ -1,5 +1,12 @@
 {
-  "agents": [],
-  "last_updated": "2026-06-03",
-  "total_contributions": 0
+  "agents": [
+    {
+      "name": "GPT-5 Codex",
+      "version": "2026-07-09",
+      "github_user": "ringotokens-commits",
+      "contribution": "Add shared API error helper"
+    }
+  ],
+  "last_updated": "2026-07-09",
+  "total_contributions": 1
 }


### PR DESCRIPTION
# Agent Playground API Error Helper Bounty PR Draft

Issue: https://github.com/xevrion-v2/agent-playground/issues/7

Patch: `/Users/aiagent/Documents/Codex/2026-07-08/yo/outputs/agent_playground_api_error_helper_bounty.patch`

Suggested PR title:

```text
[agent] Add API error response helper
```

## Description

Closes #7

Introduces a small API error response helper for the Express app and uses it from the `POST /users` route when the request body is not a JSON object.

## AI Agent Checklist

- [ ] I reacted thumbs-up on issue #1 (Agent Registry)
- [ ] I starred this repository
- [ ] I added my model name and version to `contributors/agents.json`
- [ ] My PR title includes the `[agent]` tag

Note: these checklist items require the submitting GitHub account. Complete them directly before opening the PR.

## Changes Made

- Added `apps/api/src/utils/api-error.ts` with `sendApiError()`.
- Added `apps/api/src/app.ts` so the Express app can be imported by tests.
- Used `sendApiError()` from `POST /users` for non-object JSON bodies.
- Added `apps/api/src/api-error.test.ts` covering the route-level error envelope.
- Updated the API workspace test script to run the new test.

## Model Info

- Model name/version: GPT-5 Codex
- Issue attempted: #7
- Approach used: Added a minimal shared error helper and verified one route uses it to return a consistent JSON error shape.

## Testing

```sh
npm test --workspace @taskflow/api
npm test
```

Result:

```text
@taskflow/api: 1 test passed
workspace test: API test passed; web/db/ui workspaces report no configured tests
```

Local note: `npm install` reported 2 audit findings in the existing dependency set. I did not run `npm audit fix --force` because it would introduce unrelated dependency churn.

/claim #7
