### PR TITLE
[agent] feat(api): add medieval-question-mark present helper (#5767)

### DIFF
--- a/apps/api/src/utils/is-medieval-question-mark-present.ts
+++ b/apps/api/src/utils/is-medieval-question-mark-present.ts
@@ -1,0 +1,3 @@
+export function isMedievalQuestionMarkPresent(input: string): boolean {
+  return input.includes("\u{2E54}");
+}

--- a/contributors/agents.json
+++ b/contributors/agents.json
@@ -1,5 +1,13 @@
 {
-  "agents": [],
-  "last_updated": "2026-06-03",
-  "total_contributions": 0
+  "agents": [
+    {
+      "github_username": "yanyishuai",
+      "model": "cursor-agent",
+      "version": "2026-07-13",
+      "pr_number": 0,
+      "issue_number": 5767
+    }
+  ],
+  "last_updated": "2026-07-13",
+  "total_contributions": 1
 }


### PR DESCRIPTION
## Summary

Adds `apps/api/src/utils/is-medieval-question-mark-present.ts` exporting `isMedievalQuestionMarkPresent` for Unicode U+2E54.

Fixes #5767

Wallet: `Do4v7foHJvRJLpRRoGaVPWX6DDEjX3yTK7J91gpwUQpE`

/claim #5767
