### PR TITLE
feat(api): add hiragana ta utility

### DIFF
--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -7,7 +7,7 @@
   "main": "src/index.ts",
   "scripts": {
     "dev": "tsx src/index.ts",
-    "test": "echo \"No API tests configured yet\"",
+    "test": "node --test --import tsx test/is-hiragana-letter-ta-present.test.ts",
     "lint": "echo \"No API lint configured yet\""
   },
   "dependencies": {

--- a/apps/api/src/utils/is-hiragana-letter-ta-present.ts
+++ b/apps/api/src/utils/is-hiragana-letter-ta-present.ts
@@ -1,0 +1,3 @@
+export function isHiraganaLetterTaPresent(input: string): boolean {
+  return input.includes("た");
+}

--- a/apps/api/test/is-hiragana-letter-ta-present.test.ts
+++ b/apps/api/test/is-hiragana-letter-ta-present.test.ts
@@ -1,0 +1,12 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+
+import { isHiraganaLetterTaPresent } from "../src/utils/is-hiragana-letter-ta-present";
+
+test("isHiraganaLetterTaPresent returns true when the input contains た", () => {
+  assert.equal(isHiraganaLetterTaPresent("たこ"), true);
+});
+
+test("isHiraganaLetterTaPresent returns false when the input does not contain た", () => {
+  assert.equal(isHiraganaLetterTaPresent("こ"), false);
+});


### PR DESCRIPTION
Closes #7192

Adds `isHiraganaLetterTaPresent()` plus a small smoke test for the Hiragana TA character (U+305F). I also wire the API test script to run the new test file so the helper is covered by the existing TypeScript smoke-test flow.

Validation:
- `npm test -w apps/api`
- `git diff --check`