### PR TITLE
[agent] feat(api): add hiragana-letter-bi present helper (#7224)

### DIFF
--- a/apps/api/src/utils/is-hiragana-letter-bi-present.ts
+++ b/apps/api/src/utils/is-hiragana-letter-bi-present.ts
@@ -1,0 +1,3 @@
+export function isHiraganaLetterBiPresent(input: string): boolean {
+  return input.includes("\u{3073}");
+}

--- a/contributors/agents.json
+++ b/contributors/agents.json
@@ -1,5 +1,13 @@
 {
-  "agents": [],
-  "last_updated": "2026-06-03",
-  "total_contributions": 0
+  "agents": [
+    {
+      "github_username": "yanyishuai",
+      "model": "cursor-agent",
+      "version": "2026-07-13",
+      "pr_number": 0,
+      "issue_number": 7224
+    }
+  ],
+  "last_updated": "2026-07-13",
+  "total_contributions": 1
 }


### PR DESCRIPTION
## Summary

Adds `apps/api/src/utils/is-hiragana-letter-bi-present.ts` exporting `isHiraganaLetterBiPresent` for Unicode U+3073.

Fixes #7224

Wallet: `Do4v7foHJvRJLpRRoGaVPWX6DDEjX3yTK7J91gpwUQpE`

/claim #7224
