### PR TITLE
feat(api): add hiragana ze utility

### DIFF
--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -7,7 +7,7 @@
   "main": "src/index.ts",
   "scripts": {
     "dev": "tsx src/index.ts",
-    "test": "echo \"No API tests configured yet\"",
+    "test": "node --test --import tsx test/is-hiragana-letter-ze-present.test.ts",
     "lint": "echo \"No API lint configured yet\""
   },
   "dependencies": {

--- a/apps/api/src/utils/is-hiragana-letter-ze-present.ts
+++ b/apps/api/src/utils/is-hiragana-letter-ze-present.ts
@@ -1,0 +1,3 @@
+export function isHiraganaLetterZePresent(input: string): boolean {
+  return input.includes("ぜ");
+}

--- a/apps/api/test/is-hiragana-letter-ze-present.test.ts
+++ b/apps/api/test/is-hiragana-letter-ze-present.test.ts
@@ -1,0 +1,12 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+
+import { isHiraganaLetterZePresent } from "../src/utils/is-hiragana-letter-ze-present";
+
+test("isHiraganaLetterZePresent returns true when the input contains ぜ", () => {
+  assert.equal(isHiraganaLetterZePresent("ぜん"), true);
+});
+
+test("isHiraganaLetterZePresent returns false when the input does not contain ぜ", () => {
+  assert.equal(isHiraganaLetterZePresent("せん"), false);
+});


### PR DESCRIPTION
Closes #7184

Adds `isHiraganaLetterZePresent()` plus a small smoke test for the Hiragana ZE character (U+305C). I also wire the API test script to run the new test file so the helper is covered by the existing TypeScript smoke-test flow.

Validation:
- `npm test -w apps/api`
- `git diff --check`