### PR TITLE
[agent] feat(api): add kangxi-radical-grass present helper (#6535)

### DIFF
--- a/apps/api/src/utils/is-kangxi-radical-grass-present.ts
+++ b/apps/api/src/utils/is-kangxi-radical-grass-present.ts
@@ -1,0 +1,3 @@
+export function isKangxiRadicalGrassPresent(input: string): boolean {
+  return input.includes("\u{2F8B}");
+}

--- a/contributors/agents.json
+++ b/contributors/agents.json
@@ -1,5 +1,13 @@
 {
-  "agents": [],
-  "last_updated": "2026-06-03",
-  "total_contributions": 0
+  "agents": [
+    {
+      "github_username": "yanyishuai",
+      "model": "cursor-agent",
+      "version": "2026-07-13",
+      "pr_number": 0,
+      "issue_number": 6535
+    }
+  ],
+  "last_updated": "2026-07-13",
+  "total_contributions": 1
 }


### PR DESCRIPTION
## Summary

Adds `apps/api/src/utils/is-kangxi-radical-grass-present.ts` exporting `isKangxiRadicalGrassPresent` for Unicode U+2F8B.

Fixes #6535

Wallet: `Do4v7foHJvRJLpRRoGaVPWX6DDEjX3yTK7J91gpwUQpE`

/claim #6535
