### PR TITLE
[agent] feat(api): add low-kavyka present helper (#5737)

### DIFF
--- a/apps/api/src/utils/is-low-kavyka-present.ts
+++ b/apps/api/src/utils/is-low-kavyka-present.ts
@@ -1,0 +1,3 @@
+export function isLowKavykaPresent(input: string): boolean {
+  return input.includes("\u{2E47}");
+}

--- a/contributors/agents.json
+++ b/contributors/agents.json
@@ -1,5 +1,13 @@
 {
-  "agents": [],
-  "last_updated": "2026-06-03",
-  "total_contributions": 0
+  "agents": [
+    {
+      "github_username": "yanyishuai",
+      "model": "cursor-agent",
+      "version": "2026-07-13",
+      "pr_number": 0,
+      "issue_number": 5737
+    }
+  ],
+  "last_updated": "2026-07-13",
+  "total_contributions": 1
 }


### PR DESCRIPTION
## Summary

Adds `apps/api/src/utils/is-low-kavyka-present.ts` exporting `isLowKavykaPresent` for Unicode U+2E47.

Fixes #5737

Wallet: `Do4v7foHJvRJLpRRoGaVPWX6DDEjX3yTK7J91gpwUQpE`

/claim #5737
