### PR TITLE
Add kangxi radical sweet API utility

### DIFF
--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -7,7 +7,7 @@
   "main": "src/index.ts",
   "scripts": {
     "dev": "tsx src/index.ts",
-    "test": "echo \"No API tests configured yet\"",
+    "test": "tsx src/utils/batch-smoke-test.ts",
     "lint": "echo \"No API lint configured yet\""
   },
   "dependencies": {

--- a/apps/api/src/utils/batch-smoke-test.ts
+++ b/apps/api/src/utils/batch-smoke-test.ts
@@ -1,0 +1,11 @@
+import assert from "node:assert/strict";
+
+import { $fn as isKangxiRadicalSweetPresent } from "./is-kangxi-radical-sweet-present";
+
+assert.equal(isKangxiRadicalSweetPresent(""), false);
+assert.equal(isKangxiRadicalSweetPresent("plain ascii text"), false);
+assert.equal(isKangxiRadicalSweetPresent("contains \u2f62 radical"), true);
+assert.equal(isKangxiRadicalSweetPresent("\u2f62"), true);
+assert.equal(isKangxiRadicalSweetPresent("nearby radical \u2f61"), false);
+
+console.log("API utils smoke tests passed");

--- a/apps/api/src/utils/is-kangxi-radical-sweet-present.ts
+++ b/apps/api/src/utils/is-kangxi-radical-sweet-present.ts
@@ -1,0 +1,5 @@
+const KANGXI_RADICAL_SWEET = "\u2f62";
+
+export function $fn(input: string): boolean {
+  return input.includes(KANGXI_RADICAL_SWEET);
+}


### PR DESCRIPTION
## Summary
- Added `apps/api/src/utils/is-kangxi-radical-sweet-present.ts` with dependency-free `$fn(input: string): boolean` detection for U+2F62.
- Added API utils smoke coverage for empty, negative, positive, exact-character, and nearby-character cases.
- Wired the API workspace test script to run the smoke test.

Fixes #6340
/claim #6340

## Verification
- `npm.cmd test --workspace @taskflow/api`

Result: `API utils smoke tests passed`

## Payout/contact
- PayPal: https://paypal.me/nhatminh122004
- Email: nhatminh122004@gmail.com