### PR TITLE
feat: improve type annotations for Button component

### DIFF
--- a/packages/ui/src/index.ts
+++ b/packages/ui/src/index.ts
@@ -3,10 +3,17 @@ export type ButtonProps = {
   disabled?: boolean;
 };
 
-export function Button({ label, disabled = false }: ButtonProps) {
+/** The shape returned by {@link Button}. */
+export type ButtonReturn = {
+  readonly type: "button";
+  readonly label: string;
+  readonly disabled: boolean;
+};
+
+export function Button({ label, disabled = false }: ButtonProps): ButtonReturn {
   return {
     type: "button",
     label,
-    disabled
-  };
+    disabled,
+  } as const;
 }


### PR DESCRIPTION
## Summary

Improve type annotations for the shared Button stub without changing its public shape.

## Changes

- Added `ButtonReturn` type with `readonly` properties and literal `type: "button"`
- Added explicit return type `: ButtonReturn` to the `Button` function
- Used `as const` assertion for proper literal type inference
- Added JSDoc documentation linking the return type to Button

### Before
```ts
export function Button({ label, disabled = false }: ButtonProps) {
  return { type: "button", label, disabled };
}
```

### After
```ts
export function Button({ label, disabled = false }: ButtonProps): ButtonReturn {
  return { type: "button", label, disabled } as const;
}
```

✅ TypeScript compiles without errors

Closes #3