### PR TITLE
feat(api): add hiragana de utility

### DIFF
--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -7,7 +7,7 @@
   "main": "src/index.ts",
   "scripts": {
     "dev": "tsx src/index.ts",
-    "test": "echo \"No API tests configured yet\"",
+    "test": "node --test --import tsx test/is-hiragana-letter-de-present.test.ts",
     "lint": "echo \"No API lint configured yet\""
   },
   "dependencies": {

--- a/apps/api/src/utils/is-hiragana-letter-de-present.ts
+++ b/apps/api/src/utils/is-hiragana-letter-de-present.ts
@@ -1,0 +1,3 @@
+export function isHiraganaLetterDePresent(input: string): boolean {
+  return input.includes("で");
+}

--- a/apps/api/test/is-hiragana-letter-de-present.test.ts
+++ b/apps/api/test/is-hiragana-letter-de-present.test.ts
@@ -1,0 +1,12 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+
+import { isHiraganaLetterDePresent } from "../src/utils/is-hiragana-letter-de-present";
+
+test("isHiraganaLetterDePresent returns true when the input contains で", () => {
+  assert.equal(isHiraganaLetterDePresent("でん"), true);
+});
+
+test("isHiraganaLetterDePresent returns false when the input does not contain で", () => {
+  assert.equal(isHiraganaLetterDePresent("てん"), false);
+});


### PR DESCRIPTION
Closes #7204

Adds `isHiraganaLetterDePresent()` plus a small smoke test for the Hiragana DE character (U+3067). I also wire the API test script to run the new test file so the helper is covered by the existing TypeScript smoke-test flow.

Validation:
- `npm test -w apps/api`
- `git diff --check`