### PR TITLE
fix(api): add JSON request body size limit

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,3 +83,13 @@ with models for:
 
 Each app/package expects its own .env values for DB, auth, 
 and integrations.
+
+### API (`apps/api`)
+
+| Variable | Default | Description |
+| --- | --- | --- |
+| `PORT` | `4000` | HTTP port for the Express server |
+| `JSON_BODY_LIMIT` | `100kb` | Max JSON request body size for `express.json()` |
+
+The API uses a conservative `100kb` JSON body limit by default to reduce risk from oversized payloads. Set `JSON_BODY_LIMIT` only when a larger (or smaller) limit is required.
+

--- a/apps/api/src/index.ts
+++ b/apps/api/src/index.ts
@@ -5,7 +5,10 @@ import usersRouter from "./routes/users";
 const app = express();
 const port = process.env.PORT || 4000;
 
-app.use(express.json());
+// Conservative default protects against oversized JSON payload DoS.
+// Override with JSON_BODY_LIMIT (e.g. "50kb", "1mb") when needed.
+const JSON_BODY_LIMIT = process.env.JSON_BODY_LIMIT ?? "100kb";
+app.use(express.json({ limit: JSON_BODY_LIMIT }));
 
 app.get("/health", (_req, res) => {
   res.json({ status: "ok", service: "taskflow-api" });


### PR DESCRIPTION
## Summary
Add a configurable JSON body size limit for the Express API.

## Changes
- `express.json({ limit })` with default `100kb`
- Document `JSON_BODY_LIMIT` / `PORT` in README

Closes #9

/bounty $50