### PR TITLE
feat(utils): add Kangxi radical life detector (U+2F63)

### DIFF
--- a/apps/api/src/utils/is-kangxi-radical-life-present.test.ts
+++ b/apps/api/src/utils/is-kangxi-radical-life-present.test.ts
@@ -1,0 +1,18 @@
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+import { isKangxiRadicalLifePresent } from "./is-kangxi-radical-life-present.js";
+
+describe("isKangxiRadicalLifePresent (U+2F63 ⽣)", () => {
+  it("returns true when the life radical is present", () => {
+    assert.equal(isKangxiRadicalLifePresent("\u2F63"), true);
+    assert.equal(isKangxiRadicalLifePresent("prefix\u2F63suffix"), true);
+    assert.equal(isKangxiRadicalLifePresent("a\u2F63b"), true);
+  });
+
+  it("returns false when the life radical is absent", () => {
+    assert.equal(isKangxiRadicalLifePresent(""), false);
+    assert.equal(isKangxiRadicalLifePresent("life"), false);
+    assert.equal(isKangxiRadicalLifePresent("\u2F65"), false); // field, not life
+    assert.equal(isKangxiRadicalLifePresent("\u2F62"), false); // sweet, not life
+  });
+});

--- a/apps/api/src/utils/is-kangxi-radical-life-present.ts
+++ b/apps/api/src/utils/is-kangxi-radical-life-present.ts
@@ -1,0 +1,8 @@
+/**
+ * Detects whether a string contains the Unicode Kangxi radical life character (U+2F63 ⽣).
+ * @param input - The string to check.
+ * @returns `true` if the input contains the Kangxi radical life character, `false` otherwise.
+ */
+export function isKangxiRadicalLifePresent(input: string): boolean {
+  return input.includes('\u2F63');
+}


### PR DESCRIPTION
Adds `isKangxiRadicalLifePresent(input: string): boolean` that returns `true` iff the input string contains the Kangxi radical life character (U+2F63 ⽣).

- `apps/api/src/utils/is-kangxi-radical-life-present.ts` — implementation
- `apps/api/src/utils/is-kangxi-radical-life-present.test.ts` — smoke tests

Zero dependencies. Closes #6341