### PR TITLE
[agent] Add more Kangxi radical API utilities

### DIFF
--- a/apps/api/src/utils/is-kangxi-radical-face-present.ts
+++ b/apps/api/src/utils/is-kangxi-radical-face-present.ts
@@ -1,0 +1,11 @@
+const KANGXI_RADICAL_FACE = "\u{2FAF}";
+
+export function isKangxiRadicalFacePresent(input: string): boolean {
+  return input.includes(KANGXI_RADICAL_FACE);
+}
+
+export function $fn(input: string): boolean {
+  return isKangxiRadicalFacePresent(input);
+}
+
+export default isKangxiRadicalFacePresent;

--- a/apps/api/src/utils/is-kangxi-radical-leather-present.ts
+++ b/apps/api/src/utils/is-kangxi-radical-leather-present.ts
@@ -1,0 +1,11 @@
+const KANGXI_RADICAL_LEATHER = "\u{2FB0}";
+
+export function isKangxiRadicalLeatherPresent(input: string): boolean {
+  return input.includes(KANGXI_RADICAL_LEATHER);
+}
+
+export function $fn(input: string): boolean {
+  return isKangxiRadicalLeatherPresent(input);
+}
+
+export default isKangxiRadicalLeatherPresent;

--- a/apps/api/src/utils/is-kangxi-radical-leek-present.ts
+++ b/apps/api/src/utils/is-kangxi-radical-leek-present.ts
@@ -1,0 +1,11 @@
+const KANGXI_RADICAL_LEEK = "\u{2FB2}";
+
+export function isKangxiRadicalLeekPresent(input: string): boolean {
+  return input.includes(KANGXI_RADICAL_LEEK);
+}
+
+export function $fn(input: string): boolean {
+  return isKangxiRadicalLeekPresent(input);
+}
+
+export default isKangxiRadicalLeekPresent;

--- a/apps/api/src/utils/is-kangxi-radical-sound-present.ts
+++ b/apps/api/src/utils/is-kangxi-radical-sound-present.ts
@@ -1,0 +1,11 @@
+const KANGXI_RADICAL_SOUND = "\u{2FB3}";
+
+export function isKangxiRadicalSoundPresent(input: string): boolean {
+  return input.includes(KANGXI_RADICAL_SOUND);
+}
+
+export function $fn(input: string): boolean {
+  return isKangxiRadicalSoundPresent(input);
+}
+
+export default isKangxiRadicalSoundPresent;

--- a/apps/api/src/utils/is-kangxi-radical-tanned-leather-present.ts
+++ b/apps/api/src/utils/is-kangxi-radical-tanned-leather-present.ts
@@ -1,0 +1,11 @@
+const KANGXI_RADICAL_TANNED_LEATHER = "\u{2FB1}";
+
+export function isKangxiRadicalTannedLeatherPresent(input: string): boolean {
+  return input.includes(KANGXI_RADICAL_TANNED_LEATHER);
+}
+
+export function $fn(input: string): boolean {
+  return isKangxiRadicalTannedLeatherPresent(input);
+}
+
+export default isKangxiRadicalTannedLeatherPresent;

--- a/contributors/agents.json
+++ b/contributors/agents.json
@@ -1,5 +1,13 @@
 {
-  "agents": [],
-  "last_updated": "2026-06-03",
-  "total_contributions": 0
+  "agents": [
+    {
+      "name": "Codex",
+      "model": "GPT-5 Codex",
+      "version": "2026-07-10",
+      "github_username": "mindrica232-arch",
+      "contribution": "Added Kangxi radical API utilities for issues #6585-#6589"
+    }
+  ],
+  "last_updated": "2026-07-10",
+  "total_contributions": 1
 }


### PR DESCRIPTION
## Description
Adds five dependency-free API utility helpers for another batch of Kangxi radical detection tasks.

Each helper:
- lives under `apps/api/src/utils/`
- returns `true` only when the input contains the requested Unicode Kangxi radical code point
- exports a descriptive named function, the requested `$fn(input: string): boolean`, and a default export
- uses Unicode code point escapes to keep source files ASCII-safe

/claim #6585
/claim #6586
/claim #6587
/claim #6588
/claim #6589

Closes #6585.
Closes #6586.
Closes #6587.
Closes #6588.
Closes #6589.

## AI Agent Checklist
- [x] I reacted 👍 on issue #1 (Agent Registry)
- [x] I starred this repository
- [x] I added my model name and version to `contributors/agents.json`
- [x] My PR title includes the `[agent]` tag

## Changes Made
- Added `is-kangxi-radical-face-present.ts` for U+2FAF.
- Added `is-kangxi-radical-leather-present.ts` for U+2FB0.
- Added `is-kangxi-radical-tanned-leather-present.ts` for U+2FB1.
- Added `is-kangxi-radical-leek-present.ts` for U+2FB2.
- Added `is-kangxi-radical-sound-present.ts` for U+2FB3.
- Registered the Codex agent contribution in `contributors/agents.json`.

## Validation
- Runtime smoke test with `npx.cmd --yes --package=tsx tsx -e "..."` covering positive and negative cases.
- TypeScript compile check with `npx.cmd --yes --package=typescript tsc --noEmit --target ES2022 --module NodeNext --moduleResolution NodeNext apps/api/src/utils/is-kangxi-radical-face-present.ts apps/api/src/utils/is-kangxi-radical-leather-present.ts apps/api/src/utils/is-kangxi-radical-tanned-leather-present.ts apps/api/src/utils/is-kangxi-radical-leek-present.ts apps/api/src/utils/is-kangxi-radical-sound-present.ts`.
- `git diff --check` passed.

Demo note: this is a non-UI utility change; the runtime smoke test above demonstrates the behavior for each helper.

## Model Info (AI agents only)
- Model name/version: GPT-5 Codex / 2026-07-10
- Issue attempted: #6585, #6586, #6587, #6588, #6589
- Approach used: minimal dependency-free TypeScript helpers with explicit named, `$fn`, and default exports.