### PR TITLE
feat(api): add hiragana small ya utility

### DIFF
--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -7,7 +7,7 @@
   "main": "src/index.ts",
   "scripts": {
     "dev": "tsx src/index.ts",
-    "test": "echo \"No API tests configured yet\"",
+    "test": "node --test --import tsx test/is-hiragana-letter-small-ya-present.test.ts",
     "lint": "echo \"No API lint configured yet\""
   },
   "dependencies": {

--- a/apps/api/src/utils/is-hiragana-letter-small-ya-present.ts
+++ b/apps/api/src/utils/is-hiragana-letter-small-ya-present.ts
@@ -1,0 +1,3 @@
+export function isHiraganaLetterSmallYaPresent(input: string): boolean {
+  return input.includes("ゃ");
+}

--- a/apps/api/test/is-hiragana-letter-small-ya-present.test.ts
+++ b/apps/api/test/is-hiragana-letter-small-ya-present.test.ts
@@ -1,0 +1,12 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+
+import { isHiraganaLetterSmallYaPresent } from "../src/utils/is-hiragana-letter-small-ya-present";
+
+test("isHiraganaLetterSmallYaPresent returns true when the input contains ゃ", () => {
+  assert.equal(isHiraganaLetterSmallYaPresent("きゃ"), true);
+});
+
+test("isHiraganaLetterSmallYaPresent returns false when the input does not contain ゃ", () => {
+  assert.equal(isHiraganaLetterSmallYaPresent("きや"), false);
+});


### PR DESCRIPTION
Closes #7276

Adds `isHiraganaLetterSmallYaPresent()` plus a small smoke test for the Hiragana small YA character (U+3083). I also wire the API test script to run the new test file so the helper is covered by the existing TypeScript smoke-test flow.

Validation:
- `npm test -w apps/api`
- `git diff --check`