### PR TITLE
fix: use correct label name 'good first issue' in task template

### DIFF
--- a/.github/ISSUE_TEMPLATE/task.md
+++ b/.github/ISSUE_TEMPLATE/task.md
@@ -2,7 +2,7 @@
 name: Small task
 about: Small maintenance task for first-time contributors
 title: ""
-labels: good-first-issue
+labels: good first issue
 assignees: ""
 ---
 


### PR DESCRIPTION
## Problem

The small task issue template uses the hyphenated label `good-first-issue` but the repository's label configuration defines it as `good first issue` (with spaces). Issues created from the template miss the expected discovery label or create a non-standard duplicate.

## Fix

Changed `labels: good-first-issue` to `labels: good first issue` in `.github/ISSUE_TEMPLATE/task.md`.

Resolves #769