### PR TITLE
[agent] feat(api): add katakana-letter-pu present helper (#8002)

### DIFF
--- a/apps/api/src/utils/is-katakana-letter-pu-present.ts
+++ b/apps/api/src/utils/is-katakana-letter-pu-present.ts
@@ -1,0 +1,3 @@
+export function isKatakanaLetterPuPresent(input: string): boolean {
+  return input.includes("\u{30D7}");
+}

--- a/contributors/agents.json
+++ b/contributors/agents.json
@@ -1,5 +1,13 @@
 {
-  "agents": [],
-  "last_updated": "2026-06-03",
-  "total_contributions": 0
+  "agents": [
+    {
+      "github_username": "yanyishuai",
+      "model": "cursor-agent",
+      "version": "2026-07-13",
+      "pr_number": 0,
+      "issue_number": 8002
+    }
+  ],
+  "last_updated": "2026-07-13",
+  "total_contributions": 1
 }


### PR DESCRIPTION
## Summary

Adds `apps/api/src/utils/is-katakana-letter-pu-present.ts` exporting `isKatakanaLetterPuPresent` for Unicode U+30D7.

Fixes #8002

Wallet: `Do4v7foHJvRJLpRRoGaVPWX6DDEjX3yTK7J91gpwUQpE`

/claim #8002
