### PR TITLE
Add kangxi radical slave API utility

### DIFF
--- a/apps/api/src/utils/batch-smoke-test.ts
+++ b/apps/api/src/utils/batch-smoke-test.ts
@@ -1,0 +1,9 @@
+import { strict as assert } from "node:assert";
+
+import { $fn as isKangxiRadicalSlavePresent } from "./is-kangxi-radical-slave-present";
+
+assert.equal(isKangxiRadicalSlavePresent(""), false);
+assert.equal(isKangxiRadicalSlavePresent("plain ascii text"), false);
+assert.equal(isKangxiRadicalSlavePresent("contains \u2faa radical"), true);
+assert.equal(isKangxiRadicalSlavePresent("\u2faa"), true);
+assert.equal(isKangxiRadicalSlavePresent("nearby radical \u2fab"), false);

--- a/apps/api/src/utils/is-kangxi-radical-slave-present.ts
+++ b/apps/api/src/utils/is-kangxi-radical-slave-present.ts
@@ -1,0 +1,5 @@
+const KANGXI_RADICAL_SLAVE = "\u2faa";
+
+export function $fn(input: string): boolean {
+  return input.includes(KANGXI_RADICAL_SLAVE);
+}


### PR DESCRIPTION
## Summary
- Add dependency-free `is-kangxi-radical-slave-present` utility for U+2FAA.
- Add batch smoke coverage for empty input, plain text, embedded radical, exact radical, and nearby radical negative case.

## Testing
- `npx.cmd tsx apps/api/src/utils/batch-smoke-test.ts`

/claim #6578

Payment/contact if accepted:
https://paypal.me/nhatminh122004
nhatminh122004@gmail.com