### PR TITLE
feat(api): add hiragana zo utility

### DIFF
--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -7,7 +7,7 @@
   "main": "src/index.ts",
   "scripts": {
     "dev": "tsx src/index.ts",
-    "test": "echo \"No API tests configured yet\"",
+    "test": "node --test --import tsx test/is-hiragana-letter-zo-present.test.ts",
     "lint": "echo \"No API lint configured yet\""
   },
   "dependencies": {

--- a/apps/api/src/utils/is-hiragana-letter-zo-present.ts
+++ b/apps/api/src/utils/is-hiragana-letter-zo-present.ts
@@ -1,0 +1,3 @@
+export function isHiraganaLetterZoPresent(input: string): boolean {
+  return input.includes("ぞ");
+}

--- a/apps/api/test/is-hiragana-letter-zo-present.test.ts
+++ b/apps/api/test/is-hiragana-letter-zo-present.test.ts
@@ -1,0 +1,12 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+
+import { isHiraganaLetterZoPresent } from "../src/utils/is-hiragana-letter-zo-present";
+
+test("isHiraganaLetterZoPresent returns true when the input contains ぞ", () => {
+  assert.equal(isHiraganaLetterZoPresent("ぞう"), true);
+});
+
+test("isHiraganaLetterZoPresent returns false when the input does not contain ぞ", () => {
+  assert.equal(isHiraganaLetterZoPresent("そう"), false);
+});


### PR DESCRIPTION
Closes #7186

Adds `isHiraganaLetterZoPresent()` plus a small smoke test for the Hiragana ZO character (U+305E). I also wire the API test script to run the new test file so the helper is covered by the existing TypeScript smoke-test flow.

Validation:
- `npm test -w apps/api`
- `git diff --check`