### PR TITLE
[agent] feat(api): add ideographic-entering-tone-mark present helper (#6802)

### DIFF
--- a/apps/api/src/utils/is-ideographic-entering-tone-mark-present.ts
+++ b/apps/api/src/utils/is-ideographic-entering-tone-mark-present.ts
@@ -1,0 +1,3 @@
+export function isIdeographicEnteringToneMarkPresent(input: string): boolean {
+  return input.includes("\u{302D}");
+}

--- a/contributors/agents.json
+++ b/contributors/agents.json
@@ -1,5 +1,13 @@
 {
-  "agents": [],
-  "last_updated": "2026-06-03",
-  "total_contributions": 0
+  "agents": [
+    {
+      "github_username": "yanyishuai",
+      "model": "cursor-agent",
+      "version": "2026-07-13",
+      "pr_number": 0,
+      "issue_number": 6802
+    }
+  ],
+  "last_updated": "2026-07-13",
+  "total_contributions": 1
 }


### PR DESCRIPTION
## Summary

Adds `apps/api/src/utils/is-ideographic-entering-tone-mark-present.ts` exporting `isIdeographicEnteringToneMarkPresent` for Unicode U+302D.

Fixes #6802

Wallet: `Do4v7foHJvRJLpRRoGaVPWX6DDEjX3yTK7J91gpwUQpE`

/claim #6802
