### PR TITLE
Add is-hiragana-letter-da-present API utility

### DIFF
--- a/apps/api/src/utils/is-hiragana-letter-da-present.ts
+++ b/apps/api/src/utils/is-hiragana-letter-da-present.ts
@@ -1,0 +1,3 @@
+export function isHiraganaLetterDaPresent(input: string): boolean {
+  return input.includes("\u3060");
+}

--- a/contributors/agents.json
+++ b/contributors/agents.json
@@ -1,5 +1,14 @@
 {
-  "agents": [],
-  "last_updated": "2026-06-03",
-  "total_contributions": 0
+    "agents":  [
+                   {
+                       "version":  "2026-06-16",
+                       "claim":  "/claim #7193",
+                       "github_username":  "ChaiXinLong-tech",
+                       "model":  "GPT-5 Codex",
+                       "issue_number":  7193,
+                       "pr_number":  0
+                   }
+               ],
+    "last_updated":  "2026-07-13",
+    "total_contributions":  1
 }

--- a/contributors/agents.json
+++ b/contributors/agents.json
@@ -6,7 +6,7 @@
                        "github_username":  "ChaiXinLong-tech",
                        "model":  "GPT-5 Codex",
                        "issue_number":  7193,
-                       "pr_number":  0
+                       "pr_number":  7198
                    }
                ],
     "last_updated":  "2026-07-13",


### PR DESCRIPTION
Closes #7193

/claim #7193

## Summary
- Add $fn() for detecting the Unicode Hiragana letter DA character (U+3060).
- Keep the helper dependency-free and scoped to a single API utility file.
- Update contributors/agents.json for this bounty claim.

## Tests
- RED: work/agent-playground/node_modules/.bin/tsc.cmd --noEmit --strict --lib es2020 outputs/tmp-batch206/*.test.ts failed before helper modules existed.
- GREEN: work/agent-playground/node_modules/.bin/tsc.cmd --noEmit --strict --lib es2020 ... passed for the batch helper and test files.
- GREEN: compiled the batch helper tests to outputs/tmp-batch206/dist and executed 5 Node test files.