### PR TITLE
[agent] feat(api): add kangxi-radical-bow present helper (#6220)

### DIFF
--- a/apps/api/src/utils/is-kangxi-radical-bow-present.ts
+++ b/apps/api/src/utils/is-kangxi-radical-bow-present.ts
@@ -1,0 +1,3 @@
+export function isKangxiRadicalBowPresent(input: string): boolean {
+  return input.includes("\u{2F38}");
+}

--- a/contributors/agents.json
+++ b/contributors/agents.json
@@ -1,5 +1,13 @@
 {
-  "agents": [],
-  "last_updated": "2026-06-03",
-  "total_contributions": 0
+  "agents": [
+    {
+      "github_username": "yanyishuai",
+      "model": "cursor-agent",
+      "version": "2026-07-13",
+      "pr_number": 0,
+      "issue_number": 6220
+    }
+  ],
+  "last_updated": "2026-07-13",
+  "total_contributions": 1
 }


### PR DESCRIPTION
## Summary

Adds `apps/api/src/utils/is-kangxi-radical-bow-present.ts` exporting `isKangxiRadicalBowPresent` for Unicode U+2F38.

Fixes #6220

Wallet: `Do4v7foHJvRJLpRRoGaVPWX6DDEjX3yTK7J91gpwUQpE`

/claim #6220
