### PR TITLE
Add isKangxiRadicalSicknessPresent utility for U+2F67 detection

### DIFF
--- a/apps/api/src/utils/is-kangxi-radical-sickness-present.test.ts
+++ b/apps/api/src/utils/is-kangxi-radical-sickness-present.test.ts
@@ -1,0 +1,20 @@
+import { strict as assert } from "node:assert";
+import { test } from "node:test";
+
+import { isKangxiRadicalSicknessPresent } from "./is-kangxi-radical-sickness-present";
+
+test("returns true when kangxi radical sickness char is present", () => {
+  assert.equal(isKangxiRadicalSicknessPresent("text ⽧"), true);
+});
+
+test("returns false when kangxi radical sickness char is absent", () => {
+  assert.equal(isKangxiRadicalSicknessPresent("normal text"), false);
+});
+
+test("returns false for empty string", () => {
+  assert.equal(isKangxiRadicalSicknessPresent(""), false);
+});
+
+test("returns true for string that is just the char", () => {
+  assert.equal(isKangxiRadicalSicknessPresent("⽧"), true);
+});

--- a/apps/api/src/utils/is-kangxi-radical-sickness-present.ts
+++ b/apps/api/src/utils/is-kangxi-radical-sickness-present.ts
@@ -1,0 +1,3 @@
+export function isKangxiRadicalSicknessPresent(input: string): boolean {
+  return input.includes("\u2F67");
+}


### PR DESCRIPTION
Adds a dependency-free TypeScript helper that checks whether a string contains the Unicode kangxi radical sickness character (U+2F67).

The utility is exported from `apps/api/src/utils/is-kangxi-radical-sickness-present.ts` and includes basic smoke tests.

Closes #6377