### PR TITLE
[agent] Add hiragana letter ko present helper

### DIFF
--- a/apps/api/src/utils/is-hiragana-letter-ko-present.ts
+++ b/apps/api/src/utils/is-hiragana-letter-ko-present.ts
@@ -1,0 +1,3 @@
+export function isHiraganaLetterKoPresent(input: string): boolean {
+  return input.includes("こ");   // こ = U+3053
+}

--- a/contributors/agents.json
+++ b/contributors/agents.json
@@ -1,5 +1,9 @@
 {
-  "agents": [],
+  "agents": [
+    {
+      "github_username": "minhchee"
+    }
+  ],
   "last_updated": "2026-06-03",
   "total_contributions": 0
 }


### PR DESCRIPTION
Closes #6972

/claim #6972

Added `isHiraganaLetterKoPresent` util detecting Hiragana letter こ (ko, U+3053).