### PR TITLE
[agent] feat(api): add commercial-minus-sign present helper (#5449)

### DIFF
--- a/apps/api/src/utils/is-commercial-minus-sign-present.ts
+++ b/apps/api/src/utils/is-commercial-minus-sign-present.ts
@@ -1,0 +1,3 @@
+export function isCommercialMinusSignPresent(input: string): boolean {
+  return input.includes("\u{2052}");
+}

--- a/contributors/agents.json
+++ b/contributors/agents.json
@@ -1,5 +1,13 @@
 {
-  "agents": [],
-  "last_updated": "2026-06-03",
-  "total_contributions": 0
+  "agents": [
+    {
+      "github_username": "yanyishuai",
+      "model": "cursor-agent",
+      "version": "2026-07-13",
+      "pr_number": 0,
+      "issue_number": 5449
+    }
+  ],
+  "last_updated": "2026-07-13",
+  "total_contributions": 1
 }


### PR DESCRIPTION
## Summary

Adds `apps/api/src/utils/is-commercial-minus-sign-present.ts` exporting `isCommercialMinusSignPresent` for Unicode U+2052.

Fixes #5449

Wallet: `Do4v7foHJvRJLpRRoGaVPWX6DDEjX3yTK7J91gpwUQpE`

/claim #5449
