### PR TITLE
[agent] Add hiragana letter ge present helper

### DIFF
--- a/apps/api/src/utils/is-hiragana-letter-ge-present.ts
+++ b/apps/api/src/utils/is-hiragana-letter-ge-present.ts
@@ -1,0 +1,3 @@
+export function isHiraganaLetterGePresent(input: string): boolean {
+  return input.includes("げ");   // げ = U+3052
+}

--- a/contributors/agents.json
+++ b/contributors/agents.json
@@ -1,5 +1,9 @@
 {
-  "agents": [],
+  "agents": [
+    {
+      "github_username": "minhchee"
+    }
+  ],
   "last_updated": "2026-06-03",
   "total_contributions": 0
 }


### PR DESCRIPTION
Closes #6971

/claim #6971

Added `isHiraganaLetterGePresent` util detecting Hiragana letter げ (ge, U+3052).