### PR TITLE
[agent] feat(api): add katakana-letter-pa present helper (#7991)

### DIFF
--- a/apps/api/src/utils/is-katakana-letter-pa-present.ts
+++ b/apps/api/src/utils/is-katakana-letter-pa-present.ts
@@ -1,0 +1,3 @@
+export function isKatakanaLetterPaPresent(input: string): boolean {
+  return input.includes("\u{30D1}");
+}

--- a/contributors/agents.json
+++ b/contributors/agents.json
@@ -1,5 +1,13 @@
 {
-  "agents": [],
-  "last_updated": "2026-06-03",
-  "total_contributions": 0
+  "agents": [
+    {
+      "github_username": "yanyishuai",
+      "model": "cursor-agent",
+      "version": "2026-07-13",
+      "pr_number": 0,
+      "issue_number": 7991
+    }
+  ],
+  "last_updated": "2026-07-13",
+  "total_contributions": 1
 }


### PR DESCRIPTION
## Summary

Adds `apps/api/src/utils/is-katakana-letter-pa-present.ts` exporting `isKatakanaLetterPaPresent` for Unicode U+30D1.

Fixes #7991

Wallet: `Do4v7foHJvRJLpRRoGaVPWX6DDEjX3yTK7J91gpwUQpE`

/claim #7991
