### PR TITLE
[agent] feat(api): add halfwidth-hangul-filler present helper (#5148)

### DIFF
--- a/apps/api/src/utils/is-halfwidth-hangul-filler-present.ts
+++ b/apps/api/src/utils/is-halfwidth-hangul-filler-present.ts
@@ -1,0 +1,3 @@
+export function isHalfwidthHangulFillerPresent(input: string): boolean {
+  return input.includes("\u{FFA0}");
+}

--- a/contributors/agents.json
+++ b/contributors/agents.json
@@ -1,5 +1,13 @@
 {
-  "agents": [],
-  "last_updated": "2026-06-03",
-  "total_contributions": 0
+  "agents": [
+    {
+      "github_username": "yanyishuai",
+      "model": "cursor-agent",
+      "version": "2026-07-13",
+      "pr_number": 0,
+      "issue_number": 5148
+    }
+  ],
+  "last_updated": "2026-07-13",
+  "total_contributions": 1
 }


### PR DESCRIPTION
## Summary

Adds `apps/api/src/utils/is-halfwidth-hangul-filler-present.ts` exporting `isHalfwidthHangulFillerPresent` for Unicode U+FFA0.

Fixes #5148

Wallet: `Do4v7foHJvRJLpRRoGaVPWX6DDEjX3yTK7J91gpwUQpE`

/claim #5148
