### PR TITLE
Document environment variables (#4)

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,5 +81,17 @@ with models for:
 
 ## Environment Variables
 
-Each app/package expects its own .env values for DB, auth, 
-and integrations.
+Each app/package expects its own `.env` file (not committed). Typical local values:
+
+### apps/api
+- `PORT` — port the Express server listens on (default 4000)
+- `DATABASE_URL` — PostgreSQL connection string used by Prisma
+- `JWT_SECRET` — secret used to sign auth tokens
+- `STRIPE_SECRET_KEY` — (optional) Stripe API key for payments
+
+### apps/web
+- `NEXT_PUBLIC_API_URL` — base URL of the API the frontend calls
+- `NEXT_PUBLIC_APP_URL` — public base URL of the web app
+- `DATABASE_URL` — (optional) used by Prisma tooling
+
+Copy `.env.example` → `.env` in each workspace and fill in local values.


### PR DESCRIPTION
## What\nExpands the README 'Environment Variables' section with concrete, expected local variables for apps/api (PORT, DATABASE_URL, JWT_SECRET, STRIPE_SECRET_KEY) and apps/web (NEXT_PUBLIC_API_URL, NEXT_PUBLIC_APP_URL, DATABASE_URL).\n\n## Why\nResolves issue #4. Focused documentation change; no code altered.\n\n## Verification\n- README documents expected env vars per app.\n\nRelated to #4