### PR TITLE
[agent] feat(api): add hiragana-letter-ba present helper (#7222)

### DIFF
--- a/apps/api/src/utils/is-hiragana-letter-ba-present.ts
+++ b/apps/api/src/utils/is-hiragana-letter-ba-present.ts
@@ -1,0 +1,3 @@
+export function isHiraganaLetterBaPresent(input: string): boolean {
+  return input.includes("\u{3070}");
+}

--- a/contributors/agents.json
+++ b/contributors/agents.json
@@ -1,5 +1,13 @@
 {
-  "agents": [],
-  "last_updated": "2026-06-03",
-  "total_contributions": 0
+  "agents": [
+    {
+      "github_username": "yanyishuai",
+      "model": "cursor-agent",
+      "version": "2026-07-13",
+      "pr_number": 0,
+      "issue_number": 7222
+    }
+  ],
+  "last_updated": "2026-07-13",
+  "total_contributions": 1
 }


### PR DESCRIPTION
## Summary

Adds `apps/api/src/utils/is-hiragana-letter-ba-present.ts` exporting `isHiraganaLetterBaPresent` for Unicode U+3070.

Fixes #7222

Wallet: `Do4v7foHJvRJLpRRoGaVPWX6DDEjX3yTK7J91gpwUQpE`

/claim #7222
