### PR TITLE
Add is-hiragana-letter-pi-present API utility

### DIFF
--- a/apps/api/src/tests/is-hiragana-letter-pi-present.test.ts
+++ b/apps/api/src/tests/is-hiragana-letter-pi-present.test.ts
@@ -1,0 +1,13 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+
+import { IsHiraganaLetterPiPresent } from '../utils/is-hiragana-letter-pi-present.ts';
+
+test('detects the Hiragana letter PI character', () => {
+  assert.equal(IsHiraganaLetterPiPresent('target: \u3074'), true);
+});
+
+test('returns false when the Hiragana letter PI character is absent', () => {
+  assert.equal(IsHiraganaLetterPiPresent('plain latin text'), false);
+  assert.equal(IsHiraganaLetterPiPresent('nearby Hiragana but not target: \u3042'), false);
+});

--- a/apps/api/src/utils/is-hiragana-letter-pi-present.ts
+++ b/apps/api/src/utils/is-hiragana-letter-pi-present.ts
@@ -1,0 +1,3 @@
+export function IsHiraganaLetterPiPresent(input: string): boolean {
+  return input.includes('\u3074');
+}


### PR DESCRIPTION
Closes #7225

## Summary
- Add `apps/api/src/utils/is-hiragana-letter-pi-present.ts`.
- Export `isHiraganaLetterPiPresent(input: string): boolean`.
- Return true only when input contains Hiragana letter PI (`U+3074`).
- Add focused `tsx --test` coverage for present/absent cases.

## Validation
- `node_modules/.bin/tsx --test apps/api/src/tests/is-hiragana-letter-pi-present.test.ts`
- `git diff --check`