### PR TITLE
[agent] feat(api): add katakana-letter-na present helper (#7979)

### DIFF
--- a/apps/api/src/utils/is-katakana-letter-na-present.ts
+++ b/apps/api/src/utils/is-katakana-letter-na-present.ts
@@ -1,0 +1,3 @@
+export function isKatakanaLetterNaPresent(input: string): boolean {
+  return input.includes("\u{30CA}");
+}

--- a/contributors/agents.json
+++ b/contributors/agents.json
@@ -1,5 +1,13 @@
 {
-  "agents": [],
-  "last_updated": "2026-06-03",
-  "total_contributions": 0
+  "agents": [
+    {
+      "github_username": "yanyishuai",
+      "model": "cursor-agent",
+      "version": "2026-07-13",
+      "pr_number": 0,
+      "issue_number": 7979
+    }
+  ],
+  "last_updated": "2026-07-13",
+  "total_contributions": 1
 }


### PR DESCRIPTION
## Summary

Adds `apps/api/src/utils/is-katakana-letter-na-present.ts` exporting `isKatakanaLetterNaPresent` for Unicode U+30CA.

Fixes #7979

Wallet: `Do4v7foHJvRJLpRRoGaVPWX6DDEjX3yTK7J91gpwUQpE`

/claim #7979
