### PR TITLE
Add type annotations to shared Button props (#3)

### DIFF
--- a/packages/ui/src/index.ts
+++ b/packages/ui/src/index.ts
@@ -1,9 +1,28 @@
+/** Props for the {@link Button} component. */
 export type ButtonProps = {
+  /** Visible text rendered on the button. */
   label: string;
+  /** When true the button is non-interactive. Defaults to false. */
   disabled?: boolean;
 };
 
-export function Button({ label, disabled = false }: ButtonProps) {
+/** Serializable description of a rendered button (not a DOM/node element). */
+export type ButtonElement = {
+  type: "button";
+  label: string;
+  disabled: boolean;
+};
+
+/**
+ * Create a Button description.
+ *
+ * Returns a plain, serializable object describing the button rather than a
+ * DOM/node element, so it can be rendered or transmitted without a runtime.
+ *
+ * @param props - The button's label and optional disabled flag.
+ * @returns A {@link ButtonElement} describing the button.
+ */
+export function Button({ label, disabled = false }: ButtonProps): ButtonElement {
   return {
     type: "button",
     label,


### PR DESCRIPTION
## What
Improves the type annotations on the shared Button stub in packages/ui without changing its public shape:
- Adds JSDoc to ButtonProps and its fields.
- Introduces an explicit ButtonElement return type.
- Annotates the Button function signature and return type.
- ## Why
- Resolves issue #3. Purely a type-level, non-behavioral change; the emitted object shape is identical.
- ## Verification
- No runtime behavior changed; Button still returns { type, label, disabled }.
- Related to #3