### PR TITLE
Add isKangxiRadicalWhitePresent utility for U+2F69 detection

### DIFF
--- a/apps/api/src/utils/is-kangxi-radical-white-present.test.ts
+++ b/apps/api/src/utils/is-kangxi-radical-white-present.test.ts
@@ -1,0 +1,20 @@
+import { strict as assert } from "node:assert";
+import { test } from "node:test";
+
+import { isKangxiRadicalWhitePresent } from "./is-kangxi-radical-white-present";
+
+test("returns true when kangxi radical white char is present", () => {
+  assert.equal(isKangxiRadicalWhitePresent("text ⽩"), true);
+});
+
+test("returns false when kangxi radical white char is absent", () => {
+  assert.equal(isKangxiRadicalWhitePresent("normal text"), false);
+});
+
+test("returns false for empty string", () => {
+  assert.equal(isKangxiRadicalWhitePresent(""), false);
+});
+
+test("returns true for string that is just the char", () => {
+  assert.equal(isKangxiRadicalWhitePresent("⽩"), true);
+});

--- a/apps/api/src/utils/is-kangxi-radical-white-present.ts
+++ b/apps/api/src/utils/is-kangxi-radical-white-present.ts
@@ -1,0 +1,3 @@
+export function isKangxiRadicalWhitePresent(input: string): boolean {
+  return input.includes("\u2F69");
+}


### PR DESCRIPTION
Adds a dependency-free TypeScript helper that checks whether a string contains the Unicode kangxi radical white character (U+2F69).

The utility is exported from `apps/api/src/utils/is-kangxi-radical-white-present.ts` and includes basic smoke tests.

Closes #6379