### PR TITLE
feat(api): add hiragana small yu utility

### DIFF
--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -7,7 +7,7 @@
   "main": "src/index.ts",
   "scripts": {
     "dev": "tsx src/index.ts",
-    "test": "echo \"No API tests configured yet\"",
+    "test": "node --test --import tsx test/is-hiragana-letter-small-yu-present.test.ts",
     "lint": "echo \"No API lint configured yet\""
   },
   "dependencies": {

--- a/apps/api/src/utils/is-hiragana-letter-small-yu-present.ts
+++ b/apps/api/src/utils/is-hiragana-letter-small-yu-present.ts
@@ -1,0 +1,3 @@
+export function isHiraganaLetterSmallYuPresent(input: string): boolean {
+  return input.includes("ゅ");
+}

--- a/apps/api/test/is-hiragana-letter-small-yu-present.test.ts
+++ b/apps/api/test/is-hiragana-letter-small-yu-present.test.ts
@@ -1,0 +1,12 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+
+import { isHiraganaLetterSmallYuPresent } from "../src/utils/is-hiragana-letter-small-yu-present";
+
+test("isHiraganaLetterSmallYuPresent returns true when the input contains ゅ", () => {
+  assert.equal(isHiraganaLetterSmallYuPresent("きゅ"), true);
+});
+
+test("isHiraganaLetterSmallYuPresent returns false when the input does not contain ゅ", () => {
+  assert.equal(isHiraganaLetterSmallYuPresent("きゆ"), false);
+});


### PR DESCRIPTION
Closes #7284

Adds `isHiraganaLetterSmallYuPresent()` plus a small smoke test for the Hiragana small YU character (U+3085). I also wire the API test script to run the new test file so the helper is covered by the existing TypeScript smoke-test flow.

Validation:
- `npm test -w apps/api`
- `git diff --check`