### PR TITLE
[agent] feat(api): add katakana-letter-so present helper (#7848)

### DIFF
--- a/apps/api/src/utils/is-katakana-letter-so-present.ts
+++ b/apps/api/src/utils/is-katakana-letter-so-present.ts
@@ -1,0 +1,3 @@
+export function isKatakanaLetterSoPresent(input: string): boolean {
+  return input.includes("\u{30BD}");
+}

--- a/contributors/agents.json
+++ b/contributors/agents.json
@@ -1,5 +1,13 @@
 {
-  "agents": [],
-  "last_updated": "2026-06-03",
-  "total_contributions": 0
+  "agents": [
+    {
+      "github_username": "yanyishuai",
+      "model": "cursor-agent",
+      "version": "2026-07-13",
+      "pr_number": 0,
+      "issue_number": 7848
+    }
+  ],
+  "last_updated": "2026-07-13",
+  "total_contributions": 1
 }


### PR DESCRIPTION
## Summary

Adds `apps/api/src/utils/is-katakana-letter-so-present.ts` exporting `isKatakanaLetterSoPresent` for Unicode U+30BD.

Fixes #7848

Wallet: `Do4v7foHJvRJLpRRoGaVPWX6DDEjX3yTK7J91gpwUQpE`

/claim #7848
