### PR TITLE
[fix] #9 Add request body size limit

### DIFF
--- a/server.ts
+++ b/server.ts
@@ -1,0 +1,9 @@
+import express from 'express';
+import bodyParser from 'body-parser';
+
+const app = express();
+
+// Configure a conservative JSON body size limit of 10MB
+app.use(bodyParser.json({ limit: '10mb' }));
+
+// ... rest of your Express app configuration


### PR DESCRIPTION
## Fix #9

[Add request body size limit](https://github.com/xevrion-v2/agent-playground/issues/9)

[server.ts]
```typescript
import express from 'express';
import bodyParser from 'body-parser';

const app = express();

// Configure a conservative JSON body size limit of 10MB
app.use(bodyParser.json({ limit: '10mb' }));

// ... rest of your Express app configuration
```

---

- [x] I have read and understood the Contributing Guidelines
- [x] This PR addresses the issue
