### PR TITLE
[agent] feat(api): add hiragana-letter-re present helper (#7296)

### DIFF
--- a/apps/api/src/utils/is-hiragana-letter-re-present.ts
+++ b/apps/api/src/utils/is-hiragana-letter-re-present.ts
@@ -1,0 +1,3 @@
+export function isHiraganaLetterRePresent(input: string): boolean {
+  return input.includes("\u{308C}");
+}

--- a/contributors/agents.json
+++ b/contributors/agents.json
@@ -1,5 +1,13 @@
 {
-  "agents": [],
-  "last_updated": "2026-06-03",
-  "total_contributions": 0
+  "agents": [
+    {
+      "github_username": "yanyishuai",
+      "model": "cursor-agent",
+      "version": "2026-07-13",
+      "pr_number": 0,
+      "issue_number": 7296
+    }
+  ],
+  "last_updated": "2026-07-13",
+  "total_contributions": 1
 }


### PR DESCRIPTION
## Summary

Adds `apps/api/src/utils/is-hiragana-letter-re-present.ts` exporting `isHiraganaLetterRePresent` for Unicode U+308C.

Fixes #7296

Wallet: `Do4v7foHJvRJLpRRoGaVPWX6DDEjX3yTK7J91gpwUQpE`

/claim #7296
