### PR TITLE
feat(api): add hiragana pi utility

### DIFF
--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -7,7 +7,7 @@
   "main": "src/index.ts",
   "scripts": {
     "dev": "tsx src/index.ts",
-    "test": "echo \"No API tests configured yet\"",
+    "test": "node --test --import tsx test/is-hiragana-letter-pi-present.test.ts",
     "lint": "echo \"No API lint configured yet\""
   },
   "dependencies": {

--- a/apps/api/src/utils/is-hiragana-letter-pi-present.ts
+++ b/apps/api/src/utils/is-hiragana-letter-pi-present.ts
@@ -1,0 +1,3 @@
+export function isHiraganaLetterPiPresent(input: string): boolean {
+  return input.includes("ぴ");
+}

--- a/apps/api/test/is-hiragana-letter-pi-present.test.ts
+++ b/apps/api/test/is-hiragana-letter-pi-present.test.ts
@@ -1,0 +1,12 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+
+import { isHiraganaLetterPiPresent } from "../src/utils/is-hiragana-letter-pi-present";
+
+test("isHiraganaLetterPiPresent returns true when the input contains ぴ", () => {
+  assert.equal(isHiraganaLetterPiPresent("ぴょ"), true);
+});
+
+test("isHiraganaLetterPiPresent returns false when the input does not contain ぴ", () => {
+  assert.equal(isHiraganaLetterPiPresent("ひょ"), false);
+});


### PR DESCRIPTION
Closes #7225

Adds `isHiraganaLetterPiPresent()` plus a small smoke test for the Hiragana PI character (U+3074). I also wire the API test script to run the new test file so the helper is covered by the existing TypeScript smoke-test flow.

Validation:
- `npm test -w apps/api`
- `git diff --check`