### PR TITLE
Add API error response helper (#7)

### DIFF
--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -7,7 +7,7 @@
   "main": "src/index.ts",
   "scripts": {
     "dev": "tsx src/index.ts",
-    "test": "echo \"No API tests configured yet\"",
+    "test": "node --import tsx --test src/routes/users.test.ts src/lib/error.test.ts",
     "lint": "echo \"No API lint configured yet\""
   },
   "dependencies": {

--- a/apps/api/src/lib/error.test.ts
+++ b/apps/api/src/lib/error.test.ts
@@ -1,0 +1,33 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { sendError } from "./error.ts";
+
+function mockRes() {
+  const res: any = { statusCode: 0, body: undefined };
+  res.status = (code: number) => {
+    res.statusCode = code;
+    return res;
+  };
+  res.json = (obj: unknown) => {
+    res.body = obj;
+    return res;
+  };
+  return res;
+}
+
+test("sendError writes status + envelope and returns the response", () => {
+  const res = mockRes();
+  const out = sendError(res, 400, "bad input", { field: "email" });
+  assert.equal(res.statusCode, 400);
+  assert.equal(res.body.error, "error");
+  assert.equal(res.body.message, "bad input");
+  assert.deepEqual(res.body.details, { field: "email" });
+  assert.equal(out, res);
+});
+
+test("sendError omits details when undefined", () => {
+  const res = mockRes();
+  sendError(res, 500, "boom");
+  assert.equal(res.statusCode, 500);
+  assert.equal(res.body.details, undefined);
+});

--- a/apps/api/src/lib/error.ts
+++ b/apps/api/src/lib/error.ts
@@ -1,0 +1,29 @@
+import type { Response } from "express";
+
+export type ApiErrorShape = {
+  error: "error";
+  message: string;
+  details?: unknown;
+};
+
+/**
+ * Write a consistent JSON error envelope to the response.
+ *
+ * @param res - The Express response to write to.
+ * @param status - HTTP status code to send.
+ * @param message - Human-readable error message (safe to expose to clients).
+ * @param details - Optional structured details. Avoid leaking secrets here.
+ * @returns The same `res` for chaining.
+ */
+export function sendError(
+  res: Response,
+  status: number,
+  message: string,
+  details?: unknown
+): Response {
+  const body: ApiErrorShape = { error: "error", message };
+  if (details !== undefined) {
+    body.details = details;
+  }
+  return res.status(status).json(body);
+}

--- a/apps/api/src/routes/users.test.ts
+++ b/apps/api/src/routes/users.test.ts
@@ -1,0 +1,37 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import router from "./users.ts";
+
+function mockRes() {
+  const res: any = { statusCode: 0, body: undefined };
+  res.status = (code: number) => {
+    res.statusCode = code;
+    return res;
+  };
+  res.json = (obj: unknown) => {
+    res.body = obj;
+    return res;
+  };
+  return res;
+}
+
+function mockReq(body: unknown) {
+  return { method: "POST", url: "/", body } as any;
+}
+
+test("POST /users rejects non-object bodies with a 400 error envelope", () => {
+  const req = mockReq([1, 2, 3]);
+  const res = mockRes();
+  router.handle(req, res, () => {});
+  assert.equal(res.statusCode, 400);
+  assert.equal(res.body.error, "error");
+  assert.equal(res.body.message, "Request body must be a JSON object.");
+});
+
+test("POST /users returns 201 for object bodies", () => {
+  const req = mockReq({ email: "a@b.com" });
+  const res = mockRes();
+  router.handle(req, res, () => {});
+  assert.equal(res.statusCode, 201);
+  assert.equal(res.body.data.id, "stub-user-id");
+});

--- a/apps/api/src/routes/users.ts
+++ b/apps/api/src/routes/users.ts
@@ -1,4 +1,5 @@
 import { Router } from "express";
+import { sendError } from "../lib/error";
 
 const router = Router();
 
@@ -10,6 +11,10 @@ router.get("/", (_req, res) => {
 });
 
 router.post("/", (req, res) => {
+  if (typeof req.body !== "object" || req.body === null || Array.isArray(req.body)) {
+    sendError(res, 400, "Request body must be a JSON object.");
+    return;
+  }
   res.status(201).json({
     data: {
       id: "stub-user-id",


### PR DESCRIPTION
## What
Adds a shared sendError(res, status, message, details?) helper in apps/api/src/lib/error.ts that writes a consistent JSON error envelope ({ error, message, details? }). Wires it into the users route (rejecting non-object POST bodies with a 400) and adds tests for both the helper and the route.

## Why
Resolves issue #7. Centralizes error formatting so every route emits the same shape.

## Verification
- node --import tsx --test runs 4 tests (2 for sendError, 2 for the users route) - all pass.
- npm test updated to run the new suite.

Related to #7