### PR TITLE
feat(api): add hiragana no utility

### DIFF
--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -7,7 +7,7 @@
   "main": "src/index.ts",
   "scripts": {
     "dev": "tsx src/index.ts",
-    "test": "echo \"No API tests configured yet\"",
+    "test": "node --test --import tsx test/is-hiragana-letter-no-present.test.ts",
     "lint": "echo \"No API lint configured yet\""
   },
   "dependencies": {

--- a/apps/api/src/utils/is-hiragana-letter-no-present.ts
+++ b/apps/api/src/utils/is-hiragana-letter-no-present.ts
@@ -1,0 +1,3 @@
+export function isHiraganaLetterNoPresent(input: string): boolean {
+  return input.includes("の");
+}

--- a/apps/api/test/is-hiragana-letter-no-present.test.ts
+++ b/apps/api/test/is-hiragana-letter-no-present.test.ts
@@ -1,0 +1,12 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+
+import { isHiraganaLetterNoPresent } from "../src/utils/is-hiragana-letter-no-present";
+
+test("isHiraganaLetterNoPresent returns true when the input contains の", () => {
+  assert.equal(isHiraganaLetterNoPresent("のり"), true);
+});
+
+test("isHiraganaLetterNoPresent returns false when the input does not contain の", () => {
+  assert.equal(isHiraganaLetterNoPresent("なり"), false);
+});


### PR DESCRIPTION
Closes #7215

Adds `isHiraganaLetterNoPresent()` plus a small smoke test for the Hiragana NO character (U+306E). I also wire the API test script to run the new test file so the helper is covered by the existing TypeScript smoke-test flow.

Validation:
- `npm test -w apps/api`
- `git diff --check`