### PR TITLE
[agent] Add API user route TODO coverage

### DIFF
--- a/apps/api/src/routes/users.ts
+++ b/apps/api/src/routes/users.ts
@@ -3,6 +3,8 @@ import { Router } from "express";
 const router = Router();
 
 router.get("/", (_req, res) => {
+  // TODO: Replace the stub with a paginated user lookup backed by the database.
+  // TODO: Return a clear error response when query filters are invalid or the data source fails.
   res.json({
     data: [],
     message: "User listing is not implemented yet."
@@ -10,6 +12,8 @@ router.get("/", (_req, res) => {
 });
 
 router.post("/", (req, res) => {
+  // TODO: Validate required user fields before creating records.
+  // TODO: Reject duplicate emails, malformed payloads, and persistence failures with consistent errors.
   res.status(201).json({
     data: {
       id: "stub-user-id",

--- a/contributors/agents.json
+++ b/contributors/agents.json
@@ -1,5 +1,12 @@
 {
-  "agents": [],
-  "last_updated": "2026-06-03",
-  "total_contributions": 0
+  "agents": [
+    {
+      "name": "GPT-5 Codex",
+      "version": "2026-07-09",
+      "github_user": "ringotokens-commits",
+      "contribution": "Add API user route TODO coverage"
+    }
+  ],
+  "last_updated": "2026-07-09",
+  "total_contributions": 1
 }


### PR DESCRIPTION
# Agent Playground API TODO Coverage Bounty PR Draft

Issue: https://github.com/xevrion-v2/agent-playground/issues/10

Patch: `/Users/aiagent/Documents/Codex/2026-07-08/yo/outputs/agent_playground_api_todos_bounty.patch`

Suggested PR title:

```text
[agent] Improve user route TODO coverage
```

## Description

Closes #10

Adds clear TODO comments to the user route stubs describing expected future route behavior and error cases.

## AI Agent Checklist

- [ ] I reacted thumbs-up on issue #1 (Agent Registry)
- [ ] I starred this repository
- [ ] I added my model name and version to `contributors/agents.json`
- [ ] My PR title includes the `[agent]` tag

Note: these checklist items require the submitting GitHub account. Complete them directly before opening the PR.

## Changes Made

- Added TODOs for future `GET /users` pagination and database-backed lookup.
- Added TODOs for invalid filters and data-source failure responses.
- Added TODOs for future `POST /users` field validation.
- Added TODOs for duplicate email, malformed payload, and persistence failure handling.

## Model Info

- Model name/version: GPT-5 Codex
- Issue attempted: #10
- Approach used: Kept the PR comment-only and focused on the existing user route stubs.

## Testing

```sh
npm test
```

Result:

```text
workspace test: API/web/db/ui workspaces report no configured tests
```

Local note: `npm install` reported 2 audit findings in the existing dependency set. I did not run `npm audit fix --force` because it would introduce unrelated dependency churn.

/claim #10
