### PR TITLE
Add JSDoc to userService (#1)

### DIFF
--- a/apps/api/src/routes/users.ts
+++ b/apps/api/src/routes/users.ts
@@ -2,6 +2,14 @@ import { Router } from "express";
 
 const router = Router();
 
+/**
+ * GET /users
+ * Returns the collection of users.
+ *
+ * Currently a stub: responds with an empty `data` array and a message noting
+ * that real user listing is not implemented yet. The intended behavior is to
+ * return the persisted set of users once a data layer exists.
+ */
 router.get("/", (_req, res) => {
   res.json({
     data: [],
@@ -9,6 +17,18 @@ router.get("/", (_req, res) => {
   });
 });
 
+/**
+ * POST /users
+ * Creates a new user from the JSON request body.
+ *
+ * Currently a stub: echoes the request body back with a placeholder
+ * `stub-user-id` and a "not implemented yet" message. The intended behavior is
+ * to validate the payload, persist the user, and return the created record
+ * with a server-generated id and a `201 Created` status.
+ *
+ * @param req - Express request carrying the new user fields in `req.body`.
+ * @param res - Express response; returns `201` with the created user stub.
+ */
 router.post("/", (req, res) => {
   res.status(201).json({
     data: {


### PR DESCRIPTION
## What
Adds concise JSDoc comments to the user service route handlers in `apps/api/src/routes/users.ts` (GET /users and POST /users) describing their intended behavior for future contributors.

## Why
Resolves the request in issue #1 to document the user service functions. This is a comment-only change; runtime behavior is unchanged.

## Verification
- Documentation only (no logic altered); existing behavior is preserved.
- Focused, single-file PR as required by the issue acceptance criteria.

Related to #1