### PR TITLE
feat(api): add kangxi radical cart utility

### DIFF
--- a/apps/api/src/utils/is-kangxi-radical-cart-present.ts
+++ b/apps/api/src/utils/is-kangxi-radical-cart-present.ts
@@ -1,0 +1,3 @@
+export function isKangxiRadicalCartPresent(input: string): boolean {
+  return input.includes("\u2f9e");
+}


### PR DESCRIPTION
/claim #6566

## Summary
- Add `isKangxiRadicalCartPresent(input: string): boolean`
- Detect U+2F9E using a dependency-free string check

## Verification
- `pnpm --filter @taskflow/api test` (package currently reports no API tests configured)