### PR TITLE
feat(api): add hiragana du utility

### DIFF
--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -7,7 +7,7 @@
   "main": "src/index.ts",
   "scripts": {
     "dev": "tsx src/index.ts",
-    "test": "echo \"No API tests configured yet\"",
+    "test": "node --test --import tsx test/is-hiragana-letter-du-present.test.ts",
     "lint": "echo \"No API lint configured yet\""
   },
   "dependencies": {

--- a/apps/api/src/utils/is-hiragana-letter-du-present.ts
+++ b/apps/api/src/utils/is-hiragana-letter-du-present.ts
@@ -1,0 +1,3 @@
+export function isHiraganaLetterDuPresent(input: string): boolean {
+  return input.includes("づ");
+}

--- a/apps/api/test/is-hiragana-letter-du-present.test.ts
+++ b/apps/api/test/is-hiragana-letter-du-present.test.ts
@@ -1,0 +1,12 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+
+import { isHiraganaLetterDuPresent } from "../src/utils/is-hiragana-letter-du-present";
+
+test("isHiraganaLetterDuPresent returns true when the input contains づ", () => {
+  assert.equal(isHiraganaLetterDuPresent("づく"), true);
+});
+
+test("isHiraganaLetterDuPresent returns false when the input does not contain づ", () => {
+  assert.equal(isHiraganaLetterDuPresent("つく"), false);
+});


### PR DESCRIPTION
Closes #7202

Adds `isHiraganaLetterDuPresent()` plus a small smoke test for the Hiragana DU character (U+3065). I also wire the API test script to run the new test file so the helper is covered by the existing TypeScript smoke-test flow.

Validation:
- `npm test -w apps/api`
- `git diff --check`