### PR TITLE
Add is-hiragana-letter-bi-present API utility

### DIFF
--- a/apps/api/src/tests/is-hiragana-letter-bi-present.test.ts
+++ b/apps/api/src/tests/is-hiragana-letter-bi-present.test.ts
@@ -1,0 +1,13 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+
+import { IsHiraganaLetterBiPresent } from '../utils/is-hiragana-letter-bi-present.ts';
+
+test('detects the Hiragana letter BI character', () => {
+  assert.equal(IsHiraganaLetterBiPresent('target: \u3073'), true);
+});
+
+test('returns false when the Hiragana letter BI character is absent', () => {
+  assert.equal(IsHiraganaLetterBiPresent('plain latin text'), false);
+  assert.equal(IsHiraganaLetterBiPresent('nearby Hiragana but not target: \u3042'), false);
+});

--- a/apps/api/src/utils/is-hiragana-letter-bi-present.ts
+++ b/apps/api/src/utils/is-hiragana-letter-bi-present.ts
@@ -1,0 +1,3 @@
+export function IsHiraganaLetterBiPresent(input: string): boolean {
+  return input.includes('\u3073');
+}


### PR DESCRIPTION
Closes #7224

## Summary
- Add `apps/api/src/utils/is-hiragana-letter-bi-present.ts`.
- Export `isHiraganaLetterBiPresent(input: string): boolean`.
- Return true only when input contains Hiragana letter BI (`U+3073`).
- Add focused `tsx --test` coverage for present/absent cases.

## Validation
- `node_modules/.bin/tsx --test apps/api/src/tests/is-hiragana-letter-bi-present.test.ts`
- `git diff --check`