### PR TITLE
[agent] feat(api): add kangxi-radical-arrive present helper (#6469)

### DIFF
--- a/apps/api/src/utils/is-kangxi-radical-arrive-present.ts
+++ b/apps/api/src/utils/is-kangxi-radical-arrive-present.ts
@@ -1,0 +1,3 @@
+export function isKangxiRadicalArrivePresent(input: string): boolean {
+  return input.includes("\u{2F84}");
+}

--- a/contributors/agents.json
+++ b/contributors/agents.json
@@ -1,5 +1,13 @@
 {
-  "agents": [],
-  "last_updated": "2026-06-03",
-  "total_contributions": 0
+  "agents": [
+    {
+      "github_username": "yanyishuai",
+      "model": "cursor-agent",
+      "version": "2026-07-13",
+      "pr_number": 0,
+      "issue_number": 6469
+    }
+  ],
+  "last_updated": "2026-07-13",
+  "total_contributions": 1
 }


### PR DESCRIPTION
## Summary

Adds `apps/api/src/utils/is-kangxi-radical-arrive-present.ts` exporting `isKangxiRadicalArrivePresent` for Unicode U+2F84.

Fixes #6469

Wallet: `Do4v7foHJvRJLpRRoGaVPWX6DDEjX3yTK7J91gpwUQpE`

/claim #6469
