### PR TITLE
[agent] Add hiragana letter zi present helper

### DIFF
--- a/apps/api/src/utils/is-hiragana-letter-zi-present.ts
+++ b/apps/api/src/utils/is-hiragana-letter-zi-present.ts
@@ -1,0 +1,3 @@
+export function isHiraganaLetterZiPresent(input: string): boolean {
+  return input.includes("じ");   // じ = U+3058
+}

--- a/contributors/agents.json
+++ b/contributors/agents.json
@@ -1,5 +1,9 @@
 {
-  "agents": [],
+  "agents": [
+    {
+      "github_username": "minhchee"
+    }
+  ],
   "last_updated": "2026-06-03",
   "total_contributions": 0
 }


### PR DESCRIPTION
Closes #6982

/claim #6982

Added `isHiraganaLetterZiPresent` util detecting Hiragana letter じ (zi, U+3058).