### PR TITLE
feat(api): add kangxi radical bitter utility

### DIFF
--- a/apps/api/src/utils/is-kangxi-radical-bitter-present.ts
+++ b/apps/api/src/utils/is-kangxi-radical-bitter-present.ts
@@ -1,0 +1,3 @@
+export function isKangxiRadicalBitterPresent(input: string): boolean {
+  return input.includes("\u2f9f");
+}


### PR DESCRIPTION
/claim #6567

## Summary
- Add `isKangxiRadicalBitterPresent(input: string): boolean`
- Detect U+2F9F using a dependency-free string check

## Verification
- `pnpm --filter @taskflow/api test` (package currently reports no API tests configured)