### PR TITLE
[agent] feat(api): add vertical-kana-repeat-with-voiced-sound-mark present helper (#6812)

### DIFF
--- a/apps/api/src/utils/is-vertical-kana-repeat-with-voiced-sound-mark-present.ts
+++ b/apps/api/src/utils/is-vertical-kana-repeat-with-voiced-sound-mark-present.ts
@@ -1,0 +1,3 @@
+export function isVerticalKanaRepeatWithVoicedSoundMarkPresent(input: string): boolean {
+  return input.includes("\u{3032}");
+}

--- a/contributors/agents.json
+++ b/contributors/agents.json
@@ -1,5 +1,13 @@
 {
-  "agents": [],
-  "last_updated": "2026-06-03",
-  "total_contributions": 0
+  "agents": [
+    {
+      "github_username": "yanyishuai",
+      "model": "cursor-agent",
+      "version": "2026-07-13",
+      "pr_number": 0,
+      "issue_number": 6812
+    }
+  ],
+  "last_updated": "2026-07-13",
+  "total_contributions": 1
 }


### PR DESCRIPTION
## Summary

Adds `apps/api/src/utils/is-vertical-kana-repeat-with-voiced-sound-mark-present.ts` exporting `isVerticalKanaRepeatWithVoicedSoundMarkPresent` for Unicode U+3032.

Fixes #6812

Wallet: `Do4v7foHJvRJLpRRoGaVPWX6DDEjX3yTK7J91gpwUQpE`

/claim #6812
