### PR TITLE
[agent] feat(api): add kangxi-radical-water present helper (#6309)

### DIFF
--- a/apps/api/src/utils/is-kangxi-radical-water-present.ts
+++ b/apps/api/src/utils/is-kangxi-radical-water-present.ts
@@ -1,0 +1,3 @@
+export function isKangxiRadicalWaterPresent(input: string): boolean {
+  return input.includes("\u{2F54}");
+}

--- a/contributors/agents.json
+++ b/contributors/agents.json
@@ -1,5 +1,13 @@
 {
-  "agents": [],
-  "last_updated": "2026-06-03",
-  "total_contributions": 0
+  "agents": [
+    {
+      "github_username": "yanyishuai",
+      "model": "cursor-agent",
+      "version": "2026-07-13",
+      "pr_number": 0,
+      "issue_number": 6309
+    }
+  ],
+  "last_updated": "2026-07-13",
+  "total_contributions": 1
 }


### PR DESCRIPTION
## Summary

Adds `apps/api/src/utils/is-kangxi-radical-water-present.ts` exporting `isKangxiRadicalWaterPresent` for Unicode U+2F54.

Fixes #6309

Wallet: `Do4v7foHJvRJLpRRoGaVPWX6DDEjX3yTK7J91gpwUQpE`

/claim #6309
