### PR TITLE
feat(api): add hiragana ma utility

### DIFF
--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -7,7 +7,7 @@
   "main": "src/index.ts",
   "scripts": {
     "dev": "tsx src/index.ts",
-    "test": "echo \"No API tests configured yet\"",
+    "test": "node --test --import tsx test/is-hiragana-letter-ma-present.test.ts",
     "lint": "echo \"No API lint configured yet\""
   },
   "dependencies": {

--- a/apps/api/src/utils/is-hiragana-letter-ma-present.ts
+++ b/apps/api/src/utils/is-hiragana-letter-ma-present.ts
@@ -1,0 +1,3 @@
+export function isHiraganaLetterMaPresent(input: string): boolean {
+  return input.includes("ま");
+}

--- a/apps/api/test/is-hiragana-letter-ma-present.test.ts
+++ b/apps/api/test/is-hiragana-letter-ma-present.test.ts
@@ -1,0 +1,12 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+
+import { isHiraganaLetterMaPresent } from "../src/utils/is-hiragana-letter-ma-present";
+
+test("isHiraganaLetterMaPresent returns true when the input contains ま", () => {
+  assert.equal(isHiraganaLetterMaPresent("まち"), true);
+});
+
+test("isHiraganaLetterMaPresent returns false when the input does not contain ま", () => {
+  assert.equal(isHiraganaLetterMaPresent("みち"), false);
+});


### PR DESCRIPTION
Closes #7261

Adds `isHiraganaLetterMaPresent()` plus a small smoke test for the Hiragana MA character (U+307E). I also wire the API test script to run the new test file so the helper is covered by the existing TypeScript smoke-test flow.

Validation:
- `npm test -w apps/api`
- `git diff --check`