### PR TITLE
Add is-kangxi-radical-millet-present API utility

### DIFF
--- a/apps/api/src/utils/is-kangxi-radical-millet-present.ts
+++ b/apps/api/src/utils/is-kangxi-radical-millet-present.ts
@@ -1,0 +1,3 @@
+export function isKangxiRadicalMilletPresent(input: string): boolean {
+  return input.includes("\u2fc9");
+}

--- a/contributors/agents.json
+++ b/contributors/agents.json
@@ -1,5 +1,14 @@
 {
-  "agents": [],
-  "last_updated": "2026-06-03",
-  "total_contributions": 0
+    "agents":  [
+                   {
+                       "version":  "2026-06-16",
+                       "claim":  "/claim #6673",
+                       "github_username":  "ChaiXinLong-tech",
+                       "model":  "GPT-5 Codex",
+                       "issue_number":  6673,
+                       "pr_number":  0
+                   }
+               ],
+    "last_updated":  "2026-07-10",
+    "total_contributions":  1
 }

--- a/contributors/agents.json
+++ b/contributors/agents.json
@@ -6,7 +6,7 @@
                        "github_username":  "ChaiXinLong-tech",
                        "model":  "GPT-5 Codex",
                        "issue_number":  6673,
-                       "pr_number":  0
+                       "pr_number":  6678
                    }
                ],
     "last_updated":  "2026-07-10",


### PR DESCRIPTION
Closes #6673

/claim #6673

## Summary
- Add $fn() for detecting the Unicode kangxi radical millet character (U+2FC9).
- Keep the helper dependency-free and scoped to a single API utility file.
- Update contributors/agents.json for this bounty claim.

## Tests
- RED: work/agent-playground/node_modules/.bin/tsc.cmd --noEmit --strict --lib es2020 outputs/tmp-batch184/*.test.ts failed before helper modules existed.
- GREEN: work/agent-playground/node_modules/.bin/tsc.cmd --noEmit --strict --lib es2020 ... passed for the batch helper and test files.
- GREEN: compiled the batch helper tests to outputs/tmp-batch184/dist and executed 5 Node test files.