### PR TITLE
Make manual seed workflows idempotent

### DIFF
--- a/.github/workflows/seed-issues.yml
+++ b/.github/workflows/seed-issues.yml
@@ -90,7 +90,27 @@ jobs:
               }
             ];
 
+            const existingIssues = await github.paginate(github.rest.issues.listForRepo, {
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              state: "all",
+              per_page: 100
+            });
+            const existingIssueTitles = new Set(
+              existingIssues
+                .filter((issue) => !issue.pull_request)
+                .map((issue) => issue.title)
+            );
+            let createdCount = 0;
+            let skippedCount = 0;
+
             for (const issue of issues) {
+              if (existingIssueTitles.has(issue.title)) {
+                core.info(`Skipping existing starter issue: ${issue.title}`);
+                skippedCount += 1;
+                continue;
+              }
+
               await github.rest.issues.create({
                 owner: context.repo.owner,
                 repo: context.repo.repo,
@@ -98,4 +118,8 @@ jobs:
                 body: issue.body,
                 labels: ["good first issue", "bounty", "AI agent friendly"]
               });
+              existingIssueTitles.add(issue.title);
+              createdCount += 1;
             }
+
+            core.info(`Starter issue seed complete: ${createdCount} created, ${skippedCount} skipped.`);

--- a/.github/workflows/seed-meta-issue.yml
+++ b/.github/workflows/seed-meta-issue.yml
@@ -35,10 +35,32 @@ jobs:
               "description, the better."
             ].join("\n");
 
+            const metaIssueTitle = "Bug Bounty Program — How to Participate";
+            const existingIssues = await github.paginate(github.rest.issues.listForRepo, {
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              state: "all",
+              per_page: 100
+            });
+            const existingIssue = existingIssues.find(
+              (issue) => !issue.pull_request && issue.title === metaIssueTitle
+            );
+
+            if (existingIssue) {
+              await github.rest.issues.update({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: existingIssue.number,
+                body: bodyForIssue(existingIssue.number)
+              });
+              core.info(`Updated existing bug bounty program issue #${existingIssue.number}.`);
+              return;
+            }
+
             const createdIssue = await github.rest.issues.create({
               owner: context.repo.owner,
               repo: context.repo.repo,
-              title: "Bug Bounty Program — How to Participate",
+              title: metaIssueTitle,
               body: bodyForIssue("[NUMBER]"),
               labels: ["bounty", "good first issue", "AI agent friendly"]
             });


### PR DESCRIPTION
/claim #805

## Summary

- Make `seed-issues.yml` load existing non-PR repository issues and skip starter issue titles that already exist.
- Make `seed-meta-issue.yml` reuse the existing program meta issue issue and update its body with the correct issue number instead of creating a duplicate.
- Preserve the existing starter issue body text, labels, and new meta issue pinning path.

Closes #805

## Validation

- `actionlint .github/workflows/seed-issues.yml .github/workflows/seed-meta-issue.yml`
- `npm test`
- Local workflow smoke test that executes both embedded `github-script` blocks with mocked GitHub issue APIs, including rerun cases.
