### PR TITLE
feat(utils): add Kangxi radical bolt-of-cloth detector (U+2F66)

### DIFF
--- a/apps/api/src/utils/is-kangxi-radical-bolt-of-cloth-present.test.ts
+++ b/apps/api/src/utils/is-kangxi-radical-bolt-of-cloth-present.test.ts
@@ -1,0 +1,18 @@
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+import { isKangxiRadicalBoltOfClothPresent } from "./is-kangxi-radical-bolt-of-cloth-present.js";
+
+describe("isKangxiRadicalBoltOfClothPresent (U+2F66 ⽦)", () => {
+  it("returns true when the bolt-of-cloth radical is present", () => {
+    assert.equal(isKangxiRadicalBoltOfClothPresent("\u2F66"), true);
+    assert.equal(isKangxiRadicalBoltOfClothPresent("prefix\u2F66suffix"), true);
+    assert.equal(isKangxiRadicalBoltOfClothPresent("a\u2F66b"), true);
+  });
+
+  it("returns false when the bolt-of-cloth radical is absent", () => {
+    assert.equal(isKangxiRadicalBoltOfClothPresent(""), false);
+    assert.equal(isKangxiRadicalBoltOfClothPresent("bolt-of-cloth"), false);
+    assert.equal(isKangxiRadicalBoltOfClothPresent("\u2F65"), false); // field, not bolt-of-cloth
+    assert.equal(isKangxiRadicalBoltOfClothPresent("\u2F67"), false); // sickness, not bolt-of-cloth
+  });
+});

--- a/apps/api/src/utils/is-kangxi-radical-bolt-of-cloth-present.ts
+++ b/apps/api/src/utils/is-kangxi-radical-bolt-of-cloth-present.ts
@@ -1,0 +1,8 @@
+/**
+ * Detects whether a string contains the Unicode Kangxi radical bolt-of-cloth character (U+2F66 ⽦).
+ * @param input - The string to check.
+ * @returns `true` if the input contains the Kangxi radical bolt-of-cloth character, `false` otherwise.
+ */
+export function isKangxiRadicalBoltOfClothPresent(input: string): boolean {
+  return input.includes('\u2F66');
+}


### PR DESCRIPTION
Adds `isKangxiRadicalBoltOfClothPresent(input: string): boolean` that returns `true` iff the input string contains the Kangxi radical bolt-of-cloth character (U+2F66 ⽦).

- `apps/api/src/utils/is-kangxi-radical-bolt-of-cloth-present.ts` — implementation
- `apps/api/src/utils/is-kangxi-radical-bolt-of-cloth-present.test.ts` — smoke tests

Zero dependencies. Closes #6376