### PR TITLE
Add kangxi radical sound API utility

### DIFF
--- a/apps/api/src/utils/batch-smoke-test.ts
+++ b/apps/api/src/utils/batch-smoke-test.ts
@@ -1,0 +1,9 @@
+import { strict as assert } from "node:assert";
+
+import { $fn as isKangxiRadicalSoundPresent } from "./is-kangxi-radical-sound-present";
+
+assert.equal(isKangxiRadicalSoundPresent(""), false);
+assert.equal(isKangxiRadicalSoundPresent("plain ascii text"), false);
+assert.equal(isKangxiRadicalSoundPresent("contains \u2fb3 radical"), true);
+assert.equal(isKangxiRadicalSoundPresent("\u2fb3"), true);
+assert.equal(isKangxiRadicalSoundPresent("nearby radical \u2fb2"), false);

--- a/apps/api/src/utils/is-kangxi-radical-sound-present.ts
+++ b/apps/api/src/utils/is-kangxi-radical-sound-present.ts
@@ -1,0 +1,5 @@
+const KANGXI_RADICAL_SOUND = "\u2fb3";
+
+export function $fn(input: string): boolean {
+  return input.includes(KANGXI_RADICAL_SOUND);
+}


### PR DESCRIPTION
## Summary
- Add dependency-free `is-kangxi-radical-sound-present` utility for U+2FB3.
- Add batch smoke coverage for empty input, plain text, embedded radical, exact radical, and nearby radical negative case.

## Testing
- `npx.cmd tsx apps/api/src/utils/batch-smoke-test.ts`

/claim #6589

Payment/contact if accepted:
https://paypal.me/nhatminh122004
nhatminh122004@gmail.com