### PR TITLE
[fix] #13 Write unit tests for UI Button stub

### DIFF
--- a/src/components/Button/Button.test.tsx
+++ b/src/components/Button/Button.test.tsx
@@ -1,0 +1,19 @@
+
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import Button from './Button';
+
+describe('Button component', () => {
+  it('renders with the correct label', () => {
+    const label = 'Click Me';
+    render(<Button label={label} />);
+    expect(screen.getByText(label)).toBeInTheDocument();
+  });
+
+  it('displays disabled state correctly', () => {
+    const label = 'Disabled Button';
+    render(<Button label={label} disabled />);
+    expect(screen.getByText(label)).toBeDisabled();
+  });
+});
+```


### PR DESCRIPTION
## Fix #13

[Write unit tests for UI Button stub](https://github.com/xevrion-v2/agent-playground/issues/13)

1) `src/components/Button/Button.test.tsx`

```markdown
// src/components/Button/Button.test.tsx

import { render, screen } from '@testing-library/react';
import userEvent from '@testing-library/user-event';
import Button from './Button';

describe('Button component', () => {
  it('renders with the correct label', () => {
    const label = 'Click Me';
    render(<Button label={label} />);
    expect(screen.getByText(label)).toBeInTheDocument();
  });

  it('displays disabled state correctly', () => {
    const label = 'Disabled Button';
    render(<Button label={label} disabled />);
    expect(screen.getByText(label)).toBeDisabled();
  });
});
```

---

- [x] I have read and understood the Contributing Guidelines
- [x] This PR addresses the issue
