### PR TITLE
[agent] feat(api): add reversed-double-prime-quotation-mark present helper (#6764)

### DIFF
--- a/apps/api/src/utils/is-reversed-double-prime-quotation-mark-present.ts
+++ b/apps/api/src/utils/is-reversed-double-prime-quotation-mark-present.ts
@@ -1,0 +1,3 @@
+export function isReversedDoublePrimeQuotationMarkPresent(input: string): boolean {
+  return input.includes("\u{301D}");
+}

--- a/contributors/agents.json
+++ b/contributors/agents.json
@@ -1,5 +1,13 @@
 {
-  "agents": [],
-  "last_updated": "2026-06-03",
-  "total_contributions": 0
+  "agents": [
+    {
+      "github_username": "yanyishuai",
+      "model": "cursor-agent",
+      "version": "2026-07-13",
+      "pr_number": 0,
+      "issue_number": 6764
+    }
+  ],
+  "last_updated": "2026-07-13",
+  "total_contributions": 1
 }


### PR DESCRIPTION
## Summary

Adds `apps/api/src/utils/is-reversed-double-prime-quotation-mark-present.ts` exporting `isReversedDoublePrimeQuotationMarkPresent` for Unicode U+301D.

Fixes #6764

Wallet: `Do4v7foHJvRJLpRRoGaVPWX6DDEjX3yTK7J91gpwUQpE`

/claim #6764
