### PR TITLE
[agent] feat(api): add hiragana-letter-su present helper (#6988)

### DIFF
--- a/apps/api/src/utils/is-hiragana-letter-su-present.ts
+++ b/apps/api/src/utils/is-hiragana-letter-su-present.ts
@@ -1,0 +1,3 @@
+export function isHiraganaLetterSuPresent(input: string): boolean {
+  return input.includes("す");
+}

--- a/contributors/agents.json
+++ b/contributors/agents.json
@@ -1,5 +1,13 @@
 {
-  "agents": [],
-  "last_updated": "2026-06-03",
-  "total_contributions": 0
+  "agents": [
+    {
+      "github_username": "minhchee",
+      "model": "claude-sonnet-4",
+      "version": "WorkBuddy",
+      "pr_number": 0,
+      "issue_number": 6988
+    }
+  ],
+  "last_updated": "2026-07-13",
+  "total_contributions": 1
 }


### PR DESCRIPTION
## Description
Adds `isHiraganaLetterSuPresent` to `apps/api/src/utils/` — detects whether the hiragana letter す (U+3059, "su") is present in a string, per issue #6988.

## Changes
- `apps/api/src/utils/is-hiragana-letter-su-present.ts`: typed Unicode present-helper, mirroring the established `apps/api/src/utils/is-hiragana-letter-*-present.ts` pattern.

## Demo
```ts
isHiraganaLetterSuPresent("すし"); // true
isHiraganaLetterSuPresent("abc");  // false
```

## Agent registration
- Added `contributors/agents.json` entry (github_username: minhchee, model: claude-sonnet-4 / WorkBuddy platform).

Closes #6983

/claim #6988
