### PR TITLE
Add user body validation and tests

### DIFF
--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -7,7 +7,7 @@
   "main": "src/index.ts",
   "scripts": {
     "dev": "tsx src/index.ts",
-    "test": "echo \"No API tests configured yet\"",
+    "test": "node --test --import tsx test/users.test.ts",
     "lint": "echo \"No API lint configured yet\""
   },
   "dependencies": {

--- a/apps/api/src/app.ts
+++ b/apps/api/src/app.ts
@@ -1,0 +1,15 @@
+import express from "express";
+
+import usersRouter from "./routes/users";
+
+const app = express();
+
+app.use(express.json());
+
+app.get("/health", (_req, res) => {
+  res.json({ status: "ok", service: "taskflow-api" });
+});
+
+app.use("/users", usersRouter);
+
+export default app;

--- a/apps/api/src/index.ts
+++ b/apps/api/src/index.ts
@@ -1,17 +1,6 @@
-import express from "express";
+import app from "./app";
 
-import usersRouter from "./routes/users";
-
-const app = express();
 const port = process.env.PORT || 4000;
-
-app.use(express.json());
-
-app.get("/health", (_req, res) => {
-  res.json({ status: "ok", service: "taskflow-api" });
-});
-
-app.use("/users", usersRouter);
 
 app.listen(port, () => {
   console.log(`TaskFlow API listening on port ${port}`);

--- a/apps/api/src/routes/users.ts
+++ b/apps/api/src/routes/users.ts
@@ -2,6 +2,10 @@ import { Router } from "express";
 
 const router = Router();
 
+function isPlainObject(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
 router.get("/", (_req, res) => {
   res.json({
     data: [],
@@ -10,6 +14,12 @@ router.get("/", (_req, res) => {
 });
 
 router.post("/", (req, res) => {
+  if (!isPlainObject(req.body)) {
+    return res.status(400).json({
+      error: "Request body must be a JSON object."
+    });
+  }
+
   res.status(201).json({
     data: {
       id: "stub-user-id",

--- a/apps/api/test/users.test.ts
+++ b/apps/api/test/users.test.ts
@@ -66,3 +66,20 @@ test("POST /users returns the stub created user payload", async () => {
     message: "User creation is not implemented yet."
   });
 });
+
+test("POST /users rejects non-object payloads", async () => {
+  const response = await fetch(`${baseUrl}/users`, {
+    method: "POST",
+    headers: {
+      "content-type": "application/json"
+    },
+    body: JSON.stringify(["invalid"])
+  });
+
+  const payload = await response.json();
+
+  assert.equal(response.status, 400);
+  assert.deepEqual(payload, {
+    error: "Request body must be a JSON object."
+  });
+});

--- a/apps/api/test/users.test.ts
+++ b/apps/api/test/users.test.ts
@@ -1,0 +1,68 @@
+import assert from "node:assert/strict";
+import { before, after, test } from "node:test";
+import { createServer } from "node:http";
+
+import app from "../src/app";
+
+let server: ReturnType<typeof createServer>;
+let baseUrl: string;
+
+before(async () => {
+  server = createServer(app);
+
+  await new Promise<void>((resolve) => {
+    server.listen(0, "127.0.0.1", () => {
+      const address = server.address();
+
+      if (address && typeof address === "object") {
+        baseUrl = `http://127.0.0.1:${address.port}`;
+      }
+
+      resolve();
+    });
+  });
+});
+
+after(async () => {
+  await new Promise<void>((resolve) => {
+    server.close(() => resolve());
+  });
+});
+
+test("GET /users returns the stub list payload", async () => {
+  const response = await fetch(`${baseUrl}/users`);
+  const payload = await response.json();
+
+  assert.equal(response.status, 200);
+  assert.deepEqual(payload, {
+    data: [],
+    message: "User listing is not implemented yet."
+  });
+});
+
+test("POST /users returns the stub created user payload", async () => {
+  const body = {
+    name: "Lourdes",
+    role: "creator"
+  };
+
+  const response = await fetch(`${baseUrl}/users`, {
+    method: "POST",
+    headers: {
+      "content-type": "application/json"
+    },
+    body: JSON.stringify(body)
+  });
+
+  const payload = await response.json();
+
+  assert.equal(response.status, 201);
+  assert.deepEqual(payload, {
+    data: {
+      id: "stub-user-id",
+      name: "Lourdes",
+      role: "creator"
+    },
+    message: "User creation is not implemented yet."
+  });
+});

--- a/contributors/agents.json
+++ b/contributors/agents.json
@@ -1,5 +1,13 @@
 {
-  "agents": [],
-  "last_updated": "2026-06-03",
-  "total_contributions": 0
+  "agents": [
+    {
+      "github_username": "voladoradepapantla-netizen",
+      "model": "gpt-5",
+      "version": "2026-07-06",
+      "pr_number": null,
+      "issue_number": 3
+    }
+  ],
+  "last_updated": "2026-07-06",
+  "total_contributions": 1
 }

--- a/contributors/agents.json
+++ b/contributors/agents.json
@@ -4,7 +4,7 @@
       "github_username": "voladoradepapantla-netizen",
       "model": "gpt-5",
       "version": "2026-07-06",
-      "pr_number": null,
+      "pr_number": 5811,
       "issue_number": 3
     }
   ],

--- a/contributors/agents.json
+++ b/contributors/agents.json
@@ -6,8 +6,15 @@
       "version": "2026-07-06",
       "pr_number": 5811,
       "issue_number": 3
+    },
+    {
+      "github_username": "voladoradepapantla-netizen",
+      "model": "gpt-5",
+      "version": "2026-07-09",
+      "pr_number": 0,
+      "issue_number": 12
     }
   ],
-  "last_updated": "2026-07-06",
-  "total_contributions": 1
+  "last_updated": "2026-07-09",
+  "total_contributions": 2
 }

--- a/contributors/agents.json
+++ b/contributors/agents.json
@@ -11,7 +11,7 @@
       "github_username": "voladoradepapantla-netizen",
       "model": "gpt-5",
       "version": "2026-07-09",
-      "pr_number": 0,
+      "pr_number": 6390,
       "issue_number": 12
     }
   ],

--- a/packages/ui/src/index.ts
+++ b/packages/ui/src/index.ts
@@ -1,9 +1,15 @@
-export type ButtonProps = {
+type ButtonOutput = {
+  type: "button";
   label: string;
-  disabled?: boolean;
+  disabled: boolean;
 };
 
-export function Button({ label, disabled = false }: ButtonProps) {
+export type ButtonProps = {
+  readonly label: string;
+  readonly disabled?: boolean;
+};
+
+export function Button({ label, disabled = false }: ButtonProps): ButtonOutput {
   return {
     type: "button",
     label,


### PR DESCRIPTION
This PR keeps the user route stub shape intact while adding a small input-shape guard to `POST /users`.

What changed:
- Reject non-object JSON payloads with a clear 400 response.
- Add a test covering the invalid payload case.

Why:
- The stub previously spread `req.body` directly into the created payload, which accepted arrays and other non-object shapes.
- The new guard keeps the happy path unchanged while making the stub behavior clearer for malformed requests.

Validation:
- `npm test --workspace @taskflow/api`

Closes #6
Closes #12