### PR TITLE
feat(api): add hiragana po utility

### DIFF
--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -7,7 +7,7 @@
   "main": "src/index.ts",
   "scripts": {
     "dev": "tsx src/index.ts",
-    "test": "echo \"No API tests configured yet\"",
+    "test": "node --test --import tsx test/is-hiragana-letter-po-present.test.ts",
     "lint": "echo \"No API lint configured yet\""
   },
   "dependencies": {

--- a/apps/api/src/utils/is-hiragana-letter-po-present.ts
+++ b/apps/api/src/utils/is-hiragana-letter-po-present.ts
@@ -1,0 +1,3 @@
+export function isHiraganaLetterPoPresent(input: string): boolean {
+  return input.includes("ぽ");
+}

--- a/apps/api/test/is-hiragana-letter-po-present.test.ts
+++ b/apps/api/test/is-hiragana-letter-po-present.test.ts
@@ -1,0 +1,12 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+
+import { isHiraganaLetterPoPresent } from "../src/utils/is-hiragana-letter-po-present";
+
+test("isHiraganaLetterPoPresent returns true when the input contains ぽ", () => {
+  assert.equal(isHiraganaLetterPoPresent("ぽけっと"), true);
+});
+
+test("isHiraganaLetterPoPresent returns false when the input does not contain ぽ", () => {
+  assert.equal(isHiraganaLetterPoPresent("ぱけっと"), false);
+});


### PR DESCRIPTION
Closes #7260

Adds `isHiraganaLetterPoPresent()` plus a small smoke test for the Hiragana PO character (U+307D). I also wire the API test script to run the new test file so the helper is covered by the existing TypeScript smoke-test flow.

Validation:
- `npm test -w apps/api`
- `git diff --check`