### PR TITLE
feat(api): add hiragana ha utility

### DIFF
--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -7,7 +7,7 @@
   "main": "src/index.ts",
   "scripts": {
     "dev": "tsx src/index.ts",
-    "test": "echo \"No API tests configured yet\"",
+    "test": "node --test --import tsx test/is-hiragana-letter-ha-present.test.ts",
     "lint": "echo \"No API lint configured yet\""
   },
   "dependencies": {

--- a/apps/api/src/utils/is-hiragana-letter-ha-present.ts
+++ b/apps/api/src/utils/is-hiragana-letter-ha-present.ts
@@ -1,0 +1,3 @@
+export function isHiraganaLetterHaPresent(input: string): boolean {
+  return input.includes("は");
+}

--- a/apps/api/test/is-hiragana-letter-ha-present.test.ts
+++ b/apps/api/test/is-hiragana-letter-ha-present.test.ts
@@ -1,0 +1,12 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+
+import { isHiraganaLetterHaPresent } from "../src/utils/is-hiragana-letter-ha-present";
+
+test("isHiraganaLetterHaPresent returns true when the input contains は", () => {
+  assert.equal(isHiraganaLetterHaPresent("はな"), true);
+});
+
+test("isHiraganaLetterHaPresent returns false when the input does not contain は", () => {
+  assert.equal(isHiraganaLetterHaPresent("ひな"), false);
+});


### PR DESCRIPTION
Closes #7216

Adds `isHiraganaLetterHaPresent()` plus a small smoke test for the Hiragana HA character (U+306F). I also wire the API test script to run the new test file so the helper is covered by the existing TypeScript smoke-test flow.

Validation:
- `npm test -w apps/api`
- `git diff --check`