### PR TITLE
[agent] feat(api): add kangxi-radical-divination present helper (#6156)

### DIFF
--- a/apps/api/src/utils/is-kangxi-radical-divination-present.ts
+++ b/apps/api/src/utils/is-kangxi-radical-divination-present.ts
@@ -1,0 +1,3 @@
+export function isKangxiRadicalDivinationPresent(input: string): boolean {
+  return input.includes("\u{2F18}");
+}

--- a/contributors/agents.json
+++ b/contributors/agents.json
@@ -1,5 +1,13 @@
 {
-  "agents": [],
-  "last_updated": "2026-06-03",
-  "total_contributions": 0
+  "agents": [
+    {
+      "github_username": "yanyishuai",
+      "model": "cursor-agent",
+      "version": "2026-07-13",
+      "pr_number": 0,
+      "issue_number": 6156
+    }
+  ],
+  "last_updated": "2026-07-13",
+  "total_contributions": 1
 }


### PR DESCRIPTION
## Summary

Adds `apps/api/src/utils/is-kangxi-radical-divination-present.ts` exporting `isKangxiRadicalDivinationPresent` for Unicode U+2F18.

Fixes #6156

Wallet: `Do4v7foHJvRJLpRRoGaVPWX6DDEjX3yTK7J91gpwUQpE`

/claim #6156
