### PR TITLE
feat: Add is-hangzhou-numeral-nine-present API utility

### DIFF
--- a/apps/api/src/utils/is-hangzhou-numeral-nine-present.test.ts
+++ b/apps/api/src/utils/is-hangzhou-numeral-nine-present.test.ts
@@ -1,0 +1,17 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { isHangzhouNumeralNinePresent } from "./is-hangzhou-numeral-nine-present";
+
+test("returns true when the value contains Hangzhou numeral nine (U+3029)", () => {
+  assert.equal(isHangzhouNumeralNinePresent("prefix〩suffix"), true);
+  assert.equal(isHangzhouNumeralNinePresent("〩leading"), true);
+  assert.equal(isHangzhouNumeralNinePresent("trailing〩"), true);
+});
+
+test("returns false for other characters and empty values", () => {
+  assert.equal(isHangzhouNumeralNinePresent("prefix9suffix"), false);
+  assert.equal(isHangzhouNumeralNinePresent("prefix九suffix"), false);
+  assert.equal(isHangzhouNumeralNinePresent("left right"), false);
+  assert.equal(isHangzhouNumeralNinePresent(""), false);
+});

--- a/apps/api/src/utils/is-hangzhou-numeral-nine-present.ts
+++ b/apps/api/src/utils/is-hangzhou-numeral-nine-present.ts
@@ -1,0 +1,5 @@
+const HANGZHOU_NUMERAL_NINE = "〩";
+
+export function isHangzhouNumeralNinePresent(input: string): boolean {
+  return input.includes(HANGZHOU_NUMERAL_NINE);
+}


### PR DESCRIPTION
## Summary
Add is-hangzhou-numeral-nine-present API utility.

Automated BFOS+Grok implementation for issue #6798.
Focused change; professional style; no payment claim by bot.

Closes #6798


/bounty $50