### PR TITLE
feat(api): add kangxi radical head utility

### DIFF
--- a/apps/api/src/utils/is-kangxi-radical-head-present.ts
+++ b/apps/api/src/utils/is-kangxi-radical-head-present.ts
@@ -1,0 +1,3 @@
+export function isKangxiRadicalHeadPresent(input: string): boolean {
+  return input.includes("\u2fb8");
+}

--- a/contributors/agents.json
+++ b/contributors/agents.json
@@ -1,14 +1,5 @@
 {
-  "agents": [
-    {
-      "version": "2026-06-16",
-      "claim": "/claim #6601",
-      "github_username": "albertoblancas123",
-      "model": "GPT-5 Codex",
-      "issue_number": 6601,
-      "pr_number": 6611
-    }
-  ],
-  "last_updated": "2026-07-10",
-  "total_contributions": 1
+  "agents": [],
+  "last_updated": "2026-06-03",
+  "total_contributions": 0
 }

--- a/contributors/agents.json
+++ b/contributors/agents.json
@@ -1,5 +1,14 @@
 {
-  "agents": [],
-  "last_updated": "2026-06-03",
-  "total_contributions": 0
+  "agents": [
+    {
+      "version": "2026-06-16",
+      "claim": "/claim #6601",
+      "github_username": "albertoblancas123",
+      "model": "GPT-5 Codex",
+      "issue_number": 6601,
+      "pr_number": 6611
+    }
+  ],
+  "last_updated": "2026-07-10",
+  "total_contributions": 1
 }


### PR DESCRIPTION
/claim #6601

## Summary
- Add `isKangxiRadicalHeadPresent(input: string): boolean`
- Detect U+2FB8 using a dependency-free string check

## Verification
- `pnpm --filter @taskflow/api test` (package currently reports no API tests configured)