### PR TITLE
feat(api): add hiragana zu utility

### DIFF
--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -7,7 +7,7 @@
   "main": "src/index.ts",
   "scripts": {
     "dev": "tsx src/index.ts",
-    "test": "echo \"No API tests configured yet\"",
+    "test": "node --test --import tsx test/is-hiragana-letter-zu-present.test.ts",
     "lint": "echo \"No API lint configured yet\""
   },
   "dependencies": {

--- a/apps/api/src/utils/is-hiragana-letter-zu-present.ts
+++ b/apps/api/src/utils/is-hiragana-letter-zu-present.ts
@@ -1,0 +1,3 @@
+export function isHiraganaLetterZuPresent(input: string): boolean {
+  return input.includes("ず");
+}

--- a/apps/api/test/is-hiragana-letter-zu-present.test.ts
+++ b/apps/api/test/is-hiragana-letter-zu-present.test.ts
@@ -1,0 +1,12 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+
+import { isHiraganaLetterZuPresent } from "../src/utils/is-hiragana-letter-zu-present";
+
+test("isHiraganaLetterZuPresent returns true when the input contains ず", () => {
+  assert.equal(isHiraganaLetterZuPresent("ずし"), true);
+});
+
+test("isHiraganaLetterZuPresent returns false when the input does not contain ず", () => {
+  assert.equal(isHiraganaLetterZuPresent("すし"), false);
+});


### PR DESCRIPTION
Closes #7182

Adds `isHiraganaLetterZuPresent()` plus a small smoke test for the Hiragana ZU character (U+305A). I also wire the API test script to run the new test file so the helper is covered by the existing TypeScript smoke-test flow.

Validation:
- `npm test -w apps/api`
- `git diff --check`