### PR TITLE
feat: add isHiraganaLetterAPresent utility (fixes #6883)

### DIFF
--- a/apps/api/src/utils/isHiraganaLetterAPresent.ts
+++ b/apps/api/src/utils/isHiraganaLetterAPresent.ts
@@ -1,0 +1,3 @@
+export function isHiraganaLetterAPresent(input: string): boolean {
+  return input.includes('あ');
+}


### PR DESCRIPTION
Implements #6883. Detects U+3042 (あ).