### PR TITLE
[agent] feat(api): add ideographic-description-character-surround-from-right present helper (#6702)

### DIFF
--- a/apps/api/src/utils/is-ideographic-description-character-surround-from-right-present.ts
+++ b/apps/api/src/utils/is-ideographic-description-character-surround-from-right-present.ts
@@ -1,0 +1,3 @@
+export function isIdeographicDescriptionCharacterSurroundFromRightPresent(input: string): boolean {
+  return input.includes("\u{2FFC}");
+}

--- a/contributors/agents.json
+++ b/contributors/agents.json
@@ -1,5 +1,13 @@
 {
-  "agents": [],
-  "last_updated": "2026-06-03",
-  "total_contributions": 0
+  "agents": [
+    {
+      "github_username": "yanyishuai",
+      "model": "cursor-agent",
+      "version": "2026-07-13",
+      "pr_number": 0,
+      "issue_number": 6702
+    }
+  ],
+  "last_updated": "2026-07-13",
+  "total_contributions": 1
 }


### PR DESCRIPTION
## Summary

Adds `apps/api/src/utils/is-ideographic-description-character-surround-from-right-present.ts` exporting `isIdeographicDescriptionCharacterSurroundFromRightPresent` for Unicode U+2FFC.

Fixes #6702

Wallet: `Do4v7foHJvRJLpRRoGaVPWX6DDEjX3yTK7J91gpwUQpE`

/claim #6702
