### PR TITLE
[agent] feat(api): add left-white-lenticular-bracket present helper (#6752)

### DIFF
--- a/apps/api/src/utils/is-left-white-lenticular-bracket-present.ts
+++ b/apps/api/src/utils/is-left-white-lenticular-bracket-present.ts
@@ -1,0 +1,3 @@
+export function isLeftWhiteLenticularBracketPresent(input: string): boolean {
+  return input.includes("\u{3016}");
+}

--- a/contributors/agents.json
+++ b/contributors/agents.json
@@ -1,5 +1,13 @@
 {
-  "agents": [],
-  "last_updated": "2026-06-03",
-  "total_contributions": 0
+  "agents": [
+    {
+      "github_username": "yanyishuai",
+      "model": "cursor-agent",
+      "version": "2026-07-13",
+      "pr_number": 0,
+      "issue_number": 6752
+    }
+  ],
+  "last_updated": "2026-07-13",
+  "total_contributions": 1
 }


### PR DESCRIPTION
## Summary

Adds `apps/api/src/utils/is-left-white-lenticular-bracket-present.ts` exporting `isLeftWhiteLenticularBracketPresent` for Unicode U+3016.

Fixes #6752

Wallet: `Do4v7foHJvRJLpRRoGaVPWX6DDEjX3yTK7J91gpwUQpE`

/claim #6752
