### PR TITLE
feat(api): add hiragana mo utility

### DIFF
--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -7,7 +7,7 @@
   "main": "src/index.ts",
   "scripts": {
     "dev": "tsx src/index.ts",
-    "test": "echo \"No API tests configured yet\"",
+    "test": "node --test --import tsx test/is-hiragana-letter-mo-present.test.ts",
     "lint": "echo \"No API lint configured yet\""
   },
   "dependencies": {

--- a/apps/api/src/utils/is-hiragana-letter-mo-present.ts
+++ b/apps/api/src/utils/is-hiragana-letter-mo-present.ts
@@ -1,0 +1,3 @@
+export function isHiraganaLetterMoPresent(input: string): boolean {
+  return input.includes("も");
+}

--- a/apps/api/test/is-hiragana-letter-mo-present.test.ts
+++ b/apps/api/test/is-hiragana-letter-mo-present.test.ts
@@ -1,0 +1,12 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+
+import { isHiraganaLetterMoPresent } from "../src/utils/is-hiragana-letter-mo-present";
+
+test("isHiraganaLetterMoPresent returns true when the input contains も", () => {
+  assert.equal(isHiraganaLetterMoPresent("もり"), true);
+});
+
+test("isHiraganaLetterMoPresent returns false when the input does not contain も", () => {
+  assert.equal(isHiraganaLetterMoPresent("まり"), false);
+});


### PR DESCRIPTION
Closes #7274

Adds `isHiraganaLetterMoPresent()` plus a small smoke test for the Hiragana MO character (U+3082). I also wire the API test script to run the new test file so the helper is covered by the existing TypeScript smoke-test flow.

Validation:
- `npm test -w apps/api`
- `git diff --check`