### PR TITLE
Add kangxi radical leek API utility

### DIFF
--- a/apps/api/src/utils/batch-smoke-test.ts
+++ b/apps/api/src/utils/batch-smoke-test.ts
@@ -1,0 +1,9 @@
+import { strict as assert } from "node:assert";
+
+import { $fn as isKangxiRadicalLeekPresent } from "./is-kangxi-radical-leek-present";
+
+assert.equal(isKangxiRadicalLeekPresent(""), false);
+assert.equal(isKangxiRadicalLeekPresent("plain ascii text"), false);
+assert.equal(isKangxiRadicalLeekPresent("contains \u2fb2 radical"), true);
+assert.equal(isKangxiRadicalLeekPresent("\u2fb2"), true);
+assert.equal(isKangxiRadicalLeekPresent("nearby radical \u2fb3"), false);

--- a/apps/api/src/utils/is-kangxi-radical-leek-present.ts
+++ b/apps/api/src/utils/is-kangxi-radical-leek-present.ts
@@ -1,0 +1,5 @@
+const KANGXI_RADICAL_LEEK = "\u2fb2";
+
+export function $fn(input: string): boolean {
+  return input.includes(KANGXI_RADICAL_LEEK);
+}


### PR DESCRIPTION
## Summary
- Add dependency-free `is-kangxi-radical-leek-present` utility for U+2FB2.
- Add batch smoke coverage for empty input, plain text, embedded radical, exact radical, and nearby radical negative case.

## Testing
- `npx.cmd tsx apps/api/src/utils/batch-smoke-test.ts`

/claim #6588

Payment/contact if accepted:
https://paypal.me/nhatminh122004
nhatminh122004@gmail.com