### PR TITLE
[agent] feat(api): add left-sideways-u-bracket present helper (#5629)

### DIFF
--- a/apps/api/src/utils/is-left-sideways-u-bracket-present.ts
+++ b/apps/api/src/utils/is-left-sideways-u-bracket-present.ts
@@ -1,0 +1,3 @@
+export function isLeftSidewaysUBracketPresent(input: string): boolean {
+  return input.includes("\u{2E26}");
+}

--- a/contributors/agents.json
+++ b/contributors/agents.json
@@ -1,5 +1,13 @@
 {
-  "agents": [],
-  "last_updated": "2026-06-03",
-  "total_contributions": 0
+  "agents": [
+    {
+      "github_username": "yanyishuai",
+      "model": "cursor-agent",
+      "version": "2026-07-13",
+      "pr_number": 0,
+      "issue_number": 5629
+    }
+  ],
+  "last_updated": "2026-07-13",
+  "total_contributions": 1
 }


### PR DESCRIPTION
## Summary

Adds `apps/api/src/utils/is-left-sideways-u-bracket-present.ts` exporting `isLeftSidewaysUBracketPresent` for Unicode U+2E26.

Fixes #5629

Wallet: `Do4v7foHJvRJLpRRoGaVPWX6DDEjX3yTK7J91gpwUQpE`

/claim #5629
