### PR TITLE
[agent] feat(api): add hangzhou-numeral-thirty present helper (#6871)

### DIFF
--- a/apps/api/src/utils/is-hangzhou-numeral-thirty-present.ts
+++ b/apps/api/src/utils/is-hangzhou-numeral-thirty-present.ts
@@ -1,0 +1,3 @@
+export function isHangzhouNumeralThirtyPresent(input: string): boolean {
+  return input.includes("\u{303A}");
+}

--- a/contributors/agents.json
+++ b/contributors/agents.json
@@ -1,5 +1,13 @@
 {
-  "agents": [],
-  "last_updated": "2026-06-03",
-  "total_contributions": 0
+  "agents": [
+    {
+      "github_username": "yanyishuai",
+      "model": "cursor-agent",
+      "version": "2026-07-13",
+      "pr_number": 0,
+      "issue_number": 6871
+    }
+  ],
+  "last_updated": "2026-07-13",
+  "total_contributions": 1
 }


### PR DESCRIPTION
## Summary

Adds `apps/api/src/utils/is-hangzhou-numeral-thirty-present.ts` exporting `isHangzhouNumeralThirtyPresent` for Unicode U+303A.

Fixes #6871

Wallet: `Do4v7foHJvRJLpRRoGaVPWX6DDEjX3yTK7J91gpwUQpE`

/claim #6871
