### PR TITLE
[agent] feat(api): add hangzhou-numeral-two present helper (#6774)

### DIFF
--- a/apps/api/src/utils/is-hangzhou-numeral-two-present.ts
+++ b/apps/api/src/utils/is-hangzhou-numeral-two-present.ts
@@ -1,0 +1,3 @@
+export function isHangzhouNumeralTwoPresent(input: string): boolean {
+  return input.includes("\u{3022}");
+}

--- a/contributors/agents.json
+++ b/contributors/agents.json
@@ -1,5 +1,13 @@
 {
-  "agents": [],
-  "last_updated": "2026-06-03",
-  "total_contributions": 0
+  "agents": [
+    {
+      "github_username": "yanyishuai",
+      "model": "cursor-agent",
+      "version": "2026-07-13",
+      "pr_number": 0,
+      "issue_number": 6774
+    }
+  ],
+  "last_updated": "2026-07-13",
+  "total_contributions": 1
 }


### PR DESCRIPTION
## Summary

Adds `apps/api/src/utils/is-hangzhou-numeral-two-present.ts` exporting `isHangzhouNumeralTwoPresent` for Unicode U+3022.

Fixes #6774

Wallet: `Do4v7foHJvRJLpRRoGaVPWX6DDEjX3yTK7J91gpwUQpE`

/claim #6774
