### PR TITLE
feat: add isHiraganaLetterSmallEPresent utility (fixes #6891)

### DIFF
--- a/apps/api/src/utils/isHiraganaLetterSmallEPresent.ts
+++ b/apps/api/src/utils/isHiraganaLetterSmallEPresent.ts
@@ -1,0 +1,3 @@
+export function isHiraganaLetterSmallEPresent(input: string): boolean {
+  return input.includes('ぇ');
+}


### PR DESCRIPTION
Implements #6891. Detects U+3047 (ぇ).