### PR TITLE
feat(api): add hiragana ho utility

### DIFF
--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -7,7 +7,7 @@
   "main": "src/index.ts",
   "scripts": {
     "dev": "tsx src/index.ts",
-    "test": "echo \"No API tests configured yet\"",
+    "test": "node --test --import tsx test/is-hiragana-letter-ho-present.test.ts",
     "lint": "echo \"No API lint configured yet\""
   },
   "dependencies": {

--- a/apps/api/src/utils/is-hiragana-letter-ho-present.ts
+++ b/apps/api/src/utils/is-hiragana-letter-ho-present.ts
@@ -1,0 +1,3 @@
+export function isHiraganaLetterHoPresent(input: string): boolean {
+  return input.includes("ほ");
+}

--- a/apps/api/test/is-hiragana-letter-ho-present.test.ts
+++ b/apps/api/test/is-hiragana-letter-ho-present.test.ts
@@ -1,0 +1,12 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+
+import { isHiraganaLetterHoPresent } from "../src/utils/is-hiragana-letter-ho-present";
+
+test("isHiraganaLetterHoPresent returns true when the input contains ほ", () => {
+  assert.equal(isHiraganaLetterHoPresent("ほし"), true);
+});
+
+test("isHiraganaLetterHoPresent returns false when the input does not contain ほ", () => {
+  assert.equal(isHiraganaLetterHoPresent("はし"), false);
+});


### PR DESCRIPTION
Closes #7258

Adds `isHiraganaLetterHoPresent()` plus a small smoke test for the Hiragana HO character (U+307B). I also wire the API test script to run the new test file so the helper is covered by the existing TypeScript smoke-test flow.

Validation:
- `npm test -w apps/api`
- `git diff --check`