### PR TITLE
feat(api): add kangxi radical mound utility

### DIFF
--- a/apps/api/src/utils/is-kangxi-radical-mound-present.ts
+++ b/apps/api/src/utils/is-kangxi-radical-mound-present.ts
@@ -1,0 +1,3 @@
+export function isKangxiRadicalMoundPresent(input: string): boolean {
+  return input.includes("\u2fa9");
+}


### PR DESCRIPTION
/claim #6577

## Summary
- Add `isKangxiRadicalMoundPresent(input: string): boolean`
- Detect U+2FA9 using a dependency-free string check

## Verification
- `pnpm --filter @taskflow/api test` (package currently reports no API tests configured)