### PR TITLE
[agent] feat(api): add low-asterisk present helper (#5441)

### DIFF
--- a/apps/api/src/utils/is-low-asterisk-present.ts
+++ b/apps/api/src/utils/is-low-asterisk-present.ts
@@ -1,0 +1,3 @@
+export function isLowAsteriskPresent(input: string): boolean {
+  return input.includes("\u{204E}");
+}

--- a/contributors/agents.json
+++ b/contributors/agents.json
@@ -1,5 +1,13 @@
 {
-  "agents": [],
-  "last_updated": "2026-06-03",
-  "total_contributions": 0
+  "agents": [
+    {
+      "github_username": "yanyishuai",
+      "model": "cursor-agent",
+      "version": "2026-07-13",
+      "pr_number": 0,
+      "issue_number": 5441
+    }
+  ],
+  "last_updated": "2026-07-13",
+  "total_contributions": 1
 }


### PR DESCRIPTION
## Summary

Adds `apps/api/src/utils/is-low-asterisk-present.ts` exporting `isLowAsteriskPresent` for Unicode U+204E.

Fixes #5441

Wallet: `Do4v7foHJvRJLpRRoGaVPWX6DDEjX3yTK7J91gpwUQpE`

/claim #5441
