### PR TITLE
test: add unit tests for Button component

### DIFF
--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -9,6 +9,7 @@
     "lint": "echo \"No UI lint configured yet\""
   },
   "devDependencies": {
-    "typescript": "^5.4.5"
+    "typescript": "^5.4.5",
+    "vitest": "^4.1.10"
   }
 }

--- a/packages/ui/src/__tests__/button.test.ts
+++ b/packages/ui/src/__tests__/button.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from "vitest";
-import { Button, ButtonProps } from "../index";
+import { Button } from "../index";
 
 describe("Button", () => {
   it("returns an object with type 'button'", () => {

--- a/packages/ui/src/__tests__/button.test.ts
+++ b/packages/ui/src/__tests__/button.test.ts
@@ -1,0 +1,45 @@
+import { describe, it, expect } from "vitest";
+import { Button, ButtonProps } from "../index";
+
+describe("Button", () => {
+  it("returns an object with type 'button'", () => {
+    const result = Button({ label: "Click me" });
+    expect(result).toBeDefined();
+    expect(result.type).toBe("button");
+  });
+
+  it("renders the provided label", () => {
+    const result = Button({ label: "Submit" });
+    expect(result.label).toBe("Submit");
+  });
+
+  it("defaults disabled to false", () => {
+    const result = Button({ label: "Click me" });
+    expect(result.disabled).toBe(false);
+  });
+
+  it("accepts an explicit disabled value", () => {
+    const result = Button({ label: "Click me", disabled: true });
+    expect(result.disabled).toBe(true);
+  });
+
+  it("preserves label when disabled is true", () => {
+    const result = Button({ label: "Save", disabled: true });
+    expect(result.label).toBe("Save");
+    expect(result.disabled).toBe(true);
+  });
+
+  it("works with empty label string", () => {
+    const result = Button({ label: "" });
+    expect(result.label).toBe("");
+    expect(result.disabled).toBe(false);
+  });
+
+  it("works with long label strings", () => {
+    const longLabel = "A".repeat(1000);
+    const result = Button({ label: longLabel });
+    expect(result.label).toBe(longLabel);
+    expect(result.label.length).toBe(1000);
+  });
+
+});


### PR DESCRIPTION
## Summary

Add unit tests for the shared Button stub covering label and disabled values.

## Changes

- Added `src/__tests__/button.test.ts` with 7 vitest tests:
  - Returns type "button"
  - Renders provided label
  - Defaults disabled to false
  - Accepts explicit disabled value
  - Preserves label when disabled
  - Works with empty label string
  - Works with long label strings (1000 chars)

## Test Results

```bash
npx vitest run  # 7/7 pass
```

Closes #13