### PR TITLE
feat(api): add hiragana se utility

### DIFF
--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -7,7 +7,7 @@
   "main": "src/index.ts",
   "scripts": {
     "dev": "tsx src/index.ts",
-    "test": "echo \"No API tests configured yet\"",
+    "test": "node --test --import tsx test/is-hiragana-letter-se-present.test.ts",
     "lint": "echo \"No API lint configured yet\""
   },
   "dependencies": {

--- a/apps/api/src/utils/is-hiragana-letter-se-present.ts
+++ b/apps/api/src/utils/is-hiragana-letter-se-present.ts
@@ -1,0 +1,3 @@
+export function isHiraganaLetterSePresent(input: string): boolean {
+  return input.includes("せ");
+}

--- a/apps/api/test/is-hiragana-letter-se-present.test.ts
+++ b/apps/api/test/is-hiragana-letter-se-present.test.ts
@@ -1,0 +1,12 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+
+import { isHiraganaLetterSePresent } from "../src/utils/is-hiragana-letter-se-present";
+
+test("isHiraganaLetterSePresent returns true when the input contains せ", () => {
+  assert.equal(isHiraganaLetterSePresent("せん"), true);
+});
+
+test("isHiraganaLetterSePresent returns false when the input does not contain せ", () => {
+  assert.equal(isHiraganaLetterSePresent("ぜん"), false);
+});


### PR DESCRIPTION
Closes #7183

Adds `isHiraganaLetterSePresent()` plus a small smoke test for the Hiragana SE character (U+305B). I also wire the API test script to run the new test file so the helper is covered by the existing TypeScript smoke-test flow.

Validation:
- `npm test -w apps/api`
- `git diff --check`