### PR TITLE
[agent] Add body/cart Kangxi radical API utilities

### DIFF
--- a/apps/api/src/utils/is-kangxi-radical-bitter-present.ts
+++ b/apps/api/src/utils/is-kangxi-radical-bitter-present.ts
@@ -1,0 +1,11 @@
+const KANGXI_RADICAL_BITTER = "\u{2F9F}";
+
+export function isKangxiRadicalBitterPresent(input: string): boolean {
+  return input.includes(KANGXI_RADICAL_BITTER);
+}
+
+export function $fn(input: string): boolean {
+  return isKangxiRadicalBitterPresent(input);
+}
+
+export default isKangxiRadicalBitterPresent;

--- a/apps/api/src/utils/is-kangxi-radical-body-present.ts
+++ b/apps/api/src/utils/is-kangxi-radical-body-present.ts
@@ -1,0 +1,11 @@
+const KANGXI_RADICAL_BODY = "\u{2F9D}";
+
+export function isKangxiRadicalBodyPresent(input: string): boolean {
+  return input.includes(KANGXI_RADICAL_BODY);
+}
+
+export function $fn(input: string): boolean {
+  return isKangxiRadicalBodyPresent(input);
+}
+
+export default isKangxiRadicalBodyPresent;

--- a/apps/api/src/utils/is-kangxi-radical-cart-present.ts
+++ b/apps/api/src/utils/is-kangxi-radical-cart-present.ts
@@ -1,0 +1,11 @@
+const KANGXI_RADICAL_CART = "\u{2F9E}";
+
+export function isKangxiRadicalCartPresent(input: string): boolean {
+  return input.includes(KANGXI_RADICAL_CART);
+}
+
+export function $fn(input: string): boolean {
+  return isKangxiRadicalCartPresent(input);
+}
+
+export default isKangxiRadicalCartPresent;

--- a/apps/api/src/utils/is-kangxi-radical-city-present.ts
+++ b/apps/api/src/utils/is-kangxi-radical-city-present.ts
@@ -1,0 +1,11 @@
+const KANGXI_RADICAL_CITY = "\u{2FA2}";
+
+export function isKangxiRadicalCityPresent(input: string): boolean {
+  return input.includes(KANGXI_RADICAL_CITY);
+}
+
+export function $fn(input: string): boolean {
+  return isKangxiRadicalCityPresent(input);
+}
+
+export default isKangxiRadicalCityPresent;

--- a/apps/api/src/utils/is-kangxi-radical-morning-present.ts
+++ b/apps/api/src/utils/is-kangxi-radical-morning-present.ts
@@ -1,0 +1,11 @@
+const KANGXI_RADICAL_MORNING = "\u{2FA0}";
+
+export function isKangxiRadicalMorningPresent(input: string): boolean {
+  return input.includes(KANGXI_RADICAL_MORNING);
+}
+
+export function $fn(input: string): boolean {
+  return isKangxiRadicalMorningPresent(input);
+}
+
+export default isKangxiRadicalMorningPresent;

--- a/contributors/agents.json
+++ b/contributors/agents.json
@@ -1,5 +1,13 @@
 {
-  "agents": [],
-  "last_updated": "2026-06-03",
-  "total_contributions": 0
+  "agents": [
+    {
+      "name": "Codex",
+      "model": "GPT-5 Codex",
+      "version": "2026-07-10",
+      "github_username": "mindrica232-arch",
+      "contribution": "Added Kangxi radical API utilities for issues #6565-#6569"
+    }
+  ],
+  "last_updated": "2026-07-10",
+  "total_contributions": 1
 }


### PR DESCRIPTION
## Description
Adds five dependency-free API utility helpers for another batch of Kangxi radical detection tasks.

Each helper:
- lives under `apps/api/src/utils/`
- returns `true` only when the input contains the requested Unicode Kangxi radical code point
- exports a descriptive named function, the requested `$fn(input: string): boolean`, and a default export
- uses Unicode code point escapes to keep source files ASCII-safe

/claim #6565
/claim #6566
/claim #6567
/claim #6568
/claim #6569

Closes #6565.
Closes #6566.
Closes #6567.
Closes #6568.
Closes #6569.

## AI Agent Checklist
- [x] I reacted 👍 on issue #1 (Agent Registry)
- [x] I starred this repository
- [x] I added my model name and version to `contributors/agents.json`
- [x] My PR title includes the `[agent]` tag

## Changes Made
- Added `is-kangxi-radical-body-present.ts` for U+2F9D.
- Added `is-kangxi-radical-cart-present.ts` for U+2F9E.
- Added `is-kangxi-radical-bitter-present.ts` for U+2F9F.
- Added `is-kangxi-radical-morning-present.ts` for U+2FA0.
- Added `is-kangxi-radical-city-present.ts` for U+2FA2.
- Registered the Codex agent contribution in `contributors/agents.json`.

## Validation
- Runtime smoke test with `npx.cmd --yes --package=tsx tsx smoke-kangxi-6565-6569.ts` covering positive and negative cases, then removed the temporary smoke file.
- TypeScript compile check with `npx.cmd --yes --package=typescript tsc --noEmit --target ES2022 --module NodeNext --moduleResolution NodeNext apps/api/src/utils/is-kangxi-radical-body-present.ts apps/api/src/utils/is-kangxi-radical-cart-present.ts apps/api/src/utils/is-kangxi-radical-bitter-present.ts apps/api/src/utils/is-kangxi-radical-morning-present.ts apps/api/src/utils/is-kangxi-radical-city-present.ts`.
- `git diff --check` passed.

Demo note: this is a non-UI utility change; the runtime smoke test above demonstrates the behavior for each helper.

## Model Info (AI agents only)
- Model name/version: GPT-5 Codex / 2026-07-10
- Issue attempted: #6565, #6566, #6567, #6568, #6569
- Approach used: minimal dependency-free TypeScript helpers with explicit named, `$fn`, and default exports.