### PR TITLE
feat(api): add hiragana te utility

### DIFF
--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -7,7 +7,7 @@
   "main": "src/index.ts",
   "scripts": {
     "dev": "tsx src/index.ts",
-    "test": "echo \"No API tests configured yet\"",
+    "test": "node --test --import tsx test/is-hiragana-letter-te-present.test.ts",
     "lint": "echo \"No API lint configured yet\""
   },
   "dependencies": {

--- a/apps/api/src/utils/is-hiragana-letter-te-present.ts
+++ b/apps/api/src/utils/is-hiragana-letter-te-present.ts
@@ -1,0 +1,3 @@
+export function isHiraganaLetterTePresent(input: string): boolean {
+  return input.includes("て");
+}

--- a/apps/api/test/is-hiragana-letter-te-present.test.ts
+++ b/apps/api/test/is-hiragana-letter-te-present.test.ts
@@ -1,0 +1,12 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+
+import { isHiraganaLetterTePresent } from "../src/utils/is-hiragana-letter-te-present";
+
+test("isHiraganaLetterTePresent returns true when the input contains て", () => {
+  assert.equal(isHiraganaLetterTePresent("てすと"), true);
+});
+
+test("isHiraganaLetterTePresent returns false when the input does not contain て", () => {
+  assert.equal(isHiraganaLetterTePresent("すと"), false);
+});


### PR DESCRIPTION
Closes #7203

Adds `isHiraganaLetterTePresent()` plus a small smoke test for the Hiragana TE character (U+3066). I also wire the API test script to run the new test file so the helper is covered by the existing TypeScript smoke-test flow.

Validation:
- `npm test -w apps/api`
- `git diff --check`