### PR TITLE
Add infinite sequence iterator (#15)

### DIFF
--- a/apps/api/src/lib/sequence.test.ts
+++ b/apps/api/src/lib/sequence.test.ts
@@ -1,0 +1,19 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { naturalNumbers, take, firstNaturalNumbers } from "./sequence.ts";
+
+test("firstNaturalNumbers returns a safe prefix", () => {
+  assert.deepEqual(firstNaturalNumbers(5), [0, 1, 2, 3, 4]);
+  assert.deepEqual(firstNaturalNumbers(0), []);
+});
+
+test("naturalNumbers is infinite but safe to take from", () => {
+  const gen = naturalNumbers();
+  assert.equal(gen.next().value, 0);
+  assert.equal(gen.next().value, 1);
+  assert.deepEqual(take(naturalNumbers(), 3), [0, 1, 2]);
+});
+
+test("take rejects a negative count", () => {
+  assert.throws(() => take(naturalNumbers(), -1));
+});

--- a/apps/api/src/lib/sequence.ts
+++ b/apps/api/src/lib/sequence.ts
@@ -1,0 +1,37 @@
+/**
+ * Infinite sequence utilities.
+ *
+ * `naturalNumbers()` is a lazy generator yielding 0, 1, 2, 3, ... forever.
+ * Because it is a generator it never materializes the whole sequence; consume
+ * it safely with `take()` (a bounded prefix) or by `break`-ing a `for...of`.
+ */
+
+export function* naturalNumbers(): Generator<number> {
+  let n = 0;
+  while (true) {
+    yield n;
+    n += 1;
+  }
+}
+
+/**
+ * Return the first `count` values from an (possibly infinite) iterable.
+ * Always terminates because it stops after `count` items.
+ */
+export function take<T>(source: Iterable<T>, count: number): T[] {
+  if (!Number.isInteger(count) || count < 0) {
+    throw new Error("count must be a non-negative integer");
+  }
+  if (count === 0) return [];
+  const out: T[] = [];
+  for (const value of source) {
+    out.push(value);
+    if (out.length >= count) break;
+  }
+  return out;
+}
+
+/** First `count` natural numbers, safely bounded. */
+export function firstNaturalNumbers(count: number): number[] {
+  return take(naturalNumbers(), count);
+}


### PR DESCRIPTION
## What
Adds apps/api/src/lib/sequence.ts with a lazy infinite natural-number generator (naturalNumbers), a bounded take() helper, and firstNaturalNumbers(). Includes safe-iteration examples in JSDoc and tests covering prefixes, the empty case, and invalid input.

## Why
Resolves issue #15. Demonstrates a correct infinite sequence utility that can never exhaust memory because consumption is always bounded.

## Verification
- node --import tsx --test src/lib/sequence.test.ts passes (3 tests).

Related to #15