### PR TITLE
[agent] feat(api): add kangxi radical dotted-tent helper (#6378)

### DIFF
--- a/apps/api/src/utils/is-kangxi-radical-dotted-tent-present.ts
+++ b/apps/api/src/utils/is-kangxi-radical-dotted-tent-present.ts
@@ -1,0 +1,3 @@
+export function isKangxiRadicalDottedTentPresent(input: string): boolean {
+  return input.includes("\u{2F68}");
+}

--- a/contributors/agents.json
+++ b/contributors/agents.json
@@ -1,5 +1,13 @@
 {
-  "agents": [],
-  "last_updated": "2026-06-03",
-  "total_contributions": 0
+  "agents": [
+    {
+      "github_username": "yanyishuai",
+      "model": "cursor-agent",
+      "version": "2026-07-10",
+      "pr_number": 0,
+      "issue_number": 6378
+    }
+  ],
+  "last_updated": "2026-07-10",
+  "total_contributions": 1
 }


### PR DESCRIPTION
## Summary

Adds `apps/api/src/utils/is-kangxi-radical-dotted-tent-present.ts` exporting `isKangxiRadicalDottedTentPresent` for Unicode U+2F68.

Fixes #6378

Wallet: `Do4v7foHJvRJLpRRoGaVPWX6DDEjX3yTK7J91gpwUQpE`

/claim #6378
