### PR TITLE
Add kangxi radical village API utility

### DIFF
--- a/apps/api/src/utils/batch-smoke-test.ts
+++ b/apps/api/src/utils/batch-smoke-test.ts
@@ -1,0 +1,9 @@
+import { strict as assert } from "node:assert";
+
+import { $fn as isKangxiRadicalVillagePresent } from "./is-kangxi-radical-village-present";
+
+assert.equal(isKangxiRadicalVillagePresent(""), false);
+assert.equal(isKangxiRadicalVillagePresent("plain ascii text"), false);
+assert.equal(isKangxiRadicalVillagePresent("contains \u2fa5 radical"), true);
+assert.equal(isKangxiRadicalVillagePresent("\u2fa5"), true);
+assert.equal(isKangxiRadicalVillagePresent("nearby radical \u2fa6"), false);

--- a/apps/api/src/utils/is-kangxi-radical-village-present.ts
+++ b/apps/api/src/utils/is-kangxi-radical-village-present.ts
@@ -1,0 +1,5 @@
+const KANGXI_RADICAL_VILLAGE = "\u2fa5";
+
+export function $fn(input: string): boolean {
+  return input.includes(KANGXI_RADICAL_VILLAGE);
+}


### PR DESCRIPTION
## Summary
- Add dependency-free `is-kangxi-radical-village-present` utility for U+2FA5.
- Add batch smoke coverage for empty input, plain text, embedded radical, exact radical, and nearby radical negative case.

## Testing
- `npx.cmd tsx apps/api/src/utils/batch-smoke-test.ts`

/claim #6575

Payment/contact if accepted:
https://paypal.me/nhatminh122004
nhatminh122004@gmail.com