### PR TITLE
Add kangxi radical horse API utility

### DIFF
--- a/apps/api/src/utils/batch-smoke-test.ts
+++ b/apps/api/src/utils/batch-smoke-test.ts
@@ -1,0 +1,9 @@
+import { strict as assert } from "node:assert";
+
+import { $fn as isKangxiRadicalHorsePresent } from "./is-kangxi-radical-horse-present";
+
+assert.equal(isKangxiRadicalHorsePresent(""), false);
+assert.equal(isKangxiRadicalHorsePresent("plain ascii text"), false);
+assert.equal(isKangxiRadicalHorsePresent("contains \u2fba radical"), true);
+assert.equal(isKangxiRadicalHorsePresent("\u2fba"), true);
+assert.equal(isKangxiRadicalHorsePresent("nearby radical \u2fb9"), false);

--- a/apps/api/src/utils/is-kangxi-radical-horse-present.ts
+++ b/apps/api/src/utils/is-kangxi-radical-horse-present.ts
@@ -1,0 +1,5 @@
+const KANGXI_RADICAL_HORSE = "\u2fba";
+
+export function $fn(input: string): boolean {
+  return input.includes(KANGXI_RADICAL_HORSE);
+}


### PR DESCRIPTION
## Summary
- Add dependency-free `is-kangxi-radical-horse-present` utility for U+2FBA.
- Cover empty input, plain text, positive embedded character, exact character, and nearby radical negative case in the batch smoke test.

## Testing
- `npx.cmd tsx apps/api/src/utils/batch-smoke-test.ts`

/claim #6603

Payment/contact if accepted:
https://paypal.me/nhatminh122004
nhatminh122004@gmail.com
