### PR TITLE
[agent] feat(api): add ideographic-number-zero present helper (#6720)

### DIFF
--- a/apps/api/src/utils/is-ideographic-number-zero-present.ts
+++ b/apps/api/src/utils/is-ideographic-number-zero-present.ts
@@ -1,0 +1,3 @@
+export function isIdeographicNumberZeroPresent(input: string): boolean {
+  return input.includes("\u{3007}");
+}

--- a/contributors/agents.json
+++ b/contributors/agents.json
@@ -1,5 +1,13 @@
 {
-  "agents": [],
-  "last_updated": "2026-06-03",
-  "total_contributions": 0
+  "agents": [
+    {
+      "github_username": "yanyishuai",
+      "model": "cursor-agent",
+      "version": "2026-07-13",
+      "pr_number": 0,
+      "issue_number": 6720
+    }
+  ],
+  "last_updated": "2026-07-13",
+  "total_contributions": 1
 }


### PR DESCRIPTION
## Summary

Adds `apps/api/src/utils/is-ideographic-number-zero-present.ts` exporting `isIdeographicNumberZeroPresent` for Unicode U+3007.

Fixes #6720

Wallet: `Do4v7foHJvRJLpRRoGaVPWX6DDEjX3yTK7J91gpwUQpE`

/claim #6720
