### PR TITLE
[agent] feat(api): add cornish-verse-divider present helper (#5758)

### DIFF
--- a/apps/api/src/utils/is-cornish-verse-divider-present.ts
+++ b/apps/api/src/utils/is-cornish-verse-divider-present.ts
@@ -1,0 +1,3 @@
+export function isCornishVerseDividerPresent(input: string): boolean {
+  return input.includes("\u{2E4F}");
+}

--- a/contributors/agents.json
+++ b/contributors/agents.json
@@ -1,5 +1,13 @@
 {
-  "agents": [],
-  "last_updated": "2026-06-03",
-  "total_contributions": 0
+  "agents": [
+    {
+      "github_username": "yanyishuai",
+      "model": "cursor-agent",
+      "version": "2026-07-13",
+      "pr_number": 0,
+      "issue_number": 5758
+    }
+  ],
+  "last_updated": "2026-07-13",
+  "total_contributions": 1
 }


### PR DESCRIPTION
## Summary

Adds `apps/api/src/utils/is-cornish-verse-divider-present.ts` exporting `isCornishVerseDividerPresent` for Unicode U+2E4F.

Fixes #5758

Wallet: `Do4v7foHJvRJLpRRoGaVPWX6DDEjX3yTK7J91gpwUQpE`

/claim #5758
