### PR TITLE
[agent] feat(api): add nominal-digit-shapes present helper (#5131)

### DIFF
--- a/apps/api/src/utils/is-nominal-digit-shapes-present.ts
+++ b/apps/api/src/utils/is-nominal-digit-shapes-present.ts
@@ -1,0 +1,3 @@
+export function isNominalDigitShapesPresent(input: string): boolean {
+  return input.includes("\u{206F}");
+}

--- a/contributors/agents.json
+++ b/contributors/agents.json
@@ -1,5 +1,13 @@
 {
-  "agents": [],
-  "last_updated": "2026-06-03",
-  "total_contributions": 0
+  "agents": [
+    {
+      "github_username": "yanyishuai",
+      "model": "cursor-agent",
+      "version": "2026-07-13",
+      "pr_number": 0,
+      "issue_number": 5131
+    }
+  ],
+  "last_updated": "2026-07-13",
+  "total_contributions": 1
 }


### PR DESCRIPTION
## Summary

Adds `apps/api/src/utils/is-nominal-digit-shapes-present.ts` exporting `isNominalDigitShapesPresent` for Unicode U+206F.

Fixes #5131

Wallet: `Do4v7foHJvRJLpRRoGaVPWX6DDEjX3yTK7J91gpwUQpE`

/claim #5131
