### PR TITLE
[agent] feat(api): add top-half-right-parenthesis present helper (#5777)

### DIFF
--- a/apps/api/src/utils/is-top-half-right-parenthesis-present.ts
+++ b/apps/api/src/utils/is-top-half-right-parenthesis-present.ts
@@ -1,0 +1,3 @@
+export function isTopHalfRightParenthesisPresent(input: string): boolean {
+  return input.includes("\u{2E5A}");
+}

--- a/contributors/agents.json
+++ b/contributors/agents.json
@@ -1,5 +1,13 @@
 {
-  "agents": [],
-  "last_updated": "2026-06-03",
-  "total_contributions": 0
+  "agents": [
+    {
+      "github_username": "yanyishuai",
+      "model": "cursor-agent",
+      "version": "2026-07-13",
+      "pr_number": 0,
+      "issue_number": 5777
+    }
+  ],
+  "last_updated": "2026-07-13",
+  "total_contributions": 1
 }


### PR DESCRIPTION
## Summary

Adds `apps/api/src/utils/is-top-half-right-parenthesis-present.ts` exporting `isTopHalfRightParenthesisPresent` for Unicode U+2E5A.

Fixes #5777

Wallet: `Do4v7foHJvRJLpRRoGaVPWX6DDEjX3yTK7J91gpwUQpE`

/claim #5777
