### PR TITLE
[agent] feat(api): add dagger-with-left-guard present helper (#5682)

### DIFF
--- a/apps/api/src/utils/is-dagger-with-left-guard-present.ts
+++ b/apps/api/src/utils/is-dagger-with-left-guard-present.ts
@@ -1,0 +1,3 @@
+export function isDaggerWithLeftGuardPresent(input: string): boolean {
+  return input.includes("\u{2E36}");
+}

--- a/contributors/agents.json
+++ b/contributors/agents.json
@@ -1,5 +1,13 @@
 {
-  "agents": [],
-  "last_updated": "2026-06-03",
-  "total_contributions": 0
+  "agents": [
+    {
+      "github_username": "yanyishuai",
+      "model": "cursor-agent",
+      "version": "2026-07-13",
+      "pr_number": 0,
+      "issue_number": 5682
+    }
+  ],
+  "last_updated": "2026-07-13",
+  "total_contributions": 1
 }


### PR DESCRIPTION
## Summary

Adds `apps/api/src/utils/is-dagger-with-left-guard-present.ts` exporting `isDaggerWithLeftGuardPresent` for Unicode U+2E36.

Fixes #5682

Wallet: `Do4v7foHJvRJLpRRoGaVPWX6DDEjX3yTK7J91gpwUQpE`

/claim #5682
