### PR TITLE
[agent] feat(api): add black-rightwards-bullet present helper (#5440)

### DIFF
--- a/apps/api/src/utils/is-black-rightwards-bullet-present.ts
+++ b/apps/api/src/utils/is-black-rightwards-bullet-present.ts
@@ -1,0 +1,3 @@
+export function isBlackRightwardsBulletPresent(input: string): boolean {
+  return input.includes("\u{204D}");
+}

--- a/contributors/agents.json
+++ b/contributors/agents.json
@@ -1,5 +1,13 @@
 {
-  "agents": [],
-  "last_updated": "2026-06-03",
-  "total_contributions": 0
+  "agents": [
+    {
+      "github_username": "yanyishuai",
+      "model": "cursor-agent",
+      "version": "2026-07-13",
+      "pr_number": 0,
+      "issue_number": 5440
+    }
+  ],
+  "last_updated": "2026-07-13",
+  "total_contributions": 1
 }


### PR DESCRIPTION
## Summary

Adds `apps/api/src/utils/is-black-rightwards-bullet-present.ts` exporting `isBlackRightwardsBulletPresent` for Unicode U+204D.

Fixes #5440

Wallet: `Do4v7foHJvRJLpRRoGaVPWX6DDEjX3yTK7J91gpwUQpE`

/claim #5440
