### PR TITLE
feat(api): add hiragana do utility

### DIFF
--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -7,7 +7,7 @@
   "main": "src/index.ts",
   "scripts": {
     "dev": "tsx src/index.ts",
-    "test": "echo \"No API tests configured yet\"",
+    "test": "node --test --import tsx test/is-hiragana-letter-do-present.test.ts",
     "lint": "echo \"No API lint configured yet\""
   },
   "dependencies": {

--- a/apps/api/src/utils/is-hiragana-letter-do-present.ts
+++ b/apps/api/src/utils/is-hiragana-letter-do-present.ts
@@ -1,0 +1,3 @@
+export function isHiraganaLetterDoPresent(input: string): boolean {
+  return input.includes("ど");
+}

--- a/apps/api/test/is-hiragana-letter-do-present.test.ts
+++ b/apps/api/test/is-hiragana-letter-do-present.test.ts
@@ -1,0 +1,12 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+
+import { isHiraganaLetterDoPresent } from "../src/utils/is-hiragana-letter-do-present";
+
+test("isHiraganaLetterDoPresent returns true when the input contains ど", () => {
+  assert.equal(isHiraganaLetterDoPresent("どら"), true);
+});
+
+test("isHiraganaLetterDoPresent returns false when the input does not contain ど", () => {
+  assert.equal(isHiraganaLetterDoPresent("とら"), false);
+});


### PR DESCRIPTION
Closes #7205

Adds `isHiraganaLetterDoPresent()` plus a small smoke test for the Hiragana DO character (U+3069). I also wire the API test script to run the new test file so the helper is covered by the existing TypeScript smoke-test flow.

Validation:
- `npm test -w apps/api`
- `git diff --check`