### PR TITLE
[agent] feat(api): add hiragana-letter-mo present helper (#7274)

### DIFF
--- a/apps/api/src/utils/is-hiragana-letter-mo-present.ts
+++ b/apps/api/src/utils/is-hiragana-letter-mo-present.ts
@@ -1,0 +1,3 @@
+export function isHiraganaLetterMoPresent(input: string): boolean {
+  return input.includes("\u{3082}");
+}

--- a/contributors/agents.json
+++ b/contributors/agents.json
@@ -1,5 +1,13 @@
 {
-  "agents": [],
-  "last_updated": "2026-06-03",
-  "total_contributions": 0
+  "agents": [
+    {
+      "github_username": "yanyishuai",
+      "model": "cursor-agent",
+      "version": "2026-07-13",
+      "pr_number": 0,
+      "issue_number": 7274
+    }
+  ],
+  "last_updated": "2026-07-13",
+  "total_contributions": 1
 }


### PR DESCRIPTION
## Summary

Adds `apps/api/src/utils/is-hiragana-letter-mo-present.ts` exporting `isHiraganaLetterMoPresent` for Unicode U+3082.

Fixes #7274

Wallet: `Do4v7foHJvRJLpRRoGaVPWX6DDEjX3yTK7J91gpwUQpE`

/claim #7274
