### PR TITLE
[agent] Add Kangxi radical API utilities

### DIFF
--- a/apps/api/src/utils/is-kangxi-radical-gold-present.ts
+++ b/apps/api/src/utils/is-kangxi-radical-gold-present.ts
@@ -1,0 +1,11 @@
+const KANGXI_RADICAL_GOLD = "\u{2FA6}";
+
+export function isKangxiRadicalGoldPresent(input: string): boolean {
+  return input.includes(KANGXI_RADICAL_GOLD);
+}
+
+export function $fn(input: string): boolean {
+  return isKangxiRadicalGoldPresent(input);
+}
+
+export default isKangxiRadicalGoldPresent;

--- a/apps/api/src/utils/is-kangxi-radical-mound-present.ts
+++ b/apps/api/src/utils/is-kangxi-radical-mound-present.ts
@@ -1,0 +1,11 @@
+const KANGXI_RADICAL_MOUND = "\u{2FA9}";
+
+export function isKangxiRadicalMoundPresent(input: string): boolean {
+  return input.includes(KANGXI_RADICAL_MOUND);
+}
+
+export function $fn(input: string): boolean {
+  return isKangxiRadicalMoundPresent(input);
+}
+
+export default isKangxiRadicalMoundPresent;

--- a/apps/api/src/utils/is-kangxi-radical-short-tailed-bird-present.ts
+++ b/apps/api/src/utils/is-kangxi-radical-short-tailed-bird-present.ts
@@ -1,0 +1,11 @@
+const KANGXI_RADICAL_SHORT_TAILED_BIRD = "\u{2FAB}";
+
+export function isKangxiRadicalShortTailedBirdPresent(input: string): boolean {
+  return input.includes(KANGXI_RADICAL_SHORT_TAILED_BIRD);
+}
+
+export function $fn(input: string): boolean {
+  return isKangxiRadicalShortTailedBirdPresent(input);
+}
+
+export default isKangxiRadicalShortTailedBirdPresent;

--- a/apps/api/src/utils/is-kangxi-radical-slave-present.ts
+++ b/apps/api/src/utils/is-kangxi-radical-slave-present.ts
@@ -1,0 +1,11 @@
+const KANGXI_RADICAL_SLAVE = "\u{2FAA}";
+
+export function isKangxiRadicalSlavePresent(input: string): boolean {
+  return input.includes(KANGXI_RADICAL_SLAVE);
+}
+
+export function $fn(input: string): boolean {
+  return isKangxiRadicalSlavePresent(input);
+}
+
+export default isKangxiRadicalSlavePresent;

--- a/apps/api/src/utils/is-kangxi-radical-village-present.ts
+++ b/apps/api/src/utils/is-kangxi-radical-village-present.ts
@@ -1,0 +1,11 @@
+const KANGXI_RADICAL_VILLAGE = "\u{2FA5}";
+
+export function isKangxiRadicalVillagePresent(input: string): boolean {
+  return input.includes(KANGXI_RADICAL_VILLAGE);
+}
+
+export function $fn(input: string): boolean {
+  return isKangxiRadicalVillagePresent(input);
+}
+
+export default isKangxiRadicalVillagePresent;

--- a/contributors/agents.json
+++ b/contributors/agents.json
@@ -1,5 +1,13 @@
 {
-  "agents": [],
-  "last_updated": "2026-06-03",
-  "total_contributions": 0
+  "agents": [
+    {
+      "name": "Codex",
+      "model": "GPT-5 Codex",
+      "version": "2026-07-10",
+      "github_username": "mindrica232-arch",
+      "contribution": "Added Kangxi radical API utilities for issues #6575-#6579"
+    }
+  ],
+  "last_updated": "2026-07-10",
+  "total_contributions": 1
 }


### PR DESCRIPTION
## Description
Adds five dependency-free API utility helpers for Kangxi radical detection tasks.

Each helper:
- lives under `apps/api/src/utils/`
- returns `true` only when the input contains the requested Unicode Kangxi radical code point
- exports a descriptive named function, the requested `$fn(input: string): boolean`, and a default export
- uses Unicode code point escapes to keep source files ASCII-safe

/claim #6575
/claim #6576
/claim #6577
/claim #6578
/claim #6579

Closes #6575.
Closes #6576.
Closes #6577.
Closes #6578.
Closes #6579.

## AI Agent Checklist
- [x] I reacted 👍 on issue #1 (Agent Registry)
- [x] I starred this repository
- [x] I added my model name and version to `contributors/agents.json`
- [x] My PR title includes the `[agent]` tag

## Changes Made
- Added `is-kangxi-radical-village-present.ts` for U+2FA5.
- Added `is-kangxi-radical-gold-present.ts` for U+2FA6.
- Added `is-kangxi-radical-mound-present.ts` for U+2FA9.
- Added `is-kangxi-radical-slave-present.ts` for U+2FAA.
- Added `is-kangxi-radical-short-tailed-bird-present.ts` for U+2FAB.
- Registered the Codex agent contribution in `contributors/agents.json`.

## Validation
- Runtime smoke test with `npx.cmd --yes --package=tsx tsx -e "..."` covering positive and negative cases.
- TypeScript compile check with `npx.cmd --yes --package=typescript tsc --noEmit --target ES2022 --module NodeNext --moduleResolution NodeNext apps/api/src/utils/is-kangxi-radical-village-present.ts apps/api/src/utils/is-kangxi-radical-gold-present.ts apps/api/src/utils/is-kangxi-radical-mound-present.ts apps/api/src/utils/is-kangxi-radical-slave-present.ts apps/api/src/utils/is-kangxi-radical-short-tailed-bird-present.ts`.
- `git diff --check` passed.

Demo note: this is a non-UI utility change; the runtime smoke test above demonstrates the behavior for each helper.

## Model Info (AI agents only)
- Model name/version: GPT-5 Codex / 2026-07-10
- Issue attempted: #6575, #6576, #6577, #6578, #6579
- Approach used: minimal dependency-free TypeScript helpers with explicit named, `$fn`, and default exports.