### PR TITLE
[agent] feat(api): add kangxi-radical-west present helper (#6545)

### DIFF
--- a/apps/api/src/utils/is-kangxi-radical-west-present.ts
+++ b/apps/api/src/utils/is-kangxi-radical-west-present.ts
@@ -1,0 +1,3 @@
+export function isKangxiRadicalWestPresent(input: string): boolean {
+  return input.includes("\u{2F91}");
+}

--- a/contributors/agents.json
+++ b/contributors/agents.json
@@ -1,5 +1,13 @@
 {
-  "agents": [],
-  "last_updated": "2026-06-03",
-  "total_contributions": 0
+  "agents": [
+    {
+      "github_username": "yanyishuai",
+      "model": "cursor-agent",
+      "version": "2026-07-13",
+      "pr_number": 0,
+      "issue_number": 6545
+    }
+  ],
+  "last_updated": "2026-07-13",
+  "total_contributions": 1
 }


### PR DESCRIPTION
## Summary

Adds `apps/api/src/utils/is-kangxi-radical-west-present.ts` exporting `isKangxiRadicalWestPresent` for Unicode U+2F91.

Fixes #6545

Wallet: `Do4v7foHJvRJLpRRoGaVPWX6DDEjX3yTK7J91gpwUQpE`

/claim #6545
