### PR TITLE
fix: Add is-newline-symbol-present API utility

### DIFF
--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -7,7 +7,7 @@
   "main": "src/index.ts",
   "scripts": {
     "dev": "tsx src/index.ts",
-    "test": "echo \"No API tests configured yet\"",
+    "test": "tsx --test src/**/*.test.ts",
     "lint": "echo \"No API lint configured yet\""
   },
   "dependencies": {

--- a/apps/api/src/utils/is-newline-symbol-present.test.ts
+++ b/apps/api/src/utils/is-newline-symbol-present.test.ts
@@ -1,0 +1,17 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { isNewlineSymbolPresent } from "./is-newline-symbol-present";
+
+test("returns true when the value contains a newline symbol", () => {
+  assert.equal(isNewlineSymbolPresent("left\nright"), true);
+  assert.equal(isNewlineSymbolPresent("\nleading"), true);
+  assert.equal(isNewlineSymbolPresent("trailing\n"), true);
+});
+
+test("returns false for adjacent control symbols and empty values", () => {
+  assert.equal(isNewlineSymbolPresent("left right"), false);
+  assert.equal(isNewlineSymbolPresent("left\tright"), false);
+  assert.equal(isNewlineSymbolPresent("left\rright"), false);
+  assert.equal(isNewlineSymbolPresent(""), false);
+});

--- a/apps/api/src/utils/is-newline-symbol-present.ts
+++ b/apps/api/src/utils/is-newline-symbol-present.ts
@@ -1,0 +1,5 @@
+const NEWLINE_SYMBOL = "\n";
+
+export function isNewlineSymbolPresent(value: string): boolean {
+  return value.includes(NEWLINE_SYMBOL);
+}


### PR DESCRIPTION
## Summary
Add is-newline-symbol-present API utility

Automated BFOS+Grok implementation for issue #4827.
Focused change; professional style; no payment claim by bot.

Closes #4827


/bounty $50
