### PR TITLE
[agent] feat(api): add ideographic-level-tone-mark present helper (#6799)

### DIFF
--- a/apps/api/src/utils/is-ideographic-level-tone-mark-present.ts
+++ b/apps/api/src/utils/is-ideographic-level-tone-mark-present.ts
@@ -1,0 +1,3 @@
+export function isIdeographicLevelToneMarkPresent(input: string): boolean {
+  return input.includes("\u{302A}");
+}

--- a/contributors/agents.json
+++ b/contributors/agents.json
@@ -1,5 +1,13 @@
 {
-  "agents": [],
-  "last_updated": "2026-06-03",
-  "total_contributions": 0
+  "agents": [
+    {
+      "github_username": "yanyishuai",
+      "model": "cursor-agent",
+      "version": "2026-07-13",
+      "pr_number": 0,
+      "issue_number": 6799
+    }
+  ],
+  "last_updated": "2026-07-13",
+  "total_contributions": 1
 }


### PR DESCRIPTION
## Summary

Adds `apps/api/src/utils/is-ideographic-level-tone-mark-present.ts` exporting `isIdeographicLevelToneMarkPresent` for Unicode U+302A.

Fixes #6799

Wallet: `Do4v7foHJvRJLpRRoGaVPWX6DDEjX3yTK7J91gpwUQpE`

/claim #6799
