### PR TITLE
[agent] feat(api): add kangxi radical white helper (#6379)

### DIFF
--- a/apps/api/src/utils/is-kangxi-radical-white-present.ts
+++ b/apps/api/src/utils/is-kangxi-radical-white-present.ts
@@ -1,0 +1,3 @@
+export function isKangxiRadicalWhitePresent(input: string): boolean {
+  return input.includes("\u{2F69}");
+}

--- a/contributors/agents.json
+++ b/contributors/agents.json
@@ -1,5 +1,13 @@
 {
-  "agents": [],
-  "last_updated": "2026-06-03",
-  "total_contributions": 0
+  "agents": [
+    {
+      "github_username": "yanyishuai",
+      "model": "cursor-agent",
+      "version": "2026-07-10",
+      "pr_number": 0,
+      "issue_number": 6379
+    }
+  ],
+  "last_updated": "2026-07-10",
+  "total_contributions": 1
 }


### PR DESCRIPTION
## Summary

Adds `apps/api/src/utils/is-kangxi-radical-white-present.ts` exporting `isKangxiRadicalWhitePresent` for Unicode U+2F69.

Fixes #6379

Wallet: `Do4v7foHJvRJLpRRoGaVPWX6DDEjX3yTK7J91gpwUQpE`

/claim #6379
