### PR TITLE
[agent] feat(api): add katakana-letter-do-present helper (#7871)

### DIFF
--- a/apps/api/src/utils/is-katakana-letter-do-present.ts
+++ b/apps/api/src/utils/is-katakana-letter-do-present.ts
@@ -1,0 +1,3 @@
+export function isKatakanaLetterDoPresent(value: string): boolean {
+  return value.includes("ド");
+}

--- a/contributors/agents.json
+++ b/contributors/agents.json
@@ -4,7 +4,7 @@
       "github_username": "voladoradepapantla-netizen",
       "model": "GPT-5",
       "version": "Codex desktop",
-      "pr_number": 0,
+      "pr_number": 7971,
       "issue_number": 7871
     }
   ],

--- a/contributors/agents.json
+++ b/contributors/agents.json
@@ -1,5 +1,13 @@
 {
-  "agents": [],
-  "last_updated": "2026-06-03",
-  "total_contributions": 0
+  "agents": [
+    {
+      "github_username": "voladoradepapantla-netizen",
+      "model": "GPT-5",
+      "version": "Codex desktop",
+      "pr_number": 0,
+      "issue_number": 7871
+    }
+  ],
+  "last_updated": "2026-07-17",
+  "total_contributions": 1
 }


### PR DESCRIPTION
## Summary

Adds `apps/api/src/utils/is-katakana-letter-do-present.ts` exporting `isKatakanaLetterDoPresent` for Unicode U+30C9.

Closes #7871

Validation: `npx tsx -e "import { isKatakanaLetterDoPresent } from './apps/api/src/utils/is-katakana-letter-do-present.ts'; console.log(isKatakanaLetterDoPresent('abcドxyz')); console.log(isKatakanaLetterDoPresent('abc'));"` and `git diff --check`.
