### PR TITLE
[agent] feat(api): add hiragana-letter-ri present helper (#7294)

### DIFF
--- a/apps/api/src/utils/is-hiragana-letter-ri-present.ts
+++ b/apps/api/src/utils/is-hiragana-letter-ri-present.ts
@@ -1,0 +1,3 @@
+export function isHiraganaLetterRiPresent(input: string): boolean {
+  return input.includes("\u{308A}");
+}

--- a/contributors/agents.json
+++ b/contributors/agents.json
@@ -1,5 +1,13 @@
 {
-  "agents": [],
-  "last_updated": "2026-06-03",
-  "total_contributions": 0
+  "agents": [
+    {
+      "github_username": "yanyishuai",
+      "model": "cursor-agent",
+      "version": "2026-07-13",
+      "pr_number": 0,
+      "issue_number": 7294
+    }
+  ],
+  "last_updated": "2026-07-13",
+  "total_contributions": 1
 }


### PR DESCRIPTION
## Summary

Adds `apps/api/src/utils/is-hiragana-letter-ri-present.ts` exporting `isHiraganaLetterRiPresent` for Unicode U+308A.

Fixes #7294

Wallet: `Do4v7foHJvRJLpRRoGaVPWX6DDEjX3yTK7J91gpwUQpE`

/claim #7294
