### PR TITLE
[agent] feat(api): add left-double-parenthesis present helper (#5631)

### DIFF
--- a/apps/api/src/utils/is-left-double-parenthesis-present.ts
+++ b/apps/api/src/utils/is-left-double-parenthesis-present.ts
@@ -1,0 +1,3 @@
+export function isLeftDoubleParenthesisPresent(input: string): boolean {
+  return input.includes("\u{2E28}");
+}

--- a/contributors/agents.json
+++ b/contributors/agents.json
@@ -1,5 +1,13 @@
 {
-  "agents": [],
-  "last_updated": "2026-06-03",
-  "total_contributions": 0
+  "agents": [
+    {
+      "github_username": "yanyishuai",
+      "model": "cursor-agent",
+      "version": "2026-07-13",
+      "pr_number": 0,
+      "issue_number": 5631
+    }
+  ],
+  "last_updated": "2026-07-13",
+  "total_contributions": 1
 }


### PR DESCRIPTION
## Summary

Adds `apps/api/src/utils/is-left-double-parenthesis-present.ts` exporting `isLeftDoubleParenthesisPresent` for Unicode U+2E28.

Fixes #5631

Wallet: `Do4v7foHJvRJLpRRoGaVPWX6DDEjX3yTK7J91gpwUQpE`

/claim #5631
