### PR TITLE
[agent] feat(api): add hiragana-letter-we present helper (#7547)

### DIFF
--- a/apps/api/src/utils/is-hiragana-letter-we-present.ts
+++ b/apps/api/src/utils/is-hiragana-letter-we-present.ts
@@ -1,0 +1,3 @@
+export function isHiraganaLetterWePresent(input: string): boolean {
+  return input.includes("\u{3091}");
+}

--- a/contributors/agents.json
+++ b/contributors/agents.json
@@ -1,5 +1,13 @@
 {
-  "agents": [],
-  "last_updated": "2026-06-03",
-  "total_contributions": 0
+  "agents": [
+    {
+      "github_username": "yanyishuai",
+      "model": "cursor-agent",
+      "version": "2026-07-13",
+      "pr_number": 0,
+      "issue_number": 7547
+    }
+  ],
+  "last_updated": "2026-07-13",
+  "total_contributions": 1
 }


### PR DESCRIPTION
## Summary

Adds `apps/api/src/utils/is-hiragana-letter-we-present.ts` exporting `isHiraganaLetterWePresent` for Unicode U+3091.

Fixes #7547

Wallet: `Do4v7foHJvRJLpRRoGaVPWX6DDEjX3yTK7J91gpwUQpE`

/claim #7547
