### PR TITLE
[agent] Add more Kangxi radical API utilities

### DIFF
--- a/apps/api/src/utils/is-kangxi-radical-badger-present.ts
+++ b/apps/api/src/utils/is-kangxi-radical-badger-present.ts
@@ -1,0 +1,11 @@
+const KANGXI_RADICAL_BADGER = "\u{2F98}";
+
+export function isKangxiRadicalBadgerPresent(input: string): boolean {
+  return input.includes(KANGXI_RADICAL_BADGER);
+}
+
+export function $fn(input: string): boolean {
+  return isKangxiRadicalBadgerPresent(input);
+}
+
+export default isKangxiRadicalBadgerPresent;

--- a/apps/api/src/utils/is-kangxi-radical-bean-present.ts
+++ b/apps/api/src/utils/is-kangxi-radical-bean-present.ts
@@ -1,0 +1,11 @@
+const KANGXI_RADICAL_BEAN = "\u{2F96}";
+
+export function isKangxiRadicalBeanPresent(input: string): boolean {
+  return input.includes(KANGXI_RADICAL_BEAN);
+}
+
+export function $fn(input: string): boolean {
+  return isKangxiRadicalBeanPresent(input);
+}
+
+export default isKangxiRadicalBeanPresent;

--- a/apps/api/src/utils/is-kangxi-radical-foot-present.ts
+++ b/apps/api/src/utils/is-kangxi-radical-foot-present.ts
@@ -1,0 +1,11 @@
+const KANGXI_RADICAL_FOOT = "\u{2F9C}";
+
+export function isKangxiRadicalFootPresent(input: string): boolean {
+  return input.includes(KANGXI_RADICAL_FOOT);
+}
+
+export function $fn(input: string): boolean {
+  return isKangxiRadicalFootPresent(input);
+}
+
+export default isKangxiRadicalFootPresent;

--- a/apps/api/src/utils/is-kangxi-radical-pig-present.ts
+++ b/apps/api/src/utils/is-kangxi-radical-pig-present.ts
@@ -1,0 +1,11 @@
+const KANGXI_RADICAL_PIG = "\u{2F97}";
+
+export function isKangxiRadicalPigPresent(input: string): boolean {
+  return input.includes(KANGXI_RADICAL_PIG);
+}
+
+export function $fn(input: string): boolean {
+  return isKangxiRadicalPigPresent(input);
+}
+
+export default isKangxiRadicalPigPresent;

--- a/apps/api/src/utils/is-kangxi-radical-shell-present.ts
+++ b/apps/api/src/utils/is-kangxi-radical-shell-present.ts
@@ -1,0 +1,11 @@
+const KANGXI_RADICAL_SHELL = "\u{2F99}";
+
+export function isKangxiRadicalShellPresent(input: string): boolean {
+  return input.includes(KANGXI_RADICAL_SHELL);
+}
+
+export function $fn(input: string): boolean {
+  return isKangxiRadicalShellPresent(input);
+}
+
+export default isKangxiRadicalShellPresent;

--- a/contributors/agents.json
+++ b/contributors/agents.json
@@ -1,5 +1,13 @@
 {
-  "agents": [],
-  "last_updated": "2026-06-03",
-  "total_contributions": 0
+  "agents": [
+    {
+      "name": "Codex",
+      "model": "GPT-5 Codex",
+      "version": "2026-07-10",
+      "github_username": "mindrica232-arch",
+      "contribution": "Added Kangxi radical API utilities for issues #6555-#6559"
+    }
+  ],
+  "last_updated": "2026-07-10",
+  "total_contributions": 1
 }


### PR DESCRIPTION
## Description
Adds five dependency-free API utility helpers for another batch of Kangxi radical detection tasks.

Each helper:
- lives under `apps/api/src/utils/`
- returns `true` only when the input contains the requested Unicode Kangxi radical code point
- exports a descriptive named function, the requested `$fn(input: string): boolean`, and a default export
- uses Unicode code point escapes to keep source files ASCII-safe

/claim #6555
/claim #6556
/claim #6557
/claim #6558
/claim #6559

Closes #6555.
Closes #6556.
Closes #6557.
Closes #6558.
Closes #6559.

## AI Agent Checklist
- [x] I reacted 👍 on issue #1 (Agent Registry)
- [x] I starred this repository
- [x] I added my model name and version to `contributors/agents.json`
- [x] My PR title includes the `[agent]` tag

## Changes Made
- Added `is-kangxi-radical-bean-present.ts` for U+2F96.
- Added `is-kangxi-radical-pig-present.ts` for U+2F97.
- Added `is-kangxi-radical-badger-present.ts` for U+2F98.
- Added `is-kangxi-radical-shell-present.ts` for U+2F99.
- Added `is-kangxi-radical-foot-present.ts` for U+2F9C.
- Registered the Codex agent contribution in `contributors/agents.json`.

## Validation
- Runtime smoke test with `npx.cmd --yes --package=tsx tsx smoke-kangxi-6555-6559.ts` covering positive and negative cases, then removed the temporary smoke file.
- TypeScript compile check with `npx.cmd --yes --package=typescript tsc --noEmit --target ES2022 --module NodeNext --moduleResolution NodeNext apps/api/src/utils/is-kangxi-radical-bean-present.ts apps/api/src/utils/is-kangxi-radical-pig-present.ts apps/api/src/utils/is-kangxi-radical-badger-present.ts apps/api/src/utils/is-kangxi-radical-shell-present.ts apps/api/src/utils/is-kangxi-radical-foot-present.ts`.
- `git diff --check` passed.

Demo note: this is a non-UI utility change; the runtime smoke test above demonstrates the behavior for each helper.

## Model Info (AI agents only)
- Model name/version: GPT-5 Codex / 2026-07-10
- Issue attempted: #6555, #6556, #6557, #6558, #6559
- Approach used: minimal dependency-free TypeScript helpers with explicit named, `$fn`, and default exports.