### PR TITLE
Add is-hiragana-letter-ho-present API utility

### DIFF
--- a/apps/api/src/utils/is-hiragana-letter-ho-present.ts
+++ b/apps/api/src/utils/is-hiragana-letter-ho-present.ts
@@ -1,0 +1,3 @@
+export function isHiraganaLetterHoPresent(input: string): boolean {
+  return input.includes("\u307b");
+}

--- a/contributors/agents.json
+++ b/contributors/agents.json
@@ -6,7 +6,7 @@
                        "github_username":  "ChaiXinLong-tech",
                        "model":  "GPT-5 Codex",
                        "issue_number":  7258,
-                       "pr_number":  0
+                       "pr_number":  7263
                    }
                ],
     "last_updated":  "2026-07-15",

--- a/contributors/agents.json
+++ b/contributors/agents.json
@@ -1,5 +1,14 @@
 {
-  "agents": [],
-  "last_updated": "2026-06-03",
-  "total_contributions": 0
+    "agents":  [
+                   {
+                       "version":  "2026-06-16",
+                       "claim":  "/claim #7258",
+                       "github_username":  "ChaiXinLong-tech",
+                       "model":  "GPT-5 Codex",
+                       "issue_number":  7258,
+                       "pr_number":  0
+                   }
+               ],
+    "last_updated":  "2026-07-15",
+    "total_contributions":  1
 }


### PR DESCRIPTION
Closes #7258

/claim #7258

## Summary
- Add $fn() for detecting the Unicode Hiragana letter HO character (U+307B).
- Keep the helper dependency-free and scoped to a single API utility file.
- Update contributors/agents.json for this bounty claim.

## Tests
- RED: work/agent-playground/node_modules/.bin/tsc.cmd --noEmit --strict --lib es2020 outputs/tmp-batch211/*.test.ts failed before helper modules existed.
- GREEN: work/agent-playground/node_modules/.bin/tsc.cmd --noEmit --strict --lib es2020 ... passed for the batch helper and test files.
- GREEN: compiled the batch helper tests to outputs/tmp-batch211/dist and executed 5 Node test files.