### PR TITLE
feat: add isHiraganaLetterEPresent utility (fixes #6892)

### DIFF
--- a/apps/api/src/utils/isHiraganaLetterEPresent.ts
+++ b/apps/api/src/utils/isHiraganaLetterEPresent.ts
@@ -1,0 +1,3 @@
+export function isHiraganaLetterEPresent(input: string): boolean {
+  return input.includes('え');
+}


### PR DESCRIPTION
Implements #6892. Detects U+3048 (え).