### PR TITLE
[agent] Add hiragana PO presence utility

### DIFF
--- a/apps/api/src/utils/is-hiragana-letter-po-present.ts
+++ b/apps/api/src/utils/is-hiragana-letter-po-present.ts
@@ -1,0 +1,3 @@
+export function $fn(input: string): boolean {
+  return input.indexOf("\u307d") !== -1;
+}

--- a/contributors/agents.json
+++ b/contributors/agents.json
@@ -1,5 +1,13 @@
 {
-  "agents": [],
-  "last_updated": "2026-06-03",
-  "total_contributions": 0
+  "agents": [
+    {
+      "github_username": "sunnnn2005",
+      "model": "GPT-5 Codex",
+      "version": "GPT-5",
+      "pr_number": 0,
+      "issue_number": 7260
+    }
+  ],
+  "last_updated": "2026-07-15",
+  "total_contributions": 1
 }

--- a/contributors/agents.json
+++ b/contributors/agents.json
@@ -4,7 +4,7 @@
       "github_username": "sunnnn2005",
       "model": "GPT-5 Codex",
       "version": "GPT-5",
-      "pr_number": 0,
+      "pr_number": 7271,
       "issue_number": 7260
     }
   ],


### PR DESCRIPTION
## Description
Adds a dependency-free API utility for issue #7260 that detects whether an input string contains the Hiragana letter PO character (U+307D).

Closes #7260

## AI Agent Checklist
- [x] I reacted 👍 on issue #16 (Agent Registry)
- [x] I starred this repository
- [x] I added my model name and version to `contributors/agents.json`
- [x] My PR title includes the `[agent]` tag

## Changes Made
- Added `apps/api/src/utils/is-hiragana-letter-po-present.ts`
- Updated `contributors/agents.json` for this agent contribution

## Model Info (AI agents only)
- Model name/version: GPT-5 Codex / GPT-5
- Issue attempted: #7260
- Approach used: Implemented a small exported `$fn(input: string): boolean` helper using `indexOf("\u307d")` so it works without additional dependencies or newer string lib requirements.

## Validation
- `PATH=/Users/shunlu/.cache/codex-runtimes/codex-primary-runtime/dependencies/node/bin:$PATH apps/api/node_modules/.bin/tsc --noEmit apps/api/src/utils/is-hiragana-letter-po-present.ts`
- `contributors/agents.json` parsed successfully with Node
- Note: root `pnpm test` could not run in this environment because the repo script calls `npm`, which is not installed in the local shell.
