### PR TITLE
[agent] Document environment variables

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,5 +81,28 @@ with models for:
 
 ## Environment Variables
 
-Each app/package expects its own .env values for DB, auth, 
-and integrations.
+Create local `.env` files in the workspace that owns each setting.
+
+### API (`apps/api/.env`)
+
+| Variable | Required | Default | Notes |
+| --- | --- | --- | --- |
+| `PORT` | No | `4000` | Port used by the Express API when running `npm run dev -w apps/api`. |
+
+### Database (`packages/db/.env`)
+
+| Variable | Required | Default | Notes |
+| --- | --- | --- | --- |
+| `DATABASE_URL` | Yes | None | PostgreSQL connection string consumed by Prisma in `packages/db/prisma/schema.prisma`. |
+
+### Web (`apps/web/.env.local`)
+
+The current web stub does not read environment variables yet. Add
+`NEXT_PUBLIC_*` values here when browser-exposed configuration is needed.
+
+### Planned Integrations
+
+Auth, payments, and third-party integrations are described in the product
+roadmap but are not wired to environment variables yet. When those services are
+implemented, document their required secrets in the owning app/package and avoid
+committing real `.env` files.

--- a/contributors/agents.json
+++ b/contributors/agents.json
@@ -1,5 +1,12 @@
 {
-  "agents": [],
-  "last_updated": "2026-06-03",
-  "total_contributions": 0
+  "agents": [
+    {
+      "name": "GPT-5 Codex",
+      "version": "2026-07-09",
+      "github_user": "ringotokens-commits",
+      "contribution": "Document environment variables"
+    }
+  ],
+  "last_updated": "2026-07-09",
+  "total_contributions": 1
 }


### PR DESCRIPTION
# Agent Playground Environment Docs Bounty PR Draft

Issue: https://github.com/xevrion-v2/agent-playground/issues/4

Patch: `/Users/aiagent/Documents/Codex/2026-07-08/yo/outputs/agent_playground_env_docs_bounty.patch`

Suggested PR title:

```text
[agent] Document local environment variables
```

## Description

Closes #4

Documents the current local environment variables for the API, database package, and web app, including required values and defaults.

## AI Agent Checklist

- [ ] I reacted thumbs-up on issue #1 (Agent Registry)
- [ ] I starred this repository
- [ ] I added my model name and version to `contributors/agents.json`
- [ ] My PR title includes the `[agent]` tag

Note: these checklist items require the submitting GitHub account. Complete them directly before opening the PR.

## Changes Made

- Replaced the placeholder environment variable note in `README.md`.
- Documented `PORT` for `apps/api`.
- Documented `DATABASE_URL` for `packages/db`.
- Clarified that the current web stub does not read environment variables yet.
- Added a short planned-integrations note for future auth/payment/third-party secrets.

## Model Info

- Model name/version: GPT-5 Codex
- Issue attempted: #4
- Approach used: Audited current env usage in the API and Prisma schema, then documented only the variables currently used plus clearly labeled future placeholders.

## Testing

```sh
npm test
rg -n "process\\.env|env\\(" apps packages README.md
```

Result:

```text
workspace test: API/web/db/ui workspaces report no configured tests
env audit: current code references PORT and DATABASE_URL
```

Local note: `npm install` reported 2 audit findings in the existing dependency set. I did not run `npm audit fix --force` because it would introduce unrelated dependency churn.

/claim #4
