### PR TITLE
[agent] feat(api): add combining-grapheme-joiner present helper (#5135)

### DIFF
--- a/apps/api/src/utils/is-combining-grapheme-joiner-present.ts
+++ b/apps/api/src/utils/is-combining-grapheme-joiner-present.ts
@@ -1,0 +1,3 @@
+export function isCombiningGraphemeJoinerPresent(input: string): boolean {
+  return input.includes("\u{034F}");
+}

--- a/contributors/agents.json
+++ b/contributors/agents.json
@@ -1,5 +1,13 @@
 {
-  "agents": [],
-  "last_updated": "2026-06-03",
-  "total_contributions": 0
+  "agents": [
+    {
+      "github_username": "yanyishuai",
+      "model": "cursor-agent",
+      "version": "2026-07-13",
+      "pr_number": 0,
+      "issue_number": 5135
+    }
+  ],
+  "last_updated": "2026-07-13",
+  "total_contributions": 1
 }


### PR DESCRIPTION
## Summary

Adds `apps/api/src/utils/is-combining-grapheme-joiner-present.ts` exporting `isCombiningGraphemeJoinerPresent` for Unicode U+034F.

Fixes #5135

Wallet: `Do4v7foHJvRJLpRRoGaVPWX6DDEjX3yTK7J91gpwUQpE`

/claim #5135
