### PR TITLE
fix: deduplicate seed-issues workflow to skip existing issues

### DIFF
--- a/.github/workflows/seed-issues.yml
+++ b/.github/workflows/seed-issues.yml
@@ -90,7 +90,35 @@ jobs:
               }
             ];
 
+            // Get all existing open issue titles for deduplication
+            const existingTitles = new Set();
+            let page = 1;
+            while (true) {
+              const { data: existingIssues } = await github.rest.issues.listForRepo({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                state: 'open',
+                per_page: 100,
+                page
+              });
+              if (existingIssues.length === 0) break;
+              for (const issue of existingIssues) {
+                existingTitles.add(issue.title);
+              }
+              if (existingIssues.length < 100) break;
+              page++;
+            }
+
+            let createdCount = 0;
+            let skippedCount = 0;
+
             for (const issue of issues) {
+              if (existingTitles.has(issue.title)) {
+                console.log(`Skipping existing issue: ${issue.title}`);
+                skippedCount++;
+                continue;
+              }
+
               await github.rest.issues.create({
                 owner: context.repo.owner,
                 repo: context.repo.repo,
@@ -98,4 +126,8 @@ jobs:
                 body: issue.body,
                 labels: ["good first issue", "bounty", "AI agent friendly"]
               });
+              existingTitles.add(issue.title);
+              createdCount++;
             }
+
+            core.summary.addHeading(`Seed Good First Issues: ${createdCount} created, ${skippedCount} skipped`, 2);


### PR DESCRIPTION
## Problem
The `Seed Good First Issues` workflow creates all starter issues without checking if they already exist. If a maintainer reruns the workflow, it creates duplicate issues for the same starter tasks, splitting contributor attempts and confusing bounty tracking.

## Solution
- Fetch all existing open issue titles before creating any new ones
- Skip issue creation if a title already exists
- Report created/skipped counts in the workflow summary

## Changes
- Add `github.rest.issues.listForRepo` call to get existing issue titles
- Wrap each `issues.create` in a title existence check
- Add `createdCount` and `skippedCount` tracking with summary output

Resolves #875