### PR TITLE
fix(ui): improve Button type annotations

### DIFF
--- a/packages/ui/src/index.ts
+++ b/packages/ui/src/index.ts
@@ -1,12 +1,23 @@
+/** Shared UI Button stub props — keep this surface stable for callers. */
 export type ButtonProps = {
   label: string;
   disabled?: boolean;
 };
 
-export function Button({ label, disabled = false }: ButtonProps) {
+/** Runtime object returned by Button; matches the public stub shape. */
+export type ButtonElement = {
+  readonly type: "button";
+  readonly label: string;
+  readonly disabled: boolean;
+};
+
+export function Button({
+  label,
+  disabled = false,
+}: ButtonProps): ButtonElement {
   return {
     type: "button",
     label,
-    disabled
+    disabled,
   };
 }


### PR DESCRIPTION
## Summary
Improve TypeScript annotations for the shared Button stub without changing its public runtime shape.

## Changes
- Export `ButtonElement` for the returned `{ type, label, disabled }` object
- Annotate `Button` return type as `ButtonElement`
- Use `readonly` fields for the return shape
- Keep default `disabled = false` and `type: \"button\"` behavior

## Test plan
- [x] Review `packages/ui/src/index.ts` for shape stability
- [x] Focused single-file change

Closes #3

/bounty 