### PR TITLE
[agent] feat(api): add raised-dotted-interpolation-marker present helper (#5480)

### DIFF
--- a/apps/api/src/utils/is-raised-dotted-interpolation-marker-present.ts
+++ b/apps/api/src/utils/is-raised-dotted-interpolation-marker-present.ts
@@ -1,0 +1,3 @@
+export function isRaisedDottedInterpolationMarkerPresent(input: string): boolean {
+  return input.includes("\u{2E07}");
+}

--- a/contributors/agents.json
+++ b/contributors/agents.json
@@ -1,5 +1,13 @@
 {
-  "agents": [],
-  "last_updated": "2026-06-03",
-  "total_contributions": 0
+  "agents": [
+    {
+      "github_username": "yanyishuai",
+      "model": "cursor-agent",
+      "version": "2026-07-13",
+      "pr_number": 0,
+      "issue_number": 5480
+    }
+  ],
+  "last_updated": "2026-07-13",
+  "total_contributions": 1
 }


### PR DESCRIPTION
## Summary

Adds `apps/api/src/utils/is-raised-dotted-interpolation-marker-present.ts` exporting `isRaisedDottedInterpolationMarkerPresent` for Unicode U+2E07.

Fixes #5480

Wallet: `Do4v7foHJvRJLpRRoGaVPWX6DDEjX3yTK7J91gpwUQpE`

/claim #5480
