### PR TITLE
feat(api): add hiragana small yo utility

### DIFF
--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -7,7 +7,7 @@
   "main": "src/index.ts",
   "scripts": {
     "dev": "tsx src/index.ts",
-    "test": "echo \"No API tests configured yet\"",
+    "test": "node --test --import tsx test/is-hiragana-letter-small-yo-present.test.ts",
     "lint": "echo \"No API lint configured yet\""
   },
   "dependencies": {

--- a/apps/api/src/utils/is-hiragana-letter-small-yo-present.ts
+++ b/apps/api/src/utils/is-hiragana-letter-small-yo-present.ts
@@ -1,0 +1,3 @@
+export function isHiraganaLetterSmallYoPresent(input: string): boolean {
+  return input.includes("ょ");
+}

--- a/apps/api/test/is-hiragana-letter-small-yo-present.test.ts
+++ b/apps/api/test/is-hiragana-letter-small-yo-present.test.ts
@@ -1,0 +1,12 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+
+import { isHiraganaLetterSmallYoPresent } from "../src/utils/is-hiragana-letter-small-yo-present";
+
+test("isHiraganaLetterSmallYoPresent returns true when the input contains ょ", () => {
+  assert.equal(isHiraganaLetterSmallYoPresent("きょ"), true);
+});
+
+test("isHiraganaLetterSmallYoPresent returns false when the input does not contain ょ", () => {
+  assert.equal(isHiraganaLetterSmallYoPresent("きよ"), false);
+});


### PR DESCRIPTION
Closes #7286

Adds `isHiraganaLetterSmallYoPresent()` plus a small smoke test for the Hiragana small YO character (U+3087). I also wire the API test script to run the new test file so the helper is covered by the existing TypeScript smoke-test flow.

Validation:
- `npm test -w apps/api`
- `git diff --check`