### PR TITLE
feat(api): add hiragana bo utility

### DIFF
--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -7,7 +7,7 @@
   "main": "src/index.ts",
   "scripts": {
     "dev": "tsx src/index.ts",
-    "test": "echo \"No API tests configured yet\"",
+    "test": "node --test --import tsx test/is-hiragana-letter-bo-present.test.ts",
     "lint": "echo \"No API lint configured yet\""
   },
   "dependencies": {

--- a/apps/api/src/utils/is-hiragana-letter-bo-present.ts
+++ b/apps/api/src/utils/is-hiragana-letter-bo-present.ts
@@ -1,0 +1,3 @@
+export function isHiraganaLetterBoPresent(input: string): boolean {
+  return input.includes("ぼ");
+}

--- a/apps/api/test/is-hiragana-letter-bo-present.test.ts
+++ b/apps/api/test/is-hiragana-letter-bo-present.test.ts
@@ -1,0 +1,12 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+
+import { isHiraganaLetterBoPresent } from "../src/utils/is-hiragana-letter-bo-present";
+
+test("isHiraganaLetterBoPresent returns true when the input contains ぼ", () => {
+  assert.equal(isHiraganaLetterBoPresent("ぼく"), true);
+});
+
+test("isHiraganaLetterBoPresent returns false when the input does not contain ぼ", () => {
+  assert.equal(isHiraganaLetterBoPresent("ばく"), false);
+});


### PR DESCRIPTION
Closes #7259

Adds `isHiraganaLetterBoPresent()` plus a small smoke test for the Hiragana BO character (U+307C). I also wire the API test script to run the new test file so the helper is covered by the existing TypeScript smoke-test flow.

Validation:
- `npm test -w apps/api`
- `git diff --check`