### PR TITLE
[agent] feat(api): add kangxi-radical-down-box present helper (#6135)

### DIFF
--- a/apps/api/src/utils/is-kangxi-radical-down-box-present.ts
+++ b/apps/api/src/utils/is-kangxi-radical-down-box-present.ts
@@ -1,0 +1,3 @@
+export function isKangxiRadicalDownBoxPresent(input: string): boolean {
+  return input.includes("\u{2F0C}");
+}

--- a/contributors/agents.json
+++ b/contributors/agents.json
@@ -1,5 +1,13 @@
 {
-  "agents": [],
-  "last_updated": "2026-06-03",
-  "total_contributions": 0
+  "agents": [
+    {
+      "github_username": "yanyishuai",
+      "model": "cursor-agent",
+      "version": "2026-07-13",
+      "pr_number": 0,
+      "issue_number": 6135
+    }
+  ],
+  "last_updated": "2026-07-13",
+  "total_contributions": 1
 }


### PR DESCRIPTION
## Summary

Adds `apps/api/src/utils/is-kangxi-radical-down-box-present.ts` exporting `isKangxiRadicalDownBoxPresent` for Unicode U+2F0C.

Fixes #6135

Wallet: `Do4v7foHJvRJLpRRoGaVPWX6DDEjX3yTK7J91gpwUQpE`

/claim #6135
