### PR TITLE
[agent] feat(api): add kangxi-radical-bitter present helper (#6567)

### DIFF
--- a/apps/api/src/utils/is-kangxi-radical-bitter-present.ts
+++ b/apps/api/src/utils/is-kangxi-radical-bitter-present.ts
@@ -1,0 +1,3 @@
+export function isKangxiRadicalBitterPresent(input: string): boolean {
+  return input.includes("\u{2F9F}");
+}

--- a/contributors/agents.json
+++ b/contributors/agents.json
@@ -1,5 +1,13 @@
 {
-  "agents": [],
-  "last_updated": "2026-06-03",
-  "total_contributions": 0
+  "agents": [
+    {
+      "github_username": "yanyishuai",
+      "model": "cursor-agent",
+      "version": "2026-07-13",
+      "pr_number": 0,
+      "issue_number": 6567
+    }
+  ],
+  "last_updated": "2026-07-13",
+  "total_contributions": 1
 }


### PR DESCRIPTION
## Summary

Adds `apps/api/src/utils/is-kangxi-radical-bitter-present.ts` exporting `isKangxiRadicalBitterPresent` for Unicode U+2F9F.

Fixes #6567

Wallet: `Do4v7foHJvRJLpRRoGaVPWX6DDEjX3yTK7J91gpwUQpE`

/claim #6567
