### PR TITLE
[agent] Add Kangxi radical line utility

### DIFF
--- a/apps/api/src/utils/is-kangxi-radical-line-present.ts
+++ b/apps/api/src/utils/is-kangxi-radical-line-present.ts
@@ -1,0 +1,3 @@
+export function isKangxiRadicalLinePresent(input: string): boolean {
+  return input.includes("⼁");
+}

--- a/apps/api/test/is-kangxi-radical-line-present.test.ts
+++ b/apps/api/test/is-kangxi-radical-line-present.test.ts
@@ -1,0 +1,14 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+
+import { isKangxiRadicalLinePresent } from "../src/utils/is-kangxi-radical-line-present";
+
+test("isKangxiRadicalLinePresent returns true when the input contains ⼁", () => {
+  assert.equal(isKangxiRadicalLinePresent("⼁"), true);
+  assert.equal(isKangxiRadicalLinePresent("foo⼁bar"), true);
+});
+
+test("isKangxiRadicalLinePresent returns false when the input does not contain ⼁", () => {
+  assert.equal(isKangxiRadicalLinePresent("一"), false);
+  assert.equal(isKangxiRadicalLinePresent("foo"), false);
+});

--- a/contributors/agents.json
+++ b/contributors/agents.json
@@ -1,5 +1,13 @@
 {
-  "agents": [],
-  "last_updated": "2026-06-03",
-  "total_contributions": 0
+  "agents": [
+    {
+      "github_username": "voladoradepapantla-netizen",
+      "model": "gpt-5",
+      "version": "2026-07-15",
+      "pr_number": 7469,
+      "issue_number": 6106
+    }
+  ],
+  "last_updated": "2026-07-15",
+  "total_contributions": 1
 }


### PR DESCRIPTION
Closes #6106

Adds a dependency-free helper and focused node:test coverage for exact U+2F01 detection.