### PR TITLE
[agent] feat(api): add hiragana-letter-ro present helper (#7297)

### DIFF
--- a/apps/api/src/utils/is-hiragana-letter-ro-present.ts
+++ b/apps/api/src/utils/is-hiragana-letter-ro-present.ts
@@ -1,0 +1,3 @@
+export function isHiraganaLetterRoPresent(input: string): boolean {
+  return input.includes("\u{308D}");
+}

--- a/contributors/agents.json
+++ b/contributors/agents.json
@@ -1,5 +1,13 @@
 {
-  "agents": [],
-  "last_updated": "2026-06-03",
-  "total_contributions": 0
+  "agents": [
+    {
+      "github_username": "yanyishuai",
+      "model": "cursor-agent",
+      "version": "2026-07-13",
+      "pr_number": 0,
+      "issue_number": 7297
+    }
+  ],
+  "last_updated": "2026-07-13",
+  "total_contributions": 1
 }


### PR DESCRIPTION
## Summary

Adds `apps/api/src/utils/is-hiragana-letter-ro-present.ts` exporting `isHiraganaLetterRoPresent` for Unicode U+308D.

Fixes #7297

Wallet: `Do4v7foHJvRJLpRRoGaVPWX6DDEjX3yTK7J91gpwUQpE`

/claim #7297
