### PR TITLE
[agent] feat(api): add kangxi-radical-shoot present helper (#6219)

### DIFF
--- a/apps/api/src/utils/is-kangxi-radical-shoot-present.ts
+++ b/apps/api/src/utils/is-kangxi-radical-shoot-present.ts
@@ -1,0 +1,3 @@
+export function isKangxiRadicalShootPresent(input: string): boolean {
+  return input.includes("\u{2F37}");
+}

--- a/contributors/agents.json
+++ b/contributors/agents.json
@@ -1,5 +1,13 @@
 {
-  "agents": [],
-  "last_updated": "2026-06-03",
-  "total_contributions": 0
+  "agents": [
+    {
+      "github_username": "yanyishuai",
+      "model": "cursor-agent",
+      "version": "2026-07-13",
+      "pr_number": 0,
+      "issue_number": 6219
+    }
+  ],
+  "last_updated": "2026-07-13",
+  "total_contributions": 1
 }


### PR DESCRIPTION
## Summary

Adds `apps/api/src/utils/is-kangxi-radical-shoot-present.ts` exporting `isKangxiRadicalShootPresent` for Unicode U+2F37.

Fixes #6219

Wallet: `Do4v7foHJvRJLpRRoGaVPWX6DDEjX3yTK7J91gpwUQpE`

/claim #6219
