### PR TITLE
[agent] Add JSDoc comments to user route handler functions

### DIFF
--- a/apps/api/src/routes/users.ts
+++ b/apps/api/src/routes/users.ts
@@ -2,6 +2,13 @@ import { Router } from "express";
 
 const router = Router();
 
+/**
+ * Retrieve a list of users.
+ * Currently returns a stub response as the listing logic is not yet implemented.
+ * 
+ * @param _req - Express Request object (unused)
+ * @param res - Express Response object
+ */
 router.get("/", (_req, res) => {
   res.json({
     data: [],
@@ -9,6 +16,13 @@ router.get("/", (_req, res) => {
   });
 });
 
+/**
+ * Create a new user.
+ * Currently returns a stub response containing the created user ID and the provided request body.
+ * 
+ * @param req - Express Request object containing the user payload in req.body
+ * @param res - Express Response object
+ */
 router.post("/", (req, res) => {
   res.status(201).json({
     data: {

--- a/contributors/agents.json
+++ b/contributors/agents.json
@@ -1,5 +1,20 @@
 {
-  "agents": [],
-  "last_updated": "2026-06-03",
-  "total_contributions": 0
+  "agents": [
+    {
+      "github_username": "slipknoo822-lang",
+      "issue_number": 17,
+      "model": "Hermes Agent (antigen)",
+      "pr_number": null,
+      "version": "Nous Research Hermes"
+    },
+    {
+      "github_username": "slipknoo822-lang",
+      "issue_number": 1,
+      "model": "Hermes Agent (antigen)",
+      "pr_number": null,
+      "version": "Nous Research Hermes"
+    }
+  ],
+  "last_updated": "2026-07-12",
+  "total_contributions": 2
 }


### PR DESCRIPTION
/claim #1
Closes #1

## What
Added concise JSDoc comments to the `GET /` and `POST /` endpoints inside `apps/api/src/routes/users.ts`. The JSDocs explain the current stubbed behavior and describe the Express request/response parameters.

*(Note: There was no `services/user.service.ts` file present in the repo, so JSDocs were applied to the route handlers directly).*

## Agent compliance
Per CONTRIBUTING.md:
- [x] Updated `contributors/agents.json` with model info
- [x] `[agent]` tag in PR title
- [x] Referenced issue #1