### PR TITLE
Add unit tests for user routes (#12)

### DIFF
--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -7,7 +7,7 @@
   "main": "src/index.ts",
   "scripts": {
     "dev": "tsx src/index.ts",
-    "test": "echo \"No API tests configured yet\"",
+    "test": "node --import tsx --test src/routes/users.test.ts",
     "lint": "echo \"No API lint configured yet\""
   },
   "dependencies": {

--- a/apps/api/src/routes/users.test.ts
+++ b/apps/api/src/routes/users.test.ts
@@ -1,0 +1,37 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import router from "./users.ts";
+
+function mockRes() {
+  const res: any = { statusCode: 200, body: undefined };
+  res.status = (code: number) => {
+    res.statusCode = code;
+    return res;
+  };
+  res.json = (obj: unknown) => {
+    res.body = obj;
+    return res;
+  };
+  return res;
+}
+
+function mockReq(method: string, url: string, body?: unknown) {
+  return { method, url, body } as any;
+}
+
+test("GET /users returns 200 with an empty user list", () => {
+  const req = mockReq("GET", "/");
+  const res = mockRes();
+  router.handle(req, res, () => {});
+  assert.equal(res.statusCode, 200);
+  assert.ok(Array.isArray(res.body.data));
+  assert.equal(res.body.data.length, 0);
+});
+
+test("POST /users returns 201 with a stub user id", () => {
+  const req = mockReq("POST", "/", { email: "a@b.com", name: "Ada" });
+  const res = mockRes();
+  router.handle(req, res, () => {});
+  assert.equal(res.statusCode, 201);
+  assert.equal(res.body.data.id, "stub-user-id");
+});


### PR DESCRIPTION
## What
Adds apps/api/src/routes/users.test.ts covering the user route stubs: GET /users returns 200 with an empty list, and POST /users returns 201 with a stub user id. Updates the API test script to run it.

## Why
Resolves issue #12. The API previously had no tests for its route stubs.

## Verification
- node --import tsx --test src/routes/users.test.ts passes (2 tests).

Related to #12