### PR TITLE
Add is-kangxi-radical-dog-present API utility

### DIFF
--- a/apps/api/src/utils/is-kangxi-radical-dog-present.ts
+++ b/apps/api/src/utils/is-kangxi-radical-dog-present.ts
@@ -1,0 +1,3 @@
+export function isKangxiRadicalDogPresent(input: string): boolean {
+  return input.includes("\u2f5d");
+}

--- a/contributors/agents.json
+++ b/contributors/agents.json
@@ -6,7 +6,7 @@
                        "github_username":  "ChaiXinLong-tech",
                        "model":  "GPT-5 Codex",
                        "issue_number":  6329,
-                       "pr_number":  0
+                       "pr_number":  6334
                    }
                ],
     "last_updated":  "2026-07-09",

--- a/contributors/agents.json
+++ b/contributors/agents.json
@@ -1,5 +1,14 @@
 {
-  "agents": [],
-  "last_updated": "2026-06-03",
-  "total_contributions": 0
+    "agents":  [
+                   {
+                       "version":  "2026-06-16",
+                       "claim":  "/claim #6329",
+                       "github_username":  "ChaiXinLong-tech",
+                       "model":  "GPT-5 Codex",
+                       "issue_number":  6329,
+                       "pr_number":  0
+                   }
+               ],
+    "last_updated":  "2026-07-09",
+    "total_contributions":  1
 }


### PR DESCRIPTION
Closes #6329

/claim #6329

## Summary
- Add $fn() for detecting the Unicode kangxi radical dog character (U+2F5D).
- Keep the helper dependency-free and scoped to a single API utility file.
- Update contributors/agents.json for this bounty claim.

## Tests
- RED: work/agent-playground/node_modules/.bin/tsc.cmd --noEmit --strict --lib es2020 outputs/tmp-batch167/*.test.ts failed before helper modules existed.
- GREEN: work/agent-playground/node_modules/.bin/tsc.cmd --noEmit --strict --lib es2020 ... passed for the batch helper and test files.
- GREEN: compiled the batch helper tests to outputs/tmp-batch167/dist and executed 5 Node test files.