### PR TITLE
[agent] feat(api): add kangxi-radical-tongue present helper (#6475)

### DIFF
--- a/apps/api/src/utils/is-kangxi-radical-tongue-present.ts
+++ b/apps/api/src/utils/is-kangxi-radical-tongue-present.ts
@@ -1,0 +1,3 @@
+export function isKangxiRadicalTonguePresent(input: string): boolean {
+  return input.includes("\u{2F86}");
+}

--- a/contributors/agents.json
+++ b/contributors/agents.json
@@ -1,5 +1,13 @@
 {
-  "agents": [],
-  "last_updated": "2026-06-03",
-  "total_contributions": 0
+  "agents": [
+    {
+      "github_username": "yanyishuai",
+      "model": "cursor-agent",
+      "version": "2026-07-13",
+      "pr_number": 0,
+      "issue_number": 6475
+    }
+  ],
+  "last_updated": "2026-07-13",
+  "total_contributions": 1
 }


### PR DESCRIPTION
## Summary

Adds `apps/api/src/utils/is-kangxi-radical-tongue-present.ts` exporting `isKangxiRadicalTonguePresent` for Unicode U+2F86.

Fixes #6475

Wallet: `Do4v7foHJvRJLpRRoGaVPWX6DDEjX3yTK7J91gpwUQpE`

/claim #6475
