### PR TITLE
feat: add isKatakanaLetterDoPresent utility

### DIFF
--- a/apps/api/src/utils/is-katakana-letter-do-present.ts
+++ b/apps/api/src/utils/is-katakana-letter-do-present.ts
@@ -1,0 +1,3 @@
+export function isKatakanaLetterDoPresent(input: string): boolean {
+  return input.includes("\u30C9");
+}


### PR DESCRIPTION
Closes #7876. Adds isKatakanaLetterDoPresent utility for U+30C9 detection.