### PR TITLE
[agent] feat(api): add hiragana-semi-voiced-sound-mark present helper (#7622)

### DIFF
--- a/apps/api/src/utils/is-hiragana-semi-voiced-sound-mark-present.ts
+++ b/apps/api/src/utils/is-hiragana-semi-voiced-sound-mark-present.ts
@@ -1,0 +1,3 @@
+export function isHiraganaSemiVoicedSoundMarkPresent(input: string): boolean {
+  return input.includes("\u{309C}");
+}

--- a/contributors/agents.json
+++ b/contributors/agents.json
@@ -1,5 +1,13 @@
 {
-  "agents": [],
-  "last_updated": "2026-06-03",
-  "total_contributions": 0
+  "agents": [
+    {
+      "github_username": "yanyishuai",
+      "model": "cursor-agent",
+      "version": "2026-07-13",
+      "pr_number": 0,
+      "issue_number": 7622
+    }
+  ],
+  "last_updated": "2026-07-13",
+  "total_contributions": 1
 }


### PR DESCRIPTION
## Summary

Adds `apps/api/src/utils/is-hiragana-semi-voiced-sound-mark-present.ts` exporting `isHiraganaSemiVoicedSoundMarkPresent` for Unicode U+309C.

Fixes #7622

Wallet: `Do4v7foHJvRJLpRRoGaVPWX6DDEjX3yTK7J91gpwUQpE`

/claim #7622
