### PR TITLE
feat(api): add hiragana bu utility

### DIFF
--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -7,7 +7,7 @@
   "main": "src/index.ts",
   "scripts": {
     "dev": "tsx src/index.ts",
-    "test": "echo \"No API tests configured yet\"",
+    "test": "node --test --import tsx test/is-hiragana-letter-bu-present.test.ts",
     "lint": "echo \"No API lint configured yet\""
   },
   "dependencies": {

--- a/apps/api/src/utils/is-hiragana-letter-bu-present.ts
+++ b/apps/api/src/utils/is-hiragana-letter-bu-present.ts
@@ -1,0 +1,3 @@
+export function isHiraganaLetterBuPresent(input: string): boolean {
+  return input.includes("ぶ");
+}

--- a/apps/api/test/is-hiragana-letter-bu-present.test.ts
+++ b/apps/api/test/is-hiragana-letter-bu-present.test.ts
@@ -1,0 +1,12 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+
+import { isHiraganaLetterBuPresent } from "../src/utils/is-hiragana-letter-bu-present";
+
+test("isHiraganaLetterBuPresent returns true when the input contains ぶ", () => {
+  assert.equal(isHiraganaLetterBuPresent("ぶた"), true);
+});
+
+test("isHiraganaLetterBuPresent returns false when the input does not contain ぶ", () => {
+  assert.equal(isHiraganaLetterBuPresent("ふた"), false);
+});


### PR DESCRIPTION
Closes #7247

Adds `isHiraganaLetterBuPresent()` plus a small smoke test for the Hiragana BU character (U+3076). I also wire the API test script to run the new test file so the helper is covered by the existing TypeScript smoke-test flow.

Validation:
- `npm test -w apps/api`
- `git diff --check`