### PR TITLE
Add isKangxiRadicalDottedTentPresent utility for U+2F68 detection

### DIFF
--- a/apps/api/src/utils/is-kangxi-radical-dotted-tent-present.test.ts
+++ b/apps/api/src/utils/is-kangxi-radical-dotted-tent-present.test.ts
@@ -1,0 +1,20 @@
+import { strict as assert } from "node:assert";
+import { test } from "node:test";
+
+import { isKangxiRadicalDottedTentPresent } from "./is-kangxi-radical-dotted-tent-present";
+
+test("returns true when kangxi radical dotted tent char is present", () => {
+  assert.equal(isKangxiRadicalDottedTentPresent("text ⽨"), true);
+});
+
+test("returns false when kangxi radical dotted tent char is absent", () => {
+  assert.equal(isKangxiRadicalDottedTentPresent("normal text"), false);
+});
+
+test("returns false for empty string", () => {
+  assert.equal(isKangxiRadicalDottedTentPresent(""), false);
+});
+
+test("returns true for string that is just the char", () => {
+  assert.equal(isKangxiRadicalDottedTentPresent("⽨"), true);
+});

--- a/apps/api/src/utils/is-kangxi-radical-dotted-tent-present.ts
+++ b/apps/api/src/utils/is-kangxi-radical-dotted-tent-present.ts
@@ -1,0 +1,3 @@
+export function isKangxiRadicalDottedTentPresent(input: string): boolean {
+  return input.includes("\u2F68");
+}


### PR DESCRIPTION
Adds a dependency-free TypeScript helper that checks whether a string contains the Unicode kangxi radical dotted tent character (U+2F68).

The utility is exported from `apps/api/src/utils/is-kangxi-radical-dotted-tent-present.ts` and includes basic smoke tests.

Closes #6378