### PR TITLE
[agent] feat(api): add right-white-lenticular-bracket present helper (#6753)

### DIFF
--- a/apps/api/src/utils/is-right-white-lenticular-bracket-present.ts
+++ b/apps/api/src/utils/is-right-white-lenticular-bracket-present.ts
@@ -1,0 +1,3 @@
+export function isRightWhiteLenticularBracketPresent(input: string): boolean {
+  return input.includes("\u{3017}");
+}

--- a/contributors/agents.json
+++ b/contributors/agents.json
@@ -1,5 +1,13 @@
 {
-  "agents": [],
-  "last_updated": "2026-06-03",
-  "total_contributions": 0
+  "agents": [
+    {
+      "github_username": "yanyishuai",
+      "model": "cursor-agent",
+      "version": "2026-07-13",
+      "pr_number": 0,
+      "issue_number": 6753
+    }
+  ],
+  "last_updated": "2026-07-13",
+  "total_contributions": 1
 }


### PR DESCRIPTION
## Summary

Adds `apps/api/src/utils/is-right-white-lenticular-bracket-present.ts` exporting `isRightWhiteLenticularBracketPresent` for Unicode U+3017.

Fixes #6753

Wallet: `Do4v7foHJvRJLpRRoGaVPWX6DDEjX3yTK7J91gpwUQpE`

/claim #6753
