### PR TITLE
[agent] feat(api): add empty object guard

### DIFF
--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -7,7 +7,7 @@
   "main": "src/index.ts",
   "scripts": {
     "dev": "tsx src/index.ts",
-    "test": "echo \"No API tests configured yet\"",
+    "test": "node --test test/is-empty-object.test.ts",
     "lint": "echo \"No API lint configured yet\""
   },
   "dependencies": {

--- a/apps/api/src/utils/is-empty-object.ts
+++ b/apps/api/src/utils/is-empty-object.ts
@@ -1,0 +1,11 @@
+export function isEmptyObject(value: unknown): value is Record<PropertyKey, never> {
+  if (value === null || typeof value !== "object" || Array.isArray(value)) {
+    return false;
+  }
+
+  if (Object.getPrototypeOf(value) !== Object.prototype) {
+    return false;
+  }
+
+  return Reflect.ownKeys(value).length === 0;
+}

--- a/apps/api/test/is-empty-object.test.ts
+++ b/apps/api/test/is-empty-object.test.ts
@@ -1,0 +1,28 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+
+import { isEmptyObject } from "../src/utils/is-empty-object.ts";
+
+test("returns true for a plain object with no own keys", () => {
+  assert.equal(isEmptyObject({}), true);
+});
+
+test("returns false when a plain object has string, symbol, or non-enumerable own keys", () => {
+  const hidden = {};
+  Object.defineProperty(hidden, "secret", {
+    enumerable: false,
+    value: "shh",
+  });
+
+  assert.equal(isEmptyObject({ value: undefined }), false);
+  assert.equal(isEmptyObject({ [Symbol("hidden")]: true }), false);
+  assert.equal(isEmptyObject(hidden), false);
+});
+
+test("returns false for arrays, nullish values, and non-plain objects", () => {
+  assert.equal(isEmptyObject([]), false);
+  assert.equal(isEmptyObject(null), false);
+  assert.equal(isEmptyObject(undefined), false);
+  assert.equal(isEmptyObject(new Date()), false);
+  assert.equal(isEmptyObject(Object.create(null)), false);
+});

--- a/contributors/agents.json
+++ b/contributors/agents.json
@@ -1,5 +1,13 @@
 {
-  "agents": [],
-  "last_updated": "2026-06-03",
-  "total_contributions": 0
+  "agents": [
+    {
+      "github_username": "voladoradepapantla-netizen",
+      "model": "GPT-5",
+      "version": "Codex desktop",
+      "pr_number": 7930,
+      "issue_number": 3117
+    }
+  ],
+  "last_updated": "2026-07-16",
+  "total_contributions": 1
 }


### PR DESCRIPTION
Closes #3117

## Summary
- add a dependency-free `isEmptyObject` helper under `apps/api/src/utils`
- reject nullish values, arrays, and non-plain objects
- treat any own key, including symbol and non-enumerable keys, as non-empty via `Reflect.ownKeys`
- add focused `node:test` coverage for the helper

## Validation
- `npm test --workspace apps/api`