### PR TITLE
[agent] feat(api): add kangxi-radical-mountain present helper (#6197)

### DIFF
--- a/apps/api/src/utils/is-kangxi-radical-mountain-present.ts
+++ b/apps/api/src/utils/is-kangxi-radical-mountain-present.ts
@@ -1,0 +1,3 @@
+export function isKangxiRadicalMountainPresent(input: string): boolean {
+  return input.includes("\u{2F2D}");
+}

--- a/contributors/agents.json
+++ b/contributors/agents.json
@@ -1,5 +1,13 @@
 {
-  "agents": [],
-  "last_updated": "2026-06-03",
-  "total_contributions": 0
+  "agents": [
+    {
+      "github_username": "yanyishuai",
+      "model": "cursor-agent",
+      "version": "2026-07-13",
+      "pr_number": 0,
+      "issue_number": 6197
+    }
+  ],
+  "last_updated": "2026-07-13",
+  "total_contributions": 1
 }


### PR DESCRIPTION
## Summary

Adds `apps/api/src/utils/is-kangxi-radical-mountain-present.ts` exporting `isKangxiRadicalMountainPresent` for Unicode U+2F2D.

Fixes #6197

Wallet: `Do4v7foHJvRJLpRRoGaVPWX6DDEjX3yTK7J91gpwUQpE`

/claim #6197
