### PR TITLE
[agent] feat(api): add hiragana-combining-semi-voiced-sound-mark present helper (#7620)

### DIFF
--- a/apps/api/src/utils/is-hiragana-combining-semi-voiced-sound-mark-present.ts
+++ b/apps/api/src/utils/is-hiragana-combining-semi-voiced-sound-mark-present.ts
@@ -1,0 +1,3 @@
+export function isHiraganaCombiningSemiVoicedSoundMarkPresent(input: string): boolean {
+  return input.includes("\u{309A}");
+}

--- a/contributors/agents.json
+++ b/contributors/agents.json
@@ -1,5 +1,13 @@
 {
-  "agents": [],
-  "last_updated": "2026-06-03",
-  "total_contributions": 0
+  "agents": [
+    {
+      "github_username": "yanyishuai",
+      "model": "cursor-agent",
+      "version": "2026-07-13",
+      "pr_number": 0,
+      "issue_number": 7620
+    }
+  ],
+  "last_updated": "2026-07-13",
+  "total_contributions": 1
 }


### PR DESCRIPTION
## Summary

Adds `apps/api/src/utils/is-hiragana-combining-semi-voiced-sound-mark-present.ts` exporting `isHiraganaCombiningSemiVoicedSoundMarkPresent` for Unicode U+309A.

Fixes #7620

Wallet: `Do4v7foHJvRJLpRRoGaVPWX6DDEjX3yTK7J91gpwUQpE`

/claim #7620
