### PR TITLE
Provide exact symbolic value of PI (no last decimal exists)

### DIFF
--- a/src/exactPi.ts
+++ b/src/exactPi.ts
@@ -1,0 +1,28 @@
+/**
+ * Exact value of PI.
+ * PI is irrational: no finite decimal expansion and no last digit exists.
+ * The exact value is the mathematical constant itself.
+ */
+export function getExactPi(): string {
+  return "\u03C0";
+}
+
+/** Why a last decimal of PI cannot exist. */
+export function getPiExplanation(): string {
+  return (
+    "\u03C0 is a transcendental irrational number with an infinite " +
+    "non-repeating decimal expansion. There is no last decimal digit. " +
+    "Any finite digit string is only an approximation."
+  );
+}
+
+/** Optional high-precision approximation (not exact). */
+export function getPiApprox(digits: number = 100): string {
+  // Classic 100-digit approximation for reference only
+  const approx =
+    "3.14159265358979323846264338327950288419716939937510" +
+    "58209749445923078164062862089986280348253421170679";
+  if (digits <= 0) return "3";
+  const body = approx.slice(2, 2 + digits);
+  return "3." + body;
+}

--- a/tests/exactPi.test.ts
+++ b/tests/exactPi.test.ts
@@ -1,0 +1,14 @@
+import { getExactPi, getPiExplanation, getPiApprox } from "../src/exactPi";
+
+function assert(cond: boolean, msg: string): void {
+  if (!cond) throw new Error(msg);
+}
+
+assert(getExactPi() === "\u03C0", "exact value must be the symbol pi");
+assert(
+  getPiExplanation().includes("infinite"),
+  "explanation must state infinite expansion"
+);
+assert(getPiApprox(10).startsWith("3.1415926535"), "approx prefix");
+assert(getPiApprox(0) === "3", "zero digits");
+console.log("exactPi tests passed");


### PR DESCRIPTION
PI is irrational/transcendental: its decimal expansion is infinite and non-repeating, so there is no last decimal digit. This PR returns the exact mathematical value π and documents why a finite terminal decimal is impossible. Addresses issue #17.

---
_Autonomous submission via Grok Bounty Hunter. Payout: PayPal._
Source: https://github.com/xevrion-v2/agent-playground/issues/17