### PR TITLE
Add is-hiragana-voiced-sound-mark-present API utility

### DIFF
--- a/apps/api/src/utils/is-hiragana-voiced-sound-mark-present.ts
+++ b/apps/api/src/utils/is-hiragana-voiced-sound-mark-present.ts
@@ -1,0 +1,3 @@
+export function isHiraganaVoicedSoundMarkPresent(input: string): boolean {
+  return input.includes("\u309b");
+}

--- a/contributors/agents.json
+++ b/contributors/agents.json
@@ -1,5 +1,14 @@
 {
-  "agents": [],
-  "last_updated": "2026-06-03",
-  "total_contributions": 0
+    "agents":  [
+                   {
+                       "version":  "2026-06-16",
+                       "claim":  "/claim #7621",
+                       "github_username":  "ChaiXinLong-tech",
+                       "model":  "GPT-5 Codex",
+                       "issue_number":  7621,
+                       "pr_number":  0
+                   }
+               ],
+    "last_updated":  "2026-07-15",
+    "total_contributions":  1
 }

--- a/contributors/agents.json
+++ b/contributors/agents.json
@@ -6,7 +6,7 @@
                        "github_username":  "ChaiXinLong-tech",
                        "model":  "GPT-5 Codex",
                        "issue_number":  7621,
-                       "pr_number":  0
+                       "pr_number":  7628
                    }
                ],
     "last_updated":  "2026-07-15",


### PR DESCRIPTION
Closes #7621

/claim #7621

## Summary
- Add $fn() for detecting the Unicode Hiragana voiced sound mark character (U+309B).
- Keep the helper dependency-free and scoped to a single API utility file.
- Update contributors/agents.json for this bounty claim.

## Tests
- RED: work/agent-playground/node_modules/.bin/tsc.cmd --noEmit --strict --lib es2020 outputs/tmp-batch216/*.test.ts failed before helper modules existed.
- GREEN: work/agent-playground/node_modules/.bin/tsc.cmd --noEmit --strict --lib es2020 ... passed for the batch helper and test files.
- GREEN: compiled the batch helper tests to outputs/tmp-batch216/dist and executed 5 Node test files.