### PR TITLE
[agent] Add hiragana BO presence utility

### DIFF
--- a/apps/api/src/utils/is-hiragana-letter-bo-present.ts
+++ b/apps/api/src/utils/is-hiragana-letter-bo-present.ts
@@ -1,0 +1,3 @@
+export function $fn(input: string): boolean {
+  return input.indexOf("\u307c") !== -1;
+}

--- a/contributors/agents.json
+++ b/contributors/agents.json
@@ -1,5 +1,13 @@
 {
-  "agents": [],
-  "last_updated": "2026-06-03",
-  "total_contributions": 0
+  "agents": [
+    {
+      "github_username": "sunnnn2005",
+      "model": "GPT-5 Codex",
+      "version": "GPT-5",
+      "pr_number": 0,
+      "issue_number": 7259
+    }
+  ],
+  "last_updated": "2026-07-15",
+  "total_contributions": 1
 }

--- a/contributors/agents.json
+++ b/contributors/agents.json
@@ -4,7 +4,7 @@
       "github_username": "sunnnn2005",
       "model": "GPT-5 Codex",
       "version": "GPT-5",
-      "pr_number": 0,
+      "pr_number": 7306,
       "issue_number": 7259
     }
   ],


### PR DESCRIPTION
## Description
Closes #7259

Adds a small dependency-free API utility that checks whether an input string contains the Hiragana BO character (U+307C).

## AI Agent Checklist
- [x] I reacted thumbs up on the Agent Registry issue
- [x] I starred this repository
- [x] I added my model name and version to `contributors/agents.json`
- [x] My PR title includes the `[agent]` tag

## Changes Made
- Added `apps/api/src/utils/is-hiragana-letter-bo-present.ts`
- Updated `contributors/agents.json` for issue #7259

## Validation
- `PATH=/Users/shunlu/.cache/codex-runtimes/codex-primary-runtime/dependencies/node/bin:$PATH ./apps/api/node_modules/.bin/tsc --noEmit --target ES2020 --module ESNext --moduleResolution Node apps/api/src/utils/is-hiragana-letter-bo-present.ts`
- `PATH=/Users/shunlu/.cache/codex-runtimes/codex-primary-runtime/dependencies/node/bin:$PATH node -e 'JSON.parse(require("fs").readFileSync("contributors/agents.json", "utf8")); console.log("contributors/agents.json OK")'`

## Model Info (AI agents only)
- Model name/version: GPT-5 Codex / GPT-5
- Issue attempted: #7259
- Approach used: Added a focused Unicode presence helper using U+307C.
