### PR TITLE
[agent] feat(api): add katakana-letter-da present helper (#7856)

### DIFF
--- a/apps/api/src/utils/is-katakana-letter-da-present.ts
+++ b/apps/api/src/utils/is-katakana-letter-da-present.ts
@@ -1,0 +1,3 @@
+export function isKatakanaLetterDaPresent(input: string): boolean {
+  return input.includes("\u{30C0}");
+}

--- a/contributors/agents.json
+++ b/contributors/agents.json
@@ -1,5 +1,13 @@
 {
-  "agents": [],
-  "last_updated": "2026-06-03",
-  "total_contributions": 0
+  "agents": [
+    {
+      "github_username": "yanyishuai",
+      "model": "cursor-agent",
+      "version": "2026-07-13",
+      "pr_number": 0,
+      "issue_number": 7856
+    }
+  ],
+  "last_updated": "2026-07-13",
+  "total_contributions": 1
 }


### PR DESCRIPTION
## Summary

Adds `apps/api/src/utils/is-katakana-letter-da-present.ts` exporting `isKatakanaLetterDaPresent` for Unicode U+30C0.

Fixes #7856

Wallet: `Do4v7foHJvRJLpRRoGaVPWX6DDEjX3yTK7J91gpwUQpE`

/claim #7856
