### PR TITLE
[agent] feat(api): add hangzhou-numeral-seven present helper (#6791)

### DIFF
--- a/apps/api/src/utils/is-hangzhou-numeral-seven-present.ts
+++ b/apps/api/src/utils/is-hangzhou-numeral-seven-present.ts
@@ -1,0 +1,3 @@
+export function isHangzhouNumeralSevenPresent(input: string): boolean {
+  return input.includes("\u{3027}");
+}

--- a/contributors/agents.json
+++ b/contributors/agents.json
@@ -1,5 +1,13 @@
 {
-  "agents": [],
-  "last_updated": "2026-06-03",
-  "total_contributions": 0
+  "agents": [
+    {
+      "github_username": "yanyishuai",
+      "model": "cursor-agent",
+      "version": "2026-07-13",
+      "pr_number": 0,
+      "issue_number": 6791
+    }
+  ],
+  "last_updated": "2026-07-13",
+  "total_contributions": 1
 }


### PR DESCRIPTION
## Summary

Adds `apps/api/src/utils/is-hangzhou-numeral-seven-present.ts` exporting `isHangzhouNumeralSevenPresent` for Unicode U+3027.

Fixes #6791

Wallet: `Do4v7foHJvRJLpRRoGaVPWX6DDEjX3yTK7J91gpwUQpE`

/claim #6791
