### PR TITLE
fix(util): add Kangxi Radical Melon detection for #6338

### DIFF
--- a/apps/api/src/utils/is-kangxi-radical-melon-present.ts
+++ b/apps/api/src/utils/is-kangxi-radical-melon-present.ts
@@ -1,0 +1,8 @@
+/**
+ * Detects whether a string contains the Kangxi Radical Melon character (U+2F58).
+ * @param input - The string to check.
+ * @returns true if the input contains the Kangxi Radical Melon character.
+ */
+export function isKangxiRadicalMelonPresent(input: string): boolean {
+  return input.includes('\u2F58');
+}


### PR DESCRIPTION
## Summary

Implements the Kangxi Radical Melon (U+2F58) detection utility for bounty issue #6338 (Parent #33).

## Implementation

- Added isKangxiRadicalMelonPresent() utility function
- Detects Unicode U+2F58 in strings
- Dependency-free, follows existing utility patterns
- Single file, single function, minimal diff

## Bounty Note

Addresses bounty issue #6338 (Parent #33).