### PR TITLE
Add kangxi radical leather API utility

### DIFF
--- a/apps/api/src/utils/batch-smoke-test.ts
+++ b/apps/api/src/utils/batch-smoke-test.ts
@@ -1,0 +1,9 @@
+import { strict as assert } from "node:assert";
+
+import { $fn as isKangxiRadicalLeatherPresent } from "./is-kangxi-radical-leather-present";
+
+assert.equal(isKangxiRadicalLeatherPresent(""), false);
+assert.equal(isKangxiRadicalLeatherPresent("plain ascii text"), false);
+assert.equal(isKangxiRadicalLeatherPresent("contains \u2fb0 radical"), true);
+assert.equal(isKangxiRadicalLeatherPresent("\u2fb0"), true);
+assert.equal(isKangxiRadicalLeatherPresent("nearby radical \u2fb1"), false);

--- a/apps/api/src/utils/is-kangxi-radical-leather-present.ts
+++ b/apps/api/src/utils/is-kangxi-radical-leather-present.ts
@@ -1,0 +1,5 @@
+const KANGXI_RADICAL_LEATHER = "\u2fb0";
+
+export function $fn(input: string): boolean {
+  return input.includes(KANGXI_RADICAL_LEATHER);
+}


### PR DESCRIPTION
## Summary
- Add dependency-free `is-kangxi-radical-leather-present` utility for U+2FB0.
- Add batch smoke coverage for empty input, plain text, embedded radical, exact radical, and nearby radical negative case.

## Testing
- `npx.cmd tsx apps/api/src/utils/batch-smoke-test.ts`

/claim #6586

Payment/contact if accepted:
https://paypal.me/nhatminh122004
nhatminh122004@gmail.com