### PR TITLE
Add is-hiragana-letter-ba-present API utility

### DIFF
--- a/apps/api/src/tests/is-hiragana-letter-ba-present.test.ts
+++ b/apps/api/src/tests/is-hiragana-letter-ba-present.test.ts
@@ -1,0 +1,13 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+
+import { IsHiraganaLetterBaPresent } from '../utils/is-hiragana-letter-ba-present.ts';
+
+test('detects the Hiragana letter BA character', () => {
+  assert.equal(IsHiraganaLetterBaPresent('target: \u3070'), true);
+});
+
+test('returns false when the Hiragana letter BA character is absent', () => {
+  assert.equal(IsHiraganaLetterBaPresent('plain latin text'), false);
+  assert.equal(IsHiraganaLetterBaPresent('nearby Hiragana but not target: \u3042'), false);
+});

--- a/apps/api/src/utils/is-hiragana-letter-ba-present.ts
+++ b/apps/api/src/utils/is-hiragana-letter-ba-present.ts
@@ -1,0 +1,3 @@
+export function IsHiraganaLetterBaPresent(input: string): boolean {
+  return input.includes('\u3070');
+}


### PR DESCRIPTION
Closes #7222

## Summary
- Add `apps/api/src/utils/is-hiragana-letter-ba-present.ts`.
- Export `isHiraganaLetterBaPresent(input: string): boolean`.
- Return true only when input contains Hiragana letter BA (`U+3070`).
- Add focused `tsx --test` coverage for present/absent cases.

## Validation
- `node_modules/.bin/tsx --test apps/api/src/tests/is-hiragana-letter-ba-present.test.ts`
- `git diff --check`