### PR TITLE
[agent] feat(api): add cjk-radical-heart-one present helper (#5866)

### DIFF
--- a/apps/api/src/utils/is-cjk-radical-heart-one-present.ts
+++ b/apps/api/src/utils/is-cjk-radical-heart-one-present.ts
@@ -1,0 +1,3 @@
+export function isCjkRadicalHeartOnePresent(input: string): boolean {
+  return input.includes("\u{2E96}");
+}

--- a/contributors/agents.json
+++ b/contributors/agents.json
@@ -1,5 +1,13 @@
 {
-  "agents": [],
-  "last_updated": "2026-06-03",
-  "total_contributions": 0
+  "agents": [
+    {
+      "github_username": "yanyishuai",
+      "model": "cursor-agent",
+      "version": "2026-07-13",
+      "pr_number": 0,
+      "issue_number": 5866
+    }
+  ],
+  "last_updated": "2026-07-13",
+  "total_contributions": 1
 }


### PR DESCRIPTION
## Summary

Adds `apps/api/src/utils/is-cjk-radical-heart-one-present.ts` exporting `isCjkRadicalHeartOnePresent` for Unicode U+2E96.

Fixes #5866

Wallet: `Do4v7foHJvRJLpRRoGaVPWX6DDEjX3yTK7J91gpwUQpE`

/claim #5866
