### PR TITLE
Add isKangxiRadicalSkinPresent utility for U+2F6A detection

### DIFF
--- a/apps/api/src/utils/is-kangxi-radical-skin-present.test.ts
+++ b/apps/api/src/utils/is-kangxi-radical-skin-present.test.ts
@@ -1,0 +1,20 @@
+import { strict as assert } from "node:assert";
+import { test } from "node:test";
+
+import { isKangxiRadicalSkinPresent } from "./is-kangxi-radical-skin-present";
+
+test("returns true when kangxi radical skin char is present", () => {
+  assert.equal(isKangxiRadicalSkinPresent("text ⽪"), true);
+});
+
+test("returns false when kangxi radical skin char is absent", () => {
+  assert.equal(isKangxiRadicalSkinPresent("normal text"), false);
+});
+
+test("returns false for empty string", () => {
+  assert.equal(isKangxiRadicalSkinPresent(""), false);
+});
+
+test("returns true for string that is just the char", () => {
+  assert.equal(isKangxiRadicalSkinPresent("⽪"), true);
+});

--- a/apps/api/src/utils/is-kangxi-radical-skin-present.ts
+++ b/apps/api/src/utils/is-kangxi-radical-skin-present.ts
@@ -1,0 +1,3 @@
+export function isKangxiRadicalSkinPresent(input: string): boolean {
+  return input.includes("\u2F6A");
+}


### PR DESCRIPTION
Adds a dependency-free TypeScript helper that checks whether a string contains the Unicode kangxi radical skin character (U+2F6A).

The utility is exported from `apps/api/src/utils/is-kangxi-radical-skin-present.ts` and includes basic smoke tests.

Closes #6380