### PR TITLE
Add kangxi radical tanned leather API utility

### DIFF
--- a/apps/api/src/utils/batch-smoke-test.ts
+++ b/apps/api/src/utils/batch-smoke-test.ts
@@ -1,0 +1,9 @@
+import { strict as assert } from "node:assert";
+
+import { $fn as isKangxiRadicalTannedLeatherPresent } from "./is-kangxi-radical-tanned-leather-present";
+
+assert.equal(isKangxiRadicalTannedLeatherPresent(""), false);
+assert.equal(isKangxiRadicalTannedLeatherPresent("plain ascii text"), false);
+assert.equal(isKangxiRadicalTannedLeatherPresent("contains \u2fb1 radical"), true);
+assert.equal(isKangxiRadicalTannedLeatherPresent("\u2fb1"), true);
+assert.equal(isKangxiRadicalTannedLeatherPresent("nearby radical \u2fb0"), false);

--- a/apps/api/src/utils/is-kangxi-radical-tanned-leather-present.ts
+++ b/apps/api/src/utils/is-kangxi-radical-tanned-leather-present.ts
@@ -1,0 +1,5 @@
+const KANGXI_RADICAL_TANNED_LEATHER = "\u2fb1";
+
+export function $fn(input: string): boolean {
+  return input.includes(KANGXI_RADICAL_TANNED_LEATHER);
+}


### PR DESCRIPTION
## Summary
- Add dependency-free `is-kangxi-radical-tanned-leather-present` utility for U+2FB1.
- Add batch smoke coverage for empty input, plain text, embedded radical, exact radical, and nearby radical negative case.

## Testing
- `npx.cmd tsx apps/api/src/utils/batch-smoke-test.ts`

/claim #6587

Payment/contact if accepted:
https://paypal.me/nhatminh122004
nhatminh122004@gmail.com