### PR TITLE
feat(api): add hiragana ra utility

### DIFF
--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -7,7 +7,7 @@
   "main": "src/index.ts",
   "scripts": {
     "dev": "tsx src/index.ts",
-    "test": "echo \"No API tests configured yet\"",
+    "test": "node --test --import tsx test/is-hiragana-letter-ra-present.test.ts",
     "lint": "echo \"No API lint configured yet\""
   },
   "dependencies": {

--- a/apps/api/src/utils/is-hiragana-letter-ra-present.ts
+++ b/apps/api/src/utils/is-hiragana-letter-ra-present.ts
@@ -1,0 +1,3 @@
+export function isHiraganaLetterRaPresent(input: string): boolean {
+  return input.includes("ら");
+}

--- a/apps/api/test/is-hiragana-letter-ra-present.test.ts
+++ b/apps/api/test/is-hiragana-letter-ra-present.test.ts
@@ -1,0 +1,12 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+
+import { isHiraganaLetterRaPresent } from "../src/utils/is-hiragana-letter-ra-present";
+
+test("isHiraganaLetterRaPresent returns true when the input contains ら", () => {
+  assert.equal(isHiraganaLetterRaPresent("さら"), true);
+});
+
+test("isHiraganaLetterRaPresent returns false when the input does not contain ら", () => {
+  assert.equal(isHiraganaLetterRaPresent("さと"), false);
+});


### PR DESCRIPTION
Closes #7287

Adds `isHiraganaLetterRaPresent()` plus a small smoke test for the Hiragana RA character (U+3089). I also wire the API test script to run the new test file so the helper is covered by the existing TypeScript smoke-test flow.

Validation:
- `npm test -w apps/api`
- `git diff --check`