### PR TITLE
[agent] feat(api): add katakana-letter-wi present helper (#8083)

### DIFF
--- a/apps/api/src/utils/is-katakana-letter-wi-present.ts
+++ b/apps/api/src/utils/is-katakana-letter-wi-present.ts
@@ -1,0 +1,3 @@
+export function isKatakanaLetterWiPresent(input: string): boolean {
+  return input.includes("\u{30F0}");
+}

--- a/contributors/agents.json
+++ b/contributors/agents.json
@@ -1,5 +1,13 @@
 {
-  "agents": [],
-  "last_updated": "2026-06-03",
-  "total_contributions": 0
+  "agents": [
+    {
+      "github_username": "yanyishuai",
+      "model": "cursor-agent",
+      "version": "2026-07-13",
+      "pr_number": 0,
+      "issue_number": 8083
+    }
+  ],
+  "last_updated": "2026-07-13",
+  "total_contributions": 1
 }


### PR DESCRIPTION
## Summary

Adds `apps/api/src/utils/is-katakana-letter-wi-present.ts` exporting `isKatakanaLetterWiPresent` for Unicode U+30F0.

Fixes #8083

Wallet: `Do4v7foHJvRJLpRRoGaVPWX6DDEjX3yTK7J91gpwUQpE`

/claim #8083
