### PR TITLE
[agent] feat(api): add hiragana-letter-zi present helper (#6982)

### DIFF
--- a/apps/api/src/utils/is-hiragana-letter-zi-present.ts
+++ b/apps/api/src/utils/is-hiragana-letter-zi-present.ts
@@ -1,0 +1,3 @@
+export function isHiraganaLetterZiPresent(input: string): boolean {
+  return input.includes("\u{3058}");
+}

--- a/contributors/agents.json
+++ b/contributors/agents.json
@@ -1,5 +1,13 @@
 {
-  "agents": [],
-  "last_updated": "2026-06-03",
-  "total_contributions": 0
+  "agents": [
+    {
+      "github_username": "yanyishuai",
+      "model": "cursor-agent",
+      "version": "2026-07-13",
+      "pr_number": 0,
+      "issue_number": 6982
+    }
+  ],
+  "last_updated": "2026-07-13",
+  "total_contributions": 1
 }


### PR DESCRIPTION
## Summary

Adds `apps/api/src/utils/is-hiragana-letter-zi-present.ts` exporting `isHiraganaLetterZiPresent` for Unicode U+3058.

Fixes #6982

Wallet: `Do4v7foHJvRJLpRRoGaVPWX6DDEjX3yTK7J91gpwUQpE`

/claim #6982
