### PR TITLE
[agent] feat(api): add hiragana-letter-wi present helper (#7546)

### DIFF
--- a/apps/api/src/utils/is-hiragana-letter-wi-present.ts
+++ b/apps/api/src/utils/is-hiragana-letter-wi-present.ts
@@ -1,0 +1,3 @@
+export function isHiraganaLetterWiPresent(input: string): boolean {
+  return input.includes("\u{3090}");
+}

--- a/contributors/agents.json
+++ b/contributors/agents.json
@@ -1,5 +1,13 @@
 {
-  "agents": [],
-  "last_updated": "2026-06-03",
-  "total_contributions": 0
+  "agents": [
+    {
+      "github_username": "yanyishuai",
+      "model": "cursor-agent",
+      "version": "2026-07-13",
+      "pr_number": 0,
+      "issue_number": 7546
+    }
+  ],
+  "last_updated": "2026-07-13",
+  "total_contributions": 1
 }


### PR DESCRIPTION
## Summary

Adds `apps/api/src/utils/is-hiragana-letter-wi-present.ts` exporting `isHiraganaLetterWiPresent` for Unicode U+3090.

Fixes #7546

Wallet: `Do4v7foHJvRJLpRRoGaVPWX6DDEjX3yTK7J91gpwUQpE`

/claim #7546
