### PR TITLE
[agent] feat(api): add right-angle-dotted-substitution-marker present helper (#5469)

### DIFF
--- a/apps/api/src/utils/is-right-angle-dotted-substitution-marker-present.ts
+++ b/apps/api/src/utils/is-right-angle-dotted-substitution-marker-present.ts
@@ -1,0 +1,3 @@
+export function isRightAngleDottedSubstitutionMarkerPresent(input: string): boolean {
+  return input.includes("\u{2E01}");
+}

--- a/contributors/agents.json
+++ b/contributors/agents.json
@@ -1,5 +1,13 @@
 {
-  "agents": [],
-  "last_updated": "2026-06-03",
-  "total_contributions": 0
+  "agents": [
+    {
+      "github_username": "yanyishuai",
+      "model": "cursor-agent",
+      "version": "2026-07-13",
+      "pr_number": 0,
+      "issue_number": 5469
+    }
+  ],
+  "last_updated": "2026-07-13",
+  "total_contributions": 1
 }


### PR DESCRIPTION
## Summary

Adds `apps/api/src/utils/is-right-angle-dotted-substitution-marker-present.ts` exporting `isRightAngleDottedSubstitutionMarkerPresent` for Unicode U+2E01.

Fixes #5469

Wallet: `Do4v7foHJvRJLpRRoGaVPWX6DDEjX3yTK7J91gpwUQpE`

/claim #5469
