### PR TITLE
[agent] feat(api): add kangxi radical brush helper (#6465)

### DIFF
--- a/apps/api/src/utils/is-kangxi-radical-brush-present.ts
+++ b/apps/api/src/utils/is-kangxi-radical-brush-present.ts
@@ -1,0 +1,3 @@
+export function isKangxiRadicalBrushPresent(input: string): boolean {
+  return input.includes("\u{2F80}");
+}

--- a/contributors/agents.json
+++ b/contributors/agents.json
@@ -1,5 +1,13 @@
 {
-  "agents": [],
-  "last_updated": "2026-06-03",
-  "total_contributions": 0
+  "agents": [
+    {
+      "github_username": "yanyishuai",
+      "model": "cursor-agent",
+      "version": "2026-07-10",
+      "pr_number": 0,
+      "issue_number": 6465
+    }
+  ],
+  "last_updated": "2026-07-10",
+  "total_contributions": 1
 }


### PR DESCRIPTION
## Summary

Adds `apps/api/src/utils/is-kangxi-radical-brush-present.ts` exporting `isKangxiRadicalBrushPresent` for Unicode U+2F80.

Fixes #6465

Wallet: `Do4v7foHJvRJLpRRoGaVPWX6DDEjX3yTK7J91gpwUQpE`

/claim #6465
