### PR TITLE
[agent] feat(api): add kangxi-radical-river present helper (#6198)

### DIFF
--- a/apps/api/src/utils/is-kangxi-radical-river-present.ts
+++ b/apps/api/src/utils/is-kangxi-radical-river-present.ts
@@ -1,0 +1,3 @@
+export function isKangxiRadicalRiverPresent(input: string): boolean {
+  return input.includes("\u{2F2E}");
+}

--- a/contributors/agents.json
+++ b/contributors/agents.json
@@ -1,5 +1,13 @@
 {
-  "agents": [],
-  "last_updated": "2026-06-03",
-  "total_contributions": 0
+  "agents": [
+    {
+      "github_username": "yanyishuai",
+      "model": "cursor-agent",
+      "version": "2026-07-13",
+      "pr_number": 0,
+      "issue_number": 6198
+    }
+  ],
+  "last_updated": "2026-07-13",
+  "total_contributions": 1
 }


### PR DESCRIPTION
## Summary

Adds `apps/api/src/utils/is-kangxi-radical-river-present.ts` exporting `isKangxiRadicalRiverPresent` for Unicode U+2F2E.

Fixes #6198

Wallet: `Do4v7foHJvRJLpRRoGaVPWX6DDEjX3yTK7J91gpwUQpE`

/claim #6198
