### PR TITLE
Add exact arbitrary-precision PI calculator (#14)

### DIFF
--- a/apps/api/src/lib/pi.test.ts
+++ b/apps/api/src/lib/pi.test.ts
@@ -1,0 +1,17 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { computePi } from "./pi.ts";
+
+test("computePi returns the known first digits of PI", () => {
+  assert.equal(computePi(15), "3.141592653589793");
+  assert.equal(computePi(5), "3.14159");
+});
+
+test("computePi(0) returns '3'", () => {
+  assert.equal(computePi(0), "3");
+});
+
+test("computePi rejects invalid input", () => {
+  assert.throws(() => computePi(-1));
+  assert.throws(() => computePi(1.5));
+});

--- a/apps/api/src/lib/pi.ts
+++ b/apps/api/src/lib/pi.ts
@@ -1,0 +1,50 @@
+/**
+ * Arbitrary-precision digits of PI using Jeremy Gibbons' unbounded spigot
+ * algorithm (https://www.cs.ox.ac.uk/people/jeremy.gibbons/publications/spigot.pdf).
+ *
+ * `computePi(digits)` returns a string "3.dddd..." with exactly `digits` decimal
+ * places. The algorithm is exact: each emitted digit is correct, so the result
+ * matches known PI digits for any requested precision (unlike a fixed IEEE-754
+ * `Math.PI`, which caps out near 15-16 decimal digits).
+ */
+export function computePi(digits: number): string {
+  if (!Number.isInteger(digits) || digits < 0) {
+    throw new Error("digits must be a non-negative integer");
+  }
+  if (digits === 0) return "3";
+
+  let q = 1n;
+  let r = 0n;
+  let t = 1n;
+  let k = 1n;
+  let n = 3n;
+  let l = 3n;
+  const out: string[] = [];
+
+  while (out.length < digits + 1) {
+    if (4n * q + r - t < n * t) {
+      out.push(n.toString());
+      const rq = 10n * q;
+      const rr = 10n * (r - n * t);
+      const rn = (10n * (3n * q + r)) / t - 10n * n;
+      q = rq;
+      r = rr;
+      n = rn;
+    } else {
+      const rq = q * k;
+      const rr = (2n * q + r) * l;
+      const rt = t * l;
+      const rk = k + 1n;
+      const rn = (q * (7n * k + 2n) + r * l) / (t * l);
+      const rl = l + 2n;
+      q = rq;
+      r = rr;
+      t = rt;
+      k = rk;
+      n = rn;
+      l = rl;
+    }
+  }
+
+  return `3.${out.slice(1).join("")}`;
+}


### PR DESCRIPTION
## What
Adds apps/api/src/lib/pi.ts implementing computePi(digits) via Jeremy Gibbons' unbounded spigot algorithm, returning an exact string of PI to any requested precision. Adds tests verifying the known first 15 digits (3.141592653589793), the 0-digit case, and invalid-input guards.

## Why
Resolves issue #14. Unlike a fixed IEEE-754 Math.PI (capped near 15 digits), this computes PI to arbitrarily many correct decimal places.

## Verification
- node --import tsx --test src/lib/pi.test.ts passes (3 tests).

Related to #14