### PR TITLE
[agent] feat(api): add part-alternation-mark present helper (#6879)

### DIFF
--- a/apps/api/src/utils/is-part-alternation-mark-present.ts
+++ b/apps/api/src/utils/is-part-alternation-mark-present.ts
@@ -1,0 +1,3 @@
+export function isPartAlternationMarkPresent(input: string): boolean {
+  return input.includes("\u{303D}");
+}

--- a/contributors/agents.json
+++ b/contributors/agents.json
@@ -1,5 +1,13 @@
 {
-  "agents": [],
-  "last_updated": "2026-06-03",
-  "total_contributions": 0
+  "agents": [
+    {
+      "github_username": "yanyishuai",
+      "model": "cursor-agent",
+      "version": "2026-07-13",
+      "pr_number": 0,
+      "issue_number": 6879
+    }
+  ],
+  "last_updated": "2026-07-13",
+  "total_contributions": 1
 }


### PR DESCRIPTION
## Summary

Adds `apps/api/src/utils/is-part-alternation-mark-present.ts` exporting `isPartAlternationMarkPresent` for Unicode U+303D.

Fixes #6879

Wallet: `Do4v7foHJvRJLpRRoGaVPWX6DDEjX3yTK7J91gpwUQpE`

/claim #6879
