### PR TITLE
[agent] feat(api): add squared-four-dot-punctuation present helper (#5639)

### DIFF
--- a/apps/api/src/utils/is-squared-four-dot-punctuation-present.ts
+++ b/apps/api/src/utils/is-squared-four-dot-punctuation-present.ts
@@ -1,0 +1,3 @@
+export function isSquaredFourDotPunctuationPresent(input: string): boolean {
+  return input.includes("\u{2E2C}");
+}

--- a/contributors/agents.json
+++ b/contributors/agents.json
@@ -1,5 +1,13 @@
 {
-  "agents": [],
-  "last_updated": "2026-06-03",
-  "total_contributions": 0
+  "agents": [
+    {
+      "github_username": "yanyishuai",
+      "model": "cursor-agent",
+      "version": "2026-07-13",
+      "pr_number": 0,
+      "issue_number": 5639
+    }
+  ],
+  "last_updated": "2026-07-13",
+  "total_contributions": 1
 }


### PR DESCRIPTION
## Summary

Adds `apps/api/src/utils/is-squared-four-dot-punctuation-present.ts` exporting `isSquaredFourDotPunctuationPresent` for Unicode U+2E2C.

Fixes #5639

Wallet: `Do4v7foHJvRJLpRRoGaVPWX6DDEjX3yTK7J91gpwUQpE`

/claim #5639
