### PR TITLE
Add kangxi radical mound API utility

### DIFF
--- a/apps/api/src/utils/batch-smoke-test.ts
+++ b/apps/api/src/utils/batch-smoke-test.ts
@@ -1,0 +1,9 @@
+import { strict as assert } from "node:assert";
+
+import { $fn as isKangxiRadicalMoundPresent } from "./is-kangxi-radical-mound-present";
+
+assert.equal(isKangxiRadicalMoundPresent(""), false);
+assert.equal(isKangxiRadicalMoundPresent("plain ascii text"), false);
+assert.equal(isKangxiRadicalMoundPresent("contains \u2fa9 radical"), true);
+assert.equal(isKangxiRadicalMoundPresent("\u2fa9"), true);
+assert.equal(isKangxiRadicalMoundPresent("nearby radical \u2faa"), false);

--- a/apps/api/src/utils/is-kangxi-radical-mound-present.ts
+++ b/apps/api/src/utils/is-kangxi-radical-mound-present.ts
@@ -1,0 +1,5 @@
+const KANGXI_RADICAL_MOUND = "\u2fa9";
+
+export function $fn(input: string): boolean {
+  return input.includes(KANGXI_RADICAL_MOUND);
+}


### PR DESCRIPTION
## Summary
- Add dependency-free `is-kangxi-radical-mound-present` utility for U+2FA9.
- Add batch smoke coverage for empty input, plain text, embedded radical, exact radical, and nearby radical negative case.

## Testing
- `npx.cmd tsx apps/api/src/utils/batch-smoke-test.ts`

/claim #6577

Payment/contact if accepted:
https://paypal.me/nhatminh122004
nhatminh122004@gmail.com