### PR TITLE
feat(api): add hiragana pa utility

### DIFF
--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -7,7 +7,7 @@
   "main": "src/index.ts",
   "scripts": {
     "dev": "tsx src/index.ts",
-    "test": "echo \"No API tests configured yet\"",
+    "test": "node --test --import tsx test/is-hiragana-letter-pa-present.test.ts",
     "lint": "echo \"No API lint configured yet\""
   },
   "dependencies": {

--- a/apps/api/src/utils/is-hiragana-letter-pa-present.ts
+++ b/apps/api/src/utils/is-hiragana-letter-pa-present.ts
@@ -1,0 +1,3 @@
+export function isHiraganaLetterPaPresent(input: string): boolean {
+  return input.includes("ぱ");
+}

--- a/apps/api/test/is-hiragana-letter-pa-present.test.ts
+++ b/apps/api/test/is-hiragana-letter-pa-present.test.ts
@@ -1,0 +1,12 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+
+import { isHiraganaLetterPaPresent } from "../src/utils/is-hiragana-letter-pa-present";
+
+test("isHiraganaLetterPaPresent returns true when the input contains ぱ", () => {
+  assert.equal(isHiraganaLetterPaPresent("ぱん"), true);
+});
+
+test("isHiraganaLetterPaPresent returns false when the input does not contain ぱ", () => {
+  assert.equal(isHiraganaLetterPaPresent("はん"), false);
+});


### PR DESCRIPTION
Closes #7223

Adds `isHiraganaLetterPaPresent()` plus a small smoke test for the Hiragana PA character (U+3071). I also wire the API test script to run the new test file so the helper is covered by the existing TypeScript smoke-test flow.

Validation:
- `npm test -w apps/api`
- `git diff --check`