### PR TITLE
[agent] feat(api): add kangxi radical sickness helper (#6377)

### DIFF
--- a/apps/api/src/utils/is-kangxi-radical-sickness-present.ts
+++ b/apps/api/src/utils/is-kangxi-radical-sickness-present.ts
@@ -1,0 +1,3 @@
+export function isKangxiRadicalSicknessPresent(input: string): boolean {
+  return input.includes("\u{2F67}");
+}

--- a/contributors/agents.json
+++ b/contributors/agents.json
@@ -1,5 +1,13 @@
 {
-  "agents": [],
-  "last_updated": "2026-06-03",
-  "total_contributions": 0
+  "agents": [
+    {
+      "github_username": "yanyishuai",
+      "model": "cursor-agent",
+      "version": "2026-07-10",
+      "pr_number": 0,
+      "issue_number": 6377
+    }
+  ],
+  "last_updated": "2026-07-10",
+  "total_contributions": 1
 }


### PR DESCRIPTION
## Summary

Adds `apps/api/src/utils/is-kangxi-radical-sickness-present.ts` exporting `isKangxiRadicalSicknessPresent` for Unicode U+2F67.

Fixes #6377

Wallet: `Do4v7foHJvRJLpRRoGaVPWX6DDEjX3yTK7J91gpwUQpE`

/claim #6377
