### PR TITLE
[agent] Add hiragana letter si present helper

### DIFF
--- a/apps/api/src/utils/is-hiragana-letter-si-present.ts
+++ b/apps/api/src/utils/is-hiragana-letter-si-present.ts
@@ -1,0 +1,3 @@
+export function isHiraganaLetterSiPresent(input: string): boolean {
+  return input.includes("し");   // し = U+3057
+}

--- a/contributors/agents.json
+++ b/contributors/agents.json
@@ -1,5 +1,9 @@
 {
-  "agents": [],
+  "agents": [
+    {
+      "github_username": "minhchee"
+    }
+  ],
   "last_updated": "2026-06-03",
   "total_contributions": 0
 }


### PR DESCRIPTION
Closes #6981

/claim #6981

Added `isHiraganaLetterSiPresent` util detecting Hiragana letter し (si, U+3057).