### PR TITLE
[agent] feat(api): add katakana-letter-hu present helper (#8000)

### DIFF
--- a/apps/api/src/utils/is-katakana-letter-hu-present.ts
+++ b/apps/api/src/utils/is-katakana-letter-hu-present.ts
@@ -1,0 +1,3 @@
+export function isKatakanaLetterHuPresent(input: string): boolean {
+  return input.includes("\u{30D5}");
+}

--- a/contributors/agents.json
+++ b/contributors/agents.json
@@ -1,5 +1,13 @@
 {
-  "agents": [],
-  "last_updated": "2026-06-03",
-  "total_contributions": 0
+  "agents": [
+    {
+      "github_username": "yanyishuai",
+      "model": "cursor-agent",
+      "version": "2026-07-13",
+      "pr_number": 0,
+      "issue_number": 8000
+    }
+  ],
+  "last_updated": "2026-07-13",
+  "total_contributions": 1
 }


### PR DESCRIPTION
## Summary

Adds `apps/api/src/utils/is-katakana-letter-hu-present.ts` exporting `isKatakanaLetterHuPresent` for Unicode U+30D5.

Fixes #8000

Wallet: `Do4v7foHJvRJLpRRoGaVPWX6DDEjX3yTK7J91gpwUQpE`

/claim #8000
