### PR TITLE
[agent] feat(api): add vertical-kana-repeat-with-voiced-sound-mark-upper-half present helper (#6857)

### DIFF
--- a/apps/api/src/utils/is-vertical-kana-repeat-with-voiced-sound-mark-upper-half-present.ts
+++ b/apps/api/src/utils/is-vertical-kana-repeat-with-voiced-sound-mark-upper-half-present.ts
@@ -1,0 +1,3 @@
+export function isVerticalKanaRepeatWithVoicedSoundMarkUpperHalfPresent(input: string): boolean {
+  return input.includes("\u{3034}");
+}

--- a/contributors/agents.json
+++ b/contributors/agents.json
@@ -1,5 +1,13 @@
 {
-  "agents": [],
-  "last_updated": "2026-06-03",
-  "total_contributions": 0
+  "agents": [
+    {
+      "github_username": "yanyishuai",
+      "model": "cursor-agent",
+      "version": "2026-07-13",
+      "pr_number": 0,
+      "issue_number": 6857
+    }
+  ],
+  "last_updated": "2026-07-13",
+  "total_contributions": 1
 }


### PR DESCRIPTION
## Summary

Adds `apps/api/src/utils/is-vertical-kana-repeat-with-voiced-sound-mark-upper-half-present.ts` exporting `isVerticalKanaRepeatWithVoicedSoundMarkUpperHalfPresent` for Unicode U+3034.

Fixes #6857

Wallet: `Do4v7foHJvRJLpRRoGaVPWX6DDEjX3yTK7J91gpwUQpE`

/claim #6857
