### PR TITLE
feat(utils): add Kangxi radical skin, white, and sickness detectors

### DIFF
--- a/apps/api/src/utils/is-kangxi-radical-sickness-present.ts
+++ b/apps/api/src/utils/is-kangxi-radical-sickness-present.ts
@@ -1,0 +1,8 @@
+/**
+ * Detects whether a string contains the Unicode Kangxi radical sickness character (U+2F67 ⽧).
+ * @param input - The string to check.
+ * @returns `true` if the input contains the Kangxi radical sickness character, `false` otherwise.
+ */
+export function isKangxiRadicalSicknessPresent(input: string): boolean {
+  return input.includes('\u2F67');
+}

--- a/apps/api/src/utils/is-kangxi-radical-skin-present.ts
+++ b/apps/api/src/utils/is-kangxi-radical-skin-present.ts
@@ -1,0 +1,8 @@
+/**
+ * Detects whether a string contains the Unicode Kangxi radical skin character (U+2F6A ⽪).
+ * @param input - The string to check.
+ * @returns `true` if the input contains the Kangxi radical skin character, `false` otherwise.
+ */
+export function isKangxiRadicalSkinPresent(input: string): boolean {
+  return input.includes('\u2F6A');
+}

--- a/apps/api/src/utils/is-kangxi-radical-white-present.ts
+++ b/apps/api/src/utils/is-kangxi-radical-white-present.ts
@@ -1,0 +1,8 @@
+/**
+ * Detects whether a string contains the Unicode Kangxi radical white character (U+2F69 ⽩).
+ * @param input - The string to check.
+ * @returns `true` if the input contains the Kangxi radical white character, `false` otherwise.
+ */
+export function isKangxiRadicalWhitePresent(input: string): boolean {
+  return input.includes('\u2F69');
+}

--- a/apps/api/src/utils/kangxi-batch-6377-6379-6380.test.ts
+++ b/apps/api/src/utils/kangxi-batch-6377-6379-6380.test.ts
@@ -1,0 +1,49 @@
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+import { isKangxiRadicalSkinPresent } from "./is-kangxi-radical-skin-present.js";
+import { isKangxiRadicalWhitePresent } from "./is-kangxi-radical-white-present.js";
+import { isKangxiRadicalSicknessPresent } from "./is-kangxi-radical-sickness-present.js";
+
+describe("Kangxi radical utility smoke tests", () => {
+  // ── is-kangxi-radical-skin-present (U+2F6A ⽪) ──────────────────────────
+  describe("isKangxiRadicalSkinPresent", () => {
+    it("returns true when the skin radical is present", () => {
+      assert.equal(isKangxiRadicalSkinPresent("\u2F6A"), true);
+      assert.equal(isKangxiRadicalSkinPresent("prefix\u2F6Asuffix"), true);
+    });
+
+    it("returns false when the skin radical is absent", () => {
+      assert.equal(isKangxiRadicalSkinPresent(""), false);
+      assert.equal(isKangxiRadicalSkinPresent("skin"), false);
+      assert.equal(isKangxiRadicalSkinPresent("\u2F69"), false); // white, not skin
+    });
+  });
+
+  // ── is-kangxi-radical-white-present (U+2F69 ⽩) ─────────────────────────
+  describe("isKangxiRadicalWhitePresent", () => {
+    it("returns true when the white radical is present", () => {
+      assert.equal(isKangxiRadicalWhitePresent("\u2F69"), true);
+      assert.equal(isKangxiRadicalWhitePresent("abc\u2F69xyz"), true);
+    });
+
+    it("returns false when the white radical is absent", () => {
+      assert.equal(isKangxiRadicalWhitePresent(""), false);
+      assert.equal(isKangxiRadicalWhitePresent("white"), false);
+      assert.equal(isKangxiRadicalWhitePresent("\u2F6A"), false); // skin, not white
+    });
+  });
+
+  // ── is-kangxi-radical-sickness-present (U+2F67 ⽧) ──────────────────────
+  describe("isKangxiRadicalSicknessPresent", () => {
+    it("returns true when the sickness radical is present", () => {
+      assert.equal(isKangxiRadicalSicknessPresent("\u2F67"), true);
+      assert.equal(isKangxiRadicalSicknessPresent("test\u2F67test"), true);
+    });
+
+    it("returns false when the sickness radical is absent", () => {
+      assert.equal(isKangxiRadicalSicknessPresent(""), false);
+      assert.equal(isKangxiRadicalSicknessPresent("sickness"), false);
+      assert.equal(isKangxiRadicalSicknessPresent("\u2F6A"), false); // skin, not sickness
+    });
+  });
+});


### PR DESCRIPTION
## Summary

Adds three dependency-free TypeScript utility functions for detecting Kangxi radical Unicode characters, along with a batch smoke test file.

## Changes

| File | Codepoint | Issue |
|------|-----------|-------|
| `apps/api/src/utils/is-kangxi-radical-skin-present.ts` | U+2F6A ⽪ | Closes #6380 |
| `apps/api/src/utils/is-kangxi-radical-white-present.ts` | U+2F69 ⽩ | Closes #6379 |
| `apps/api/src/utils/is-kangxi-radical-sickness-present.ts` | U+2F67 ⽧ | Closes #6377 |
| `apps/api/src/utils/kangxi-batch-6377-6379-6380.test.ts` | — | batch smoke tests |

## Implementation

Each helper:
- Accepts a `string` input parameter
- Returns `boolean` — `true` iff the exact Unicode codepoint is present anywhere in the string
- Is zero-dependency (pure TypeScript `String.prototype.includes`)
- Is exported as a named function following the existing naming pattern

Closes #6377
Closes #6379
Closes #6380