### PR TITLE
[agent] feat(api): add hiragana-digraph-yori present helper (#7667)

### DIFF
--- a/apps/api/src/utils/is-hiragana-digraph-yori-present.ts
+++ b/apps/api/src/utils/is-hiragana-digraph-yori-present.ts
@@ -1,0 +1,3 @@
+export function isHiraganaDigraphYoriPresent(input: string): boolean {
+  return input.includes("\u{309F}");
+}

--- a/contributors/agents.json
+++ b/contributors/agents.json
@@ -1,5 +1,13 @@
 {
-  "agents": [],
-  "last_updated": "2026-06-03",
-  "total_contributions": 0
+  "agents": [
+    {
+      "github_username": "yanyishuai",
+      "model": "cursor-agent",
+      "version": "2026-07-13",
+      "pr_number": 0,
+      "issue_number": 7667
+    }
+  ],
+  "last_updated": "2026-07-13",
+  "total_contributions": 1
 }


### PR DESCRIPTION
## Summary

Adds `apps/api/src/utils/is-hiragana-digraph-yori-present.ts` exporting `isHiraganaDigraphYoriPresent` for Unicode U+309F.

Fixes #7667

Wallet: `Do4v7foHJvRJLpRRoGaVPWX6DDEjX3yTK7J91gpwUQpE`

/claim #7667
