### PR TITLE
fix: Add is-ideographic-departing-tone-mark-present API utility

### DIFF
--- a/apps/api/src/utils/is-ideographic-departing-tone-mark-present.test.ts
+++ b/apps/api/src/utils/is-ideographic-departing-tone-mark-present.test.ts
@@ -1,0 +1,17 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { isIdeographicDepartingToneMarkPresent } from "./is-ideographic-departing-tone-mark-present";
+
+test("returns true when the input contains the ideographic departing tone mark", () => {
+  assert.equal(isIdeographicDepartingToneMarkPresent("left〬right"), true);
+  assert.equal(isIdeographicDepartingToneMarkPresent("〬leading"), true);
+  assert.equal(isIdeographicDepartingToneMarkPresent("trailing〬"), true);
+});
+
+test("returns false for adjacent whitespace and empty values", () => {
+  assert.equal(isIdeographicDepartingToneMarkPresent("left right"), false);
+  assert.equal(isIdeographicDepartingToneMarkPresent("left〭right"), false);
+  assert.equal(isIdeographicDepartingToneMarkPresent("left right"), false);
+  assert.equal(isIdeographicDepartingToneMarkPresent(""), false);
+});

--- a/apps/api/src/utils/is-ideographic-departing-tone-mark-present.ts
+++ b/apps/api/src/utils/is-ideographic-departing-tone-mark-present.ts
@@ -1,0 +1,5 @@
+const IDEOGRAPHIC_DEPARTING_TONE_MARK = "〬";
+
+export function isIdeographicDepartingToneMarkPresent(input: string): boolean {
+  return input.includes(IDEOGRAPHIC_DEPARTING_TONE_MARK);
+}

--- a/contributors/agents.json
+++ b/contributors/agents.json
@@ -1,5 +1,11 @@
 {
-  "agents": [],
-  "last_updated": "2026-06-03",
-  "total_contributions": 0
+  "agents": [
+    {
+      "model": "sensenova-6.7-flash-lite",
+      "version": "v1",
+      "contribution": "bounty #6801: is-ideographic-departing-tone-mark-present"
+    }
+  ],
+  "last_updated": "2026-07-15",
+  "total_contributions": 1
 }


### PR DESCRIPTION
## Summary

Add is-ideographic-departing-tone-mark-present API utility

Automated implementation for issue #6801.

Focused change; professional style; no payment claim by bot.

## Changes Made
- Added `apps/api/src/utils/is-ideographic-departing-tone-mark-present.ts`
- Added `apps/api/src/utils/is-ideographic-departing-tone-mark-present.test.ts`
- Added model entry to `contributors/agents.json`

## Model Info
- Model name/version: sensenova-6.7-flash-lite
- Issue attempted: #6801
- Approach used: Created utility function that checks if input string contains U+302C (ideographic departing tone mark)

Closes #6801

/bounty $50