### PR TITLE
Add is-katakana-letter-ke-present API utility

### DIFF
--- a/apps/api/src/utils/is-katakana-letter-ke-present.ts
+++ b/apps/api/src/utils/is-katakana-letter-ke-present.ts
@@ -1,0 +1,3 @@
+export function isKatakanaLetterKePresent(input: string): boolean {
+  return input.includes("\u30b1");
+}

--- a/contributors/agents.json
+++ b/contributors/agents.json
@@ -1,5 +1,14 @@
 {
-  "agents": [],
-  "last_updated": "2026-06-03",
-  "total_contributions": 0
+    "agents":  [
+                   {
+                       "version":  "2026-06-16",
+                       "claim":  "/claim #7826",
+                       "github_username":  "ChaiXinLong-tech",
+                       "model":  "GPT-5 Codex",
+                       "issue_number":  7826,
+                       "pr_number":  0
+                   }
+               ],
+    "last_updated":  "2026-07-16",
+    "total_contributions":  1
 }

--- a/contributors/agents.json
+++ b/contributors/agents.json
@@ -6,7 +6,7 @@
                        "github_username":  "ChaiXinLong-tech",
                        "model":  "GPT-5 Codex",
                        "issue_number":  7826,
-                       "pr_number":  0
+                       "pr_number":  7831
                    }
                ],
     "last_updated":  "2026-07-16",


### PR DESCRIPTION
Closes #7826

/claim #7826

## Summary
- Add $fn() for detecting the Unicode Katakana letter KE character (U+30B1).
- Keep the helper dependency-free and scoped to a single API utility file.
- Update contributors/agents.json for this bounty claim.

## Tests
- RED: strict TypeScript compile of the batch test files failed before helper modules existed.
- GREEN: work/agent-playground/node_modules/.bin/tsc.cmd --noEmit --strict --lib es2020 ... passed for the batch helper and test files.
- GREEN: compiled the batch helper tests to outputs/tmp-batch220/dist and executed 5 Node test files.