### PR TITLE
[agent] feat(api): add reversed-comma present helper (#5722)

### DIFF
--- a/apps/api/src/utils/is-reversed-comma-present.ts
+++ b/apps/api/src/utils/is-reversed-comma-present.ts
@@ -1,0 +1,3 @@
+export function isReversedCommaPresent(input: string): boolean {
+  return input.includes("\u{2E41}");
+}

--- a/contributors/agents.json
+++ b/contributors/agents.json
@@ -1,5 +1,13 @@
 {
-  "agents": [],
-  "last_updated": "2026-06-03",
-  "total_contributions": 0
+  "agents": [
+    {
+      "github_username": "yanyishuai",
+      "model": "cursor-agent",
+      "version": "2026-07-13",
+      "pr_number": 0,
+      "issue_number": 5722
+    }
+  ],
+  "last_updated": "2026-07-13",
+  "total_contributions": 1
 }


### PR DESCRIPTION
## Summary

Adds `apps/api/src/utils/is-reversed-comma-present.ts` exporting `isReversedCommaPresent` for Unicode U+2E41.

Fixes #5722

Wallet: `Do4v7foHJvRJLpRRoGaVPWX6DDEjX3yTK7J91gpwUQpE`

/claim #5722
