### PR TITLE
feat: add slugify utility with comprehensive tests

### DIFF
--- a/src/utils/slugify.js
+++ b/src/utils/slugify.js
@@ -1,0 +1,25 @@
+/**
+ * Converts a string to a URL-friendly slug.
+ * - Converts to lowercase
+ * - Replaces spaces with hyphens
+ * - Removes special characters (keeps alphanumeric, hyphens, underscores)
+ * - Handles null, undefined, and empty input gracefully
+ *
+ * @param {string|null|undefined} str - The input string to slugify
+ * @returns {string} - The slugified string
+ */
+function slugify(str) {
+  if (str == null || str === '') {
+    return '';
+  }
+
+  return String(str)
+    .toLowerCase()
+    .trim()
+    .replace(/\s+/g, '-')        // Replace spaces with hyphens
+    .replace(/[^a-z0-9\-_]/g, '') // Remove special characters
+    .replace(/-+/g, '-')          // Collapse multiple hyphens
+    .replace(/^-|-$/g, '');       // Trim leading/trailing hyphens
+}
+
+module.exports = { slugify };

--- a/src/utils/slugify.test.js
+++ b/src/utils/slugify.test.js
@@ -1,0 +1,65 @@
+const { describe, it } = require('node:test');
+const assert = require('node:assert');
+const { slugify } = require('./slugify');
+
+describe('slugify', () => {
+  it('converts spaces to hyphens', () => {
+    assert.strictEqual(slugify('hello world'), 'hello-world');
+  });
+
+  it('converts to lowercase', () => {
+    assert.strictEqual(slugify('Hello World'), 'hello-world');
+  });
+
+  it('removes special characters', () => {
+    assert.strictEqual(slugify('hello! world@ #test'), 'hello-world-test');
+  });
+
+  it('handles null input', () => {
+    assert.strictEqual(slugify(null), '');
+  });
+
+  it('handles undefined input', () => {
+    assert.strictEqual(slugify(undefined), '');
+  });
+
+  it('handles empty string', () => {
+    assert.strictEqual(slugify(''), '');
+  });
+
+  it('handles string with only whitespace', () => {
+    assert.strictEqual(slugify('   '), '');
+  });
+
+  it('keeps alphanumeric characters', () => {
+    assert.strictEqual(slugify('Hello123World'), 'hello123world');
+  });
+
+  it('keeps underscores', () => {
+    assert.strictEqual(slugify('hello_world'), 'hello_world');
+  });
+
+  it('keeps existing hyphens', () => {
+    assert.strictEqual(slugify('hello-world'), 'hello-world');
+  });
+
+  it('collapses multiple spaces into single hyphen', () => {
+    assert.strictEqual(slugify('hello   world'), 'hello-world');
+  });
+
+  it('trims leading and trailing hyphens', () => {
+    assert.strictEqual(slugify('-hello-'), 'hello');
+  });
+
+  it('handles mixed special chars and spaces', () => {
+    assert.strictEqual(slugify('  My Favorite !! Recipe #1  '), 'my-favorite-recipe-1');
+  });
+
+  it('handles already slugified input', () => {
+    assert.strictEqual(slugify('already-slugified'), 'already-slugified');
+  });
+
+  it('handles numbers only', () => {
+    assert.strictEqual(slugify('12345'), '12345');
+  });
+});


### PR DESCRIPTION
## What this adds

Adds `src/utils/slugify.js` — a utility that converts strings to URL-friendly slugs.

### Behavior
- Converts to **lowercase**
- Replaces spaces with **hyphens**
- **Removes special characters** (keeps alphanumeric, hyphens, underscores)
- Handles **null**, **undefined**, and empty input gracefully (returns empty string)

### Tests
15 tests using Node.js built-in test runner — all passing:

```
▶ slugify
  ✔ converts spaces to hyphens
  ✔ converts to lowercase
  ✔ removes special characters
  ✔ handles null input
  ✔ handles undefined input
  ✔ handles empty string
  ✔ handles string with only whitespace
  ✔ keeps alphanumeric characters
  ✔ keeps underscores
  ✔ keeps existing hyphens
  ✔ collapses multiple spaces into single hyphen
  ✔ trims leading and trailing hyphens
  ✔ handles mixed special chars and spaces
  ✔ handles already slugified input
  ✔ handles numbers only
```

Resolves #5065