### PR TITLE
[agent] feat(api): add japanese-industrial-standard-symbol present helper (#6712)

### DIFF
--- a/apps/api/src/utils/is-japanese-industrial-standard-symbol-present.ts
+++ b/apps/api/src/utils/is-japanese-industrial-standard-symbol-present.ts
@@ -1,0 +1,3 @@
+export function isJapaneseIndustrialStandardSymbolPresent(input: string): boolean {
+  return input.includes("\u{3004}");
+}

--- a/contributors/agents.json
+++ b/contributors/agents.json
@@ -1,5 +1,13 @@
 {
-  "agents": [],
-  "last_updated": "2026-06-03",
-  "total_contributions": 0
+  "agents": [
+    {
+      "github_username": "yanyishuai",
+      "model": "cursor-agent",
+      "version": "2026-07-13",
+      "pr_number": 0,
+      "issue_number": 6712
+    }
+  ],
+  "last_updated": "2026-07-13",
+  "total_contributions": 1
 }


### PR DESCRIPTION
## Summary

Adds `apps/api/src/utils/is-japanese-industrial-standard-symbol-present.ts` exporting `isJapaneseIndustrialStandardSymbolPresent` for Unicode U+3004.

Fixes #6712

Wallet: `Do4v7foHJvRJLpRRoGaVPWX6DDEjX3yTK7J91gpwUQpE`

/claim #6712
