### PR TITLE
Add kangxi radical fly API utility

### DIFF
--- a/apps/api/src/utils/batch-smoke-test.ts
+++ b/apps/api/src/utils/batch-smoke-test.ts
@@ -1,0 +1,9 @@
+import { strict as assert } from "node:assert";
+
+import { $fn as isKangxiRadicalFlyPresent } from "./is-kangxi-radical-fly-present";
+
+assert.equal(isKangxiRadicalFlyPresent(""), false);
+assert.equal(isKangxiRadicalFlyPresent("plain ascii text"), false);
+assert.equal(isKangxiRadicalFlyPresent("contains \u2fb6 radical"), true);
+assert.equal(isKangxiRadicalFlyPresent("\u2fb6"), true);
+assert.equal(isKangxiRadicalFlyPresent("nearby radical \u2fb7"), false);

--- a/apps/api/src/utils/is-kangxi-radical-fly-present.ts
+++ b/apps/api/src/utils/is-kangxi-radical-fly-present.ts
@@ -1,0 +1,5 @@
+const KANGXI_RADICAL_FLY = "\u2fb6";
+
+export function $fn(input: string): boolean {
+  return input.includes(KANGXI_RADICAL_FLY);
+}


### PR DESCRIPTION
## Summary
- Add dependency-free `is-kangxi-radical-fly-present` utility for U+2FB6.
- Add batch smoke coverage for empty input, plain text, embedded radical, exact radical, and nearby radical negative case.

## Testing
- `npx.cmd tsx apps/api/src/utils/batch-smoke-test.ts`

/claim #6599

Payment/contact if accepted:
https://paypal.me/nhatminh122004
nhatminh122004@gmail.com