### PR TITLE
[agent] feat(api): add left-to-right-embedding present helper (#5016)

### DIFF
--- a/apps/api/src/utils/is-left-to-right-embedding-present.ts
+++ b/apps/api/src/utils/is-left-to-right-embedding-present.ts
@@ -1,0 +1,3 @@
+export function isLeftToRightEmbeddingPresent(input: string): boolean {
+  return input.includes("\u{202A}");
+}

--- a/contributors/agents.json
+++ b/contributors/agents.json
@@ -1,5 +1,13 @@
 {
-  "agents": [],
-  "last_updated": "2026-06-03",
-  "total_contributions": 0
+  "agents": [
+    {
+      "github_username": "yanyishuai",
+      "model": "cursor-agent",
+      "version": "2026-07-13",
+      "pr_number": 0,
+      "issue_number": 5016
+    }
+  ],
+  "last_updated": "2026-07-13",
+  "total_contributions": 1
 }


### PR DESCRIPTION
## Summary

Adds `apps/api/src/utils/is-left-to-right-embedding-present.ts` exporting `isLeftToRightEmbeddingPresent` for Unicode U+202A.

Fixes #5016

Wallet: `Do4v7foHJvRJLpRRoGaVPWX6DDEjX3yTK7J91gpwUQpE`

/claim #5016
