### PR TITLE
[agent] feat(api): add hiragana-letter-ga present helper (#6955)

### DIFF
--- a/apps/api/src/utils/is-hiragana-letter-ga-present.ts
+++ b/apps/api/src/utils/is-hiragana-letter-ga-present.ts
@@ -1,0 +1,3 @@
+export function isHiraganaLetterGaPresent(input: string): boolean {
+  return input.includes("\u{304C}");
+}

--- a/contributors/agents.json
+++ b/contributors/agents.json
@@ -1,5 +1,13 @@
 {
-  "agents": [],
-  "last_updated": "2026-06-03",
-  "total_contributions": 0
+  "agents": [
+    {
+      "github_username": "yanyishuai",
+      "model": "cursor-agent",
+      "version": "2026-07-13",
+      "pr_number": 0,
+      "issue_number": 6955
+    }
+  ],
+  "last_updated": "2026-07-13",
+  "total_contributions": 1
 }


### PR DESCRIPTION
## Summary

Adds `apps/api/src/utils/is-hiragana-letter-ga-present.ts` exporting `isHiraganaLetterGaPresent` for Unicode U+304C.

Fixes #6955

Wallet: `Do4v7foHJvRJLpRRoGaVPWX6DDEjX3yTK7J91gpwUQpE`

/claim #6955
