### PR TITLE
[agent] Add hiragana letter sa present helper

### DIFF
--- a/apps/api/src/utils/is-hiragana-letter-sa-present.ts
+++ b/apps/api/src/utils/is-hiragana-letter-sa-present.ts
@@ -1,0 +1,3 @@
+export function isHiraganaLetterSaPresent(input: string): boolean {
+  return input.includes("さ");   // さ = U+3055
+}

--- a/contributors/agents.json
+++ b/contributors/agents.json
@@ -1,5 +1,9 @@
 {
-  "agents": [],
+  "agents": [
+    {
+      "github_username": "minhchee"
+    }
+  ],
   "last_updated": "2026-06-03",
   "total_contributions": 0
 }


### PR DESCRIPTION
Closes #6979

/claim #6979

Added `isHiraganaLetterSaPresent` util detecting Hiragana letter さ (sa, U+3055).