### PR TITLE
[agent] feat(api): add tironian-sign-et present helper (#5437)

### DIFF
--- a/apps/api/src/utils/is-tironian-sign-et-present.ts
+++ b/apps/api/src/utils/is-tironian-sign-et-present.ts
@@ -1,0 +1,3 @@
+export function isTironianSignEtPresent(input: string): boolean {
+  return input.includes("\u{204A}");
+}

--- a/contributors/agents.json
+++ b/contributors/agents.json
@@ -1,5 +1,13 @@
 {
-  "agents": [],
-  "last_updated": "2026-06-03",
-  "total_contributions": 0
+  "agents": [
+    {
+      "github_username": "yanyishuai",
+      "model": "cursor-agent",
+      "version": "2026-07-13",
+      "pr_number": 0,
+      "issue_number": 5437
+    }
+  ],
+  "last_updated": "2026-07-13",
+  "total_contributions": 1
 }


### PR DESCRIPTION
## Summary

Adds `apps/api/src/utils/is-tironian-sign-et-present.ts` exporting `isTironianSignEtPresent` for Unicode U+204A.

Fixes #5437

Wallet: `Do4v7foHJvRJLpRRoGaVPWX6DDEjX3yTK7J91gpwUQpE`

/claim #5437
