### PR TITLE
[agent] feat(api): add katakana-letter-po present helper (#8013)

### DIFF
--- a/apps/api/src/utils/is-katakana-letter-po-present.ts
+++ b/apps/api/src/utils/is-katakana-letter-po-present.ts
@@ -1,0 +1,3 @@
+export function isKatakanaLetterPoPresent(input: string): boolean {
+  return input.includes("\u{30DD}");
+}

--- a/contributors/agents.json
+++ b/contributors/agents.json
@@ -1,5 +1,13 @@
 {
-  "agents": [],
-  "last_updated": "2026-06-03",
-  "total_contributions": 0
+  "agents": [
+    {
+      "github_username": "yanyishuai",
+      "model": "cursor-agent",
+      "version": "2026-07-13",
+      "pr_number": 0,
+      "issue_number": 8013
+    }
+  ],
+  "last_updated": "2026-07-13",
+  "total_contributions": 1
 }


### PR DESCRIPTION
## Summary

Adds `apps/api/src/utils/is-katakana-letter-po-present.ts` exporting `isKatakanaLetterPoPresent` for Unicode U+30DD.

Fixes #8013

Wallet: `Do4v7foHJvRJLpRRoGaVPWX6DDEjX3yTK7J91gpwUQpE`

/claim #8013
