### PR TITLE
[agent] feat(api): add kangxi-radical-tanned-leather present helper (#6587)

### DIFF
--- a/apps/api/src/utils/is-kangxi-radical-tanned-leather-present.ts
+++ b/apps/api/src/utils/is-kangxi-radical-tanned-leather-present.ts
@@ -1,0 +1,3 @@
+export function isKangxiRadicalTannedLeatherPresent(input: string): boolean {
+  return input.includes("\u{2FB1}");
+}

--- a/contributors/agents.json
+++ b/contributors/agents.json
@@ -1,5 +1,13 @@
 {
-  "agents": [],
-  "last_updated": "2026-06-03",
-  "total_contributions": 0
+  "agents": [
+    {
+      "github_username": "yanyishuai",
+      "model": "cursor-agent",
+      "version": "2026-07-13",
+      "pr_number": 0,
+      "issue_number": 6587
+    }
+  ],
+  "last_updated": "2026-07-13",
+  "total_contributions": 1
 }


### PR DESCRIPTION
## Summary

Adds `apps/api/src/utils/is-kangxi-radical-tanned-leather-present.ts` exporting `isKangxiRadicalTannedLeatherPresent` for Unicode U+2FB1.

Fixes #6587

Wallet: `Do4v7foHJvRJLpRRoGaVPWX6DDEjX3yTK7J91gpwUQpE`

/claim #6587
