### PR TITLE
[agent] feat(api): add hangul-double-dot-tone-mark present helper (#6809)

### DIFF
--- a/apps/api/src/utils/is-hangul-double-dot-tone-mark-present.ts
+++ b/apps/api/src/utils/is-hangul-double-dot-tone-mark-present.ts
@@ -1,0 +1,3 @@
+export function isHangulDoubleDotToneMarkPresent(input: string): boolean {
+  return input.includes("\u{302F}");
+}

--- a/contributors/agents.json
+++ b/contributors/agents.json
@@ -1,5 +1,13 @@
 {
-  "agents": [],
-  "last_updated": "2026-06-03",
-  "total_contributions": 0
+  "agents": [
+    {
+      "github_username": "yanyishuai",
+      "model": "cursor-agent",
+      "version": "2026-07-13",
+      "pr_number": 0,
+      "issue_number": 6809
+    }
+  ],
+  "last_updated": "2026-07-13",
+  "total_contributions": 1
 }


### PR DESCRIPTION
## Summary

Adds `apps/api/src/utils/is-hangul-double-dot-tone-mark-present.ts` exporting `isHangulDoubleDotToneMarkPresent` for Unicode U+302F.

Fixes #6809

Wallet: `Do4v7foHJvRJLpRRoGaVPWX6DDEjX3yTK7J91gpwUQpE`

/claim #6809
