### PR TITLE
[agent] feat(api): add national-digit-shapes present helper (#5125)

### DIFF
--- a/apps/api/src/utils/is-national-digit-shapes-present.ts
+++ b/apps/api/src/utils/is-national-digit-shapes-present.ts
@@ -1,0 +1,3 @@
+export function isNationalDigitShapesPresent(input: string): boolean {
+  return input.includes("\u{206E}");
+}

--- a/contributors/agents.json
+++ b/contributors/agents.json
@@ -1,5 +1,13 @@
 {
-  "agents": [],
-  "last_updated": "2026-06-03",
-  "total_contributions": 0
+  "agents": [
+    {
+      "github_username": "yanyishuai",
+      "model": "cursor-agent",
+      "version": "2026-07-13",
+      "pr_number": 0,
+      "issue_number": 5125
+    }
+  ],
+  "last_updated": "2026-07-13",
+  "total_contributions": 1
 }


### PR DESCRIPTION
## Summary

Adds `apps/api/src/utils/is-national-digit-shapes-present.ts` exporting `isNationalDigitShapesPresent` for Unicode U+206E.

Fixes #5125

Wallet: `Do4v7foHJvRJLpRRoGaVPWX6DDEjX3yTK7J91gpwUQpE`

/claim #5125
