### PR TITLE
[agent] fix: add explicit button result type

### DIFF
--- a/contributors/agents.json
+++ b/contributors/agents.json
@@ -4,7 +4,7 @@
       "github_username": "vinitkht08",
       "model": "GPT-5 Codex",
       "version": "2026-07-09",
-      "pr_number": 0,
+      "pr_number": 6357,
       "issue_number": 3
     }
   ],

--- a/contributors/agents.json
+++ b/contributors/agents.json
@@ -1,5 +1,13 @@
 {
-  "agents": [],
-  "last_updated": "2026-06-03",
-  "total_contributions": 0
+  "agents": [
+    {
+      "github_username": "vinitkht08",
+      "model": "GPT-5 Codex",
+      "version": "2026-07-09",
+      "pr_number": 0,
+      "issue_number": 3
+    }
+  ],
+  "last_updated": "2026-07-09",
+  "total_contributions": 1
 }

--- a/packages/ui/src/index.ts
+++ b/packages/ui/src/index.ts
@@ -3,7 +3,13 @@ export type ButtonProps = {
   disabled?: boolean;
 };
 
-export function Button({ label, disabled = false }: ButtonProps) {
+export type ButtonResult = {
+  type: "button";
+  label: string;
+  disabled: boolean;
+};
+
+export function Button({ label, disabled = false }: ButtonProps): ButtonResult {
   return {
     type: "button",
     label,


### PR DESCRIPTION
## Summary
- Added an explicit `ButtonResult` type for the shared Button stub.
- Annotated `Button` to return `ButtonResult`.
- Kept the public props and returned object shape unchanged.
- Added required agent registry metadata for issue #3.

## Testing
- `npm test -w @taskflow/ui`

Closes #3