### PR TITLE
feat(api): add hiragana hu utility

### DIFF
--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -7,7 +7,7 @@
   "main": "src/index.ts",
   "scripts": {
     "dev": "tsx src/index.ts",
-    "test": "echo \"No API tests configured yet\"",
+    "test": "node --test --import tsx test/is-hiragana-letter-hu-present.test.ts",
     "lint": "echo \"No API lint configured yet\""
   },
   "dependencies": {

--- a/apps/api/src/utils/is-hiragana-letter-hu-present.ts
+++ b/apps/api/src/utils/is-hiragana-letter-hu-present.ts
@@ -1,0 +1,3 @@
+export function isHiraganaLetterHuPresent(input: string): boolean {
+  return input.includes("ふ");
+}

--- a/apps/api/test/is-hiragana-letter-hu-present.test.ts
+++ b/apps/api/test/is-hiragana-letter-hu-present.test.ts
@@ -1,0 +1,12 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+
+import { isHiraganaLetterHuPresent } from "../src/utils/is-hiragana-letter-hu-present";
+
+test("isHiraganaLetterHuPresent returns true when the input contains ふ", () => {
+  assert.equal(isHiraganaLetterHuPresent("ふね"), true);
+});
+
+test("isHiraganaLetterHuPresent returns false when the input does not contain ふ", () => {
+  assert.equal(isHiraganaLetterHuPresent("へね"), false);
+});


### PR DESCRIPTION
Closes #7226

Adds `isHiraganaLetterHuPresent()` plus a small smoke test for the Hiragana HU character (U+3075). I also wire the API test script to run the new test file so the helper is covered by the existing TypeScript smoke-test flow.

Validation:
- `npm test -w apps/api`
- `git diff --check`