### PR TITLE
[agent] feat(api): add hiragana-letter-ge present helper (#6971)

### DIFF
--- a/apps/api/src/utils/is-hiragana-letter-ge-present.ts
+++ b/apps/api/src/utils/is-hiragana-letter-ge-present.ts
@@ -1,0 +1,3 @@
+export function isHiraganaLetterGePresent(input: string): boolean {
+  return input.includes("\u{3052}");
+}

--- a/contributors/agents.json
+++ b/contributors/agents.json
@@ -1,5 +1,13 @@
 {
-  "agents": [],
-  "last_updated": "2026-06-03",
-  "total_contributions": 0
+  "agents": [
+    {
+      "github_username": "yanyishuai",
+      "model": "cursor-agent",
+      "version": "2026-07-13",
+      "pr_number": 0,
+      "issue_number": 6971
+    }
+  ],
+  "last_updated": "2026-07-13",
+  "total_contributions": 1
 }


### PR DESCRIPTION
## Summary

Adds `apps/api/src/utils/is-hiragana-letter-ge-present.ts` exporting `isHiraganaLetterGePresent` for Unicode U+3052.

Fixes #6971

Wallet: `Do4v7foHJvRJLpRRoGaVPWX6DDEjX3yTK7J91gpwUQpE`

/claim #6971
