### PR TITLE
[agent] feat(api): add ideographic-closing-mark present helper (#6719)

### DIFF
--- a/apps/api/src/utils/is-ideographic-closing-mark-present.ts
+++ b/apps/api/src/utils/is-ideographic-closing-mark-present.ts
@@ -1,0 +1,3 @@
+export function isIdeographicClosingMarkPresent(input: string): boolean {
+  return input.includes("\u{3006}");
+}

--- a/contributors/agents.json
+++ b/contributors/agents.json
@@ -1,5 +1,13 @@
 {
-  "agents": [],
-  "last_updated": "2026-06-03",
-  "total_contributions": 0
+  "agents": [
+    {
+      "github_username": "yanyishuai",
+      "model": "cursor-agent",
+      "version": "2026-07-13",
+      "pr_number": 0,
+      "issue_number": 6719
+    }
+  ],
+  "last_updated": "2026-07-13",
+  "total_contributions": 1
 }


### PR DESCRIPTION
## Summary

Adds `apps/api/src/utils/is-ideographic-closing-mark-present.ts` exporting `isIdeographicClosingMarkPresent` for Unicode U+3006.

Fixes #6719

Wallet: `Do4v7foHJvRJLpRRoGaVPWX6DDEjX3yTK7J91gpwUQpE`

/claim #6719
