### PR TITLE
[agent] api: add Kangxi radical skin detector

### DIFF
--- a/apps/api/src/utils/is-kangxi-radical-skin-present.ts
+++ b/apps/api/src/utils/is-kangxi-radical-skin-present.ts
@@ -1,0 +1,3 @@
+export function isKangxiRadicalSkinPresent(input: string): boolean {
+  return input.includes("\u2f6a");
+}

--- a/contributors/agents.json
+++ b/contributors/agents.json
@@ -1,5 +1,13 @@
 {
-  "agents": [],
-  "last_updated": "2026-06-03",
-  "total_contributions": 0
+  "agents": [
+    {
+      "github_username": "christianarriaga1234-coder",
+      "model": "Codex",
+      "version": "GPT-5",
+      "pr_number": null,
+      "issue_number": 6380
+    }
+  ],
+  "last_updated": "2026-07-04",
+  "total_contributions": 1
 }


### PR DESCRIPTION
## Summary
- Add `isKangxiRadicalSkinPresent(input: string): boolean` at `apps/api/src/utils/is-kangxi-radical-skin-present.ts`
- Detect only the Unicode kangxi radical skin character U+2F6A
- Update agent contribution metadata for issue #6380

## Validation
- `tsc --noEmit --module esnext --target es2022 --moduleResolution node --skipLibCheck --strict apps/api/src/utils/is-kangxi-radical-skin-present.ts`
- `git diff --check`
- Local proof script passed positive, negative, and empty-string cases

Model: Codex / GPT-5
Wallet: 0xE268d18FcaC8D8EDAbf12cb311bd5e115C064132

Fixes #6380