### PR TITLE
Validate user creation payloads

### DIFF
--- a/src/user_validation.py
+++ b/src/user_validation.py
@@ -1,0 +1,46 @@
+"""Validation and normalization for user creation payloads."""
+from __future__ import annotations
+
+import re
+from typing import Any, Dict, Optional, Tuple
+
+EMAIL_RE = re.compile(r"^[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\.[a-zA-Z]{2,}$")
+
+
+def normalize_email(email: str) -> str:
+    return email.strip().lower()
+
+
+def normalize_name(name: Any) -> Optional[str]:
+    if name is None or not isinstance(name, str):
+        return None
+    stripped = " ".join(name.split())
+    return stripped or None
+
+
+def validate_user_payload(body: Any) -> Tuple[Optional[Dict[str, Any]], Optional[str]]:
+    """Validate user creation body.
+
+    Returns (normalized_fields, error_message).
+    Server generates ids; client id and extra fields are ignored.
+    """
+    if not isinstance(body, dict):
+        return None, "Request body must be a JSON object"
+
+    raw_email = body.get("email")
+    if raw_email is None or not isinstance(raw_email, str) or not raw_email.strip():
+        return None, "email is required"
+
+    email = normalize_email(raw_email)
+    if not EMAIL_RE.match(email):
+        return None, "email must be a valid email address"
+
+    result: Dict[str, Any] = {"email": email}
+
+    if "name" in body:
+        name = normalize_name(body.get("name"))
+        if name is not None:
+            result["name"] = name
+
+    # Intentionally drop id and any unrelated keys
+    return result, None

--- a/tests/test_user_validation.py
+++ b/tests/test_user_validation.py
@@ -1,0 +1,51 @@
+"""Regression tests for user creation payload validation."""
+import unittest
+
+from src.user_validation import validate_user_payload
+
+
+class TestUserValidation(unittest.TestCase):
+    def test_reject_non_object_json_bodies(self):
+        for body in (None, [], "string", 42, True):
+            data, err = validate_user_payload(body)
+            self.assertIsNone(data)
+            self.assertIn("JSON object", err)
+
+    def test_require_valid_email(self):
+        data, err = validate_user_payload({})
+        self.assertIsNone(data)
+        self.assertIn("email", err.lower())
+
+        data, err = validate_user_payload({"email": ""})
+        self.assertIsNone(data)
+
+        data, err = validate_user_payload({"email": "not-an-email"})
+        self.assertIsNone(data)
+        self.assertIn("valid", err.lower())
+
+    def test_normalize_email_and_name(self):
+        data, err = validate_user_payload(
+            {"email": "  User@Example.COM  ", "name": "  Jane   Doe  "}
+        )
+        self.assertIsNone(err)
+        self.assertEqual(data["email"], "user@example.com")
+        self.assertEqual(data["name"], "Jane Doe")
+
+    def test_ignore_client_id_and_extra_fields(self):
+        data, err = validate_user_payload(
+            {
+                "email": "a@b.co",
+                "id": "client-controlled-id",
+                "role": "admin",
+                "extra": True,
+            }
+        )
+        self.assertIsNone(err)
+        self.assertEqual(data, {"email": "a@b.co"})
+        self.assertNotIn("id", data)
+        self.assertNotIn("role", data)
+        self.assertNotIn("extra", data)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Harden POST /users by validating and normalizing request bodies.

- Reject non-object JSON bodies
- Require a valid email (normalized to lowercase/trimmed)
- Normalize optional name (collapse whitespace)
- Ignore client-controlled id and unrelated fields
- Add regression tests covering acceptance criteria

References #2207

## Bounty
https://github.com/xevrion-v2/agent-playground/issues/2207

Fixes #2207
$ #2207

---
_Submitted by Grok Bounty Hunter (automated draft — review before merge)._