### PR TITLE
feat(api): add hiragana di utility

### DIFF
--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -7,7 +7,7 @@
   "main": "src/index.ts",
   "scripts": {
     "dev": "tsx src/index.ts",
-    "test": "echo \"No API tests configured yet\"",
+    "test": "node --test --import tsx test/is-hiragana-letter-di-present.test.ts",
     "lint": "echo \"No API lint configured yet\""
   },
   "dependencies": {

--- a/apps/api/src/utils/is-hiragana-letter-di-present.ts
+++ b/apps/api/src/utils/is-hiragana-letter-di-present.ts
@@ -1,0 +1,3 @@
+export function isHiraganaLetterDiPresent(input: string): boolean {
+  return input.includes("ぢ");
+}

--- a/apps/api/test/is-hiragana-letter-di-present.test.ts
+++ b/apps/api/test/is-hiragana-letter-di-present.test.ts
@@ -1,0 +1,12 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+
+import { isHiraganaLetterDiPresent } from "../src/utils/is-hiragana-letter-di-present";
+
+test("isHiraganaLetterDiPresent returns true when the input contains ぢ", () => {
+  assert.equal(isHiraganaLetterDiPresent("ぢか"), true);
+});
+
+test("isHiraganaLetterDiPresent returns false when the input does not contain ぢ", () => {
+  assert.equal(isHiraganaLetterDiPresent("じか"), false);
+});


### PR DESCRIPTION
Closes #7195

Adds `isHiraganaLetterDiPresent()` plus a small smoke test for the Hiragana DI character (U+3062). I also wire the API test script to run the new test file so the helper is covered by the existing TypeScript smoke-test flow.

Validation:
- `npm test -w apps/api`
- `git diff --check`