### PR TITLE
Add unit tests for UI Button stub (#13)

### DIFF
--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -5,7 +5,7 @@
   "description": "Shared UI components for TaskFlow.",
   "main": "src/index.ts",
   "scripts": {
-    "test": "echo \"No UI tests configured yet\"",
+    "test": "node --import tsx --test src/index.test.ts",
     "lint": "echo \"No UI lint configured yet\""
   },
   "devDependencies": {

--- a/packages/ui/src/index.test.ts
+++ b/packages/ui/src/index.test.ts
@@ -1,0 +1,14 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { Button } from "./index.ts";
+
+test("Button renders the provided label with type 'button'", () => {
+  const b = Button({ label: "Save" });
+  assert.equal(b.type, "button");
+  assert.equal(b.label, "Save");
+});
+
+test("Button defaults disabled to false and honors an explicit value", () => {
+  assert.equal(Button({ label: "A" }).disabled, false);
+  assert.equal(Button({ label: "B", disabled: true }).disabled, true);
+});


### PR DESCRIPTION
## What
Adds packages/ui/src/index.test.ts covering the shared Button stub: it renders the provided label with type 'button', defaults disabled to false, and honors an explicit disabled value. Updates the UI package test script to run it.

## Why
Resolves issue #13. The shared UI package previously had no tests; this adds baseline coverage.

## Verification
- node --import tsx --test src/index.test.ts passes (2 tests).

Related to #13