### PR TITLE
feat(api): add kangxi radical fly utility

### DIFF
--- a/apps/api/src/utils/is-kangxi-radical-fly-present.ts
+++ b/apps/api/src/utils/is-kangxi-radical-fly-present.ts
@@ -1,0 +1,3 @@
+export function isKangxiRadicalFlyPresent(input: string): boolean {
+  return input.includes("\u2fb6");
+}


### PR DESCRIPTION
/claim #6599

## Summary
- Add `isKangxiRadicalFlyPresent(input: string): boolean`
- Detect U+2FB6 using a dependency-free string check

## Verification
- `pnpm --filter @taskflow/api test` (package currently reports no API tests configured)