### PR TITLE
Add is-hiragana-letter-ha-present API utility

### DIFF
--- a/apps/api/src/tests/is-hiragana-letter-ha-present.test.ts
+++ b/apps/api/src/tests/is-hiragana-letter-ha-present.test.ts
@@ -1,0 +1,13 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+
+import { IsHiraganaLetterHaPresent } from '../utils/is-hiragana-letter-ha-present.ts';
+
+test('detects the Hiragana letter HA character', () => {
+  assert.equal(IsHiraganaLetterHaPresent('target: \u306F'), true);
+});
+
+test('returns false when the Hiragana letter HA character is absent', () => {
+  assert.equal(IsHiraganaLetterHaPresent('plain latin text'), false);
+  assert.equal(IsHiraganaLetterHaPresent('nearby Hiragana but not target: \u3042'), false);
+});

--- a/apps/api/src/utils/is-hiragana-letter-ha-present.ts
+++ b/apps/api/src/utils/is-hiragana-letter-ha-present.ts
@@ -1,0 +1,3 @@
+export function IsHiraganaLetterHaPresent(input: string): boolean {
+  return input.includes('\u306F');
+}


### PR DESCRIPTION
Closes #7216

## Summary
- Add `apps/api/src/utils/is-hiragana-letter-ha-present.ts`.
- Export `isHiraganaLetterHaPresent(input: string): boolean`.
- Return true only when input contains Hiragana letter HA (`U+306F`).
- Add focused `tsx --test` coverage for present/absent cases.

## Validation
- `node_modules/.bin/tsx --test apps/api/src/tests/is-hiragana-letter-ha-present.test.ts`
- `git diff --check`