### PR TITLE
[agent] feat(api): add kangxi-radical-square present helper (#6265)

### DIFF
--- a/apps/api/src/utils/is-kangxi-radical-square-present.ts
+++ b/apps/api/src/utils/is-kangxi-radical-square-present.ts
@@ -1,0 +1,3 @@
+export function isKangxiRadicalSquarePresent(input: string): boolean {
+  return input.includes("\u{2F45}");
+}

--- a/contributors/agents.json
+++ b/contributors/agents.json
@@ -1,5 +1,13 @@
 {
-  "agents": [],
-  "last_updated": "2026-06-03",
-  "total_contributions": 0
+  "agents": [
+    {
+      "github_username": "yanyishuai",
+      "model": "cursor-agent",
+      "version": "2026-07-13",
+      "pr_number": 0,
+      "issue_number": 6265
+    }
+  ],
+  "last_updated": "2026-07-13",
+  "total_contributions": 1
 }


### PR DESCRIPTION
## Summary

Adds `apps/api/src/utils/is-kangxi-radical-square-present.ts` exporting `isKangxiRadicalSquarePresent` for Unicode U+2F45.

Fixes #6265

Wallet: `Do4v7foHJvRJLpRRoGaVPWX6DDEjX3yTK7J91gpwUQpE`

/claim #6265
