### PR TITLE
feat(utils): add Kangxi radical field detector (U+2F65)

### DIFF
--- a/apps/api/src/utils/is-kangxi-radical-field-present.test.ts
+++ b/apps/api/src/utils/is-kangxi-radical-field-present.test.ts
@@ -1,0 +1,18 @@
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+import { isKangxiRadicalFieldPresent } from "./is-kangxi-radical-field-present.js";
+
+describe("isKangxiRadicalFieldPresent (U+2F65 ⽥)", () => {
+  it("returns true when the field radical is present", () => {
+    assert.equal(isKangxiRadicalFieldPresent("\u2F65"), true);
+    assert.equal(isKangxiRadicalFieldPresent("prefix\u2F65suffix"), true);
+    assert.equal(isKangxiRadicalFieldPresent("a\u2F65b"), true);
+  });
+
+  it("returns false when the field radical is absent", () => {
+    assert.equal(isKangxiRadicalFieldPresent(""), false);
+    assert.equal(isKangxiRadicalFieldPresent("field"), false);
+    assert.equal(isKangxiRadicalFieldPresent("\u2F63"), false); // life, not field
+    assert.equal(isKangxiRadicalFieldPresent("\u2F66"), false); // bolt-of-cloth, not field
+  });
+});

--- a/apps/api/src/utils/is-kangxi-radical-field-present.ts
+++ b/apps/api/src/utils/is-kangxi-radical-field-present.ts
@@ -1,0 +1,8 @@
+/**
+ * Detects whether a string contains the Unicode Kangxi radical field character (U+2F65 ⽥).
+ * @param input - The string to check.
+ * @returns `true` if the input contains the Kangxi radical field character, `false` otherwise.
+ */
+export function isKangxiRadicalFieldPresent(input: string): boolean {
+  return input.includes('\u2F65');
+}


### PR DESCRIPTION
Adds `isKangxiRadicalFieldPresent(input: string): boolean` that returns `true` iff the input string contains the Kangxi radical field character (U+2F65 ⽥).

- `apps/api/src/utils/is-kangxi-radical-field-present.ts` — implementation
- `apps/api/src/utils/is-kangxi-radical-field-present.test.ts` — smoke tests

Zero dependencies. Closes #6342