### PR TITLE
Add isKangxiRadicalBoltOfClothPresent utility for U+2F66 detection

### DIFF
--- a/apps/api/src/utils/is-kangxi-radical-bolt-of-cloth-present.test.ts
+++ b/apps/api/src/utils/is-kangxi-radical-bolt-of-cloth-present.test.ts
@@ -1,0 +1,20 @@
+import { strict as assert } from "node:assert";
+import { test } from "node:test";
+
+import { isKangxiRadicalBoltOfClothPresent } from "./is-kangxi-radical-bolt-of-cloth-present";
+
+test("returns true when kangxi radical bolt of cloth char is present", () => {
+  assert.equal(isKangxiRadicalBoltOfClothPresent("text ⽦"), true);
+});
+
+test("returns false when kangxi radical bolt of cloth char is absent", () => {
+  assert.equal(isKangxiRadicalBoltOfClothPresent("normal text"), false);
+});
+
+test("returns false for empty string", () => {
+  assert.equal(isKangxiRadicalBoltOfClothPresent(""), false);
+});
+
+test("returns true for string that is just the char", () => {
+  assert.equal(isKangxiRadicalBoltOfClothPresent("⽦"), true);
+});

--- a/apps/api/src/utils/is-kangxi-radical-bolt-of-cloth-present.ts
+++ b/apps/api/src/utils/is-kangxi-radical-bolt-of-cloth-present.ts
@@ -1,0 +1,3 @@
+export function isKangxiRadicalBoltOfClothPresent(input: string): boolean {
+  return input.includes("\u2F66");
+}


### PR DESCRIPTION
Adds a dependency-free TypeScript helper that checks whether a string contains the Unicode kangxi radical bolt of cloth character (U+2F66).

The utility is exported from `apps/api/src/utils/is-kangxi-radical-bolt-of-cloth-present.ts` and includes basic smoke tests.

Closes #6376