### PR TITLE
[agent] feat(api): add kangxi-radical-badger present helper (#6557)

### DIFF
--- a/apps/api/src/utils/is-kangxi-radical-badger-present.ts
+++ b/apps/api/src/utils/is-kangxi-radical-badger-present.ts
@@ -1,0 +1,3 @@
+export function isKangxiRadicalBadgerPresent(input: string): boolean {
+  return input.includes("\u{2F98}");
+}

--- a/contributors/agents.json
+++ b/contributors/agents.json
@@ -1,5 +1,13 @@
 {
-  "agents": [],
-  "last_updated": "2026-06-03",
-  "total_contributions": 0
+  "agents": [
+    {
+      "github_username": "yanyishuai",
+      "model": "cursor-agent",
+      "version": "2026-07-13",
+      "pr_number": 0,
+      "issue_number": 6557
+    }
+  ],
+  "last_updated": "2026-07-13",
+  "total_contributions": 1
 }


### PR DESCRIPTION
## Summary

Adds `apps/api/src/utils/is-kangxi-radical-badger-present.ts` exporting `isKangxiRadicalBadgerPresent` for Unicode U+2F98.

Fixes #6557

Wallet: `Do4v7foHJvRJLpRRoGaVPWX6DDEjX3yTK7J91gpwUQpE`

/claim #6557
