### PR TITLE
feat(api): add hiragana ba utility

### DIFF
--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -7,7 +7,7 @@
   "main": "src/index.ts",
   "scripts": {
     "dev": "tsx src/index.ts",
-    "test": "echo \"No API tests configured yet\"",
+    "test": "node --test --import tsx test/is-hiragana-letter-ba-present.test.ts",
     "lint": "echo \"No API lint configured yet\""
   },
   "dependencies": {

--- a/apps/api/src/utils/is-hiragana-letter-ba-present.ts
+++ b/apps/api/src/utils/is-hiragana-letter-ba-present.ts
@@ -1,0 +1,3 @@
+export function isHiraganaLetterBaPresent(input: string): boolean {
+  return input.includes("ば");
+}

--- a/apps/api/test/is-hiragana-letter-ba-present.test.ts
+++ b/apps/api/test/is-hiragana-letter-ba-present.test.ts
@@ -1,0 +1,12 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+
+import { isHiraganaLetterBaPresent } from "../src/utils/is-hiragana-letter-ba-present";
+
+test("isHiraganaLetterBaPresent returns true when the input contains ば", () => {
+  assert.equal(isHiraganaLetterBaPresent("ばな"), true);
+});
+
+test("isHiraganaLetterBaPresent returns false when the input does not contain ば", () => {
+  assert.equal(isHiraganaLetterBaPresent("はな"), false);
+});


### PR DESCRIPTION
Closes #7222

Adds `isHiraganaLetterBaPresent()` plus a small smoke test for the Hiragana BA character (U+3070). I also wire the API test script to run the new test file so the helper is covered by the existing TypeScript smoke-test flow.

Validation:
- `npm test -w apps/api`
- `git diff --check`