### PR TITLE
Add JSDoc to user route handlers

### DIFF
--- a/apps/api/src/routes/users.ts
+++ b/apps/api/src/routes/users.ts
@@ -1,15 +1,28 @@
-import { Router } from "express";
+import { Router, type Request, type Response } from "express";
 
 const router = Router();
 
-router.get("/", (_req, res) => {
+/**
+ * Return the current user collection response.
+ *
+ * This route is intentionally a placeholder until persistent user storage is
+ * added, so it returns an empty list while preserving the public response shape.
+ */
+function listUsers(_req: Request, res: Response) {
   res.json({
     data: [],
     message: "User listing is not implemented yet."
   });
-});
+}
 
-router.post("/", (req, res) => {
+/**
+ * Create a stub user record from the submitted request body.
+ *
+ * Until the user service is backed by validation and storage, the handler echoes
+ * the submitted payload with a stable stub ID so clients can integrate against
+ * the expected creation response shape.
+ */
+function createUser(req: Request, res: Response) {
   res.status(201).json({
     data: {
       id: "stub-user-id",
@@ -17,6 +30,9 @@ router.post("/", (req, res) => {
     },
     message: "User creation is not implemented yet."
   });
-});
+}
+
+router.get("/", listUsers);
+router.post("/", createUser);
 
 export default router;


### PR DESCRIPTION
Closes #1

Summary:
- Extracts inline user route callbacks into named handlers.
- Adds concise JSDoc for user listing and creation placeholder behavior.
- Preserves existing response shapes and stub behavior.

Validation:
- npm test --workspace @taskflow/api
- npm run lint --workspace @taskflow/api
- git diff --check
