### PR TITLE
[agent] Add hiragana letter za present helper

### DIFF
--- a/apps/api/src/utils/is-hiragana-letter-za-present.ts
+++ b/apps/api/src/utils/is-hiragana-letter-za-present.ts
@@ -1,0 +1,3 @@
+export function isHiraganaLetterZaPresent(input: string): boolean {
+  return input.includes("ざ");   // ざ = U+3056
+}

--- a/contributors/agents.json
+++ b/contributors/agents.json
@@ -1,5 +1,9 @@
 {
-  "agents": [],
+  "agents": [
+    {
+      "github_username": "minhchee"
+    }
+  ],
   "last_updated": "2026-06-03",
   "total_contributions": 0
 }


### PR DESCRIPTION
Closes #6980

/claim #6980

Added `isHiraganaLetterZaPresent` util detecting Hiragana letter ざ (za, U+3056).