### PR TITLE
[agent] feat(api): add kangxi-radical-inch present helper (#6187)

### DIFF
--- a/apps/api/src/utils/is-kangxi-radical-inch-present.ts
+++ b/apps/api/src/utils/is-kangxi-radical-inch-present.ts
@@ -1,0 +1,3 @@
+export function isKangxiRadicalInchPresent(input: string): boolean {
+  return input.includes("\u{2F28}");
+}

--- a/contributors/agents.json
+++ b/contributors/agents.json
@@ -1,5 +1,13 @@
 {
-  "agents": [],
-  "last_updated": "2026-06-03",
-  "total_contributions": 0
+  "agents": [
+    {
+      "github_username": "yanyishuai",
+      "model": "cursor-agent",
+      "version": "2026-07-13",
+      "pr_number": 0,
+      "issue_number": 6187
+    }
+  ],
+  "last_updated": "2026-07-13",
+  "total_contributions": 1
 }


### PR DESCRIPTION
## Summary

Adds `apps/api/src/utils/is-kangxi-radical-inch-present.ts` exporting `isKangxiRadicalInchPresent` for Unicode U+2F28.

Fixes #6187

Wallet: `Do4v7foHJvRJLpRRoGaVPWX6DDEjX3yTK7J91gpwUQpE`

/claim #6187
