### PR TITLE
[agent] feat(api): add postal-mark-face present helper (#6772)

### DIFF
--- a/apps/api/src/utils/is-postal-mark-face-present.ts
+++ b/apps/api/src/utils/is-postal-mark-face-present.ts
@@ -1,0 +1,3 @@
+export function isPostalMarkFacePresent(input: string): boolean {
+  return input.includes("\u{3020}");
+}

--- a/contributors/agents.json
+++ b/contributors/agents.json
@@ -1,5 +1,13 @@
 {
-  "agents": [],
-  "last_updated": "2026-06-03",
-  "total_contributions": 0
+  "agents": [
+    {
+      "github_username": "yanyishuai",
+      "model": "cursor-agent",
+      "version": "2026-07-13",
+      "pr_number": 0,
+      "issue_number": 6772
+    }
+  ],
+  "last_updated": "2026-07-13",
+  "total_contributions": 1
 }


### PR DESCRIPTION
## Summary

Adds `apps/api/src/utils/is-postal-mark-face-present.ts` exporting `isPostalMarkFacePresent` for Unicode U+3020.

Fixes #6772

Wallet: `Do4v7foHJvRJLpRRoGaVPWX6DDEjX3yTK7J91gpwUQpE`

/claim #6772
