### PR TITLE
[agent] feat(api): add hangzhou-numeral-ten present helper (#6869)

### DIFF
--- a/apps/api/src/utils/is-hangzhou-numeral-ten-present.ts
+++ b/apps/api/src/utils/is-hangzhou-numeral-ten-present.ts
@@ -1,0 +1,3 @@
+export function isHangzhouNumeralTenPresent(input: string): boolean {
+  return input.includes("\u{3038}");
+}

--- a/contributors/agents.json
+++ b/contributors/agents.json
@@ -1,5 +1,13 @@
 {
-  "agents": [],
-  "last_updated": "2026-06-03",
-  "total_contributions": 0
+  "agents": [
+    {
+      "github_username": "yanyishuai",
+      "model": "cursor-agent",
+      "version": "2026-07-13",
+      "pr_number": 0,
+      "issue_number": 6869
+    }
+  ],
+  "last_updated": "2026-07-13",
+  "total_contributions": 1
 }


### PR DESCRIPTION
## Summary

Adds `apps/api/src/utils/is-hangzhou-numeral-ten-present.ts` exporting `isHangzhouNumeralTenPresent` for Unicode U+3038.

Fixes #6869

Wallet: `Do4v7foHJvRJLpRRoGaVPWX6DDEjX3yTK7J91gpwUQpE`

/claim #6869
