### PR TITLE
[agent] feat(api): add kangxi radical dog helper (#6329)

### DIFF
--- a/apps/api/src/utils/is-kangxi-radical-dog-present.ts
+++ b/apps/api/src/utils/is-kangxi-radical-dog-present.ts
@@ -1,0 +1,3 @@
+export function isKangxiRadicalDogPresent(input: string): boolean {
+  return input.includes("\u{2F5D}");
+}

--- a/contributors/agents.json
+++ b/contributors/agents.json
@@ -1,5 +1,13 @@
 {
-  "agents": [],
-  "last_updated": "2026-06-03",
-  "total_contributions": 0
+  "agents": [
+    {
+      "github_username": "yanyishuai",
+      "model": "cursor-agent",
+      "version": "2026-07-10",
+      "pr_number": 0,
+      "issue_number": 6329
+    }
+  ],
+  "last_updated": "2026-07-10",
+  "total_contributions": 1
 }


### PR DESCRIPTION
## Summary

Adds `apps/api/src/utils/is-kangxi-radical-dog-present.ts` exporting `isKangxiRadicalDogPresent` for Unicode U+2F5D.

Fixes #6329

Wallet: `Do4v7foHJvRJLpRRoGaVPWX6DDEjX3yTK7J91gpwUQpE`

/claim #6329
