### PR TITLE
feat(api): add hiragana small tu utility

### DIFF
--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -7,7 +7,7 @@
   "main": "src/index.ts",
   "scripts": {
     "dev": "tsx src/index.ts",
-    "test": "echo \"No API tests configured yet\"",
+    "test": "node --test --import tsx test/is-hiragana-letter-small-tu-present.test.ts",
     "lint": "echo \"No API lint configured yet\""
   },
   "dependencies": {

--- a/apps/api/src/utils/is-hiragana-letter-small-tu-present.ts
+++ b/apps/api/src/utils/is-hiragana-letter-small-tu-present.ts
@@ -1,0 +1,3 @@
+export function isHiraganaLetterSmallTuPresent(input: string): boolean {
+  return input.includes("っ");
+}

--- a/apps/api/test/is-hiragana-letter-small-tu-present.test.ts
+++ b/apps/api/test/is-hiragana-letter-small-tu-present.test.ts
@@ -1,0 +1,12 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+
+import { isHiraganaLetterSmallTuPresent } from "../src/utils/is-hiragana-letter-small-tu-present";
+
+test("isHiraganaLetterSmallTuPresent returns true when the input contains っ", () => {
+  assert.equal(isHiraganaLetterSmallTuPresent("きって"), true);
+});
+
+test("isHiraganaLetterSmallTuPresent returns false when the input does not contain っ", () => {
+  assert.equal(isHiraganaLetterSmallTuPresent("きて"), false);
+});


### PR DESCRIPTION
Closes #7196

Adds `isHiraganaLetterSmallTuPresent()` plus a small smoke test for the Hiragana small TU character (U+3063). I also wire the API test script to run the new test file so the helper is covered by the existing TypeScript smoke-test flow.

Validation:
- `npm test -w apps/api`
- `git diff --check`