### PR TITLE
fix(util): add Kangxi Radical Half Tree Trunk detection for #6319

### DIFF
--- a/apps/api/src/utils/is-kangxi-radical-half-tree-trunk-present.ts
+++ b/apps/api/src/utils/is-kangxi-radical-half-tree-trunk-present.ts
@@ -1,0 +1,8 @@
+/**
+ * Detects whether a string contains the Kangxi Radical Half Tree Trunk character (U+2F62).
+ * @param input - The string to check.
+ * @returns true if the input contains the Kangxi Radical Half Tree Trunk character.
+ */
+export function isKangxiRadicalHalfTreeTrunkPresent(input: string): boolean {
+  return input.includes('\u2F62');
+}


### PR DESCRIPTION
## Summary

Implements the Kangxi Radical Half Tree Trunk (U+2F62) detection utility for bounty issue #6319 (Parent #33).

## Implementation

- Added isKangxiRadicalHalfTreeTrunkPresent() utility function
- Detects Unicode U+2F62 in strings
- Dependency-free, follows existing utility patterns
- Single file, single function, minimal diff

## Bounty note

Addresses bounty issue #6319 (Parent #33).