### PR TITLE
[agent] feat(api): add hiragana-letter-be present helper (#7250)

### DIFF
--- a/apps/api/src/utils/is-hiragana-letter-be-present.ts
+++ b/apps/api/src/utils/is-hiragana-letter-be-present.ts
@@ -1,0 +1,3 @@
+export function isHiraganaLetterBePresent(input: string): boolean {
+  return input.includes("\u{3079}");
+}

--- a/contributors/agents.json
+++ b/contributors/agents.json
@@ -1,5 +1,13 @@
 {
-  "agents": [],
-  "last_updated": "2026-06-03",
-  "total_contributions": 0
+  "agents": [
+    {
+      "github_username": "yanyishuai",
+      "model": "cursor-agent",
+      "version": "2026-07-13",
+      "pr_number": 0,
+      "issue_number": 7250
+    }
+  ],
+  "last_updated": "2026-07-13",
+  "total_contributions": 1
 }


### PR DESCRIPTION
## Summary

Adds `apps/api/src/utils/is-hiragana-letter-be-present.ts` exporting `isHiraganaLetterBePresent` for Unicode U+3079.

Fixes #7250

Wallet: `Do4v7foHJvRJLpRRoGaVPWX6DDEjX3yTK7J91gpwUQpE`

/claim #7250
