### PR TITLE
feat(api): add hiragana ya utility

### DIFF
--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -7,7 +7,7 @@
   "main": "src/index.ts",
   "scripts": {
     "dev": "tsx src/index.ts",
-    "test": "echo \"No API tests configured yet\"",
+    "test": "node --test --import tsx test/is-hiragana-letter-ya-present.test.ts",
     "lint": "echo \"No API lint configured yet\""
   },
   "dependencies": {

--- a/apps/api/src/utils/is-hiragana-letter-ya-present.ts
+++ b/apps/api/src/utils/is-hiragana-letter-ya-present.ts
@@ -1,0 +1,3 @@
+export function isHiraganaLetterYaPresent(input: string): boolean {
+  return input.includes("や");
+}

--- a/apps/api/test/is-hiragana-letter-ya-present.test.ts
+++ b/apps/api/test/is-hiragana-letter-ya-present.test.ts
@@ -1,0 +1,12 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+
+import { isHiraganaLetterYaPresent } from "../src/utils/is-hiragana-letter-ya-present";
+
+test("isHiraganaLetterYaPresent returns true when the input contains や", () => {
+  assert.equal(isHiraganaLetterYaPresent("やま"), true);
+});
+
+test("isHiraganaLetterYaPresent returns false when the input does not contain や", () => {
+  assert.equal(isHiraganaLetterYaPresent("よま"), false);
+});


### PR DESCRIPTION
Closes #7275

Adds `isHiraganaLetterYaPresent()` plus a small smoke test for the Hiragana YA character (U+3084). I also wire the API test script to run the new test file so the helper is covered by the existing TypeScript smoke-test flow.

Validation:
- `npm test -w apps/api`
- `git diff --check`