### PR TITLE
feat(api): add hiragana mu utility

### DIFF
--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -7,7 +7,7 @@
   "main": "src/index.ts",
   "scripts": {
     "dev": "tsx src/index.ts",
-    "test": "echo \"No API tests configured yet\"",
+    "test": "node --test --import tsx test/is-hiragana-letter-mu-present.test.ts",
     "lint": "echo \"No API lint configured yet\""
   },
   "dependencies": {

--- a/apps/api/src/utils/is-hiragana-letter-mu-present.ts
+++ b/apps/api/src/utils/is-hiragana-letter-mu-present.ts
@@ -1,0 +1,3 @@
+export function isHiraganaLetterMuPresent(input: string): boolean {
+  return input.includes("む");
+}

--- a/apps/api/test/is-hiragana-letter-mu-present.test.ts
+++ b/apps/api/test/is-hiragana-letter-mu-present.test.ts
@@ -1,0 +1,12 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+
+import { isHiraganaLetterMuPresent } from "../src/utils/is-hiragana-letter-mu-present";
+
+test("isHiraganaLetterMuPresent returns true when the input contains む", () => {
+  assert.equal(isHiraganaLetterMuPresent("むぎ"), true);
+});
+
+test("isHiraganaLetterMuPresent returns false when the input does not contain む", () => {
+  assert.equal(isHiraganaLetterMuPresent("みぎ"), false);
+});


### PR DESCRIPTION
Closes #7272

Adds `isHiraganaLetterMuPresent()` plus a small smoke test for the Hiragana MU character (U+3080). I also wire the API test script to run the new test file so the helper is covered by the existing TypeScript smoke-test flow.

Validation:
- `npm test -w apps/api`
- `git diff --check`