### PR TITLE
feat(api): add hiragana mi utility

### DIFF
--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -7,7 +7,7 @@
   "main": "src/index.ts",
   "scripts": {
     "dev": "tsx src/index.ts",
-    "test": "echo \"No API tests configured yet\"",
+    "test": "node --test --import tsx test/is-hiragana-letter-mi-present.test.ts",
     "lint": "echo \"No API lint configured yet\""
   },
   "dependencies": {

--- a/apps/api/src/utils/is-hiragana-letter-mi-present.ts
+++ b/apps/api/src/utils/is-hiragana-letter-mi-present.ts
@@ -1,0 +1,3 @@
+export function isHiraganaLetterMiPresent(input: string): boolean {
+  return input.includes("み");
+}

--- a/apps/api/test/is-hiragana-letter-mi-present.test.ts
+++ b/apps/api/test/is-hiragana-letter-mi-present.test.ts
@@ -1,0 +1,12 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+
+import { isHiraganaLetterMiPresent } from "../src/utils/is-hiragana-letter-mi-present";
+
+test("isHiraganaLetterMiPresent returns true when the input contains み", () => {
+  assert.equal(isHiraganaLetterMiPresent("みず"), true);
+});
+
+test("isHiraganaLetterMiPresent returns false when the input does not contain み", () => {
+  assert.equal(isHiraganaLetterMiPresent("むず"), false);
+});


### PR DESCRIPTION
Closes #7262

Adds `isHiraganaLetterMiPresent()` plus a small smoke test for the Hiragana MI character (U+307F). I also wire the API test script to run the new test file so the helper is covered by the existing TypeScript smoke-test flow.

Validation:
- `npm test -w apps/api`
- `git diff --check`