### PR TITLE
[agent] feat(api): add left-to-right-override present helper (#5085)

### DIFF
--- a/apps/api/src/utils/is-left-to-right-override-present.ts
+++ b/apps/api/src/utils/is-left-to-right-override-present.ts
@@ -1,0 +1,3 @@
+export function isLeftToRightOverridePresent(input: string): boolean {
+  return input.includes("\u{202D}");
+}

--- a/contributors/agents.json
+++ b/contributors/agents.json
@@ -1,5 +1,13 @@
 {
-  "agents": [],
-  "last_updated": "2026-06-03",
-  "total_contributions": 0
+  "agents": [
+    {
+      "github_username": "yanyishuai",
+      "model": "cursor-agent",
+      "version": "2026-07-13",
+      "pr_number": 0,
+      "issue_number": 5085
+    }
+  ],
+  "last_updated": "2026-07-13",
+  "total_contributions": 1
 }


### PR DESCRIPTION
## Summary

Adds `apps/api/src/utils/is-left-to-right-override-present.ts` exporting `isLeftToRightOverridePresent` for Unicode U+202D.

Fixes #5085

Wallet: `Do4v7foHJvRJLpRRoGaVPWX6DDEjX3yTK7J91gpwUQpE`

/claim #5085
