### PR TITLE
Add /health route returning 200 OK (#8)

### DIFF
--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -7,7 +7,7 @@
   "main": "src/index.ts",
   "scripts": {
     "dev": "tsx src/index.ts",
-    "test": "echo \"No API tests configured yet\"",
+    "test": "node --import tsx --test src/routes/health.test.ts",
     "lint": "echo \"No API lint configured yet\""
   },
   "dependencies": {

--- a/apps/api/src/index.ts
+++ b/apps/api/src/index.ts
@@ -1,15 +1,14 @@
 import express from "express";
 
 import usersRouter from "./routes/users";
+import healthRouter from "./routes/health";
 
 const app = express();
 const port = process.env.PORT || 4000;
 
 app.use(express.json());
 
-app.get("/health", (_req, res) => {
-  res.json({ status: "ok", service: "taskflow-api" });
-});
+app.use("/health", healthRouter);
 
 app.use("/users", usersRouter);
 

--- a/apps/api/src/routes/health.test.ts
+++ b/apps/api/src/routes/health.test.ts
@@ -1,0 +1,29 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import router from "./health.ts";
+
+function mockRes() {
+  const res: any = { statusCode: 0, body: undefined };
+  res.status = (code: number) => {
+    res.statusCode = code;
+    return res;
+  };
+  res.json = (obj: unknown) => {
+    res.body = obj;
+    return res;
+  };
+  return res;
+}
+
+function mockReq() {
+  return { method: "GET", url: "/" } as any;
+}
+
+test("GET /health returns 200 with ok status", () => {
+  const req = mockReq();
+  const res = mockRes();
+  router.handle(req, res, () => {});
+  assert.equal(res.statusCode, 200);
+  assert.equal(res.body.status, "ok");
+  assert.equal(res.body.service, "taskflow-api");
+});

--- a/apps/api/src/routes/health.ts
+++ b/apps/api/src/routes/health.ts
@@ -1,0 +1,9 @@
+import { Router } from "express";
+
+const router = Router();
+
+router.get("/", (_req, res) => {
+  res.status(200).json({ status: "ok", service: "taskflow-api" });
+});
+
+export default router;


### PR DESCRIPTION
## What
Refactors the existing /health endpoint into apps/api/src/routes/health.ts (a dedicated router) and mounts it via app.use('/health', healthRouter). The handler now sets an explicit 200 status and returns { status: 'ok', service: 'taskflow-api' }. Adds a test for the route.

## Why
Resolves issue #8. Centralizes the health route behind the same router pattern as /users and gives it a regression test (the repo previously had no API tests).

## Verification
- node --import tsx --test src/routes/health.test.ts passes (GET /health -> 200 ok).
- npm test updated to run the new suite.

Related to #8