### PR TITLE
[agent] Add JSDoc to userService

### DIFF
--- a/apps/api/src/routes/users.ts
+++ b/apps/api/src/routes/users.ts
@@ -1,20 +1,18 @@
 import { Router } from "express";
+import { createUser, listUsers } from "../services/userService";
 
 const router = Router();
 
 router.get("/", (_req, res) => {
   res.json({
-    data: [],
+    data: listUsers(),
     message: "User listing is not implemented yet."
   });
 });
 
 router.post("/", (req, res) => {
   res.status(201).json({
-    data: {
-      id: "stub-user-id",
-      ...req.body
-    },
+    data: createUser(req.body),
     message: "User creation is not implemented yet."
   });
 });

--- a/apps/api/src/services/userService.ts
+++ b/apps/api/src/services/userService.ts
@@ -1,0 +1,24 @@
+export type UserPayload = Record<string, unknown>;
+
+/**
+ * Return the current user collection for the API stub.
+ *
+ * The backing store is not implemented yet, so callers receive an empty list
+ * while the route contract remains stable for future persistence work.
+ */
+export function listUsers(): UserPayload[] {
+  return [];
+}
+
+/**
+ * Build the placeholder response object for a user creation request.
+ *
+ * The service preserves the existing stub behavior by echoing accepted request
+ * fields and assigning the fixed placeholder identifier used by the route.
+ */
+export function createUser(payload: UserPayload): UserPayload {
+  return {
+    id: "stub-user-id",
+    ...payload
+  };
+}

--- a/contributors/agents.json
+++ b/contributors/agents.json
@@ -1,5 +1,12 @@
 {
-  "agents": [],
-  "last_updated": "2026-06-03",
-  "total_contributions": 0
+  "agents": [
+    {
+      "name": "GPT-5 Codex",
+      "version": "2026-07-09",
+      "github_user": "ringotokens-commits",
+      "contribution": "Add JSDoc to user service functions"
+    }
+  ],
+  "last_updated": "2026-07-09",
+  "total_contributions": 1
 }


### PR DESCRIPTION
Closes #1

/claim #1

## Summary
- Add a focused `userService` module for the current user list/create stubs.
- Document the service functions with concise JSDoc.
- Wire the existing `/users` routes through the service without changing response shapes.
- Add required AI agent metadata.

## Testing
- `npm test`
- `git diff --check`
- `node -e "JSON.parse(require("fs").readFileSync("contributors/agents.json","utf8"))"`