### PR TITLE
[agent] feat(api): add reversed-pilcrow-sign present helper (#5438)

### DIFF
--- a/apps/api/src/utils/is-reversed-pilcrow-sign-present.ts
+++ b/apps/api/src/utils/is-reversed-pilcrow-sign-present.ts
@@ -1,0 +1,3 @@
+export function isReversedPilcrowSignPresent(input: string): boolean {
+  return input.includes("\u{204B}");
+}

--- a/contributors/agents.json
+++ b/contributors/agents.json
@@ -1,5 +1,13 @@
 {
-  "agents": [],
-  "last_updated": "2026-06-03",
-  "total_contributions": 0
+  "agents": [
+    {
+      "github_username": "yanyishuai",
+      "model": "cursor-agent",
+      "version": "2026-07-13",
+      "pr_number": 0,
+      "issue_number": 5438
+    }
+  ],
+  "last_updated": "2026-07-13",
+  "total_contributions": 1
 }


### PR DESCRIPTION
## Summary

Adds `apps/api/src/utils/is-reversed-pilcrow-sign-present.ts` exporting `isReversedPilcrowSignPresent` for Unicode U+204B.

Fixes #5438

Wallet: `Do4v7foHJvRJLpRRoGaVPWX6DDEjX3yTK7J91gpwUQpE`

/claim #5438
