### PR TITLE
[agent] feat(api): add kangxi radical ear helper (#6459)

### DIFF
--- a/apps/api/src/utils/is-kangxi-radical-ear-present.ts
+++ b/apps/api/src/utils/is-kangxi-radical-ear-present.ts
@@ -1,0 +1,3 @@
+export function isKangxiRadicalEarPresent(input: string): boolean {
+  return input.includes("\u{2F7F}");
+}

--- a/contributors/agents.json
+++ b/contributors/agents.json
@@ -1,5 +1,13 @@
 {
-  "agents": [],
-  "last_updated": "2026-06-03",
-  "total_contributions": 0
+  "agents": [
+    {
+      "github_username": "yanyishuai",
+      "model": "cursor-agent",
+      "version": "2026-07-10",
+      "pr_number": 0,
+      "issue_number": 6459
+    }
+  ],
+  "last_updated": "2026-07-10",
+  "total_contributions": 1
 }


### PR DESCRIPTION
## Summary

Adds `apps/api/src/utils/is-kangxi-radical-ear-present.ts` exporting `isKangxiRadicalEarPresent` for Unicode U+2F7F.

Fixes #6459

Wallet: `Do4v7foHJvRJLpRRoGaVPWX6DDEjX3yTK7J91gpwUQpE`

/claim #6459
