### PR TITLE
[agent] Add hiragana letter re utility and tests

### DIFF
--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -7,7 +7,7 @@
   "main": "src/index.ts",
   "scripts": {
     "dev": "tsx src/index.ts",
-    "test": "echo \"No API tests configured yet\"",
+    "test": "node --test --import tsx test/is-vertical-tab-symbol-present.test.ts test/is-hiragana-letter-re-present.test.ts test/users.test.ts",
     "lint": "echo \"No API lint configured yet\""
   },
   "dependencies": {

--- a/apps/api/src/utils/is-hiragana-letter-re-present.ts
+++ b/apps/api/src/utils/is-hiragana-letter-re-present.ts
@@ -1,0 +1,3 @@
+export function isHiraganaLetterRePresent(input: string): boolean {
+  return input.includes("\u308C");
+}

--- a/apps/api/test/is-hiragana-letter-re-present.test.ts
+++ b/apps/api/test/is-hiragana-letter-re-present.test.ts
@@ -1,0 +1,12 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+
+import { isHiraganaLetterRePresent } from "../src/utils/is-hiragana-letter-re-present";
+
+test("isHiraganaLetterRePresent returns true when the input contains a hiragana re character", () => {
+  assert.equal(isHiraganaLetterRePresent("ひらがなれ"), true);
+});
+
+test("isHiraganaLetterRePresent returns false when the input does not contain a hiragana re character", () => {
+  assert.equal(isHiraganaLetterRePresent("hiragana sample"), false);
+});

--- a/contributors/agents.json
+++ b/contributors/agents.json
@@ -1,5 +1,13 @@
 {
-  "agents": [],
-  "last_updated": "2026-06-03",
-  "total_contributions": 0
+  "agents": [
+    {
+      "github_username": "voladoradepapantla-netizen",
+      "model": "gpt-5",
+      "version": "2026-07-15",
+      "pr_number": 7309,
+      "issue_number": 7296
+    }
+  ],
+  "last_updated": "2026-07-15",
+  "total_contributions": 1
 }


### PR DESCRIPTION
/claim #7296

Closes #7296

Adds a dependency-free helper for detecting the Hiragana letter RE character, plus a matching node:test file and API test script entry so the new coverage runs with the existing smoke tests.

Validation:
- npm test in apps/api