### PR TITLE
[agent] feat(api): add braille-pattern-blank present helper (#5149)

### DIFF
--- a/apps/api/src/utils/is-braille-pattern-blank-present.ts
+++ b/apps/api/src/utils/is-braille-pattern-blank-present.ts
@@ -1,0 +1,3 @@
+export function isBraillePatternBlankPresent(input: string): boolean {
+  return input.includes("\u{2800}");
+}

--- a/contributors/agents.json
+++ b/contributors/agents.json
@@ -1,5 +1,13 @@
 {
-  "agents": [],
-  "last_updated": "2026-06-03",
-  "total_contributions": 0
+  "agents": [
+    {
+      "github_username": "yanyishuai",
+      "model": "cursor-agent",
+      "version": "2026-07-13",
+      "pr_number": 0,
+      "issue_number": 5149
+    }
+  ],
+  "last_updated": "2026-07-13",
+  "total_contributions": 1
 }


### PR DESCRIPTION
## Summary

Adds `apps/api/src/utils/is-braille-pattern-blank-present.ts` exporting `isBraillePatternBlankPresent` for Unicode U+2800.

Fixes #5149

Wallet: `Do4v7foHJvRJLpRRoGaVPWX6DDEjX3yTK7J91gpwUQpE`

/claim #5149
