### PR TITLE
Add kangxi radical short-tailed bird API utility

### DIFF
--- a/apps/api/src/utils/batch-smoke-test.ts
+++ b/apps/api/src/utils/batch-smoke-test.ts
@@ -1,0 +1,9 @@
+import { strict as assert } from "node:assert";
+
+import { $fn as isKangxiRadicalShortTailedBirdPresent } from "./is-kangxi-radical-short-tailed-bird-present";
+
+assert.equal(isKangxiRadicalShortTailedBirdPresent(""), false);
+assert.equal(isKangxiRadicalShortTailedBirdPresent("plain ascii text"), false);
+assert.equal(isKangxiRadicalShortTailedBirdPresent("contains \u2fab radical"), true);
+assert.equal(isKangxiRadicalShortTailedBirdPresent("\u2fab"), true);
+assert.equal(isKangxiRadicalShortTailedBirdPresent("nearby radical \u2faa"), false);

--- a/apps/api/src/utils/is-kangxi-radical-short-tailed-bird-present.ts
+++ b/apps/api/src/utils/is-kangxi-radical-short-tailed-bird-present.ts
@@ -1,0 +1,5 @@
+const KANGXI_RADICAL_SHORT_TAILED_BIRD = "\u2fab";
+
+export function $fn(input: string): boolean {
+  return input.includes(KANGXI_RADICAL_SHORT_TAILED_BIRD);
+}


### PR DESCRIPTION
## Summary
- Add dependency-free `is-kangxi-radical-short-tailed-bird-present` utility for U+2FAB.
- Add batch smoke coverage for empty input, plain text, embedded radical, exact radical, and nearby radical negative case.

## Testing
- `npx.cmd tsx apps/api/src/utils/batch-smoke-test.ts`

/claim #6579

Payment/contact if accepted:
https://paypal.me/nhatminh122004
nhatminh122004@gmail.com