### PR TITLE
[agent] feat(api): add kangxi radical melon helper (#6338)

### DIFF
--- a/apps/api/src/utils/is-kangxi-radical-melon-present.ts
+++ b/apps/api/src/utils/is-kangxi-radical-melon-present.ts
@@ -1,0 +1,3 @@
+export function isKangxiRadicalMelonPresent(input: string): boolean {
+  return input.includes("\u{2F60}");
+}

--- a/contributors/agents.json
+++ b/contributors/agents.json
@@ -1,5 +1,13 @@
 {
-  "agents": [],
-  "last_updated": "2026-06-03",
-  "total_contributions": 0
+  "agents": [
+    {
+      "github_username": "yanyishuai",
+      "model": "cursor-agent",
+      "version": "2026-07-10",
+      "pr_number": 0,
+      "issue_number": 6338
+    }
+  ],
+  "last_updated": "2026-07-10",
+  "total_contributions": 1
 }


### PR DESCRIPTION
## Summary

Adds `apps/api/src/utils/is-kangxi-radical-melon-present.ts` exporting `isKangxiRadicalMelonPresent` for Unicode U+2F60.

Fixes #6338

Wallet: `Do4v7foHJvRJLpRRoGaVPWX6DDEjX3yTK7J91gpwUQpE`

/claim #6338
