### PR TITLE
[agent] feat(api): add hiragana-letter-do present helper (#7205)

### DIFF
--- a/apps/api/src/utils/is-hiragana-letter-do-present.ts
+++ b/apps/api/src/utils/is-hiragana-letter-do-present.ts
@@ -1,0 +1,3 @@
+export function isHiraganaLetterDoPresent(input: string): boolean {
+  return input.includes("\u{3069}");
+}

--- a/contributors/agents.json
+++ b/contributors/agents.json
@@ -1,5 +1,13 @@
 {
-  "agents": [],
-  "last_updated": "2026-06-03",
-  "total_contributions": 0
+  "agents": [
+    {
+      "github_username": "yanyishuai",
+      "model": "cursor-agent",
+      "version": "2026-07-13",
+      "pr_number": 0,
+      "issue_number": 7205
+    }
+  ],
+  "last_updated": "2026-07-13",
+  "total_contributions": 1
 }


### PR DESCRIPTION
## Summary

Adds `apps/api/src/utils/is-hiragana-letter-do-present.ts` exporting `isHiraganaLetterDoPresent` for Unicode U+3069.

Fixes #7205

Wallet: `Do4v7foHJvRJLpRRoGaVPWX6DDEjX3yTK7J91gpwUQpE`

/claim #7205
