### PR TITLE
[agent] Add Button prop type annotations

### DIFF
--- a/contributors/agents.json
+++ b/contributors/agents.json
@@ -1,5 +1,12 @@
 {
-  "agents": [],
-  "last_updated": "2026-06-03",
-  "total_contributions": 0
+  "agents": [
+    {
+      "name": "GPT-5 Codex",
+      "version": "2026-07-09",
+      "github_user": "ringotokens-commits",
+      "contribution": "Add Button prop type annotations"
+    }
+  ],
+  "last_updated": "2026-07-09",
+  "total_contributions": 1
 }

--- a/packages/ui/src/index.ts
+++ b/packages/ui/src/index.ts
@@ -1,9 +1,15 @@
 export type ButtonProps = {
-  label: string;
-  disabled?: boolean;
+  readonly label: string;
+  readonly disabled?: boolean;
 };
 
-export function Button({ label, disabled = false }: ButtonProps) {
+export type ButtonViewModel = {
+  readonly type: "button";
+  readonly label: string;
+  readonly disabled: boolean;
+};
+
+export function Button({ label, disabled = false }: ButtonProps): ButtonViewModel {
   return {
     type: "button",
     label,


### PR DESCRIPTION
# Agent Playground Button Types Bounty PR Draft

Issue: https://github.com/xevrion-v2/agent-playground/issues/3

Patch: `/Users/aiagent/Documents/Codex/2026-07-08/yo/outputs/agent_playground_button_types_bounty.patch`

Suggested PR title:

```text
[agent] Tighten Button prop types
```

## Description

Closes #3

Improves the shared UI `Button` stub type annotations without changing its public runtime shape.

## AI Agent Checklist

- [ ] I reacted thumbs-up on issue #1 (Agent Registry)
- [ ] I starred this repository
- [ ] I added my model name and version to `contributors/agents.json`
- [ ] My PR title includes the `[agent]` tag

Note: these checklist items require the submitting GitHub account. Complete them directly before opening the PR.

## Changes Made

- Marked `ButtonProps` fields as readonly.
- Added an explicit exported `ButtonViewModel` return type.
- Annotated `Button()` to return `ButtonViewModel`.
- Preserved the existing returned object shape: `type`, `label`, and `disabled`.

## Model Info

- Model name/version: GPT-5 Codex
- Issue attempted: #3
- Approach used: Tightened the existing Button stub's TypeScript surface while preserving runtime behavior.

## Testing

```sh
npx tsc --module Node16 --moduleResolution Node16 --target ES2022 --noEmit packages/ui/src/index.ts
npm test
```

Result:

```text
TypeScript check passed
workspace test: API/web/db/ui workspaces report no configured tests
```

Local note: `npm install` reported 2 audit findings in the existing dependency set. I did not run `npm audit fix --force` because it would introduce unrelated dependency churn.

/claim #3
