### PR TITLE
docs: add JSDoc comments to users route handlers

### DIFF
--- a/apps/api/src/routes/users.ts
+++ b/apps/api/src/routes/users.ts
@@ -1,15 +1,39 @@
-import { Router } from "express";
+import { Router, Request, Response } from "express";
 
 const router = Router();
 
-router.get("/", (_req, res) => {
+/**
+ * GET /users
+ *
+ * Retrieve a list of all users.
+ *
+ * @route GET /
+ * @returns {Object} Response with empty data array and status message
+ * @returns {Array} response.data - Array of user objects (currently empty)
+ * @returns {string} response.message - Status message
+ */
+router.get("/", (_req: Request, res: Response) => {
   res.json({
     data: [],
     message: "User listing is not implemented yet."
   });
 });
 
-router.post("/", (req, res) => {
+/**
+ * POST /users
+ *
+ * Create a new user account.
+ *
+ * @route POST /
+ * @param {Object} req.body - User data to create
+ * @param {string} req.body.name - User's display name
+ * @param {string} req.body.email - User's email address
+ * @returns {Object} Response with created user data and status message
+ * @returns {Object} response.data - Created user object with generated ID
+ * @returns {string} response.data.id - Unique user identifier
+ * @returns {string} response.message - Status message
+ */
+router.post("/", (req: Request, res: Response) => {
   res.status(201).json({
     data: {
       id: "stub-user-id",


### PR DESCRIPTION
## Changes

Added comprehensive JSDoc documentation to `apps/api/src/routes/users.ts`:

### GET /users
- Documents the endpoint for retrieving all users
- Specifies return type structure (data array + message)

### POST /users
- Documents the endpoint for creating new users
- Lists expected request body parameters (name, email)
- Specifies return type with generated ID

### Additional
- Added `Request` and `Response` type imports from Express
- Proper TypeScript parameter typing on route handlers

## Example Output

```typescript
/**
 * GET /users
 *
 * Retrieve a list of all users.
 *
 * @route GET /
 * @returns {Object} Response with empty data array and status message
 * @returns {Array} response.data - Array of user objects (currently empty)
 * @returns {string} response.message - Status message
 */
```

Fixes #1