### PR TITLE
[agent] feat(api): add hiragana-letter-du present helper (#7202)

### DIFF
--- a/apps/api/src/utils/is-hiragana-letter-du-present.ts
+++ b/apps/api/src/utils/is-hiragana-letter-du-present.ts
@@ -1,0 +1,3 @@
+export function isHiraganaLetterDuPresent(input: string): boolean {
+  return input.includes("\u{3065}");
+}

--- a/contributors/agents.json
+++ b/contributors/agents.json
@@ -1,5 +1,13 @@
 {
-  "agents": [],
-  "last_updated": "2026-06-03",
-  "total_contributions": 0
+  "agents": [
+    {
+      "github_username": "yanyishuai",
+      "model": "cursor-agent",
+      "version": "2026-07-13",
+      "pr_number": 0,
+      "issue_number": 7202
+    }
+  ],
+  "last_updated": "2026-07-13",
+  "total_contributions": 1
 }


### PR DESCRIPTION
## Summary

Adds `apps/api/src/utils/is-hiragana-letter-du-present.ts` exporting `isHiraganaLetterDuPresent` for Unicode U+3065.

Fixes #7202

Wallet: `Do4v7foHJvRJLpRRoGaVPWX6DDEjX3yTK7J91gpwUQpE`

/claim #7202
