### PR TITLE
fix(util): add Kangxi Radical Step detection for #6223

### DIFF
--- a/apps/api/src/utils/is-kangxi-radical-step-present.ts
+++ b/apps/api/src/utils/is-kangxi-radical-step-present.ts
@@ -1,0 +1,8 @@
+/**
+ * Detects whether a string contains the Kangxi Radical Step character (U+2F3B).
+ * @param input - The string to check.
+ * @returns true if the input contains the Kangxi Radical Step character.
+ */
+export function isKangxiRadicalStepPresent(input: string): boolean {
+  return input.includes('\u2F3B');
+}


### PR DESCRIPTION
﻿## Summary

Implements Kangxi Radical Step (U+2F3B) detection utility for bounty issue #6223 (Parent #33).

## Implementation

- **File**: apps/api/src/utils/is-kangxi-radical-step-present.ts
- **Function**: isKangxiRadicalStepPresent(input: string): boolean
- **Unicode range**: Single character U+2F3B (Kangxi Radical Step)
- **Approach**: Uses String.prototype.includes() with the exact Unicode escape

## Acceptance Criteria

- [x] Utility file added at apps/api/src/utils/is-kangxi-radical-step-present.ts
- [x] Exports isKangxiRadicalStepPresent(input: string): boolean
- [x] Returns true only when input contains the Kangxi Radical Step character (U+2F3B)
- [x] Dependency-free, follows existing utility patterns
- [x] TypeScript compiled successfully

## Tests

Verified locally with tsx:
- isKangxiRadicalStepPresent with Kangxi Radical Step character -> true
- isKangxiRadicalStepPresent with 'hello' -> false
- isKangxiRadicalStepPresent with mixed input -> true

## Bounty Note

Addresses bounty issue #6223 (Parent #33).

This PR implements only the Kangxi Radical Step detection utility.
