### PR TITLE
[agent] fix(api): validate user creation payloads (#2207)

### DIFF
--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -7,7 +7,7 @@
   "main": "src/index.ts",
   "scripts": {
     "dev": "tsx src/index.ts",
-    "test": "echo \"No API tests configured yet\"",
+    "test": "node --test test/users.test.ts",
     "lint": "echo \"No API lint configured yet\""
   },
   "dependencies": {

--- a/apps/api/src/index.ts
+++ b/apps/api/src/index.ts
@@ -1,6 +1,6 @@
 import express from "express";
 
-import usersRouter from "./routes/users";
+import usersRouter from "./routes/users.ts";
 
 const app = express();
 const port = process.env.PORT || 4000;

--- a/apps/api/src/index.ts
+++ b/apps/api/src/index.ts
@@ -1,4 +1,5 @@
 import express from "express";
+import { pathToFileURL } from "node:url";
 
 import usersRouter from "./routes/users.ts";
 
@@ -13,6 +14,14 @@ app.get("/health", (_req, res) => {
 
 app.use("/users", usersRouter);
 
-app.listen(port, () => {
-  console.log(`TaskFlow API listening on port ${port}`);
-});
+export { app };
+
+export function startServer(listenPort: number | string = port) {
+  return app.listen(listenPort, () => {
+    console.log(`TaskFlow API listening on port ${listenPort}`);
+  });
+}
+
+if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) {
+  startServer();
+}

--- a/apps/api/src/routes/users.ts
+++ b/apps/api/src/routes/users.ts
@@ -1,21 +1,89 @@
+import { randomUUID } from "node:crypto";
 import { Router } from "express";
 
 const router = Router();
 
+type UserRecord = {
+  id: string;
+  email: string;
+  name?: string;
+};
+
+const users: UserRecord[] = [];
+
+function isPlainObject(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function normalizeEmail(value: unknown): string | null {
+  if (typeof value !== "string") {
+    return null;
+  }
+
+  const normalized = value.trim().toLowerCase();
+
+  if (!/^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(normalized)) {
+    return null;
+  }
+
+  return normalized;
+}
+
+function normalizeOptionalName(value: unknown): string | undefined {
+  if (typeof value !== "string") {
+    return undefined;
+  }
+
+  const normalized = value.trim();
+  return normalized.length > 0 ? normalized : undefined;
+}
+
 router.get("/", (_req, res) => {
   res.json({
-    data: [],
+    data: users,
     message: "User listing is not implemented yet."
   });
 });
 
 router.post("/", (req, res) => {
+  if (!isPlainObject(req.body)) {
+    res.status(400).json({
+      error: "Validation failed",
+      details: {
+        body: ["Request body must be a JSON object."]
+      }
+    });
+    return;
+  }
+
+  const email = normalizeEmail(req.body.email);
+
+  if (!email) {
+    res.status(400).json({
+      error: "Validation failed",
+      details: {
+        email: ["A valid email address is required."]
+      }
+    });
+    return;
+  }
+
+  const user: UserRecord = {
+    id: randomUUID(),
+    email,
+  };
+
+  const name = normalizeOptionalName(req.body.name);
+
+  if (name) {
+    user.name = name;
+  }
+
+  users.push(user);
+
   res.status(201).json({
-    data: {
-      id: "stub-user-id",
-      ...req.body
-    },
-    message: "User creation is not implemented yet."
+    data: user,
+    message: "User created"
   });
 });
 

--- a/apps/api/src/routes/users.ts
+++ b/apps/api/src/routes/users.ts
@@ -3,14 +3,6 @@ import { Router } from "express";
 
 const router = Router();
 
-type UserRecord = {
-  id: string;
-  email: string;
-  name?: string;
-};
-
-const users: UserRecord[] = [];
-
 function isPlainObject(value: unknown): value is Record<string, unknown> {
   return typeof value === "object" && value !== null && !Array.isArray(value);
 }
@@ -40,7 +32,7 @@ function normalizeOptionalName(value: unknown): string | undefined {
 
 router.get("/", (_req, res) => {
   res.json({
-    data: users,
+    data: [],
     message: "User listing is not implemented yet."
   });
 });
@@ -68,7 +60,7 @@ router.post("/", (req, res) => {
     return;
   }
 
-  const user: UserRecord = {
+  const user = {
     id: randomUUID(),
     email,
   };
@@ -78,8 +70,6 @@ router.post("/", (req, res) => {
   if (name) {
     user.name = name;
   }
-
-  users.push(user);
 
   res.status(201).json({
     data: user,

--- a/apps/api/test/users.test.ts
+++ b/apps/api/test/users.test.ts
@@ -1,0 +1,142 @@
+import assert from "node:assert/strict";
+import { after, before, test } from "node:test";
+import { spawn, type ChildProcessWithoutNullStreams } from "node:child_process";
+import { once } from "node:events";
+
+const port = 43123;
+const apiRoot = new URL("..", import.meta.url);
+const apiUrl = `http://127.0.0.1:${port}`;
+
+let server: ChildProcessWithoutNullStreams | null = null;
+
+async function waitForServerReady(child: ChildProcessWithoutNullStreams): Promise<void> {
+  await new Promise<void>((resolve, reject) => {
+    const onData = (chunk: Buffer) => {
+      if (chunk.toString().includes(`TaskFlow API listening on port ${port}`)) {
+        cleanup();
+        resolve();
+      }
+    };
+
+    const onError = (error: Error) => {
+      cleanup();
+      reject(error);
+    };
+
+    const onExit = (code: number | null, signal: NodeJS.Signals | null) => {
+      cleanup();
+      reject(new Error(`API exited before starting (code=${code}, signal=${signal})`));
+    };
+
+    const cleanup = () => {
+      child.stdout.off("data", onData);
+      child.stderr.off("data", onData);
+      child.off("error", onError);
+      child.off("exit", onExit);
+    };
+
+    child.stdout.on("data", onData);
+    child.stderr.on("data", onData);
+    child.on("error", onError);
+    child.on("exit", onExit);
+  });
+}
+
+before(async () => {
+  server = spawn(process.execPath, ["src/index.ts"], {
+    cwd: apiRoot,
+    env: {
+      ...process.env,
+      PORT: String(port),
+    },
+    stdio: ["ignore", "pipe", "pipe"],
+  });
+
+  await waitForServerReady(server);
+});
+
+after(async () => {
+  if (!server) {
+    return;
+  }
+
+  if (server.exitCode === null && server.signalCode === null) {
+    server.kill();
+  }
+
+  await once(server, "exit");
+});
+
+test("POST /users rejects non-object JSON bodies", async () => {
+  const response = await fetch(`${apiUrl}/users`, {
+    method: "POST",
+    headers: {
+      "content-type": "application/json",
+    },
+    body: JSON.stringify(["not", "an", "object"]),
+  });
+
+  assert.equal(response.status, 400);
+  assert.deepEqual(await response.json(), {
+    error: "Validation failed",
+    details: {
+      body: ["Request body must be a JSON object."],
+    },
+  });
+});
+
+test("POST /users normalizes the email and optional name while ignoring extra fields", async () => {
+  const response = await fetch(`${apiUrl}/users`, {
+    method: "POST",
+    headers: {
+      "content-type": "application/json",
+    },
+    body: JSON.stringify({
+      id: "client-id",
+      email: "  Ada@Example.COM  ",
+      name: "  Ada Lovelace  ",
+      role: "admin",
+    }),
+  });
+
+  assert.equal(response.status, 201);
+
+  const payload = await response.json() as {
+    data: {
+      id: string;
+      email: string;
+      name?: string;
+    };
+    message: string;
+  };
+
+  assert.equal(payload.message, "User created");
+  assert.notEqual(payload.data.id, "client-id");
+  assert.match(payload.data.id, /^[0-9a-f-]{36}$/i);
+  assert.deepEqual(payload.data, {
+    id: payload.data.id,
+    email: "ada@example.com",
+    name: "Ada Lovelace",
+  });
+});
+
+test("POST /users rejects invalid email addresses", async () => {
+  const response = await fetch(`${apiUrl}/users`, {
+    method: "POST",
+    headers: {
+      "content-type": "application/json",
+    },
+    body: JSON.stringify({
+      email: "not-an-email",
+      name: "Ada",
+    }),
+  });
+
+  assert.equal(response.status, 400);
+  assert.deepEqual(await response.json(), {
+    error: "Validation failed",
+    details: {
+      email: ["A valid email address is required."],
+    },
+  });
+});

--- a/apps/api/test/users.test.ts
+++ b/apps/api/test/users.test.ts
@@ -1,58 +1,43 @@
 import assert from "node:assert/strict";
 import { after, before, test } from "node:test";
-import { spawn, type ChildProcessWithoutNullStreams } from "node:child_process";
-import { once } from "node:events";
+import type { AddressInfo } from "node:net";
 
-const port = 43123;
-const apiRoot = new URL("..", import.meta.url);
-const apiUrl = `http://127.0.0.1:${port}`;
+import { app } from "../src/index.ts";
 
-let server: ChildProcessWithoutNullStreams | null = null;
+let baseUrl = "";
+let server: ReturnType<typeof app.listen> | null = null;
 
-async function waitForServerReady(child: ChildProcessWithoutNullStreams): Promise<void> {
-  await new Promise<void>((resolve, reject) => {
-    const onData = (chunk: Buffer) => {
-      if (chunk.toString().includes(`TaskFlow API listening on port ${port}`)) {
-        cleanup();
-        resolve();
-      }
-    };
+function getBaseUrl() {
+  return baseUrl;
+}
 
-    const onError = (error: Error) => {
-      cleanup();
-      reject(error);
-    };
+function getServerAddress() {
+  const address = server?.address();
 
-    const onExit = (code: number | null, signal: NodeJS.Signals | null) => {
-      cleanup();
-      reject(new Error(`API exited before starting (code=${code}, signal=${signal})`));
-    };
+  if (!address || typeof address === "string") {
+    throw new Error("Test server did not start on an IP port.");
+  }
 
-    const cleanup = () => {
-      child.stdout.off("data", onData);
-      child.stderr.off("data", onData);
-      child.off("error", onError);
-      child.off("exit", onExit);
-    };
+  return address as AddressInfo;
+}
 
-    child.stdout.on("data", onData);
-    child.stderr.on("data", onData);
-    child.on("error", onError);
-    child.on("exit", onExit);
-  });
+async function request(path: string, init?: RequestInit) {
+  const response = await fetch(`${getBaseUrl()}${path}`, init);
+  const body = await response.json();
+
+  return { response, body };
 }
 
 before(async () => {
-  server = spawn(process.execPath, ["src/index.ts"], {
-    cwd: apiRoot,
-    env: {
-      ...process.env,
-      PORT: String(port),
-    },
-    stdio: ["ignore", "pipe", "pipe"],
+  server = app.listen(0);
+
+  await new Promise<void>((resolve, reject) => {
+    server?.once("listening", resolve);
+    server?.once("error", reject);
   });
 
-  await waitForServerReady(server);
+  const address = getServerAddress();
+  baseUrl = `http://127.0.0.1:${address.port}`;
 });
 
 after(async () => {
@@ -60,93 +45,90 @@ after(async () => {
     return;
   }
 
-  if (server.exitCode === null && server.signalCode === null) {
-    server.kill();
-  }
+  await new Promise<void>((resolve, reject) => {
+    server?.close((error) => {
+      if (error) {
+        reject(error);
+        return;
+      }
 
-  await once(server, "exit");
+      resolve();
+    });
+  });
 });
 
 test("GET /users preserves the stub list response", async () => {
-  const response = await fetch(`${apiUrl}/users`);
+  const { response, body } = await request("/users");
 
   assert.equal(response.status, 200);
-  assert.deepEqual(await response.json(), {
+  assert.deepEqual(body, {
     data: [],
-    message: "User listing is not implemented yet.",
+    message: "User listing is not implemented yet."
   });
 });
 
 test("POST /users rejects non-object JSON bodies", async () => {
-  const response = await fetch(`${apiUrl}/users`, {
+  const { response, body } = await request("/users", {
     method: "POST",
     headers: {
-      "content-type": "application/json",
+      "content-type": "application/json"
     },
-    body: JSON.stringify(["not", "an", "object"]),
+    body: JSON.stringify(["not", "an", "object"])
   });
 
   assert.equal(response.status, 400);
-  assert.deepEqual(await response.json(), {
+  assert.deepEqual(body, {
     error: "Validation failed",
     details: {
-      body: ["Request body must be a JSON object."],
-    },
+      body: ["Request body must be a JSON object."]
+    }
   });
 });
 
-test("POST /users normalizes the email and optional name while ignoring extra fields", async () => {
-  const response = await fetch(`${apiUrl}/users`, {
+test("POST /users rejects invalid email addresses", async () => {
+  const { response, body } = await request("/users", {
     method: "POST",
     headers: {
-      "content-type": "application/json",
+      "content-type": "application/json"
+    },
+    body: JSON.stringify({
+      email: "not-an-email",
+      name: "Ada"
+    })
+  });
+
+  assert.equal(response.status, 400);
+  assert.deepEqual(body, {
+    error: "Validation failed",
+    details: {
+      email: ["A valid email address is required."]
+    }
+  });
+});
+
+test("POST /users normalizes email and name while ignoring client-controlled fields", async () => {
+  const { response, body } = await request("/users", {
+    method: "POST",
+    headers: {
+      "content-type": "application/json"
     },
     body: JSON.stringify({
       id: "client-id",
       email: "  Ada@Example.COM  ",
       name: "  Ada Lovelace  ",
-      role: "admin",
-    }),
+      role: "admin"
+    })
   });
 
   assert.equal(response.status, 201);
-
-  const payload = await response.json() as {
-    data: {
-      id: string;
-      email: string;
-      name?: string;
-    };
-    message: string;
-  };
-
-  assert.equal(payload.message, "User created");
-  assert.notEqual(payload.data.id, "client-id");
-  assert.match(payload.data.id, /^[0-9a-f-]{36}$/i);
-  assert.deepEqual(payload.data, {
-    id: payload.data.id,
+  assert.equal(body.message, "User created");
+  assert.equal(body.data.email, "ada@example.com");
+  assert.equal(body.data.name, "Ada Lovelace");
+  assert.notEqual(body.data.id, "client-id");
+  assert.match(body.data.id, /^[0-9a-f-]{36}$/i);
+  assert.deepEqual(body.data, {
+    id: body.data.id,
     email: "ada@example.com",
-    name: "Ada Lovelace",
-  });
-});
-
-test("POST /users rejects invalid email addresses", async () => {
-  const response = await fetch(`${apiUrl}/users`, {
-    method: "POST",
-    headers: {
-      "content-type": "application/json",
-    },
-    body: JSON.stringify({
-      email: "not-an-email",
-      name: "Ada",
-    }),
-  });
-
-  assert.equal(response.status, 400);
-  assert.deepEqual(await response.json(), {
-    error: "Validation failed",
-    details: {
-      email: ["A valid email address is required."],
-    },
+    name: "Ada Lovelace"
   });
 });

--- a/apps/api/test/users.test.ts
+++ b/apps/api/test/users.test.ts
@@ -67,6 +67,16 @@ after(async () => {
   await once(server, "exit");
 });
 
+test("GET /users preserves the stub list response", async () => {
+  const response = await fetch(`${apiUrl}/users`);
+
+  assert.equal(response.status, 200);
+  assert.deepEqual(await response.json(), {
+    data: [],
+    message: "User listing is not implemented yet.",
+  });
+});
+
 test("POST /users rejects non-object JSON bodies", async () => {
   const response = await fetch(`${apiUrl}/users`, {
     method: "POST",

--- a/contributors/agents.json
+++ b/contributors/agents.json
@@ -1,5 +1,13 @@
 {
-  "agents": [],
-  "last_updated": "2026-06-03",
-  "total_contributions": 0
+  "agents": [
+    {
+      "github_username": "voladoradepapantla-netizen",
+      "model": "GPT-5",
+      "version": "Codex desktop",
+      "pr_number": 7473,
+      "issue_number": 2207
+    }
+  ],
+  "last_updated": "2026-07-15",
+  "total_contributions": 1
 }


### PR DESCRIPTION
Closes #2207

This PR tightens user creation validation in the API and adds coverage for the new behavior.

It also preserves the existing `GET /users` stub response so the fix stays focused on creation validation.

Agent registry entry added in `contributors/agents.json`.

Validation:
- `npm test -w apps/api`

This should prevent malformed user payloads from reaching downstream logic and makes the route behavior easier to reason about.