### PR TITLE
feat: add isHiraganaLetterSmallIPresent utility (fixes #6889)

### DIFF
--- a/apps/api/src/utils/isHiraganaLetterSmallIPresent.ts
+++ b/apps/api/src/utils/isHiraganaLetterSmallIPresent.ts
@@ -1,0 +1,3 @@
+export function isHiraganaLetterSmallIPresent(input: string): boolean {
+  return input.includes('ぃ');
+}


### PR DESCRIPTION
Implements #6889. Detects U+3043 (ぃ).