### PR TITLE
Add is-hiragana-voiced-iteration-mark-present API utility

### DIFF
--- a/apps/api/src/utils/is-hiragana-voiced-iteration-mark-present.ts
+++ b/apps/api/src/utils/is-hiragana-voiced-iteration-mark-present.ts
@@ -1,0 +1,3 @@
+export function isHiraganaVoicedIterationMarkPresent(input: string): boolean {
+  return input.includes("\u309e");
+}

--- a/contributors/agents.json
+++ b/contributors/agents.json
@@ -6,7 +6,7 @@
                        "github_username":  "ChaiXinLong-tech",
                        "model":  "GPT-5 Codex",
                        "issue_number":  7666,
-                       "pr_number":  0
+                       "pr_number":  7673
                    }
                ],
     "last_updated":  "2026-07-15",

--- a/contributors/agents.json
+++ b/contributors/agents.json
@@ -1,5 +1,14 @@
 {
-  "agents": [],
-  "last_updated": "2026-06-03",
-  "total_contributions": 0
+    "agents":  [
+                   {
+                       "version":  "2026-06-16",
+                       "claim":  "/claim #7666",
+                       "github_username":  "ChaiXinLong-tech",
+                       "model":  "GPT-5 Codex",
+                       "issue_number":  7666,
+                       "pr_number":  0
+                   }
+               ],
+    "last_updated":  "2026-07-15",
+    "total_contributions":  1
 }


### PR DESCRIPTION
Closes #7666

/claim #7666

## Summary
- Add $fn() for detecting the Unicode Hiragana voiced iteration mark character (U+309E).
- Keep the helper dependency-free and scoped to a single API utility file.
- Update contributors/agents.json for this bounty claim.

## Tests
- RED: work/agent-playground/node_modules/.bin/tsc.cmd --noEmit --strict --lib es2020 outputs/tmp-batch217/*.test.ts failed before helper modules existed.
- GREEN: work/agent-playground/node_modules/.bin/tsc.cmd --noEmit --strict --lib es2020 ... passed for the batch helper and test files.
- GREEN: compiled the batch helper tests to outputs/tmp-batch217/dist and executed 5 Node test files.