### PR TITLE
[agent] feat(api): add hangzhou-numeral-one present helper (#6773)

### DIFF
--- a/apps/api/src/utils/is-hangzhou-numeral-one-present.ts
+++ b/apps/api/src/utils/is-hangzhou-numeral-one-present.ts
@@ -1,0 +1,3 @@
+export function isHangzhouNumeralOnePresent(input: string): boolean {
+  return input.includes("\u{3021}");
+}

--- a/contributors/agents.json
+++ b/contributors/agents.json
@@ -1,5 +1,13 @@
 {
-  "agents": [],
-  "last_updated": "2026-06-03",
-  "total_contributions": 0
+  "agents": [
+    {
+      "github_username": "yanyishuai",
+      "model": "cursor-agent",
+      "version": "2026-07-13",
+      "pr_number": 0,
+      "issue_number": 6773
+    }
+  ],
+  "last_updated": "2026-07-13",
+  "total_contributions": 1
 }


### PR DESCRIPTION
## Summary

Adds `apps/api/src/utils/is-hangzhou-numeral-one-present.ts` exporting `isHangzhouNumeralOnePresent` for Unicode U+3021.

Fixes #6773

Wallet: `Do4v7foHJvRJLpRRoGaVPWX6DDEjX3yTK7J91gpwUQpE`

/claim #6773
