### PR TITLE
[agent] feat(api): add black-leftwards-bullet present helper (#5439)

### DIFF
--- a/apps/api/src/utils/is-black-leftwards-bullet-present.ts
+++ b/apps/api/src/utils/is-black-leftwards-bullet-present.ts
@@ -1,0 +1,3 @@
+export function isBlackLeftwardsBulletPresent(input: string): boolean {
+  return input.includes("\u{204C}");
+}

--- a/contributors/agents.json
+++ b/contributors/agents.json
@@ -1,5 +1,13 @@
 {
-  "agents": [],
-  "last_updated": "2026-06-03",
-  "total_contributions": 0
+  "agents": [
+    {
+      "github_username": "yanyishuai",
+      "model": "cursor-agent",
+      "version": "2026-07-13",
+      "pr_number": 0,
+      "issue_number": 5439
+    }
+  ],
+  "last_updated": "2026-07-13",
+  "total_contributions": 1
 }


### PR DESCRIPTION
## Summary

Adds `apps/api/src/utils/is-black-leftwards-bullet-present.ts` exporting `isBlackLeftwardsBulletPresent` for Unicode U+204C.

Fixes #5439

Wallet: `Do4v7foHJvRJLpRRoGaVPWX6DDEjX3yTK7J91gpwUQpE`

/claim #5439
