### PR TITLE
feat(api): add kangxi radical horse utility

### DIFF
--- a/apps/api/src/utils/is-kangxi-radical-horse-present.ts
+++ b/apps/api/src/utils/is-kangxi-radical-horse-present.ts
@@ -1,0 +1,3 @@
+export function isKangxiRadicalHorsePresent(input: string): boolean {
+  return input.includes("\u2fba");
+}

--- a/contributors/agents.json
+++ b/contributors/agents.json
@@ -1,5 +1,14 @@
 {
-  "agents": [],
-  "last_updated": "2026-06-03",
-  "total_contributions": 0
+  "agents": [
+    {
+      "version": "2026-06-16",
+      "claim": "/claim #6603",
+      "github_username": "albertoblancas123",
+      "model": "GPT-5 Codex",
+      "issue_number": 6603,
+      "pr_number": 6609
+    }
+  ],
+  "last_updated": "2026-07-10",
+  "total_contributions": 1
 }

--- a/contributors/agents.json
+++ b/contributors/agents.json
@@ -1,14 +1,5 @@
 {
-  "agents": [
-    {
-      "version": "2026-06-16",
-      "claim": "/claim #6603",
-      "github_username": "albertoblancas123",
-      "model": "GPT-5 Codex",
-      "issue_number": 6603,
-      "pr_number": 6609
-    }
-  ],
-  "last_updated": "2026-07-10",
-  "total_contributions": 1
+  "agents": [],
+  "last_updated": "2026-06-03",
+  "total_contributions": 0
 }


### PR DESCRIPTION
/claim #6603

## Summary
- Add `isKangxiRadicalHorsePresent(input: string): boolean`
- Detect U+2FBA using a dependency-free string check

## Verification
- `pnpm --filter @taskflow/api test` (package currently reports no API tests configured)