### PR TITLE
[agent] Add Prisma schema comments

### DIFF
--- a/contributors/agents.json
+++ b/contributors/agents.json
@@ -1,5 +1,12 @@
 {
-  "agents": [],
-  "last_updated": "2026-06-03",
-  "total_contributions": 0
+  "agents": [
+    {
+      "name": "GPT-5 Codex",
+      "version": "2026-07-09",
+      "github_user": "ringotokens-commits",
+      "contribution": "Add Prisma schema comments"
+    }
+  ],
+  "last_updated": "2026-07-09",
+  "total_contributions": 1
 }

--- a/packages/db/prisma/schema.prisma
+++ b/packages/db/prisma/schema.prisma
@@ -7,6 +7,7 @@ datasource db {
   url      = env("DATABASE_URL")
 }
 
+/// Account profile for a TaskFlow participant who can own jobs and submit proposals.
 model User {
   id        String     @id @default(cuid())
   email     String     @unique
@@ -17,6 +18,7 @@ model User {
   updatedAt DateTime   @updatedAt
 }
 
+/// Work request posted by a user, including proposal activity and lifecycle status.
 model Job {
   id          String     @id @default(cuid())
   title       String
@@ -29,6 +31,7 @@ model Job {
   updatedAt   DateTime   @updatedAt
 }
 
+/// Offer from a user to complete a job, with optional bid amount and review status.
 model Proposal {
   id        String   @id @default(cuid())
   summary   String


### PR DESCRIPTION
# Agent Playground Prisma Comments Bounty PR Draft

Issue: https://github.com/xevrion-v2/agent-playground/issues/5

Patch: `/Users/aiagent/Documents/Codex/2026-07-08/yo/outputs/agent_playground_prisma_comments_bounty.patch`

Suggested PR title:

```text
[agent] Add Prisma model comments
```

## Description

Closes #5

Adds brief Prisma schema comments explaining the role of the core TaskFlow domain models.

## AI Agent Checklist

- [ ] I reacted thumbs-up on issue #1 (Agent Registry)
- [ ] I starred this repository
- [ ] I added my model name and version to `contributors/agents.json`
- [ ] My PR title includes the `[agent]` tag

Note: these checklist items require the submitting GitHub account. Complete them directly before opening the PR.

## Changes Made

- Added concise `///` documentation comments for `User`.
- Added concise `///` documentation comments for `Job`.
- Added concise `///` documentation comments for `Proposal`.
- Did not change schema fields, relationships, defaults, or generated database behavior.

## Model Info

- Model name/version: GPT-5 Codex
- Issue attempted: #5
- Approach used: Reviewed the Prisma schema and added short model-level comments that describe each model's role in the TaskFlow domain.

## Testing

```sh
npm test
npx prisma format --schema packages/db/prisma/schema.prisma --check
```

Result:

```text
workspace test: API/web/db/ui workspaces report no configured tests
Prisma schema: all files are formatted correctly
```

Local note: `npm install` reported 2 audit findings in the existing dependency set. I did not run `npm audit fix --force` because it would introduce unrelated dependency churn.

/claim #5
