### PR TITLE
[agent] feat(api): add left-square-bracket-with-double-stroke present helper (#5774)

### DIFF
--- a/apps/api/src/utils/is-left-square-bracket-with-double-stroke-present.ts
+++ b/apps/api/src/utils/is-left-square-bracket-with-double-stroke-present.ts
@@ -1,0 +1,3 @@
+export function isLeftSquareBracketWithDoubleStrokePresent(input: string): boolean {
+  return input.includes("\u{2E57}");
+}

--- a/contributors/agents.json
+++ b/contributors/agents.json
@@ -1,5 +1,13 @@
 {
-  "agents": [],
-  "last_updated": "2026-06-03",
-  "total_contributions": 0
+  "agents": [
+    {
+      "github_username": "yanyishuai",
+      "model": "cursor-agent",
+      "version": "2026-07-13",
+      "pr_number": 0,
+      "issue_number": 5774
+    }
+  ],
+  "last_updated": "2026-07-13",
+  "total_contributions": 1
 }


### PR DESCRIPTION
## Summary

Adds `apps/api/src/utils/is-left-square-bracket-with-double-stroke-present.ts` exporting `isLeftSquareBracketWithDoubleStrokePresent` for Unicode U+2E57.

Fixes #5774

Wallet: `Do4v7foHJvRJLpRRoGaVPWX6DDEjX3yTK7J91gpwUQpE`

/claim #5774
