### PR TITLE
fix(util): add Kangxi Radical Field detection for #6342

### DIFF
--- a/apps/api/src/utils/is-kangxi-radical-field-present.ts
+++ b/apps/api/src/utils/is-kangxi-radical-field-present.ts
@@ -1,4 +1,4 @@
-﻿/**
+/**
  * Detects whether a string contains the Kangxi Radical Field character (U+2F55).
  * @param input - The string to check.
  * @returns true if the input contains the Kangxi Radical Field character.

--- a/apps/api/src/utils/is-kangxi-radical-field-present.ts
+++ b/apps/api/src/utils/is-kangxi-radical-field-present.ts
@@ -1,0 +1,8 @@
+﻿/**
+ * Detects whether a string contains the Kangxi Radical Field character (U+2F55).
+ * @param input - The string to check.
+ * @returns true if the input contains the Kangxi Radical Field character.
+ */
+export function isKangxiRadicalFieldPresent(input: string): boolean {
+  return input.includes('\u2F55');
+}


### PR DESCRIPTION
## Summary

Implements the Kangxi Radical Field (U+2F55) detection utility for bounty issue #6342 (Parent #33).

## Implementation

- Added isKangxiRadicalFieldPresent() utility function
- Detects Unicode U+2F55 (Kangxi Radical Field) in strings
- Dependency-free, follows existing utility patterns
- Single file, single function, minimal diff

## Tests

Verified locally with tsx:
- isKangxiRadicalFieldPresent with Kangxi Radical Field character -> true
- isKangxiRadicalFieldPresent with 'hello' -> false
- isKangxiRadicalFieldPresent with mixed input -> true

## Bounty Note

Addresses bounty issue #6342 (Parent #33).