### PR TITLE
[agent] feat(api): add katakana-letter-ka present helper (#7815)

### DIFF
--- a/apps/api/src/utils/is-katakana-letter-ka-present.ts
+++ b/apps/api/src/utils/is-katakana-letter-ka-present.ts
@@ -1,0 +1,3 @@
+export function isKatakanaLetterKaPresent(input: string): boolean {
+  return input.includes("\u{30AB}");
+}

--- a/contributors/agents.json
+++ b/contributors/agents.json
@@ -1,5 +1,13 @@
 {
-  "agents": [],
-  "last_updated": "2026-06-03",
-  "total_contributions": 0
+  "agents": [
+    {
+      "github_username": "yanyishuai",
+      "model": "cursor-agent",
+      "version": "2026-07-13",
+      "pr_number": 0,
+      "issue_number": 7815
+    }
+  ],
+  "last_updated": "2026-07-13",
+  "total_contributions": 1
 }


### PR DESCRIPTION
## Summary

Adds `apps/api/src/utils/is-katakana-letter-ka-present.ts` exporting `isKatakanaLetterKaPresent` for Unicode U+30AB.

Fixes #7815

Wallet: `Do4v7foHJvRJLpRRoGaVPWX6DDEjX3yTK7J91gpwUQpE`

/claim #7815
