### PR TITLE
[agent] feat(api): add medieval-comma present helper (#5755)

### DIFF
--- a/apps/api/src/utils/is-medieval-comma-present.ts
+++ b/apps/api/src/utils/is-medieval-comma-present.ts
@@ -1,0 +1,3 @@
+export function isMedievalCommaPresent(input: string): boolean {
+  return input.includes("\u{2E4C}");
+}

--- a/contributors/agents.json
+++ b/contributors/agents.json
@@ -1,5 +1,13 @@
 {
-  "agents": [],
-  "last_updated": "2026-06-03",
-  "total_contributions": 0
+  "agents": [
+    {
+      "github_username": "yanyishuai",
+      "model": "cursor-agent",
+      "version": "2026-07-13",
+      "pr_number": 0,
+      "issue_number": 5755
+    }
+  ],
+  "last_updated": "2026-07-13",
+  "total_contributions": 1
 }


### PR DESCRIPTION
## Summary

Adds `apps/api/src/utils/is-medieval-comma-present.ts` exporting `isMedievalCommaPresent` for Unicode U+2E4C.

Fixes #5755

Wallet: `Do4v7foHJvRJLpRRoGaVPWX6DDEjX3yTK7J91gpwUQpE`

/claim #5755
