### PR TITLE
feat(api): add hiragana so utility

### DIFF
--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -7,7 +7,7 @@
   "main": "src/index.ts",
   "scripts": {
     "dev": "tsx src/index.ts",
-    "test": "echo \"No API tests configured yet\"",
+    "test": "node --test --import tsx test/is-hiragana-letter-so-present.test.ts",
     "lint": "echo \"No API lint configured yet\""
   },
   "dependencies": {

--- a/apps/api/src/utils/is-hiragana-letter-so-present.ts
+++ b/apps/api/src/utils/is-hiragana-letter-so-present.ts
@@ -1,0 +1,3 @@
+export function isHiraganaLetterSoPresent(input: string): boolean {
+  return input.includes("そ");
+}

--- a/apps/api/test/is-hiragana-letter-so-present.test.ts
+++ b/apps/api/test/is-hiragana-letter-so-present.test.ts
@@ -1,0 +1,12 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+
+import { isHiraganaLetterSoPresent } from "../src/utils/is-hiragana-letter-so-present";
+
+test("isHiraganaLetterSoPresent returns true when the input contains そ", () => {
+  assert.equal(isHiraganaLetterSoPresent("そう"), true);
+});
+
+test("isHiraganaLetterSoPresent returns false when the input does not contain そ", () => {
+  assert.equal(isHiraganaLetterSoPresent("とう"), false);
+});


### PR DESCRIPTION
Closes #7185

Adds `isHiraganaLetterSoPresent()` plus a small smoke test for the Hiragana SO character (U+305D). I also wire the API test script to run the new test file so the helper is covered by the existing TypeScript smoke-test flow.

Validation:
- `npm test -w apps/api`
- `git diff --check`