### PR TITLE
Add JSON request body size limit (#9)

### DIFF
--- a/apps/api/src/index.ts
+++ b/apps/api/src/index.ts
@@ -5,7 +5,8 @@ import usersRouter from "./routes/users";
 const app = express();
 const port = process.env.PORT || 4000;
 
-app.use(express.json());
+// Reject JSON bodies larger than 100kb to protect the API from oversized payloads.
+app.use(express.json({ limit: "100kb" }));
 
 app.get("/health", (_req, res) => {
   res.json({ status: "ok", service: "taskflow-api" });


### PR DESCRIPTION
## What
Caps the Express JSON body parser at 100kb via express.json({ limit: '100kb' }) in apps/api/src/index.ts.

## Why
Resolves issue #9. Protects the API from oversized request payloads.

## Verification
- Config change only; documented inline. Bodies above 100kb now yield 413.

Related to #9