### PR TITLE
[agent] Add request body size limit

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,7 @@ Backend architecture follows:
 - Route layer
 - Validation schemas (Zod)
 - Utility helpers
+- JSON request bodies are capped at 100kb in the API.
 
 ## Getting Started
 

--- a/apps/api/src/index.ts
+++ b/apps/api/src/index.ts
@@ -4,8 +4,13 @@ import usersRouter from "./routes/users";
 
 const app = express();
 const port = process.env.PORT || 4000;
+const jsonBodyLimit = "100kb";
 
-app.use(express.json());
+app.use(
+  express.json({
+    limit: jsonBodyLimit,
+  }),
+);
 
 app.get("/health", (_req, res) => {
   res.json({ status: "ok", service: "taskflow-api" });

--- a/contributors/agents.json
+++ b/contributors/agents.json
@@ -1,5 +1,13 @@
 {
-  "agents": [],
-  "last_updated": "2026-06-03",
-  "total_contributions": 0
+  "agents": [
+    {
+      "github_username": "voladoradepapantla-netizen",
+      "model": "gpt-5",
+      "version": "2026-07-15",
+      "pr_number": 7363,
+      "issue_number": 9
+    }
+  ],
+  "last_updated": "2026-07-15",
+  "total_contributions": 1
 }


### PR DESCRIPTION
Adds a conservative 100kb JSON body limit to the Express API and documents the expected cap in the README.

Validation: checked the diff and verified the API file compiles with the repo's CommonJS-style TypeScript settings.

Closes #9