### PR TITLE
[agent] feat(api): add tilde-with-dot-below present helper (#5604)

### DIFF
--- a/apps/api/src/utils/is-tilde-with-dot-below-present.ts
+++ b/apps/api/src/utils/is-tilde-with-dot-below-present.ts
@@ -1,0 +1,3 @@
+export function isTildeWithDotBelowPresent(input: string): boolean {
+  return input.includes("\u{2E1F}");
+}

--- a/contributors/agents.json
+++ b/contributors/agents.json
@@ -1,5 +1,13 @@
 {
-  "agents": [],
-  "last_updated": "2026-06-03",
-  "total_contributions": 0
+  "agents": [
+    {
+      "github_username": "yanyishuai",
+      "model": "cursor-agent",
+      "version": "2026-07-13",
+      "pr_number": 0,
+      "issue_number": 5604
+    }
+  ],
+  "last_updated": "2026-07-13",
+  "total_contributions": 1
 }


### PR DESCRIPTION
## Summary

Adds `apps/api/src/utils/is-tilde-with-dot-below-present.ts` exporting `isTildeWithDotBelowPresent` for Unicode U+2E1F.

Fixes #5604

Wallet: `Do4v7foHJvRJLpRRoGaVPWX6DDEjX3yTK7J91gpwUQpE`

/claim #5604
