### PR TITLE
[agent] feat(api): add ideographic-rising-tone-mark present helper (#6800)

### DIFF
--- a/apps/api/src/utils/is-ideographic-rising-tone-mark-present.ts
+++ b/apps/api/src/utils/is-ideographic-rising-tone-mark-present.ts
@@ -1,0 +1,3 @@
+export function isIdeographicRisingToneMarkPresent(input: string): boolean {
+  return input.includes("\u{302B}");
+}

--- a/contributors/agents.json
+++ b/contributors/agents.json
@@ -1,5 +1,13 @@
 {
-  "agents": [],
-  "last_updated": "2026-06-03",
-  "total_contributions": 0
+  "agents": [
+    {
+      "github_username": "yanyishuai",
+      "model": "cursor-agent",
+      "version": "2026-07-13",
+      "pr_number": 0,
+      "issue_number": 6800
+    }
+  ],
+  "last_updated": "2026-07-13",
+  "total_contributions": 1
 }


### PR DESCRIPTION
## Summary

Adds `apps/api/src/utils/is-ideographic-rising-tone-mark-present.ts` exporting `isIdeographicRisingToneMarkPresent` for Unicode U+302B.

Fixes #6800

Wallet: `Do4v7foHJvRJLpRRoGaVPWX6DDEjX3yTK7J91gpwUQpE`

/claim #6800
