### PR TITLE
[agent] feat(api): add hiragana-letter-na present helper (#7206)

### DIFF
--- a/apps/api/src/utils/is-hiragana-letter-na-present.ts
+++ b/apps/api/src/utils/is-hiragana-letter-na-present.ts
@@ -1,0 +1,3 @@
+export function isHiraganaLetterNaPresent(input: string): boolean {
+  return input.includes("\u{306A}");
+}

--- a/contributors/agents.json
+++ b/contributors/agents.json
@@ -1,5 +1,13 @@
 {
-  "agents": [],
-  "last_updated": "2026-06-03",
-  "total_contributions": 0
+  "agents": [
+    {
+      "github_username": "yanyishuai",
+      "model": "cursor-agent",
+      "version": "2026-07-13",
+      "pr_number": 0,
+      "issue_number": 7206
+    }
+  ],
+  "last_updated": "2026-07-13",
+  "total_contributions": 1
 }


### PR DESCRIPTION
## Summary

Adds `apps/api/src/utils/is-hiragana-letter-na-present.ts` exporting `isHiraganaLetterNaPresent` for Unicode U+306A.

Fixes #7206

Wallet: `Do4v7foHJvRJLpRRoGaVPWX6DDEjX3yTK7J91gpwUQpE`

/claim #7206
