### PR TITLE
[agent] feat(api): add cjk-radical-sun present helper (#5878)

### DIFF
--- a/apps/api/src/utils/is-cjk-radical-sun-present.ts
+++ b/apps/api/src/utils/is-cjk-radical-sun-present.ts
@@ -1,0 +1,3 @@
+export function isCjkRadicalSunPresent(input: string): boolean {
+  return input.includes("\u{2E9C}");
+}

--- a/contributors/agents.json
+++ b/contributors/agents.json
@@ -1,5 +1,13 @@
 {
-  "agents": [],
-  "last_updated": "2026-06-03",
-  "total_contributions": 0
+  "agents": [
+    {
+      "github_username": "yanyishuai",
+      "model": "cursor-agent",
+      "version": "2026-07-13",
+      "pr_number": 0,
+      "issue_number": 5878
+    }
+  ],
+  "last_updated": "2026-07-13",
+  "total_contributions": 1
 }


### PR DESCRIPTION
## Summary

Adds `apps/api/src/utils/is-cjk-radical-sun-present.ts` exporting `isCjkRadicalSunPresent` for Unicode U+2E9C.

Fixes #5878

Wallet: `Do4v7foHJvRJLpRRoGaVPWX6DDEjX3yTK7J91gpwUQpE`

/claim #5878
