### PR TITLE
feat(api): add hiragana na utility

### DIFF
--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -7,7 +7,7 @@
   "main": "src/index.ts",
   "scripts": {
     "dev": "tsx src/index.ts",
-    "test": "echo \"No API tests configured yet\"",
+    "test": "node --test --import tsx test/is-hiragana-letter-na-present.test.ts",
     "lint": "echo \"No API lint configured yet\""
   },
   "dependencies": {

--- a/apps/api/src/utils/is-hiragana-letter-na-present.ts
+++ b/apps/api/src/utils/is-hiragana-letter-na-present.ts
@@ -1,0 +1,3 @@
+export function isHiraganaLetterNaPresent(input: string): boolean {
+  return input.includes("な");
+}

--- a/apps/api/test/is-hiragana-letter-na-present.test.ts
+++ b/apps/api/test/is-hiragana-letter-na-present.test.ts
@@ -1,0 +1,12 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+
+import { isHiraganaLetterNaPresent } from "../src/utils/is-hiragana-letter-na-present";
+
+test("isHiraganaLetterNaPresent returns true when the input contains な", () => {
+  assert.equal(isHiraganaLetterNaPresent("なつ"), true);
+});
+
+test("isHiraganaLetterNaPresent returns false when the input does not contain な", () => {
+  assert.equal(isHiraganaLetterNaPresent("たつ"), false);
+});


### PR DESCRIPTION
Closes #7206

Adds `isHiraganaLetterNaPresent()` plus a small smoke test for the Hiragana NA character (U+306A). I also wire the API test script to run the new test file so the helper is covered by the existing TypeScript smoke-test flow.

Validation:
- `npm test -w apps/api`
- `git diff --check`