### PR TITLE
feat(api): add hiragana pu utility

### DIFF
--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -7,7 +7,7 @@
   "main": "src/index.ts",
   "scripts": {
     "dev": "tsx src/index.ts",
-    "test": "echo \"No API tests configured yet\"",
+    "test": "node --test --import tsx test/is-hiragana-letter-pu-present.test.ts",
     "lint": "echo \"No API lint configured yet\""
   },
   "dependencies": {

--- a/apps/api/src/utils/is-hiragana-letter-pu-present.ts
+++ b/apps/api/src/utils/is-hiragana-letter-pu-present.ts
@@ -1,0 +1,3 @@
+export function isHiraganaLetterPuPresent(input: string): boolean {
+  return input.includes("ぷ");
+}

--- a/apps/api/test/is-hiragana-letter-pu-present.test.ts
+++ b/apps/api/test/is-hiragana-letter-pu-present.test.ts
@@ -1,0 +1,12 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+
+import { isHiraganaLetterPuPresent } from "../src/utils/is-hiragana-letter-pu-present";
+
+test("isHiraganaLetterPuPresent returns true when the input contains ぷ", () => {
+  assert.equal(isHiraganaLetterPuPresent("ぷか"), true);
+});
+
+test("isHiraganaLetterPuPresent returns false when the input does not contain ぷ", () => {
+  assert.equal(isHiraganaLetterPuPresent("ふか"), false);
+});


### PR DESCRIPTION
Closes #7248

Adds `isHiraganaLetterPuPresent()` plus a small smoke test for the Hiragana PU character (U+3077). I also wire the API test script to run the new test file so the helper is covered by the existing TypeScript smoke-test flow.

Validation:
- `npm test -w apps/api`
- `git diff --check`