### PR TITLE
feat: add isHiraganaLetterSmallOPresent utility (fixes #6893)

### DIFF
--- a/apps/api/src/utils/isHiraganaLetterSmallOPresent.ts
+++ b/apps/api/src/utils/isHiraganaLetterSmallOPresent.ts
@@ -1,0 +1,3 @@
+export function isHiraganaLetterSmallOPresent(input: string): boolean {
+  return input.includes('ぉ');
+}


### PR DESCRIPTION
Implements #6893. Detects U+3049 (ぉ).