### PR TITLE
feat(api): add hiragana yu utility

### DIFF
--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -7,7 +7,7 @@
   "main": "src/index.ts",
   "scripts": {
     "dev": "tsx src/index.ts",
-    "test": "echo \"No API tests configured yet\"",
+    "test": "node --test --import tsx test/is-hiragana-letter-yu-present.test.ts",
     "lint": "echo \"No API lint configured yet\""
   },
   "dependencies": {

--- a/apps/api/src/utils/is-hiragana-letter-yu-present.ts
+++ b/apps/api/src/utils/is-hiragana-letter-yu-present.ts
@@ -1,0 +1,3 @@
+export function isHiraganaLetterYuPresent(input: string): boolean {
+  return input.includes("ゆ");
+}

--- a/apps/api/test/is-hiragana-letter-yu-present.test.ts
+++ b/apps/api/test/is-hiragana-letter-yu-present.test.ts
@@ -1,0 +1,12 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+
+import { isHiraganaLetterYuPresent } from "../src/utils/is-hiragana-letter-yu-present";
+
+test("isHiraganaLetterYuPresent returns true when the input contains ゆ", () => {
+  assert.equal(isHiraganaLetterYuPresent("ゆう"), true);
+});
+
+test("isHiraganaLetterYuPresent returns false when the input does not contain ゆ", () => {
+  assert.equal(isHiraganaLetterYuPresent("きょう"), false);
+});


### PR DESCRIPTION
Closes #7283

Adds `isHiraganaLetterYuPresent()` plus a small smoke test for the Hiragana YU character (U+3086). I also wire the API test script to run the new test file so the helper is covered by the existing TypeScript smoke-test flow.

Validation:
- `npm test -w apps/api`
- `git diff --check`