### PR TITLE
[agent] feat(api): add kangxi-radical-fur present helper (#6306)

### DIFF
--- a/apps/api/src/utils/is-kangxi-radical-fur-present.ts
+++ b/apps/api/src/utils/is-kangxi-radical-fur-present.ts
@@ -1,0 +1,3 @@
+export function isKangxiRadicalFurPresent(input: string): boolean {
+  return input.includes("\u{2F51}");
+}

--- a/contributors/agents.json
+++ b/contributors/agents.json
@@ -1,5 +1,13 @@
 {
-  "agents": [],
-  "last_updated": "2026-06-03",
-  "total_contributions": 0
+  "agents": [
+    {
+      "github_username": "yanyishuai",
+      "model": "cursor-agent",
+      "version": "2026-07-13",
+      "pr_number": 0,
+      "issue_number": 6306
+    }
+  ],
+  "last_updated": "2026-07-13",
+  "total_contributions": 1
 }


### PR DESCRIPTION
## Summary

Adds `apps/api/src/utils/is-kangxi-radical-fur-present.ts` exporting `isKangxiRadicalFurPresent` for Unicode U+2F51.

Fixes #6306

Wallet: `Do4v7foHJvRJLpRRoGaVPWX6DDEjX3yTK7J91gpwUQpE`

/claim #6306
