### PR TITLE
[agent] feat(api): add editorial-coronis present helper (#5491)

### DIFF
--- a/apps/api/src/utils/is-editorial-coronis-present.ts
+++ b/apps/api/src/utils/is-editorial-coronis-present.ts
@@ -1,0 +1,3 @@
+export function isEditorialCoronisPresent(input: string): boolean {
+  return input.includes("\u{2E0E}");
+}

--- a/contributors/agents.json
+++ b/contributors/agents.json
@@ -1,5 +1,13 @@
 {
-  "agents": [],
-  "last_updated": "2026-06-03",
-  "total_contributions": 0
+  "agents": [
+    {
+      "github_username": "yanyishuai",
+      "model": "cursor-agent",
+      "version": "2026-07-13",
+      "pr_number": 0,
+      "issue_number": 5491
+    }
+  ],
+  "last_updated": "2026-07-13",
+  "total_contributions": 1
 }


### PR DESCRIPTION
## Summary

Adds `apps/api/src/utils/is-editorial-coronis-present.ts` exporting `isEditorialCoronisPresent` for Unicode U+2E0E.

Fixes #5491

Wallet: `Do4v7foHJvRJLpRRoGaVPWX6DDEjX3yTK7J91gpwUQpE`

/claim #5491
