### PR TITLE
[agent] feat(api): add cjk-radical-water-one present helper (#5886)

### DIFF
--- a/apps/api/src/utils/is-cjk-radical-water-one-present.ts
+++ b/apps/api/src/utils/is-cjk-radical-water-one-present.ts
@@ -1,0 +1,3 @@
+export function isCjkRadicalWaterOnePresent(input: string): boolean {
+  return input.includes("\u{2EA1}");
+}

--- a/contributors/agents.json
+++ b/contributors/agents.json
@@ -1,5 +1,13 @@
 {
-  "agents": [],
-  "last_updated": "2026-06-03",
-  "total_contributions": 0
+  "agents": [
+    {
+      "github_username": "yanyishuai",
+      "model": "cursor-agent",
+      "version": "2026-07-13",
+      "pr_number": 0,
+      "issue_number": 5886
+    }
+  ],
+  "last_updated": "2026-07-13",
+  "total_contributions": 1
 }


### PR DESCRIPTION
## Summary

Adds `apps/api/src/utils/is-cjk-radical-water-one-present.ts` exporting `isCjkRadicalWaterOnePresent` for Unicode U+2EA1.

Fixes #5886

Wallet: `Do4v7foHJvRJLpRRoGaVPWX6DDEjX3yTK7J91gpwUQpE`

/claim #5886
