### PR TITLE
feat(api): add hiragana da utility

### DIFF
--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -7,7 +7,7 @@
   "main": "src/index.ts",
   "scripts": {
     "dev": "tsx src/index.ts",
-    "test": "echo \"No API tests configured yet\"",
+    "test": "node --test --import tsx test/is-hiragana-letter-da-present.test.ts",
     "lint": "echo \"No API lint configured yet\""
   },
   "dependencies": {

--- a/apps/api/src/utils/is-hiragana-letter-da-present.ts
+++ b/apps/api/src/utils/is-hiragana-letter-da-present.ts
@@ -1,0 +1,3 @@
+export function isHiraganaLetterDaPresent(input: string): boolean {
+  return input.includes("だ");
+}

--- a/apps/api/test/is-hiragana-letter-da-present.test.ts
+++ b/apps/api/test/is-hiragana-letter-da-present.test.ts
@@ -1,0 +1,12 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+
+import { isHiraganaLetterDaPresent } from "../src/utils/is-hiragana-letter-da-present";
+
+test("isHiraganaLetterDaPresent returns true when the input contains だ", () => {
+  assert.equal(isHiraganaLetterDaPresent("だん"), true);
+});
+
+test("isHiraganaLetterDaPresent returns false when the input does not contain だ", () => {
+  assert.equal(isHiraganaLetterDaPresent("たん"), false);
+});


### PR DESCRIPTION
Closes #7193

Adds `isHiraganaLetterDaPresent()` plus a small smoke test for the Hiragana DA character (U+3060). I also wire the API test script to run the new test file so the helper is covered by the existing TypeScript smoke-test flow.

Validation:
- `npm test -w apps/api`
- `git diff --check`