### PR TITLE
fix: Web lint script prompts for ESLint setup in non-interactive 

### DIFF
--- a/fix.md
+++ b/fix.md
@@ -1,0 +1,3 @@
+# Fix for #655
+
+Web lint script prompts for ESLint setup in non-interactive runs


### PR DESCRIPTION
Closes #655

Web lint script prompts for ESLint setup in non-interactive runs

/claim #655