### PR TITLE
[agent] feat(api): add ideographic-telegraph-line-feed-separator-symbol present helper (#6860)

### DIFF
--- a/apps/api/src/utils/is-ideographic-telegraph-line-feed-separator-symbol-present.ts
+++ b/apps/api/src/utils/is-ideographic-telegraph-line-feed-separator-symbol-present.ts
@@ -1,0 +1,3 @@
+export function isIdeographicTelegraphLineFeedSeparatorSymbolPresent(input: string): boolean {
+  return input.includes("\u{3037}");
+}

--- a/contributors/agents.json
+++ b/contributors/agents.json
@@ -1,5 +1,13 @@
 {
-  "agents": [],
-  "last_updated": "2026-06-03",
-  "total_contributions": 0
+  "agents": [
+    {
+      "github_username": "yanyishuai",
+      "model": "cursor-agent",
+      "version": "2026-07-13",
+      "pr_number": 0,
+      "issue_number": 6860
+    }
+  ],
+  "last_updated": "2026-07-13",
+  "total_contributions": 1
 }


### PR DESCRIPTION
## Summary

Adds `apps/api/src/utils/is-ideographic-telegraph-line-feed-separator-symbol-present.ts` exporting `isIdeographicTelegraphLineFeedSeparatorSymbolPresent` for Unicode U+3037.

Fixes #6860

Wallet: `Do4v7foHJvRJLpRRoGaVPWX6DDEjX3yTK7J91gpwUQpE`

/claim #6860
