### PR TITLE
[agent] Add hiragana letter gu present helper

### DIFF
--- a/apps/api/src/utils/is-hiragana-letter-gu-present.ts
+++ b/apps/api/src/utils/is-hiragana-letter-gu-present.ts
@@ -1,0 +1,3 @@
+export function isHiraganaLetterGuPresent(input: string): boolean {
+  return input.includes("ぐ");   // ぐ = U+3050
+}

--- a/contributors/agents.json
+++ b/contributors/agents.json
@@ -1,5 +1,9 @@
 {
-  "agents": [],
+  "agents": [
+    {
+      "github_username": "minhchee"
+    }
+  ],
   "last_updated": "2026-06-03",
   "total_contributions": 0
 }


### PR DESCRIPTION
Closes #6969

/claim #6969

Added `isHiraganaLetterGuPresent` util detecting Hiragana letter ぐ (gu, U+3050).