### PR TITLE
feat(api): validate user creation payload and normalize inputs

### DIFF
--- a/apps/api/src/routes/users.test.ts
+++ b/apps/api/src/routes/users.test.ts
@@ -1,0 +1,107 @@
+import { describe, it, beforeEach } from "node:test";
+import assert from "node:assert/strict";
+import router from "./users.js";
+
+// Mock Express req and res types
+interface MockReq {
+  body: unknown;
+}
+
+interface MockRes {
+  _status: number;
+  _json: any;
+  status(code: number): MockRes;
+  json(body: any): void;
+}
+
+function makeRes(): MockRes {
+  const res: MockRes = {
+    _status: 200,
+    _json: null,
+    status(code) {
+      res._status = code;
+      return res;
+    },
+    json(body) {
+      res._json = body;
+    }
+  };
+  return res;
+}
+
+// Retrieve the route handler from router stack
+// In Express, router.post('/') registers a layer.
+const postHandler = router.stack.find(
+  (layer) => layer.route && layer.route.path === "/" && layer.route.methods.post
+)?.route?.stack[0]?.handle;
+
+const getHandler = router.stack.find(
+  (layer) => layer.route && layer.route.path === "/" && layer.route.methods.get
+)?.route?.stack[0]?.handle;
+
+describe("Users Routes - POST /", () => {
+  let res: MockRes;
+
+  beforeEach(() => {
+    res = makeRes();
+  });
+
+  it("should reject non-object JSON bodies with 400", () => {
+    postHandler({ body: "not-an-object" } as any, res, () => {});
+    assert.equal(res._status, 400);
+    assert.equal(res._json.error, "Bad Request");
+    assert.match(res._json.message, /must be a valid JSON object/);
+  });
+
+  it("should reject arrays with 400", () => {
+    postHandler({ body: [] } as any, res, () => {});
+    assert.equal(res._status, 400);
+    assert.equal(res._json.error, "Bad Request");
+  });
+
+  it("should reject null body with 400", () => {
+    postHandler({ body: null } as any, res, () => {});
+    assert.equal(res._status, 400);
+    assert.equal(res._json.error, "Bad Request");
+  });
+
+  it("should require email field", () => {
+    postHandler({ body: { name: "Bob" } } as any, res, () => {});
+    assert.equal(res._status, 400);
+    assert.match(res._json.message, /Email is required/);
+  });
+
+  it("should reject invalid email format", () => {
+    postHandler({ body: { email: "invalid-email" } } as any, res, () => {});
+    assert.equal(res._status, 400);
+    assert.match(res._json.message, /must be a valid email address/);
+  });
+
+  it("should accept valid email, normalize it to lowercase/trimmed, and generate server id", () => {
+    const payload = {
+      email: "  Alice.Smith@EXAMPLE.com  ",
+      name: "  Alice Smith  ",
+      id: "malicious-client-id",
+      unrelatedField: "should-be-ignored"
+    };
+
+    postHandler({ body: payload } as any, res, () => {});
+    assert.equal(res._status, 201);
+    
+    const data = res._json.data;
+    assert.ok(data.id);
+    assert.notEqual(data.id, "malicious-client-id"); // Should generate id server-side
+    assert.equal(data.email, "alice.smith@example.com"); // Normalized
+    assert.equal(data.name, "Alice Smith"); // Normalized
+    assert.equal(data.unrelatedField, undefined); // Ignored
+  });
+
+  it("should handle optional name field when not provided", () => {
+    postHandler({ body: { email: "bob@example.com" } } as any, res, () => {});
+    assert.equal(res._status, 201);
+    
+    const data = res._json.data;
+    assert.equal(data.email, "bob@example.com");
+    assert.equal(data.name, undefined);
+  });
+});

--- a/apps/api/src/routes/users.ts
+++ b/apps/api/src/routes/users.ts
@@ -1,6 +1,10 @@
 import { Router } from "express";
+import crypto from "node:crypto";
 
 const router = Router();
+
+// Simple email validation regex matching standard formats
+const EMAIL_REGEX = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
 
 router.get("/", (_req, res) => {
   res.json({
@@ -10,11 +14,60 @@ router.get("/", (_req, res) => {
 });
 
 router.post("/", (req, res) => {
+  const body = req.body;
+
+  // 1. Reject non-object JSON bodies or arrays
+  if (typeof body !== "object" || body === null || Array.isArray(body)) {
+    res.status(400).json({
+      error: "Bad Request",
+      message: "Request body must be a valid JSON object."
+    });
+    return;
+  }
+
+  const { email, name } = body;
+
+  // 2. Require email and check if it is a string
+  if (typeof email !== "string") {
+    res.status(400).json({
+      error: "Bad Request",
+      message: "Email is required and must be a string."
+    });
+    return;
+  }
+
+  // 3. Normalize email value (trim and lowercase)
+  const normalizedEmail = email.trim().toLowerCase();
+
+  // 4. Validate normalized email format
+  if (!EMAIL_REGEX.test(normalizedEmail)) {
+    res.status(400).json({
+      error: "Bad Request",
+      message: "Email must be a valid email address."
+    });
+    return;
+  }
+
+  // 5. Normalize optional name value (trim if string, ignore if other type or undefined)
+  let normalizedName: string | undefined;
+  if (typeof name === "string") {
+    normalizedName = name.trim();
+  }
+
+  // 6. Generate server-side UUID and ignore client-controlled id or extra fields
+  const userId = crypto.randomUUID();
+
+  const responseData: Record<string, any> = {
+    id: userId,
+    email: normalizedEmail
+  };
+
+  if (normalizedName !== undefined) {
+    responseData.name = normalizedName;
+  }
+
   res.status(201).json({
-    data: {
-      id: "stub-user-id",
-      ...req.body
-    },
+    data: responseData,
     message: "User creation is not implemented yet."
   });
 });


### PR DESCRIPTION
## Summary

Implements payload validation and input normalization for the `POST /users` route to prevent clients from submitting custom IDs or extra fields, and enforces schema verification.

## Changes
- **Validation**: Rejects non-object bodies, arrays, and null values with HTTP 400.
- **Email requirement**: Enforces email string requirement and validates email address format.
- **Normalization**: Trims and lowercases emails; trims optional names.
- **Security**: Generates user IDs server-side using `crypto.randomUUID()` and ignores client-supplied `id` or other custom fields.
- **Regression Tests**: Adds 7 passing unit tests in `apps/api/src/routes/users.test.ts` verifying all validation/normalization criteria.

Closes #2207