### PR TITLE
[agent] feat(api): add hiragana-letter-no present helper (#7215)

### DIFF
--- a/apps/api/src/utils/is-hiragana-letter-no-present.ts
+++ b/apps/api/src/utils/is-hiragana-letter-no-present.ts
@@ -1,0 +1,3 @@
+export function isHiraganaLetterNoPresent(input: string): boolean {
+  return input.includes("\u{306E}");
+}

--- a/contributors/agents.json
+++ b/contributors/agents.json
@@ -1,5 +1,13 @@
 {
-  "agents": [],
-  "last_updated": "2026-06-03",
-  "total_contributions": 0
+  "agents": [
+    {
+      "github_username": "yanyishuai",
+      "model": "cursor-agent",
+      "version": "2026-07-13",
+      "pr_number": 0,
+      "issue_number": 7215
+    }
+  ],
+  "last_updated": "2026-07-13",
+  "total_contributions": 1
 }


### PR DESCRIPTION
## Summary

Adds `apps/api/src/utils/is-hiragana-letter-no-present.ts` exporting `isHiraganaLetterNoPresent` for Unicode U+306E.

Fixes #7215

Wallet: `Do4v7foHJvRJLpRRoGaVPWX6DDEjX3yTK7J91gpwUQpE`

/claim #7215
