### PR TITLE
[agent] Add is-hiragana-letter-hu-present API utility

### DIFF
--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -7,7 +7,7 @@
   "main": "src/index.ts",
   "scripts": {
     "dev": "tsx src/index.ts",
-    "test": "echo \"No API tests configured yet\"",
+    "test": "tsx src/utils/is-hiragana-letter-hu-present.test.ts",
     "lint": "echo \"No API lint configured yet\""
   },
   "dependencies": {

--- a/apps/api/src/utils/is-hiragana-letter-hu-present.test.ts
+++ b/apps/api/src/utils/is-hiragana-letter-hu-present.test.ts
@@ -1,0 +1,10 @@
+import assert from "node:assert/strict";
+
+import { isHiraganaLetterHuPresent } from "./is-hiragana-letter-hu-present";
+
+assert.equal(isHiraganaLetterHuPresent("prefix \u3075 suffix"), true);
+assert.equal(isHiraganaLetterHuPresent("\u3075"), true);
+assert.equal(isHiraganaLetterHuPresent(""), false);
+assert.equal(isHiraganaLetterHuPresent("prefix suffix"), false);
+assert.equal(isHiraganaLetterHuPresent("\u3074"), false);
+assert.equal(isHiraganaLetterHuPresent("\u3076"), false);

--- a/apps/api/src/utils/is-hiragana-letter-hu-present.ts
+++ b/apps/api/src/utils/is-hiragana-letter-hu-present.ts
@@ -1,0 +1,5 @@
+const HIRAGANA_LETTER_HU = "\u3075";
+
+export function isHiraganaLetterHuPresent(input: string): boolean {
+  return input.includes(HIRAGANA_LETTER_HU);
+}

--- a/contributors/agents.json
+++ b/contributors/agents.json
@@ -1,5 +1,13 @@
 {
-  "agents": [],
-  "last_updated": "2026-06-03",
-  "total_contributions": 0
+  "agents": [
+    {
+      "github_username": "HCDD1",
+      "model": "Codex / GPT-5",
+      "version": "2026-07-14",
+      "pr_number": 7232,
+      "issue_number": 7226
+    }
+  ],
+  "last_updated": "2026-07-14",
+  "total_contributions": 1
 }


### PR DESCRIPTION
## What changed
- Added `isHiraganaLetterHuPresent(input: string): boolean` for detecting U+3075 Hiragana letter HU.
- Added a focused TypeScript smoke test covering positive, negative, empty-string, and nearby-character cases.
- Wired the API workspace test script to run the smoke test.

## Testing
- `npm test -w apps/api`

Fixes #7226
/claim #7226