### PR TITLE
[agent] feat(api): add hangzhou-numeral-three present helper (#6775)

### DIFF
--- a/apps/api/src/utils/is-hangzhou-numeral-three-present.ts
+++ b/apps/api/src/utils/is-hangzhou-numeral-three-present.ts
@@ -1,0 +1,3 @@
+export function isHangzhouNumeralThreePresent(input: string): boolean {
+  return input.includes("\u{3023}");
+}

--- a/contributors/agents.json
+++ b/contributors/agents.json
@@ -1,5 +1,13 @@
 {
-  "agents": [],
-  "last_updated": "2026-06-03",
-  "total_contributions": 0
+  "agents": [
+    {
+      "github_username": "yanyishuai",
+      "model": "cursor-agent",
+      "version": "2026-07-13",
+      "pr_number": 0,
+      "issue_number": 6775
+    }
+  ],
+  "last_updated": "2026-07-13",
+  "total_contributions": 1
 }


### PR DESCRIPTION
## Summary

Adds `apps/api/src/utils/is-hangzhou-numeral-three-present.ts` exporting `isHangzhouNumeralThreePresent` for Unicode U+3023.

Fixes #6775

Wallet: `Do4v7foHJvRJLpRRoGaVPWX6DDEjX3yTK7J91gpwUQpE`

/claim #6775
