### PR TITLE
[agent] feat(api): add ideographic-full-stop present helper (#6710)

### DIFF
--- a/apps/api/src/utils/is-ideographic-full-stop-present.ts
+++ b/apps/api/src/utils/is-ideographic-full-stop-present.ts
@@ -1,0 +1,3 @@
+export function isIdeographicFullStopPresent(input: string): boolean {
+  return input.includes("\u{3002}");
+}

--- a/contributors/agents.json
+++ b/contributors/agents.json
@@ -1,5 +1,13 @@
 {
-  "agents": [],
-  "last_updated": "2026-06-03",
-  "total_contributions": 0
+  "agents": [
+    {
+      "github_username": "yanyishuai",
+      "model": "cursor-agent",
+      "version": "2026-07-13",
+      "pr_number": 0,
+      "issue_number": 6710
+    }
+  ],
+  "last_updated": "2026-07-13",
+  "total_contributions": 1
 }


### PR DESCRIPTION
## Summary

Adds `apps/api/src/utils/is-ideographic-full-stop-present.ts` exporting `isIdeographicFullStopPresent` for Unicode U+3002.

Fixes #6710

Wallet: `Do4v7foHJvRJLpRRoGaVPWX6DDEjX3yTK7J91gpwUQpE`

/claim #6710
