### PR TITLE
feat(api): add hiragana ri utility

### DIFF
--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -7,7 +7,7 @@
   "main": "src/index.ts",
   "scripts": {
     "dev": "tsx src/index.ts",
-    "test": "echo \"No API tests configured yet\"",
+    "test": "node --test --import tsx test/is-hiragana-letter-ri-present.test.ts",
     "lint": "echo \"No API lint configured yet\""
   },
   "dependencies": {

--- a/apps/api/src/utils/is-hiragana-letter-ri-present.ts
+++ b/apps/api/src/utils/is-hiragana-letter-ri-present.ts
@@ -1,0 +1,3 @@
+export function isHiraganaLetterRiPresent(input: string): boolean {
+  return input.includes("り");
+}

--- a/apps/api/test/is-hiragana-letter-ri-present.test.ts
+++ b/apps/api/test/is-hiragana-letter-ri-present.test.ts
@@ -1,0 +1,12 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+
+import { isHiraganaLetterRiPresent } from "../src/utils/is-hiragana-letter-ri-present";
+
+test("isHiraganaLetterRiPresent returns true when the input contains り", () => {
+  assert.equal(isHiraganaLetterRiPresent("さり"), true);
+});
+
+test("isHiraganaLetterRiPresent returns false when the input does not contain り", () => {
+  assert.equal(isHiraganaLetterRiPresent("さと"), false);
+});


### PR DESCRIPTION
Closes #7294

Adds `isHiraganaLetterRiPresent()` plus a small smoke test for the Hiragana RI character (U+308A). I also wire the API test script to run the new test file so the helper is covered by the existing TypeScript smoke-test flow.

Validation:
- `npm test -w apps/api`
- `git diff --check`