### PR TITLE
[agent] feat(api): add left-double-angle-bracket present helper (#6723)

### DIFF
--- a/apps/api/src/utils/is-left-double-angle-bracket-present.ts
+++ b/apps/api/src/utils/is-left-double-angle-bracket-present.ts
@@ -1,0 +1,3 @@
+export function isLeftDoubleAngleBracketPresent(input: string): boolean {
+  return input.includes("\u{300A}");
+}

--- a/contributors/agents.json
+++ b/contributors/agents.json
@@ -1,5 +1,13 @@
 {
-  "agents": [],
-  "last_updated": "2026-06-03",
-  "total_contributions": 0
+  "agents": [
+    {
+      "github_username": "yanyishuai",
+      "model": "cursor-agent",
+      "version": "2026-07-13",
+      "pr_number": 0,
+      "issue_number": 6723
+    }
+  ],
+  "last_updated": "2026-07-13",
+  "total_contributions": 1
 }


### PR DESCRIPTION
## Summary

Adds `apps/api/src/utils/is-left-double-angle-bracket-present.ts` exporting `isLeftDoubleAngleBracketPresent` for Unicode U+300A.

Fixes #6723

Wallet: `Do4v7foHJvRJLpRRoGaVPWX6DDEjX3yTK7J91gpwUQpE`

/claim #6723
