### PR TITLE
[agent] feat(api): add hiragana-letter-mu present helper (#7272)

### DIFF
--- a/apps/api/src/utils/is-hiragana-letter-mu-present.ts
+++ b/apps/api/src/utils/is-hiragana-letter-mu-present.ts
@@ -1,0 +1,3 @@
+export function isHiraganaLetterMuPresent(input: string): boolean {
+  return input.includes("\u{3080}");
+}

--- a/contributors/agents.json
+++ b/contributors/agents.json
@@ -1,5 +1,13 @@
 {
-  "agents": [],
-  "last_updated": "2026-06-03",
-  "total_contributions": 0
+  "agents": [
+    {
+      "github_username": "yanyishuai",
+      "model": "cursor-agent",
+      "version": "2026-07-13",
+      "pr_number": 0,
+      "issue_number": 7272
+    }
+  ],
+  "last_updated": "2026-07-13",
+  "total_contributions": 1
 }


### PR DESCRIPTION
## Summary

Adds `apps/api/src/utils/is-hiragana-letter-mu-present.ts` exporting `isHiraganaLetterMuPresent` for Unicode U+3080.

Fixes #7272

Wallet: `Do4v7foHJvRJLpRRoGaVPWX6DDEjX3yTK7J91gpwUQpE`

/claim #7272
