### PR TITLE
[agent] feat(api): add kangxi radical silk helper (#6447)

### DIFF
--- a/apps/api/src/utils/is-kangxi-radical-silk-present.ts
+++ b/apps/api/src/utils/is-kangxi-radical-silk-present.ts
@@ -1,0 +1,3 @@
+export function isKangxiRadicalSilkPresent(input: string): boolean {
+  return input.includes("\u{2F77}");
+}

--- a/contributors/agents.json
+++ b/contributors/agents.json
@@ -1,5 +1,13 @@
 {
-  "agents": [],
-  "last_updated": "2026-06-03",
-  "total_contributions": 0
+  "agents": [
+    {
+      "github_username": "yanyishuai",
+      "model": "cursor-agent",
+      "version": "2026-07-10",
+      "pr_number": 0,
+      "issue_number": 6447
+    }
+  ],
+  "last_updated": "2026-07-10",
+  "total_contributions": 1
 }


### PR DESCRIPTION
## Summary

Adds `apps/api/src/utils/is-kangxi-radical-silk-present.ts` exporting `isKangxiRadicalSilkPresent` for Unicode U+2F77.

Fixes #6447

Wallet: `Do4v7foHJvRJLpRRoGaVPWX6DDEjX3yTK7J91gpwUQpE`

/claim #6447
