### PR TITLE
feat(api): add hiragana ti utility

### DIFF
--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -7,7 +7,7 @@
   "main": "src/index.ts",
   "scripts": {
     "dev": "tsx src/index.ts",
-    "test": "echo \"No API tests configured yet\"",
+    "test": "node --test --import tsx test/is-hiragana-letter-ti-present.test.ts",
     "lint": "echo \"No API lint configured yet\""
   },
   "dependencies": {

--- a/apps/api/src/utils/is-hiragana-letter-ti-present.ts
+++ b/apps/api/src/utils/is-hiragana-letter-ti-present.ts
@@ -1,0 +1,3 @@
+export function isHiraganaLetterTiPresent(input: string): boolean {
+  return input.includes("ち");
+}

--- a/apps/api/test/is-hiragana-letter-ti-present.test.ts
+++ b/apps/api/test/is-hiragana-letter-ti-present.test.ts
@@ -1,0 +1,12 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+
+import { isHiraganaLetterTiPresent } from "../src/utils/is-hiragana-letter-ti-present";
+
+test("isHiraganaLetterTiPresent returns true when the input contains ち", () => {
+  assert.equal(isHiraganaLetterTiPresent("ちず"), true);
+});
+
+test("isHiraganaLetterTiPresent returns false when the input does not contain ち", () => {
+  assert.equal(isHiraganaLetterTiPresent("しず"), false);
+});


### PR DESCRIPTION
Closes #7194

Adds `isHiraganaLetterTiPresent()` plus a small smoke test for the Hiragana TI character (U+3061). I also wire the API test script to run the new test file so the helper is covered by the existing TypeScript smoke-test flow.

Validation:
- `npm test -w apps/api`
- `git diff --check`