### PR TITLE
[agent] feat(api): add kangxi-radical-speech present helper (#6548)

### DIFF
--- a/apps/api/src/utils/is-kangxi-radical-speech-present.ts
+++ b/apps/api/src/utils/is-kangxi-radical-speech-present.ts
@@ -1,0 +1,3 @@
+export function isKangxiRadicalSpeechPresent(input: string): boolean {
+  return input.includes("\u{2F94}");
+}

--- a/contributors/agents.json
+++ b/contributors/agents.json
@@ -1,5 +1,13 @@
 {
-  "agents": [],
-  "last_updated": "2026-06-03",
-  "total_contributions": 0
+  "agents": [
+    {
+      "github_username": "yanyishuai",
+      "model": "cursor-agent",
+      "version": "2026-07-13",
+      "pr_number": 0,
+      "issue_number": 6548
+    }
+  ],
+  "last_updated": "2026-07-13",
+  "total_contributions": 1
 }


### PR DESCRIPTION
## Summary

Adds `apps/api/src/utils/is-kangxi-radical-speech-present.ts` exporting `isKangxiRadicalSpeechPresent` for Unicode U+2F94.

Fixes #6548

Wallet: `Do4v7foHJvRJLpRRoGaVPWX6DDEjX3yTK7J91gpwUQpE`

/claim #6548
