### PR TITLE
[agent] Fix import-safe API entrypoint and add user route tests

### DIFF
--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -7,7 +7,7 @@
   "main": "src/index.ts",
   "scripts": {
     "dev": "tsx src/index.ts",
-    "test": "echo \"No API tests configured yet\"",
+    "test": "node --test --import tsx test/users.test.ts",
     "lint": "echo \"No API lint configured yet\""
   },
   "dependencies": {

--- a/apps/api/src/app.ts
+++ b/apps/api/src/app.ts
@@ -1,0 +1,15 @@
+import express from "express";
+
+import usersRouter from "./routes/users";
+
+const app = express();
+
+app.use(express.json());
+
+app.get("/health", (_req, res) => {
+  res.json({ status: "ok", service: "taskflow-api" });
+});
+
+app.use("/users", usersRouter);
+
+export default app;

--- a/apps/api/src/index.ts
+++ b/apps/api/src/index.ts
@@ -1,17 +1,6 @@
-import express from "express";
+import app from "./app";
 
-import usersRouter from "./routes/users";
-
-const app = express();
 const port = process.env.PORT || 4000;
-
-app.use(express.json());
-
-app.get("/health", (_req, res) => {
-  res.json({ status: "ok", service: "taskflow-api" });
-});
-
-app.use("/users", usersRouter);
 
 app.listen(port, () => {
   console.log(`TaskFlow API listening on port ${port}`);

--- a/apps/api/test/users.test.ts
+++ b/apps/api/test/users.test.ts
@@ -1,0 +1,77 @@
+import assert from "node:assert/strict";
+import { after, before, test } from "node:test";
+
+import app from "../src/app";
+
+let server: ReturnType<typeof app.listen>;
+let baseUrl = "";
+
+before(async () => {
+  server = app.listen(0);
+
+  await new Promise<void>((resolve, reject) => {
+    server.once("listening", () => {
+      const address = server.address();
+
+      if (!address || typeof address === "string") {
+        reject(new Error("Failed to determine test server port."));
+        return;
+      }
+
+      baseUrl = `http://127.0.0.1:${address.port}`;
+      resolve();
+    });
+
+    server.once("error", reject);
+  });
+});
+
+after(async () => {
+  if (!server) {
+    return;
+  }
+
+  await new Promise<void>((resolve, reject) => {
+    server.close((error) => {
+      if (error) {
+        reject(error);
+        return;
+      }
+
+      resolve();
+    });
+  });
+});
+
+test("GET /users returns the empty placeholder list", async () => {
+  const response = await fetch(`${baseUrl}/users`);
+
+  assert.equal(response.status, 200);
+  assert.deepEqual(await response.json(), {
+    data: [],
+    message: "User listing is not implemented yet."
+  });
+});
+
+test("POST /users echoes the submitted payload with a stub id", async () => {
+  const response = await fetch(`${baseUrl}/users`, {
+    method: "POST",
+    headers: {
+      "content-type": "application/json"
+    },
+    body: JSON.stringify({
+      name: "Ada",
+      email: "ada@example.com"
+    })
+  });
+
+  assert.equal(response.status, 201);
+  assert.deepEqual(await response.json(), {
+    data: {
+      id: "stub-user-id",
+      name: "Ada",
+      email: "ada@example.com"
+    },
+    message: "User creation is not implemented yet."
+  });
+});

--- a/contributors/agents.json
+++ b/contributors/agents.json
@@ -1,5 +1,13 @@
 {
-  "agents": [],
-  "last_updated": "2026-06-03",
-  "total_contributions": 0
+  "agents": [
+    {
+      "github_username": "voladoradepapantla-netizen",
+      "model": "gpt-5",
+      "version": "2026-07-15",
+      "pr_number": 7357,
+      "issue_number": 12
+    }
+  ],
+  "last_updated": "2026-07-15",
+  "total_contributions": 1
 }


### PR DESCRIPTION
Closes #12.

Splits Express app construction from server startup so the API can be imported safely in tests, and adds route coverage for the user list/create stubs.

Validation:
- npm test -w apps/api