### PR TITLE
feat(api): add hiragana ni utility

### DIFF
--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -7,7 +7,7 @@
   "main": "src/index.ts",
   "scripts": {
     "dev": "tsx src/index.ts",
-    "test": "echo \"No API tests configured yet\"",
+    "test": "node --test --import tsx test/is-hiragana-letter-ni-present.test.ts",
     "lint": "echo \"No API lint configured yet\""
   },
   "dependencies": {

--- a/apps/api/src/utils/is-hiragana-letter-ni-present.ts
+++ b/apps/api/src/utils/is-hiragana-letter-ni-present.ts
@@ -1,0 +1,3 @@
+export function isHiraganaLetterNiPresent(input: string): boolean {
+  return input.includes("に");
+}

--- a/apps/api/test/is-hiragana-letter-ni-present.test.ts
+++ b/apps/api/test/is-hiragana-letter-ni-present.test.ts
@@ -1,0 +1,12 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+
+import { isHiraganaLetterNiPresent } from "../src/utils/is-hiragana-letter-ni-present";
+
+test("isHiraganaLetterNiPresent returns true when the input contains に", () => {
+  assert.equal(isHiraganaLetterNiPresent("にわ"), true);
+});
+
+test("isHiraganaLetterNiPresent returns false when the input does not contain に", () => {
+  assert.equal(isHiraganaLetterNiPresent("ぬわ"), false);
+});


### PR DESCRIPTION
Closes #7212

Adds `isHiraganaLetterNiPresent()` plus a small smoke test for the Hiragana NI character (U+306B). I also wire the API test script to run the new test file so the helper is covered by the existing TypeScript smoke-test flow.

Validation:
- `npm test -w apps/api`
- `git diff --check`