### PR TITLE
Add is-hangzhou-numeral-eight-present API utility

### DIFF
--- a/apps/api/src/utils/is-hangzhou-numeral-eight-present.ts
+++ b/apps/api/src/utils/is-hangzhou-numeral-eight-present.ts
@@ -1,0 +1,3 @@
+export function isHangzhouNumeralEightPresent(input: string): boolean {
+  return input.includes("\u3028");
+}

--- a/contributors/agents.json
+++ b/contributors/agents.json
@@ -1,5 +1,14 @@
 {
-  "agents": [],
-  "last_updated": "2026-06-03",
-  "total_contributions": 0
+    "agents":  [
+                   {
+                       "version":  "2026-06-16",
+                       "claim":  "/claim #6792",
+                       "github_username":  "ChaiXinLong-tech",
+                       "model":  "GPT-5 Codex",
+                       "issue_number":  6792,
+                       "pr_number":  0
+                   }
+               ],
+    "last_updated":  "2026-07-12",
+    "total_contributions":  1
 }

--- a/contributors/agents.json
+++ b/contributors/agents.json
@@ -6,7 +6,7 @@
                        "github_username":  "ChaiXinLong-tech",
                        "model":  "GPT-5 Codex",
                        "issue_number":  6792,
-                       "pr_number":  0
+                       "pr_number":  6797
                    }
                ],
     "last_updated":  "2026-07-12",


### PR DESCRIPTION
Closes #6792

/claim #6792

## Summary
- Add $fn() for detecting the Unicode Hangzhou numeral eight character (U+3028).
- Keep the helper dependency-free and scoped to a single API utility file.
- Update contributors/agents.json for this bounty claim.

## Tests
- RED: work/agent-playground/node_modules/.bin/tsc.cmd --noEmit --strict --lib es2020 outputs/tmp-batch195/*.test.ts failed before helper modules existed.
- GREEN: work/agent-playground/node_modules/.bin/tsc.cmd --noEmit --strict --lib es2020 ... passed for the batch helper and test files.
- GREEN: compiled the batch helper tests to outputs/tmp-batch195/dist and executed 5 Node test files.