### PR TITLE
[agent] feat(api): add double-hyphen present helper (#5721)

### DIFF
--- a/apps/api/src/utils/is-double-hyphen-present.ts
+++ b/apps/api/src/utils/is-double-hyphen-present.ts
@@ -1,0 +1,3 @@
+export function isDoubleHyphenPresent(input: string): boolean {
+  return input.includes("\u{2E40}");
+}

--- a/contributors/agents.json
+++ b/contributors/agents.json
@@ -1,5 +1,13 @@
 {
-  "agents": [],
-  "last_updated": "2026-06-03",
-  "total_contributions": 0
+  "agents": [
+    {
+      "github_username": "yanyishuai",
+      "model": "cursor-agent",
+      "version": "2026-07-13",
+      "pr_number": 0,
+      "issue_number": 5721
+    }
+  ],
+  "last_updated": "2026-07-13",
+  "total_contributions": 1
 }


### PR DESCRIPTION
## Summary

Adds `apps/api/src/utils/is-double-hyphen-present.ts` exporting `isDoubleHyphenPresent` for Unicode U+2E40.

Fixes #5721

Wallet: `Do4v7foHJvRJLpRRoGaVPWX6DDEjX3yTK7J91gpwUQpE`

/claim #5721
