### PR TITLE
feat(api): add hiragana yo utility

### DIFF
--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -7,7 +7,7 @@
   "main": "src/index.ts",
   "scripts": {
     "dev": "tsx src/index.ts",
-    "test": "echo \"No API tests configured yet\"",
+    "test": "node --test --import tsx test/is-hiragana-letter-yo-present.test.ts",
     "lint": "echo \"No API lint configured yet\""
   },
   "dependencies": {

--- a/apps/api/src/utils/is-hiragana-letter-yo-present.ts
+++ b/apps/api/src/utils/is-hiragana-letter-yo-present.ts
@@ -1,0 +1,3 @@
+export function isHiraganaLetterYoPresent(input: string): boolean {
+  return input.includes("よ");
+}

--- a/apps/api/test/is-hiragana-letter-yo-present.test.ts
+++ b/apps/api/test/is-hiragana-letter-yo-present.test.ts
@@ -1,0 +1,12 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+
+import { isHiraganaLetterYoPresent } from "../src/utils/is-hiragana-letter-yo-present";
+
+test("isHiraganaLetterYoPresent returns true when the input contains よ", () => {
+  assert.equal(isHiraganaLetterYoPresent("きよ"), true);
+});
+
+test("isHiraganaLetterYoPresent returns false when the input does not contain よ", () => {
+  assert.equal(isHiraganaLetterYoPresent("きゆ"), false);
+});


### PR DESCRIPTION
Closes #7285

Adds `isHiraganaLetterYoPresent()` plus a small smoke test for the Hiragana YO character (U+3088). I also wire the API test script to run the new test file so the helper is covered by the existing TypeScript smoke-test flow.

Validation:
- `npm test -w apps/api`
- `git diff --check`