### PR TITLE
[agent] feat(api): add kangxi-radical-lame present helper (#6188)

### DIFF
--- a/apps/api/src/utils/is-kangxi-radical-lame-present.ts
+++ b/apps/api/src/utils/is-kangxi-radical-lame-present.ts
@@ -1,0 +1,3 @@
+export function isKangxiRadicalLamePresent(input: string): boolean {
+  return input.includes("\u{2F2A}");
+}

--- a/contributors/agents.json
+++ b/contributors/agents.json
@@ -1,5 +1,13 @@
 {
-  "agents": [],
-  "last_updated": "2026-06-03",
-  "total_contributions": 0
+  "agents": [
+    {
+      "github_username": "yanyishuai",
+      "model": "cursor-agent",
+      "version": "2026-07-13",
+      "pr_number": 0,
+      "issue_number": 6188
+    }
+  ],
+  "last_updated": "2026-07-13",
+  "total_contributions": 1
 }


### PR DESCRIPTION
## Summary

Adds `apps/api/src/utils/is-kangxi-radical-lame-present.ts` exporting `isKangxiRadicalLamePresent` for Unicode U+2F2A.

Fixes #6188

Wallet: `Do4v7foHJvRJLpRRoGaVPWX6DDEjX3yTK7J91gpwUQpE`

/claim #6188
