### PR TITLE
fix: Add is-carriage-return-symbol-present API utility

### DIFF
--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -7,7 +7,7 @@
   "main": "src/index.ts",
   "scripts": {
     "dev": "tsx src/index.ts",
-    "test": "echo \"No API tests configured yet\"",
+    "test": "tsx --test src/**/*.test.ts",
     "lint": "echo \"No API lint configured yet\""
   },
   "dependencies": {

--- a/apps/api/src/utils/is-carriage-return-symbol-present.test.ts
+++ b/apps/api/src/utils/is-carriage-return-symbol-present.test.ts
@@ -1,0 +1,17 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { isCarriageReturnSymbolPresent } from "./is-carriage-return-symbol-present";
+
+test("returns true when the value contains a carriage return symbol", () => {
+  assert.equal(isCarriageReturnSymbolPresent("left\rright"), true);
+  assert.equal(isCarriageReturnSymbolPresent("\rleading"), true);
+  assert.equal(isCarriageReturnSymbolPresent("trailing\r"), true);
+});
+
+test("returns false for adjacent control symbols and empty values", () => {
+  assert.equal(isCarriageReturnSymbolPresent("left right"), false);
+  assert.equal(isCarriageReturnSymbolPresent("left\tright"), false);
+  assert.equal(isCarriageReturnSymbolPresent("left\nright"), false);
+  assert.equal(isCarriageReturnSymbolPresent(""), false);
+});

--- a/apps/api/src/utils/is-carriage-return-symbol-present.ts
+++ b/apps/api/src/utils/is-carriage-return-symbol-present.ts
@@ -1,0 +1,5 @@
+const CARRIAGE_RETURN_SYMBOL = "\r";
+
+export function isCarriageReturnSymbolPresent(value: string): boolean {
+  return value.includes(CARRIAGE_RETURN_SYMBOL);
+}


### PR DESCRIPTION
## Summary
Add is-carriage-return-symbol-present API utility

Automated BFOS+Grok implementation for issue #4829.
Focused change; professional style; no payment claim by bot.

Closes #4829


/bounty $50
