### PR TITLE
fix(util): add Kangxi Radical Tile detection for #6339

### DIFF
--- a/apps/api/src/utils/is-kangxi-radical-tile-present.ts
+++ b/apps/api/src/utils/is-kangxi-radical-tile-present.ts
@@ -1,0 +1,8 @@
+/**
+ * Detects whether a string contains the Kangxi Radical Tile character (U+2F57).
+ * @param input - The string to check.
+ * @returns true if the input contains the Kangxi Radical Tile character.
+ */
+export function isKangxiRadicalTilePresent(input: string): boolean {
+  return input.includes('\u2F57');
+}


### PR DESCRIPTION
## Summary

Implements the Kangxi Radical Tile (U+2F57) detection utility for bounty issue #6339 (Parent #33).

## Implementation

- Added isKangxiRadicalTilePresent() utility function
- Detects Unicode U+2F57 in strings
- Dependency-free, follows existing utility patterns
- Single file, single function, minimal diff

## Bounty Note

Addresses bounty issue #6339 (Parent #33).