### PR TITLE
[agent] feat(api): add hiragana-letter-se present helper (#7183)

### DIFF
--- a/apps/api/src/utils/is-hiragana-letter-se-present.ts
+++ b/apps/api/src/utils/is-hiragana-letter-se-present.ts
@@ -1,0 +1,3 @@
+export function isHiraganaLetterSePresent(input: string): boolean {
+  return input.includes("\u{305B}");
+}

--- a/contributors/agents.json
+++ b/contributors/agents.json
@@ -1,5 +1,13 @@
 {
-  "agents": [],
-  "last_updated": "2026-06-03",
-  "total_contributions": 0
+  "agents": [
+    {
+      "github_username": "yanyishuai",
+      "model": "cursor-agent",
+      "version": "2026-07-13",
+      "pr_number": 0,
+      "issue_number": 7183
+    }
+  ],
+  "last_updated": "2026-07-13",
+  "total_contributions": 1
 }


### PR DESCRIPTION
## Summary

Adds `apps/api/src/utils/is-hiragana-letter-se-present.ts` exporting `isHiraganaLetterSePresent` for Unicode U+305B.

Fixes #7183

Wallet: `Do4v7foHJvRJLpRRoGaVPWX6DDEjX3yTK7J91gpwUQpE`

/claim #7183
