### PR TITLE
[agent] feat(api): add kangxi-radical-legs present helper (#6127)

### DIFF
--- a/apps/api/src/utils/is-kangxi-radical-legs-present.ts
+++ b/apps/api/src/utils/is-kangxi-radical-legs-present.ts
@@ -1,0 +1,3 @@
+export function isKangxiRadicalLegsPresent(input: string): boolean {
+  return input.includes("\u{2F09}");
+}

--- a/contributors/agents.json
+++ b/contributors/agents.json
@@ -1,5 +1,13 @@
 {
-  "agents": [],
-  "last_updated": "2026-06-03",
-  "total_contributions": 0
+  "agents": [
+    {
+      "github_username": "yanyishuai",
+      "model": "cursor-agent",
+      "version": "2026-07-13",
+      "pr_number": 0,
+      "issue_number": 6127
+    }
+  ],
+  "last_updated": "2026-07-13",
+  "total_contributions": 1
 }


### PR DESCRIPTION
## Summary

Adds `apps/api/src/utils/is-kangxi-radical-legs-present.ts` exporting `isKangxiRadicalLegsPresent` for Unicode U+2F09.

Fixes #6127

Wallet: `Do4v7foHJvRJLpRRoGaVPWX6DDEjX3yTK7J91gpwUQpE`

/claim #6127
