### PR TITLE
[agent] feat(api): add hyphen-with-diaeresis present helper (#5589)

### DIFF
--- a/apps/api/src/utils/is-hyphen-with-diaeresis-present.ts
+++ b/apps/api/src/utils/is-hyphen-with-diaeresis-present.ts
@@ -1,0 +1,3 @@
+export function isHyphenWithDiaeresisPresent(input: string): boolean {
+  return input.includes("\u{2E1A}");
+}

--- a/contributors/agents.json
+++ b/contributors/agents.json
@@ -1,5 +1,13 @@
 {
-  "agents": [],
-  "last_updated": "2026-06-03",
-  "total_contributions": 0
+  "agents": [
+    {
+      "github_username": "yanyishuai",
+      "model": "cursor-agent",
+      "version": "2026-07-13",
+      "pr_number": 0,
+      "issue_number": 5589
+    }
+  ],
+  "last_updated": "2026-07-13",
+  "total_contributions": 1
 }


### PR DESCRIPTION
## Summary

Adds `apps/api/src/utils/is-hyphen-with-diaeresis-present.ts` exporting `isHyphenWithDiaeresisPresent` for Unicode U+2E1A.

Fixes #5589

Wallet: `Do4v7foHJvRJLpRRoGaVPWX6DDEjX3yTK7J91gpwUQpE`

/claim #5589
