### PR TITLE
[agent] feat(api): add kangxi-radical-roof present helper (#6186)

### DIFF
--- a/apps/api/src/utils/is-kangxi-radical-roof-present.ts
+++ b/apps/api/src/utils/is-kangxi-radical-roof-present.ts
@@ -1,0 +1,3 @@
+export function isKangxiRadicalRoofPresent(input: string): boolean {
+  return input.includes("\u{2F27}");
+}

--- a/contributors/agents.json
+++ b/contributors/agents.json
@@ -1,5 +1,13 @@
 {
-  "agents": [],
-  "last_updated": "2026-06-03",
-  "total_contributions": 0
+  "agents": [
+    {
+      "github_username": "yanyishuai",
+      "model": "cursor-agent",
+      "version": "2026-07-13",
+      "pr_number": 0,
+      "issue_number": 6186
+    }
+  ],
+  "last_updated": "2026-07-13",
+  "total_contributions": 1
 }


### PR DESCRIPTION
## Summary

Adds `apps/api/src/utils/is-kangxi-radical-roof-present.ts` exporting `isKangxiRadicalRoofPresent` for Unicode U+2F27.

Fixes #6186

Wallet: `Do4v7foHJvRJLpRRoGaVPWX6DDEjX3yTK7J91gpwUQpE`

/claim #6186
