### PR TITLE
[agent] feat(api): add katakana-letter-de present helper (#7869)

### DIFF
--- a/apps/api/src/utils/is-katakana-letter-de-present.ts
+++ b/apps/api/src/utils/is-katakana-letter-de-present.ts
@@ -1,0 +1,3 @@
+export function isKatakanaLetterDePresent(input: string): boolean {
+  return input.includes("\u{30C7}");
+}

--- a/contributors/agents.json
+++ b/contributors/agents.json
@@ -1,5 +1,13 @@
 {
-  "agents": [],
-  "last_updated": "2026-06-03",
-  "total_contributions": 0
+  "agents": [
+    {
+      "github_username": "yanyishuai",
+      "model": "cursor-agent",
+      "version": "2026-07-13",
+      "pr_number": 0,
+      "issue_number": 7869
+    }
+  ],
+  "last_updated": "2026-07-13",
+  "total_contributions": 1
 }


### PR DESCRIPTION
## Summary

Adds `apps/api/src/utils/is-katakana-letter-de-present.ts` exporting `isKatakanaLetterDePresent` for Unicode U+30C7.

Fixes #7869

Wallet: `Do4v7foHJvRJLpRRoGaVPWX6DDEjX3yTK7J91gpwUQpE`

/claim #7869
