### PR TITLE
Add kangxi radical eat API utility

### DIFF
--- a/apps/api/src/utils/batch-smoke-test.ts
+++ b/apps/api/src/utils/batch-smoke-test.ts
@@ -1,0 +1,9 @@
+import { strict as assert } from "node:assert";
+
+import { $fn as isKangxiRadicalEatPresent } from "./is-kangxi-radical-eat-present";
+
+assert.equal(isKangxiRadicalEatPresent(""), false);
+assert.equal(isKangxiRadicalEatPresent("plain ascii text"), false);
+assert.equal(isKangxiRadicalEatPresent("contains \u2fb7 radical"), true);
+assert.equal(isKangxiRadicalEatPresent("\u2fb7"), true);
+assert.equal(isKangxiRadicalEatPresent("nearby radical \u2fb6"), false);

--- a/apps/api/src/utils/is-kangxi-radical-eat-present.ts
+++ b/apps/api/src/utils/is-kangxi-radical-eat-present.ts
@@ -1,0 +1,5 @@
+const KANGXI_RADICAL_EAT = "\u2fb7";
+
+export function $fn(input: string): boolean {
+  return input.includes(KANGXI_RADICAL_EAT);
+}


### PR DESCRIPTION
## Summary
- Add dependency-free `is-kangxi-radical-eat-present` utility for U+2FB7.
- Cover empty input, plain text, positive embedded character, exact character, and nearby radical negative case in the batch smoke test.

## Testing
- `npx.cmd tsx apps/api/src/utils/batch-smoke-test.ts`

/claim #6600

Payment/contact if accepted:
https://paypal.me/nhatminh122004
nhatminh122004@gmail.com