### PR TITLE
feat(api): add hiragana pe utility

### DIFF
--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -7,7 +7,7 @@
   "main": "src/index.ts",
   "scripts": {
     "dev": "tsx src/index.ts",
-    "test": "echo \"No API tests configured yet\"",
+    "test": "node --test --import tsx test/is-hiragana-letter-pe-present.test.ts",
     "lint": "echo \"No API lint configured yet\""
   },
   "dependencies": {

--- a/apps/api/src/utils/is-hiragana-letter-pe-present.ts
+++ b/apps/api/src/utils/is-hiragana-letter-pe-present.ts
@@ -1,0 +1,3 @@
+export function isHiraganaLetterPePresent(input: string): boolean {
+  return input.includes("ぺ");
+}

--- a/apps/api/test/is-hiragana-letter-pe-present.test.ts
+++ b/apps/api/test/is-hiragana-letter-pe-present.test.ts
@@ -1,0 +1,12 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+
+import { isHiraganaLetterPePresent } from "../src/utils/is-hiragana-letter-pe-present";
+
+test("isHiraganaLetterPePresent returns true when the input contains ぺ", () => {
+  assert.equal(isHiraganaLetterPePresent("ぺた"), true);
+});
+
+test("isHiraganaLetterPePresent returns false when the input does not contain ぺ", () => {
+  assert.equal(isHiraganaLetterPePresent("へた"), false);
+});


### PR DESCRIPTION
Closes #7251

Adds `isHiraganaLetterPePresent()` plus a small smoke test for the Hiragana PE character (U+307A). I also wire the API test script to run the new test file so the helper is covered by the existing TypeScript smoke-test flow.

Validation:
- `npm test -w apps/api`
- `git diff --check`