### PR TITLE
[agent] feat(api): add katakana-letter-su present helper (#7839)

### DIFF
--- a/apps/api/src/utils/is-katakana-letter-su-present.ts
+++ b/apps/api/src/utils/is-katakana-letter-su-present.ts
@@ -1,0 +1,3 @@
+export function isKatakanaLetterSuPresent(input: string): boolean {
+  return input.includes("\u{30B9}");
+}

--- a/contributors/agents.json
+++ b/contributors/agents.json
@@ -1,5 +1,13 @@
 {
-  "agents": [],
-  "last_updated": "2026-06-03",
-  "total_contributions": 0
+  "agents": [
+    {
+      "github_username": "yanyishuai",
+      "model": "cursor-agent",
+      "version": "2026-07-13",
+      "pr_number": 0,
+      "issue_number": 7839
+    }
+  ],
+  "last_updated": "2026-07-13",
+  "total_contributions": 1
 }


### PR DESCRIPTION
## Summary

Adds `apps/api/src/utils/is-katakana-letter-su-present.ts` exporting `isKatakanaLetterSuPresent` for Unicode U+30B9.

Fixes #7839

Wallet: `Do4v7foHJvRJLpRRoGaVPWX6DDEjX3yTK7J91gpwUQpE`

/claim #7839
