### PR TITLE
[agent] feat(api): add hiragana-letter-ti present helper (#7194)

### DIFF
--- a/apps/api/src/utils/is-hiragana-letter-ti-present.ts
+++ b/apps/api/src/utils/is-hiragana-letter-ti-present.ts
@@ -1,0 +1,3 @@
+export function isHiraganaLetterTiPresent(input: string): boolean {
+  return input.includes("\u{3061}");
+}

--- a/contributors/agents.json
+++ b/contributors/agents.json
@@ -1,5 +1,13 @@
 {
-  "agents": [],
-  "last_updated": "2026-06-03",
-  "total_contributions": 0
+  "agents": [
+    {
+      "github_username": "yanyishuai",
+      "model": "cursor-agent",
+      "version": "2026-07-13",
+      "pr_number": 0,
+      "issue_number": 7194
+    }
+  ],
+  "last_updated": "2026-07-13",
+  "total_contributions": 1
 }


### PR DESCRIPTION
## Summary

Adds `apps/api/src/utils/is-hiragana-letter-ti-present.ts` exporting `isHiraganaLetterTiPresent` for Unicode U+3061.

Fixes #7194

Wallet: `Do4v7foHJvRJLpRRoGaVPWX6DDEjX3yTK7J91gpwUQpE`

/claim #7194
