### PR TITLE
feat(api): add hiragana nu utility

### DIFF
--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -7,7 +7,7 @@
   "main": "src/index.ts",
   "scripts": {
     "dev": "tsx src/index.ts",
-    "test": "echo \"No API tests configured yet\"",
+    "test": "node --test --import tsx test/is-hiragana-letter-nu-present.test.ts",
     "lint": "echo \"No API lint configured yet\""
   },
   "dependencies": {

--- a/apps/api/src/utils/is-hiragana-letter-nu-present.ts
+++ b/apps/api/src/utils/is-hiragana-letter-nu-present.ts
@@ -1,0 +1,3 @@
+export function isHiraganaLetterNuPresent(input: string): boolean {
+  return input.includes("ぬ");
+}

--- a/apps/api/test/is-hiragana-letter-nu-present.test.ts
+++ b/apps/api/test/is-hiragana-letter-nu-present.test.ts
@@ -1,0 +1,12 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+
+import { isHiraganaLetterNuPresent } from "../src/utils/is-hiragana-letter-nu-present";
+
+test("isHiraganaLetterNuPresent returns true when the input contains ぬ", () => {
+  assert.equal(isHiraganaLetterNuPresent("ぬい"), true);
+});
+
+test("isHiraganaLetterNuPresent returns false when the input does not contain ぬ", () => {
+  assert.equal(isHiraganaLetterNuPresent("ない"), false);
+});


### PR DESCRIPTION
Closes #7213

Adds `isHiraganaLetterNuPresent()` plus a small smoke test for the Hiragana NU character (U+306C). I also wire the API test script to run the new test file so the helper is covered by the existing TypeScript smoke-test flow.

Validation:
- `npm test -w apps/api`
- `git diff --check`