### PR TITLE
Add kangxi radical tile API utility

### DIFF
--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -7,7 +7,7 @@
   "main": "src/index.ts",
   "scripts": {
     "dev": "tsx src/index.ts",
-    "test": "echo \"No API tests configured yet\"",
+    "test": "tsx src/utils/batch-smoke-test.ts",
     "lint": "echo \"No API lint configured yet\""
   },
   "dependencies": {

--- a/apps/api/src/utils/batch-smoke-test.ts
+++ b/apps/api/src/utils/batch-smoke-test.ts
@@ -1,0 +1,11 @@
+import assert from "node:assert/strict";
+
+import { $fn as isKangxiRadicalTilePresent } from "./is-kangxi-radical-tile-present";
+
+assert.equal(isKangxiRadicalTilePresent(""), false);
+assert.equal(isKangxiRadicalTilePresent("plain ascii text"), false);
+assert.equal(isKangxiRadicalTilePresent("contains \u2f61 radical"), true);
+assert.equal(isKangxiRadicalTilePresent("\u2f61"), true);
+assert.equal(isKangxiRadicalTilePresent("nearby radical \u2f60"), false);
+
+console.log("API utils smoke tests passed");

--- a/apps/api/src/utils/is-kangxi-radical-tile-present.ts
+++ b/apps/api/src/utils/is-kangxi-radical-tile-present.ts
@@ -1,0 +1,5 @@
+const KANGXI_RADICAL_TILE = "\u2f61";
+
+export function $fn(input: string): boolean {
+  return input.includes(KANGXI_RADICAL_TILE);
+}


### PR DESCRIPTION
## Summary
- Added `apps/api/src/utils/is-kangxi-radical-tile-present.ts` with dependency-free `$fn(input: string): boolean` detection for U+2F61.
- Added API utils smoke coverage for empty, negative, positive, exact-character, and nearby-character cases.
- Wired the API workspace test script to run the smoke test.

Fixes #6339
/claim #6339

## Verification
- `npm.cmd test --workspace @taskflow/api`

Result: `API utils smoke tests passed`

## Payout/contact
- PayPal: https://paypal.me/nhatminh122004
- Email: nhatminh122004@gmail.com