### PR TITLE
feat: add input validation to POST /users route

### DIFF
--- a/apps/api/src/index.ts
+++ b/apps/api/src/index.ts
@@ -1,4 +1,4 @@
-import express from "express";
+import express, { type Request, type Response, type NextFunction } from "express";
 
 import usersRouter from "./routes/users";
 
@@ -12,6 +12,18 @@ app.get("/health", (_req, res) => {
 });
 
 app.use("/users", usersRouter);
+
+// Global error handler — returns JSON instead of HTML for body-parser errors
+app.use((err: any, _req: Request, res: Response, _next: NextFunction) => {
+  if (err.type === "entity.parse.failed") {
+    return res.status(400).json({ error: "Invalid JSON body", status: "error" });
+  }
+  if (err.type === "entity.too.large") {
+    return res.status(413).json({ error: "Request body too large", status: "error" });
+  }
+  console.error("Unhandled error:", err);
+  res.status(500).json({ error: "Internal server error", status: "error" });
+});
 
 app.listen(port, () => {
   console.log(`TaskFlow API listening on port ${port}`);

--- a/apps/api/src/routes/users.ts
+++ b/apps/api/src/routes/users.ts
@@ -14,6 +14,7 @@ const users: User[] = [];
 
 router.get("/", (_req: Request, res: Response) => {
   res.json({
+    status: "ok",
     data: [],
     message: "User listing is not implemented yet.",
   });
@@ -23,6 +24,7 @@ router.post("/", (req: Request, res: Response) => {
   // Reject non-object bodies
   if (!req.body || typeof req.body !== "object" || Array.isArray(req.body)) {
     res.status(400).json({
+      status: "error",
       error: "Invalid request body",
       details: ["Request body must be a JSON object"],
     });
@@ -36,23 +38,33 @@ router.post("/", (req: Request, res: Response) => {
   if (!email || typeof email !== "string") {
     errors.push("Email is required and must be a string");
   } else {
-    const emailRegex = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
-    if (!emailRegex.test(email.trim())) {
-      errors.push("Email must be a valid email address");
+    const trimmedEmail = email.trim();
+    if (trimmedEmail.length > 254) {
+      errors.push("Email must be 254 characters or fewer");
+    } else {
+      const emailRegex = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
+      if (!emailRegex.test(trimmedEmail)) {
+        errors.push("Email must be a valid email address");
+      }
     }
   }
 
   // Validate name if provided
-  if (name !== undefined && name !== null) {
+  if (name != null) {
     if (typeof name !== "string") {
       errors.push("Name must be a string if provided");
-    } else if (name.trim().length === 0) {
-      errors.push("Name must not be empty if provided");
+    } else {
+      const trimmedName = name.trim();
+      if (trimmedName.length === 0) {
+        errors.push("Name must not be empty if provided");
+      } else if (trimmedName.length > 100) {
+        errors.push("Name must be 100 characters or fewer");
+      }
     }
   }
 
   if (errors.length > 0) {
-    res.status(400).json({ error: "Validation failed", details: errors });
+    res.status(400).json({ status: "error", error: "Validation failed", details: errors });
     return;
   }
 
@@ -67,6 +79,7 @@ router.post("/", (req: Request, res: Response) => {
   users.push(newUser);
 
   res.status(201).json({
+    status: "ok",
     data: newUser,
     message: "User created successfully",
   });

--- a/apps/api/src/routes/users.ts
+++ b/apps/api/src/routes/users.ts
@@ -1,21 +1,74 @@
-import { Router } from "express";
+import { Router, Request, Response } from "express";
+import crypto from "crypto";
 
 const router = Router();
 
-router.get("/", (_req, res) => {
+interface User {
+  id: string;
+  email: string;
+  name: string;
+  createdAt: string;
+}
+
+const users: User[] = [];
+
+router.get("/", (_req: Request, res: Response) => {
   res.json({
     data: [],
-    message: "User listing is not implemented yet."
+    message: "User listing is not implemented yet.",
   });
 });
 
-router.post("/", (req, res) => {
+router.post("/", (req: Request, res: Response) => {
+  // Reject non-object bodies
+  if (!req.body || typeof req.body !== "object" || Array.isArray(req.body)) {
+    res.status(400).json({
+      error: "Invalid request body",
+      details: ["Request body must be a JSON object"],
+    });
+    return;
+  }
+
+  const { email, name } = req.body;
+  const errors: string[] = [];
+
+  // Validate email
+  if (!email || typeof email !== "string") {
+    errors.push("Email is required and must be a string");
+  } else {
+    const emailRegex = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
+    if (!emailRegex.test(email.trim())) {
+      errors.push("Email must be a valid email address");
+    }
+  }
+
+  // Validate name if provided
+  if (name !== undefined && name !== null) {
+    if (typeof name !== "string") {
+      errors.push("Name must be a string if provided");
+    } else if (name.trim().length === 0) {
+      errors.push("Name must not be empty if provided");
+    }
+  }
+
+  if (errors.length > 0) {
+    res.status(400).json({ error: "Validation failed", details: errors });
+    return;
+  }
+
+  // Generate server-side ID — ignore client-provided id
+  const newUser: User = {
+    id: crypto.randomUUID(),
+    email: email.trim().toLowerCase(),
+    name: name ? name.trim() : email.split("@")[0],
+    createdAt: new Date().toISOString(),
+  };
+
+  users.push(newUser);
+
   res.status(201).json({
-    data: {
-      id: "stub-user-id",
-      ...req.body
-    },
-    message: "User creation is not implemented yet."
+    data: newUser,
+    message: "User created successfully",
   });
 });
 


### PR DESCRIPTION
## Summary

Add lightweight input validation for the POST /users endpoint so invalid request shapes return a clear error response.

## Validation rules
- Reject non-object JSON bodies
- Require a valid email format
- Validate name is a non-empty string if provided
- Generate server-side UUID (ignore any client-provided id)
- Normalize email to lowercase and trim whitespace

## Error format
Returns `{ error: "Validation failed", details: ["..."] }` with specific error messages.

Closes #6