### PR TITLE
feat(api): add hiragana ne utility

### DIFF
--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -7,7 +7,7 @@
   "main": "src/index.ts",
   "scripts": {
     "dev": "tsx src/index.ts",
-    "test": "echo \"No API tests configured yet\"",
+    "test": "node --test --import tsx test/is-hiragana-letter-ne-present.test.ts",
     "lint": "echo \"No API lint configured yet\""
   },
   "dependencies": {

--- a/apps/api/src/utils/is-hiragana-letter-ne-present.ts
+++ b/apps/api/src/utils/is-hiragana-letter-ne-present.ts
@@ -1,0 +1,3 @@
+export function isHiraganaLetterNePresent(input: string): boolean {
+  return input.includes("ね");
+}

--- a/apps/api/test/is-hiragana-letter-ne-present.test.ts
+++ b/apps/api/test/is-hiragana-letter-ne-present.test.ts
@@ -1,0 +1,12 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+
+import { isHiraganaLetterNePresent } from "../src/utils/is-hiragana-letter-ne-present";
+
+test("isHiraganaLetterNePresent returns true when the input contains ね", () => {
+  assert.equal(isHiraganaLetterNePresent("ねこ"), true);
+});
+
+test("isHiraganaLetterNePresent returns false when the input does not contain ね", () => {
+  assert.equal(isHiraganaLetterNePresent("のこ"), false);
+});


### PR DESCRIPTION
Closes #7214

Adds `isHiraganaLetterNePresent()` plus a small smoke test for the Hiragana NE character (U+306D). I also wire the API test script to run the new test file so the helper is covered by the existing TypeScript smoke-test flow.

Validation:
- `npm test -w apps/api`
- `git diff --check`