### PR TITLE
[agent] feat(api): add cjk-radical-second-two present helper (#5788)

### DIFF
--- a/apps/api/src/utils/is-cjk-radical-second-two-present.ts
+++ b/apps/api/src/utils/is-cjk-radical-second-two-present.ts
@@ -1,0 +1,3 @@
+export function isCjkRadicalSecondTwoPresent(input: string): boolean {
+  return input.includes("\u{2E83}");
+}

--- a/contributors/agents.json
+++ b/contributors/agents.json
@@ -1,5 +1,13 @@
 {
-  "agents": [],
-  "last_updated": "2026-06-03",
-  "total_contributions": 0
+  "agents": [
+    {
+      "github_username": "yanyishuai",
+      "model": "cursor-agent",
+      "version": "2026-07-13",
+      "pr_number": 0,
+      "issue_number": 5788
+    }
+  ],
+  "last_updated": "2026-07-13",
+  "total_contributions": 1
 }


### PR DESCRIPTION
## Summary

Adds `apps/api/src/utils/is-cjk-radical-second-two-present.ts` exporting `isCjkRadicalSecondTwoPresent` for Unicode U+2E83.

Fixes #5788

Wallet: `Do4v7foHJvRJLpRRoGaVPWX6DDEjX3yTK7J91gpwUQpE`

/claim #5788
