### PR TITLE
feat(api): add hiragana he utility

### DIFF
--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -7,7 +7,7 @@
   "main": "src/index.ts",
   "scripts": {
     "dev": "tsx src/index.ts",
-    "test": "echo \"No API tests configured yet\"",
+    "test": "node --test --import tsx test/is-hiragana-letter-he-present.test.ts",
     "lint": "echo \"No API lint configured yet\""
   },
   "dependencies": {

--- a/apps/api/src/utils/is-hiragana-letter-he-present.ts
+++ b/apps/api/src/utils/is-hiragana-letter-he-present.ts
@@ -1,0 +1,3 @@
+export function isHiraganaLetterHePresent(input: string): boolean {
+  return input.includes("へ");
+}

--- a/apps/api/test/is-hiragana-letter-he-present.test.ts
+++ b/apps/api/test/is-hiragana-letter-he-present.test.ts
@@ -1,0 +1,12 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+
+import { isHiraganaLetterHePresent } from "../src/utils/is-hiragana-letter-he-present";
+
+test("isHiraganaLetterHePresent returns true when the input contains へ", () => {
+  assert.equal(isHiraganaLetterHePresent("へや"), true);
+});
+
+test("isHiraganaLetterHePresent returns false when the input does not contain へ", () => {
+  assert.equal(isHiraganaLetterHePresent("ほや"), false);
+});


### PR DESCRIPTION
Closes #7249

Adds `isHiraganaLetterHePresent()` plus a small smoke test for the Hiragana HE character (U+3078). I also wire the API test script to run the new test file so the helper is covered by the existing TypeScript smoke-test flow.

Validation:
- `npm test -w apps/api`
- `git diff --check`