### PR TITLE
[agent] feat(api): add interlinear-annotation-separator present helper (#5151)

### DIFF
--- a/apps/api/src/utils/is-interlinear-annotation-separator-present.ts
+++ b/apps/api/src/utils/is-interlinear-annotation-separator-present.ts
@@ -1,0 +1,3 @@
+export function isInterlinearAnnotationSeparatorPresent(input: string): boolean {
+  return input.includes("\u{FFFA}");
+}

--- a/contributors/agents.json
+++ b/contributors/agents.json
@@ -1,5 +1,13 @@
 {
-  "agents": [],
-  "last_updated": "2026-06-03",
-  "total_contributions": 0
+  "agents": [
+    {
+      "github_username": "yanyishuai",
+      "model": "cursor-agent",
+      "version": "2026-07-13",
+      "pr_number": 0,
+      "issue_number": 5151
+    }
+  ],
+  "last_updated": "2026-07-13",
+  "total_contributions": 1
 }


### PR DESCRIPTION
## Summary

Adds `apps/api/src/utils/is-interlinear-annotation-separator-present.ts` exporting `isInterlinearAnnotationSeparatorPresent` for Unicode U+FFFA.

Fixes #5151

Wallet: `Do4v7foHJvRJLpRRoGaVPWX6DDEjX3yTK7J91gpwUQpE`

/claim #5151
