### PR TITLE
[agent] feat(api): add katakana-letter-bi present helper (#7993)

### DIFF
--- a/apps/api/src/utils/is-katakana-letter-bi-present.ts
+++ b/apps/api/src/utils/is-katakana-letter-bi-present.ts
@@ -1,0 +1,3 @@
+export function isKatakanaLetterBiPresent(input: string): boolean {
+  return input.includes("\u{30D3}");
+}

--- a/contributors/agents.json
+++ b/contributors/agents.json
@@ -1,5 +1,13 @@
 {
-  "agents": [],
-  "last_updated": "2026-06-03",
-  "total_contributions": 0
+  "agents": [
+    {
+      "github_username": "yanyishuai",
+      "model": "cursor-agent",
+      "version": "2026-07-13",
+      "pr_number": 0,
+      "issue_number": 7993
+    }
+  ],
+  "last_updated": "2026-07-13",
+  "total_contributions": 1
 }


### PR DESCRIPTION
## Summary

Adds `apps/api/src/utils/is-katakana-letter-bi-present.ts` exporting `isKatakanaLetterBiPresent` for Unicode U+30D3.

Fixes #7993

Wallet: `Do4v7foHJvRJLpRRoGaVPWX6DDEjX3yTK7J91gpwUQpE`

/claim #7993
