### PR TITLE
feat(api): add hiragana bi utility

### DIFF
--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -7,7 +7,7 @@
   "main": "src/index.ts",
   "scripts": {
     "dev": "tsx src/index.ts",
-    "test": "echo \"No API tests configured yet\"",
+    "test": "node --test --import tsx test/is-hiragana-letter-bi-present.test.ts",
     "lint": "echo \"No API lint configured yet\""
   },
   "dependencies": {

--- a/apps/api/src/utils/is-hiragana-letter-bi-present.ts
+++ b/apps/api/src/utils/is-hiragana-letter-bi-present.ts
@@ -1,0 +1,3 @@
+export function isHiraganaLetterBiPresent(input: string): boolean {
+  return input.includes("び");
+}

--- a/apps/api/test/is-hiragana-letter-bi-present.test.ts
+++ b/apps/api/test/is-hiragana-letter-bi-present.test.ts
@@ -1,0 +1,12 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+
+import { isHiraganaLetterBiPresent } from "../src/utils/is-hiragana-letter-bi-present";
+
+test("isHiraganaLetterBiPresent returns true when the input contains び", () => {
+  assert.equal(isHiraganaLetterBiPresent("びく"), true);
+});
+
+test("isHiraganaLetterBiPresent returns false when the input does not contain び", () => {
+  assert.equal(isHiraganaLetterBiPresent("ひく"), false);
+});


### PR DESCRIPTION
Closes #7224

Adds `isHiraganaLetterBiPresent()` plus a small smoke test for the Hiragana BI character (U+3073). I also wire the API test script to run the new test file so the helper is covered by the existing TypeScript smoke-test flow.

Validation:
- `npm test -w apps/api`
- `git diff --check`