### PR TITLE
Add Hiragana small o detection utility

### DIFF
--- a/apps/api/src/tests/is-hiragana-letter-small-o-present.test.ts
+++ b/apps/api/src/tests/is-hiragana-letter-small-o-present.test.ts
@@ -1,0 +1,13 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+
+import { isHiraganaLetterSmallOPresent } from '../utils/is-hiragana-letter-small-o-present.ts';
+
+test('detects the Hiragana letter small O character', () => {
+  assert.equal(isHiraganaLetterSmallOPresent('kana: ぉ'), true);
+});
+
+test('returns false when the Hiragana letter small O character is absent', () => {
+  assert.equal(isHiraganaLetterSmallOPresent('kana: お'), false);
+  assert.equal(isHiraganaLetterSmallOPresent('plain latin text'), false);
+});

--- a/apps/api/src/utils/is-hiragana-letter-small-o-present.ts
+++ b/apps/api/src/utils/is-hiragana-letter-small-o-present.ts
@@ -1,0 +1,3 @@
+export function isHiraganaLetterSmallOPresent(input: string): boolean {
+  return input.includes('\u3049');
+}


### PR DESCRIPTION
Closes #6893

Summary:
- Add a dependency-free API utility that detects U+3049, the Hiragana letter small O character.
- Add a TypeScript smoke test covering present and absent cases.

Validation:
- npx tsx --test apps/api/src/tests/is-hiragana-letter-small-o-present.test.ts
- git diff --check