### PR TITLE
[agent] Add hiragana letter ro utility and tests

### DIFF
--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -7,7 +7,7 @@
   "main": "src/index.ts",
   "scripts": {
     "dev": "tsx src/index.ts",
-    "test": "echo \"No API tests configured yet\"",
+    "test": "node --test --import tsx test/is-vertical-tab-symbol-present.test.ts test/is-hiragana-letter-ro-present.test.ts test/users.test.ts",
     "lint": "echo \"No API lint configured yet\""
   },
   "dependencies": {

--- a/apps/api/src/utils/is-hiragana-letter-ro-present.ts
+++ b/apps/api/src/utils/is-hiragana-letter-ro-present.ts
@@ -1,0 +1,3 @@
+export function isHiraganaLetterRoPresent(input: string): boolean {
+  return input.includes("\u308D");
+}

--- a/apps/api/test/is-hiragana-letter-ro-present.test.ts
+++ b/apps/api/test/is-hiragana-letter-ro-present.test.ts
@@ -1,0 +1,12 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+
+import { isHiraganaLetterRoPresent } from "../src/utils/is-hiragana-letter-ro-present";
+
+test("isHiraganaLetterRoPresent returns true when the input contains a hiragana ro character", () => {
+  assert.equal(isHiraganaLetterRoPresent("ひらがなろ"), true);
+});
+
+test("isHiraganaLetterRoPresent returns false when the input does not contain a hiragana ro character", () => {
+  assert.equal(isHiraganaLetterRoPresent("hiragana sample"), false);
+});

--- a/contributors/agents.json
+++ b/contributors/agents.json
@@ -1,5 +1,13 @@
 {
-  "agents": [],
-  "last_updated": "2026-06-03",
-  "total_contributions": 0
+  "agents": [
+    {
+      "github_username": "voladoradepapantla-netizen",
+      "model": "gpt-5",
+      "version": "2026-07-15",
+      "pr_number": 7308,
+      "issue_number": 7297
+    }
+  ],
+  "last_updated": "2026-07-15",
+  "total_contributions": 1
 }


### PR DESCRIPTION
/claim #7297

Closes #7297

Adds a dependency-free helper for detecting the Hiragana letter RO character, plus a matching node:test file and API test script entry so the new coverage runs with the existing smoke tests.

Validation:
- npm test in apps/api