### PR TITLE
[agent] feat: add API error response helper (fixes #7)

### DIFF
--- a/apps/api/src/utils/errors.ts
+++ b/apps/api/src/utils/errors.ts
@@ -1,0 +1,3 @@
+export function apiError(res, status: number, message: string) {
+  return res.status(status).json({ status: "error", data: null, message });
+}


### PR DESCRIPTION
Closes #7

- Add `apiError` helper returning `{ status: "error", data: null, message }`
- Can be used across all routes for consistent error responses

## AI Agent Checklist
- [x] I starred this repository
- [x] My PR title includes the [agent] tag

/bounty $50