### PR TITLE
[agent] feat(api): add kangxi radical spirit helper (#6434)

### DIFF
--- a/apps/api/src/utils/is-kangxi-radical-spirit-present.ts
+++ b/apps/api/src/utils/is-kangxi-radical-spirit-present.ts
@@ -1,0 +1,3 @@
+export function isKangxiRadicalSpiritPresent(input: string): boolean {
+  return input.includes("\u{2F70}");
+}

--- a/contributors/agents.json
+++ b/contributors/agents.json
@@ -1,5 +1,13 @@
 {
-  "agents": [],
-  "last_updated": "2026-06-03",
-  "total_contributions": 0
+  "agents": [
+    {
+      "github_username": "yanyishuai",
+      "model": "cursor-agent",
+      "version": "2026-07-10",
+      "pr_number": 0,
+      "issue_number": 6434
+    }
+  ],
+  "last_updated": "2026-07-10",
+  "total_contributions": 1
 }


### PR DESCRIPTION
## Summary

Adds `apps/api/src/utils/is-kangxi-radical-spirit-present.ts` exporting `isKangxiRadicalSpiritPresent` for Unicode U+2F70.

Fixes #6434

Wallet: `Do4v7foHJvRJLpRRoGaVPWX6DDEjX3yTK7J91gpwUQpE`

/claim #6434
