### PR TITLE
fix(util): add Kangxi Radical Sweet detection for #6340

### DIFF
--- a/apps/api/src/utils/is-kangxi-radical-sweet-present.ts
+++ b/apps/api/src/utils/is-kangxi-radical-sweet-present.ts
@@ -1,0 +1,8 @@
+﻿/**
+ * Detects whether a string contains the Kangxi Radical Sweet character (U+2F64).
+ * @param input - The string to check.
+ * @returns true if the input contains the Kangxi Radical Sweet character.
+ */
+export function isKangxiRadicalSweetPresent(input: string): boolean {
+  return input.includes('\u2F64');
+}

--- a/apps/api/src/utils/is-kangxi-radical-sweet-present.ts
+++ b/apps/api/src/utils/is-kangxi-radical-sweet-present.ts
@@ -1,4 +1,4 @@
-﻿/**
+/**
  * Detects whether a string contains the Kangxi Radical Sweet character (U+2F64).
  * @param input - The string to check.
  * @returns true if the input contains the Kangxi Radical Sweet character.


### PR DESCRIPTION
## Summary

Implements the Kangxi Radical Sweet (U+2F64) detection utility for bounty issue #6340 (Parent #33).

## Implementation

- Added isKangxiRadicalSweetPresent() utility function
- Detects Unicode U+2F64 in strings
- Dependency-free, follows existing utility patterns
- Single file, single function, minimal diff

## Bounty Note

Addresses bounty issue #6340 (Parent #33).