### PR TITLE
feat(api): add hiragana be utility

### DIFF
--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -7,7 +7,7 @@
   "main": "src/index.ts",
   "scripts": {
     "dev": "tsx src/index.ts",
-    "test": "echo \"No API tests configured yet\"",
+    "test": "node --test --import tsx test/is-hiragana-letter-be-present.test.ts",
     "lint": "echo \"No API lint configured yet\""
   },
   "dependencies": {

--- a/apps/api/src/utils/is-hiragana-letter-be-present.ts
+++ b/apps/api/src/utils/is-hiragana-letter-be-present.ts
@@ -1,0 +1,3 @@
+export function isHiraganaLetterBePresent(input: string): boolean {
+  return input.includes("べ");
+}

--- a/apps/api/test/is-hiragana-letter-be-present.test.ts
+++ b/apps/api/test/is-hiragana-letter-be-present.test.ts
@@ -1,0 +1,12 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+
+import { isHiraganaLetterBePresent } from "../src/utils/is-hiragana-letter-be-present";
+
+test("isHiraganaLetterBePresent returns true when the input contains べ", () => {
+  assert.equal(isHiraganaLetterBePresent("べん"), true);
+});
+
+test("isHiraganaLetterBePresent returns false when the input does not contain べ", () => {
+  assert.equal(isHiraganaLetterBePresent("へん"), false);
+});


### PR DESCRIPTION
Closes #7250

Adds `isHiraganaLetterBePresent()` plus a small smoke test for the Hiragana BE character (U+3079). I also wire the API test script to run the new test file so the helper is covered by the existing TypeScript smoke-test flow.

Validation:
- `npm test -w apps/api`
- `git diff --check`