### PR TITLE
[agent] feat(api): add kangxi-radical-deer present helper (#6669)

### DIFF
--- a/apps/api/src/utils/is-kangxi-radical-deer-present.ts
+++ b/apps/api/src/utils/is-kangxi-radical-deer-present.ts
@@ -1,0 +1,3 @@
+export function isKangxiRadicalDeerPresent(input: string): boolean {
+  return input.includes("\u{2FC5}");
+}

--- a/contributors/agents.json
+++ b/contributors/agents.json
@@ -1,5 +1,13 @@
 {
-  "agents": [],
-  "last_updated": "2026-06-03",
-  "total_contributions": 0
+  "agents": [
+    {
+      "github_username": "yanyishuai",
+      "model": "cursor-agent",
+      "version": "2026-07-13",
+      "pr_number": 0,
+      "issue_number": 6669
+    }
+  ],
+  "last_updated": "2026-07-13",
+  "total_contributions": 1
 }


### PR DESCRIPTION
## Summary

Adds `apps/api/src/utils/is-kangxi-radical-deer-present.ts` exporting `isKangxiRadicalDeerPresent` for Unicode U+2FC5.

Fixes #6669

Wallet: `Do4v7foHJvRJLpRRoGaVPWX6DDEjX3yTK7J91gpwUQpE`

/claim #6669
