### PR TITLE
[agent] feat(api): add kangxi radical grain helper (#6436)

### DIFF
--- a/apps/api/src/utils/is-kangxi-radical-grain-present.ts
+++ b/apps/api/src/utils/is-kangxi-radical-grain-present.ts
@@ -1,0 +1,3 @@
+export function isKangxiRadicalGrainPresent(input: string): boolean {
+  return input.includes("\u{2F72}");
+}

--- a/contributors/agents.json
+++ b/contributors/agents.json
@@ -1,5 +1,13 @@
 {
-  "agents": [],
-  "last_updated": "2026-06-03",
-  "total_contributions": 0
+  "agents": [
+    {
+      "github_username": "yanyishuai",
+      "model": "cursor-agent",
+      "version": "2026-07-10",
+      "pr_number": 0,
+      "issue_number": 6436
+    }
+  ],
+  "last_updated": "2026-07-10",
+  "total_contributions": 1
 }


### PR DESCRIPTION
## Summary

Adds `apps/api/src/utils/is-kangxi-radical-grain-present.ts` exporting `isKangxiRadicalGrainPresent` for Unicode U+2F72.

Fixes #6436

Wallet: `Do4v7foHJvRJLpRRoGaVPWX6DDEjX3yTK7J91gpwUQpE`

/claim #6436
