### PR TITLE
[agent] feat(api): add katakana-letter-mi present helper (#8020)

### DIFF
--- a/apps/api/src/utils/is-katakana-letter-mi-present.ts
+++ b/apps/api/src/utils/is-katakana-letter-mi-present.ts
@@ -1,0 +1,3 @@
+export function isKatakanaLetterMiPresent(input: string): boolean {
+  return input.includes("\u{30DF}");
+}

--- a/contributors/agents.json
+++ b/contributors/agents.json
@@ -1,5 +1,13 @@
 {
-  "agents": [],
-  "last_updated": "2026-06-03",
-  "total_contributions": 0
+  "agents": [
+    {
+      "github_username": "yanyishuai",
+      "model": "cursor-agent",
+      "version": "2026-07-13",
+      "pr_number": 0,
+      "issue_number": 8020
+    }
+  ],
+  "last_updated": "2026-07-13",
+  "total_contributions": 1
 }


### PR DESCRIPTION
## Summary

Adds `apps/api/src/utils/is-katakana-letter-mi-present.ts` exporting `isKatakanaLetterMiPresent` for Unicode U+30DF.

Fixes #8020

Wallet: `Do4v7foHJvRJLpRRoGaVPWX6DDEjX3yTK7J91gpwUQpE`

/claim #8020
