### PR TITLE
[agent] feat(api): add kangxi-radical-see present helper (#6546)

### DIFF
--- a/apps/api/src/utils/is-kangxi-radical-see-present.ts
+++ b/apps/api/src/utils/is-kangxi-radical-see-present.ts
@@ -1,0 +1,3 @@
+export function isKangxiRadicalSeePresent(input: string): boolean {
+  return input.includes("\u{2F92}");
+}

--- a/contributors/agents.json
+++ b/contributors/agents.json
@@ -1,5 +1,13 @@
 {
-  "agents": [],
-  "last_updated": "2026-06-03",
-  "total_contributions": 0
+  "agents": [
+    {
+      "github_username": "yanyishuai",
+      "model": "cursor-agent",
+      "version": "2026-07-13",
+      "pr_number": 0,
+      "issue_number": 6546
+    }
+  ],
+  "last_updated": "2026-07-13",
+  "total_contributions": 1
 }


### PR DESCRIPTION
## Summary

Adds `apps/api/src/utils/is-kangxi-radical-see-present.ts` exporting `isKangxiRadicalSeePresent` for Unicode U+2F92.

Fixes #6546

Wallet: `Do4v7foHJvRJLpRRoGaVPWX6DDEjX3yTK7J91gpwUQpE`

/claim #6546
