### PR TITLE
Add kangxi radical head API utility

### DIFF
--- a/apps/api/src/utils/batch-smoke-test.ts
+++ b/apps/api/src/utils/batch-smoke-test.ts
@@ -1,0 +1,9 @@
+import { strict as assert } from "node:assert";
+
+import { $fn as isKangxiRadicalHeadPresent } from "./is-kangxi-radical-head-present";
+
+assert.equal(isKangxiRadicalHeadPresent(""), false);
+assert.equal(isKangxiRadicalHeadPresent("plain ascii text"), false);
+assert.equal(isKangxiRadicalHeadPresent("contains \u2fb8 radical"), true);
+assert.equal(isKangxiRadicalHeadPresent("\u2fb8"), true);
+assert.equal(isKangxiRadicalHeadPresent("nearby radical \u2fb7"), false);

--- a/apps/api/src/utils/is-kangxi-radical-head-present.ts
+++ b/apps/api/src/utils/is-kangxi-radical-head-present.ts
@@ -1,0 +1,5 @@
+const KANGXI_RADICAL_HEAD = "\u2fb8";
+
+export function $fn(input: string): boolean {
+  return input.includes(KANGXI_RADICAL_HEAD);
+}


### PR DESCRIPTION
## Summary
- Add dependency-free `is-kangxi-radical-head-present` utility for U+2FB8.
- Cover empty input, plain text, positive embedded character, exact character, and nearby radical negative case in the batch smoke test.

## Testing
- `npx.cmd tsx apps/api/src/utils/batch-smoke-test.ts`

/claim #6601

Payment/contact if accepted:
https://paypal.me/nhatminh122004
nhatminh122004@gmail.com
