### PR TITLE
Improve Button prop and return types

### DIFF
--- a/packages/ui/src/index.ts
+++ b/packages/ui/src/index.ts
@@ -3,10 +3,17 @@ export type ButtonProps = {
   disabled?: boolean;
 };
 
-export function Button({ label, disabled = false }: ButtonProps) {
+/** Runtime model returned by the Button stub (public shape unchanged). */
+export type ButtonModel = {
+  type: "button";
+  label: string;
+  disabled: boolean;
+};
+
+export function Button({ label, disabled = false }: ButtonProps): ButtonModel {
   return {
     type: "button",
     label,
-    disabled
+    disabled,
   };
 }


### PR DESCRIPTION
Tighten types on the shared UI Button stub without changing its runtime shape. Adds ButtonModel and an explicit return type. Closes #3.