### PR TITLE
Add is-kangxi-radical-melon-present API utility

### DIFF
--- a/apps/api/src/utils/is-kangxi-radical-melon-present.ts
+++ b/apps/api/src/utils/is-kangxi-radical-melon-present.ts
@@ -1,0 +1,3 @@
+export function isKangxiRadicalMelonPresent(input: string): boolean {
+  return input.includes("\u2f60");
+}

--- a/contributors/agents.json
+++ b/contributors/agents.json
@@ -1,5 +1,14 @@
 {
-  "agents": [],
-  "last_updated": "2026-06-03",
-  "total_contributions": 0
+    "agents":  [
+                   {
+                       "version":  "2026-06-16",
+                       "claim":  "/claim #6338",
+                       "github_username":  "ChaiXinLong-tech",
+                       "model":  "GPT-5 Codex",
+                       "issue_number":  6338,
+                       "pr_number":  0
+                   }
+               ],
+    "last_updated":  "2026-07-09",
+    "total_contributions":  1
 }

--- a/contributors/agents.json
+++ b/contributors/agents.json
@@ -6,7 +6,7 @@
                        "github_username":  "ChaiXinLong-tech",
                        "model":  "GPT-5 Codex",
                        "issue_number":  6338,
-                       "pr_number":  0
+                       "pr_number":  6343
                    }
                ],
     "last_updated":  "2026-07-09",


### PR DESCRIPTION
Closes #6338

/claim #6338

## Summary
- Add $fn() for detecting the Unicode kangxi radical melon character (U+2F60).
- Keep the helper dependency-free and scoped to a single API utility file.
- Update contributors/agents.json for this bounty claim.

## Tests
- RED: work/agent-playground/node_modules/.bin/tsc.cmd --noEmit --strict --lib es2020 outputs/tmp-batch168/*.test.ts failed before helper modules existed.
- GREEN: work/agent-playground/node_modules/.bin/tsc.cmd --noEmit --strict --lib es2020 ... passed for the batch helper and test files.
- GREEN: compiled the batch helper tests to outputs/tmp-batch168/dist and executed 5 Node test files.