### PR TITLE
[agent] feat(api): add interlinear-annotation-terminator present helper (#5400)

### DIFF
--- a/apps/api/src/utils/is-interlinear-annotation-terminator-present.ts
+++ b/apps/api/src/utils/is-interlinear-annotation-terminator-present.ts
@@ -1,0 +1,3 @@
+export function isInterlinearAnnotationTerminatorPresent(input: string): boolean {
+  return input.includes("\u{FFFB}");
+}

--- a/contributors/agents.json
+++ b/contributors/agents.json
@@ -1,5 +1,13 @@
 {
-  "agents": [],
-  "last_updated": "2026-06-03",
-  "total_contributions": 0
+  "agents": [
+    {
+      "github_username": "yanyishuai",
+      "model": "cursor-agent",
+      "version": "2026-07-13",
+      "pr_number": 0,
+      "issue_number": 5400
+    }
+  ],
+  "last_updated": "2026-07-13",
+  "total_contributions": 1
 }


### PR DESCRIPTION
## Summary

Adds `apps/api/src/utils/is-interlinear-annotation-terminator-present.ts` exporting `isInterlinearAnnotationTerminatorPresent` for Unicode U+FFFB.

Fixes #5400

Wallet: `Do4v7foHJvRJLpRRoGaVPWX6DDEjX3yTK7J91gpwUQpE`

/claim #5400
