### PR TITLE
feat(api): add hiragana me utility

### DIFF
--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -7,7 +7,7 @@
   "main": "src/index.ts",
   "scripts": {
     "dev": "tsx src/index.ts",
-    "test": "echo \"No API tests configured yet\"",
+    "test": "node --test --import tsx test/is-hiragana-letter-me-present.test.ts",
     "lint": "echo \"No API lint configured yet\""
   },
   "dependencies": {

--- a/apps/api/src/utils/is-hiragana-letter-me-present.ts
+++ b/apps/api/src/utils/is-hiragana-letter-me-present.ts
@@ -1,0 +1,3 @@
+export function isHiraganaLetterMePresent(input: string): boolean {
+  return input.includes("め");
+}

--- a/apps/api/test/is-hiragana-letter-me-present.test.ts
+++ b/apps/api/test/is-hiragana-letter-me-present.test.ts
@@ -1,0 +1,12 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+
+import { isHiraganaLetterMePresent } from "../src/utils/is-hiragana-letter-me-present";
+
+test("isHiraganaLetterMePresent returns true when the input contains め", () => {
+  assert.equal(isHiraganaLetterMePresent("めい"), true);
+});
+
+test("isHiraganaLetterMePresent returns false when the input does not contain め", () => {
+  assert.equal(isHiraganaLetterMePresent("みい"), false);
+});


### PR DESCRIPTION
Closes #7273

Adds `isHiraganaLetterMePresent()` plus a small smoke test for the Hiragana ME character (U+3081). I also wire the API test script to run the new test file so the helper is covered by the existing TypeScript smoke-test flow.

Validation:
- `npm test -w apps/api`
- `git diff --check`