### PR TITLE
[agent] feat(api): add hangzhou-numeral-eight present helper (#6792)

### DIFF
--- a/apps/api/src/utils/is-hangzhou-numeral-eight-present.ts
+++ b/apps/api/src/utils/is-hangzhou-numeral-eight-present.ts
@@ -1,0 +1,3 @@
+export function isHangzhouNumeralEightPresent(input: string): boolean {
+  return input.includes("\u{3028}");
+}

--- a/contributors/agents.json
+++ b/contributors/agents.json
@@ -1,5 +1,13 @@
 {
-  "agents": [],
-  "last_updated": "2026-06-03",
-  "total_contributions": 0
+  "agents": [
+    {
+      "github_username": "yanyishuai",
+      "model": "cursor-agent",
+      "version": "2026-07-13",
+      "pr_number": 0,
+      "issue_number": 6792
+    }
+  ],
+  "last_updated": "2026-07-13",
+  "total_contributions": 1
 }


### PR DESCRIPTION
## Summary

Adds `apps/api/src/utils/is-hangzhou-numeral-eight-present.ts` exporting `isHangzhouNumeralEightPresent` for Unicode U+3028.

Fixes #6792

Wallet: `Do4v7foHJvRJLpRRoGaVPWX6DDEjX3yTK7J91gpwUQpE`

/claim #6792
