### PR TITLE
Add kangxi radical face API utility

### DIFF
--- a/apps/api/src/utils/batch-smoke-test.ts
+++ b/apps/api/src/utils/batch-smoke-test.ts
@@ -1,0 +1,9 @@
+import { strict as assert } from "node:assert";
+
+import { $fn as isKangxiRadicalFacePresent } from "./is-kangxi-radical-face-present";
+
+assert.equal(isKangxiRadicalFacePresent(""), false);
+assert.equal(isKangxiRadicalFacePresent("plain ascii text"), false);
+assert.equal(isKangxiRadicalFacePresent("contains \u2faf radical"), true);
+assert.equal(isKangxiRadicalFacePresent("\u2faf"), true);
+assert.equal(isKangxiRadicalFacePresent("nearby radical \u2fb0"), false);

--- a/apps/api/src/utils/is-kangxi-radical-face-present.ts
+++ b/apps/api/src/utils/is-kangxi-radical-face-present.ts
@@ -1,0 +1,5 @@
+const KANGXI_RADICAL_FACE = "\u2faf";
+
+export function $fn(input: string): boolean {
+  return input.includes(KANGXI_RADICAL_FACE);
+}


### PR DESCRIPTION
## Summary
- Add dependency-free `is-kangxi-radical-face-present` utility for U+2FAF.
- Add batch smoke coverage for empty input, plain text, embedded radical, exact radical, and nearby radical negative case.

## Testing
- `npx.cmd tsx apps/api/src/utils/batch-smoke-test.ts`

/claim #6585

Payment/contact if accepted:
https://paypal.me/nhatminh122004
nhatminh122004@gmail.com