### PR TITLE
Add kangxi radical gold API utility

### DIFF
--- a/apps/api/src/utils/batch-smoke-test.ts
+++ b/apps/api/src/utils/batch-smoke-test.ts
@@ -1,0 +1,9 @@
+import { strict as assert } from "node:assert";
+
+import { $fn as isKangxiRadicalGoldPresent } from "./is-kangxi-radical-gold-present";
+
+assert.equal(isKangxiRadicalGoldPresent(""), false);
+assert.equal(isKangxiRadicalGoldPresent("plain ascii text"), false);
+assert.equal(isKangxiRadicalGoldPresent("contains \u2fa6 radical"), true);
+assert.equal(isKangxiRadicalGoldPresent("\u2fa6"), true);
+assert.equal(isKangxiRadicalGoldPresent("nearby radical \u2fa5"), false);

--- a/apps/api/src/utils/is-kangxi-radical-gold-present.ts
+++ b/apps/api/src/utils/is-kangxi-radical-gold-present.ts
@@ -1,0 +1,5 @@
+const KANGXI_RADICAL_GOLD = "\u2fa6";
+
+export function $fn(input: string): boolean {
+  return input.includes(KANGXI_RADICAL_GOLD);
+}


### PR DESCRIPTION
## Summary
- Add dependency-free `is-kangxi-radical-gold-present` utility for U+2FA6.
- Add batch smoke coverage for empty input, plain text, embedded radical, exact radical, and nearby radical negative case.

## Testing
- `npx.cmd tsx apps/api/src/utils/batch-smoke-test.ts`

/claim #6576

Payment/contact if accepted:
https://paypal.me/nhatminh122004
nhatminh122004@gmail.com