### PR TITLE
Add kangxi radical fragrant API utility

### DIFF
--- a/apps/api/src/utils/batch-smoke-test.ts
+++ b/apps/api/src/utils/batch-smoke-test.ts
@@ -1,0 +1,9 @@
+import { strict as assert } from "node:assert";
+
+import { $fn as isKangxiRadicalFragrantPresent } from "./is-kangxi-radical-fragrant-present";
+
+assert.equal(isKangxiRadicalFragrantPresent(""), false);
+assert.equal(isKangxiRadicalFragrantPresent("plain ascii text"), false);
+assert.equal(isKangxiRadicalFragrantPresent("contains \u2fb9 radical"), true);
+assert.equal(isKangxiRadicalFragrantPresent("\u2fb9"), true);
+assert.equal(isKangxiRadicalFragrantPresent("nearby radical \u2fb8"), false);

--- a/apps/api/src/utils/is-kangxi-radical-fragrant-present.ts
+++ b/apps/api/src/utils/is-kangxi-radical-fragrant-present.ts
@@ -1,0 +1,5 @@
+const KANGXI_RADICAL_FRAGRANT = "\u2fb9";
+
+export function $fn(input: string): boolean {
+  return input.includes(KANGXI_RADICAL_FRAGRANT);
+}


### PR DESCRIPTION
## Summary
- Add dependency-free `is-kangxi-radical-fragrant-present` utility for U+2FB9.
- Cover empty input, plain text, positive embedded character, exact character, and nearby radical negative case in the batch smoke test.

## Testing
- `npx.cmd tsx apps/api/src/utils/batch-smoke-test.ts`

/claim #6602

Payment/contact if accepted:
https://paypal.me/nhatminh122004
nhatminh122004@gmail.com
