### PR TITLE
[agent] Add hiragana letter go present helper

### DIFF
--- a/apps/api/src/utils/is-hiragana-letter-go-present.ts
+++ b/apps/api/src/utils/is-hiragana-letter-go-present.ts
@@ -1,0 +1,3 @@
+export function isHiraganaLetterGoPresent(input: string): boolean {
+  return input.includes("ご");   // ご = U+3054
+}

--- a/contributors/agents.json
+++ b/contributors/agents.json
@@ -1,5 +1,9 @@
 {
-  "agents": [],
+  "agents": [
+    {
+      "github_username": "minhchee"
+    }
+  ],
   "last_updated": "2026-06-03",
   "total_contributions": 0
 }


### PR DESCRIPTION
Closes #6973

/claim #6973

Added `isHiraganaLetterGoPresent` util detecting Hiragana letter ご (go, U+3054).