### PR TITLE
Add request body size limit

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,6 +66,11 @@ npm run dev -w apps/web
 
 npm run dev -w apps/api
 
+### API request body size limit
+
+The Express API uses a conservative JSON request body size limit of `100kb` by default.
+Set `JSON_BODY_LIMIT` for local development or deployment environments that need a different value.
+
 ## Database
 
 Prisma schema is available in packages/db/prisma/schema.prisma 

--- a/apps/api/src/index.ts
+++ b/apps/api/src/index.ts
@@ -4,8 +4,9 @@ import usersRouter from "./routes/users";
 
 const app = express();
 const port = process.env.PORT || 4000;
+const jsonBodyLimit = process.env.JSON_BODY_LIMIT || "100kb";
 
-app.use(express.json());
+app.use(express.json({ limit: jsonBodyLimit }));
 
 app.get("/health", (_req, res) => {
   res.json({ status: "ok", service: "taskflow-api" });


### PR DESCRIPTION
## Summary                                                                               
                                                                                           
  Closes #9.                                                                               
                                                                                           
  Adds an explicit conservative JSON request body size limit to the Express API:           
                                                                                           
  - defaults to `100kb`                                                                    
  - supports override through `JSON_BODY_LIMIT`                                            
  - documents the expected default value in the README                                     
                                                                                           
  ## Validation                                                                            
                                                                                           
  - `npm run test`                                                                         
  - `npm run test -w apps/api`                                                             
  - `npm run lint -w apps/api`                                                             
  - `npx tsc --noEmit --module ESNext --moduleResolution Bundler --target ES2022           
--esModuleInterop --skipLibCheck apps/api/src/index.ts`                                    
                                                                                           
  Note: root `npm run lint` enters Next.js ESLint setup for `apps/web` because that        
workspace has no existing ESLint configuration; the API workspace lint script itself       
completes.
