### PR TITLE
[agent] feat(api): add circled-postal-mark present helper (#6859)

### DIFF
--- a/apps/api/src/utils/is-circled-postal-mark-present.ts
+++ b/apps/api/src/utils/is-circled-postal-mark-present.ts
@@ -1,0 +1,3 @@
+export function isCircledPostalMarkPresent(input: string): boolean {
+  return input.includes("\u{3036}");
+}

--- a/contributors/agents.json
+++ b/contributors/agents.json
@@ -1,5 +1,13 @@
 {
-  "agents": [],
-  "last_updated": "2026-06-03",
-  "total_contributions": 0
+  "agents": [
+    {
+      "github_username": "yanyishuai",
+      "model": "cursor-agent",
+      "version": "2026-07-13",
+      "pr_number": 0,
+      "issue_number": 6859
+    }
+  ],
+  "last_updated": "2026-07-13",
+  "total_contributions": 1
 }


### PR DESCRIPTION
## Summary

Adds `apps/api/src/utils/is-circled-postal-mark-present.ts` exporting `isCircledPostalMarkPresent` for Unicode U+3036.

Fixes #6859

Wallet: `Do4v7foHJvRJLpRRoGaVPWX6DDEjX3yTK7J91gpwUQpE`

/claim #6859
