### PR TITLE
[agent] feat(api): add kangxi-radical-halberd present helper (#6253)

### DIFF
--- a/apps/api/src/utils/is-kangxi-radical-halberd-present.ts
+++ b/apps/api/src/utils/is-kangxi-radical-halberd-present.ts
@@ -1,0 +1,3 @@
+export function isKangxiRadicalHalberdPresent(input: string): boolean {
+  return input.includes("\u{2F3D}");
+}

--- a/contributors/agents.json
+++ b/contributors/agents.json
@@ -1,5 +1,13 @@
 {
-  "agents": [],
-  "last_updated": "2026-06-03",
-  "total_contributions": 0
+  "agents": [
+    {
+      "github_username": "yanyishuai",
+      "model": "cursor-agent",
+      "version": "2026-07-13",
+      "pr_number": 0,
+      "issue_number": 6253
+    }
+  ],
+  "last_updated": "2026-07-13",
+  "total_contributions": 1
 }


### PR DESCRIPTION
## Summary

Adds `apps/api/src/utils/is-kangxi-radical-halberd-present.ts` exporting `isKangxiRadicalHalberdPresent` for Unicode U+2F3D.

Fixes #6253

Wallet: `Do4v7foHJvRJLpRRoGaVPWX6DDEjX3yTK7J91gpwUQpE`

/claim #6253
