### PR TITLE
feat: add is-ideographic-level-tone-mark-present API utility

### DIFF
--- a/apps/api/src/utils/is-ideographic-level-tone-mark-present.ts
+++ b/apps/api/src/utils/is-ideographic-level-tone-mark-present.ts
@@ -1,0 +1,3 @@
+export function isIdeographicLevelToneMarkPresent(input: string): boolean {
+  return input.includes("〪");
+}


### PR DESCRIPTION
Resolves #6799

## Summary
Adds `isIdeographicLevelToneMarkPresent(input: string): boolean` utility that detects whether a string contains the Unicode ideographic level tone mark character (U+302A, \u302A).

## Changes
- `apps/api/src/utils/is-ideographic-level-tone-mark-present.ts` — new dependency-free helper

## Acceptance
- ✅ Exports `isIdeographicLevelToneMarkPresent(input: string): boolean`
- ✅ Returns `true` only when input contains U+302A
- ✅ Dependency-free
- ✅ Covered by batch TypeScript smoke tests