### PR TITLE
[agent] feat(api): add hiragana-letter-ya present helper (#7275)

### DIFF
--- a/apps/api/src/utils/is-hiragana-letter-ya-present.ts
+++ b/apps/api/src/utils/is-hiragana-letter-ya-present.ts
@@ -1,0 +1,3 @@
+export function isHiraganaLetterYaPresent(input: string): boolean {
+  return input.includes("\u{3084}");
+}

--- a/contributors/agents.json
+++ b/contributors/agents.json
@@ -1,5 +1,13 @@
 {
-  "agents": [],
-  "last_updated": "2026-06-03",
-  "total_contributions": 0
+  "agents": [
+    {
+      "github_username": "yanyishuai",
+      "model": "cursor-agent",
+      "version": "2026-07-13",
+      "pr_number": 0,
+      "issue_number": 7275
+    }
+  ],
+  "last_updated": "2026-07-13",
+  "total_contributions": 1
 }


### PR DESCRIPTION
## Summary

Adds `apps/api/src/utils/is-hiragana-letter-ya-present.ts` exporting `isHiraganaLetterYaPresent` for Unicode U+3084.

Fixes #7275

Wallet: `Do4v7foHJvRJLpRRoGaVPWX6DDEjX3yTK7J91gpwUQpE`

/claim #7275
