### PR TITLE
Add is-ideographic-rising-tone-mark-present API utility

### DIFF
--- a/apps/api/src/utils/is-ideographic-rising-tone-mark-present.test.ts
+++ b/apps/api/src/utils/is-ideographic-rising-tone-mark-present.test.ts
@@ -1,0 +1,15 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { isIdeographicRisingToneMarkPresent } from "./is-ideographic-rising-tone-mark-present";
+
+test("returns true when the input contains the ideographic rising tone mark", () => {
+  assert.equal(isIdeographicRisingToneMarkPresent("target: \u302B"), true);
+  assert.equal(isIdeographicRisingToneMarkPresent("hello\u302B world"), true);
+});
+
+test("returns false when the ideographic rising tone mark is absent", () => {
+  assert.equal(isIdeographicRisingToneMarkPresent("plain latin text"), false);
+  assert.equal(isIdeographicRisingToneMarkPresent("nearby mark but not target: \u302A"), false);
+  assert.equal(isIdeographicRisingToneMarkPresent(""), false);
+});

--- a/apps/api/src/utils/is-ideographic-rising-tone-mark-present.ts
+++ b/apps/api/src/utils/is-ideographic-rising-tone-mark-present.ts
@@ -1,0 +1,5 @@
+const IDEOGRAPHIC_RISING_TONE_MARK = "\u302B";
+
+export function isIdeographicRisingToneMarkPresent(input: string): boolean {
+  return input.includes(IDEOGRAPHIC_RISING_TONE_MARK);
+}


### PR DESCRIPTION
Closes #6800

## Summary
- Add \`apps/api/src/utils/is-ideographic-rising-tone-mark-present.ts\`.
- Export \`isIdeographicRisingToneMarkPresent(input: string): boolean\`.
- Return true only when input contains ideographic rising tone mark (\`U+302B\`).
- Add focused \`tsx --test\` coverage for present/absent cases.

## Validation
- \`npx tsx --test apps/api/src/utils/is-ideographic-rising-tone-mark-present.test.ts\` → 2 pass, 0 fail
- \`git diff --check\`
