### PR TITLE
[agent] feat(api): add kangxi-radical-nose present helper (#6681)

### DIFF
--- a/apps/api/src/utils/is-kangxi-radical-nose-present.ts
+++ b/apps/api/src/utils/is-kangxi-radical-nose-present.ts
@@ -1,0 +1,3 @@
+export function isKangxiRadicalNosePresent(input: string): boolean {
+  return input.includes("\u{2FD0}");
+}

--- a/contributors/agents.json
+++ b/contributors/agents.json
@@ -1,5 +1,13 @@
 {
-  "agents": [],
-  "last_updated": "2026-06-03",
-  "total_contributions": 0
+  "agents": [
+    {
+      "github_username": "yanyishuai",
+      "model": "cursor-agent",
+      "version": "2026-07-13",
+      "pr_number": 0,
+      "issue_number": 6681
+    }
+  ],
+  "last_updated": "2026-07-13",
+  "total_contributions": 1
 }


### PR DESCRIPTION
## Summary

Adds `apps/api/src/utils/is-kangxi-radical-nose-present.ts` exporting `isKangxiRadicalNosePresent` for Unicode U+2FD0.

Fixes #6681

Wallet: `Do4v7foHJvRJLpRRoGaVPWX6DDEjX3yTK7J91gpwUQpE`

/claim #6681
