### PR TITLE
feat(api): add hiragana ru utility

### DIFF
--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -7,7 +7,7 @@
   "main": "src/index.ts",
   "scripts": {
     "dev": "tsx src/index.ts",
-    "test": "echo \"No API tests configured yet\"",
+    "test": "node --test --import tsx test/is-hiragana-letter-ru-present.test.ts",
     "lint": "echo \"No API lint configured yet\""
   },
   "dependencies": {

--- a/apps/api/src/utils/is-hiragana-letter-ru-present.ts
+++ b/apps/api/src/utils/is-hiragana-letter-ru-present.ts
@@ -1,0 +1,3 @@
+export function isHiraganaLetterRuPresent(input: string): boolean {
+  return input.includes("る");
+}

--- a/apps/api/test/is-hiragana-letter-ru-present.test.ts
+++ b/apps/api/test/is-hiragana-letter-ru-present.test.ts
@@ -1,0 +1,12 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+
+import { isHiraganaLetterRuPresent } from "../src/utils/is-hiragana-letter-ru-present";
+
+test("isHiraganaLetterRuPresent returns true when the input contains る", () => {
+  assert.equal(isHiraganaLetterRuPresent("さる"), true);
+});
+
+test("isHiraganaLetterRuPresent returns false when the input does not contain る", () => {
+  assert.equal(isHiraganaLetterRuPresent("さと"), false);
+});


### PR DESCRIPTION
Closes #7295

Adds `isHiraganaLetterRuPresent()` plus a small smoke test for the Hiragana RU character (U+308B). I also wire the API test script to run the new test file so the helper is covered by the existing TypeScript smoke-test flow.

Validation:
- `npm test -w apps/api`
- `git diff --check`