### PR TITLE
[agent] feat(api): add katakana-letter-re present helper (#8072)

### DIFF
--- a/apps/api/src/utils/is-katakana-letter-re-present.ts
+++ b/apps/api/src/utils/is-katakana-letter-re-present.ts
@@ -1,0 +1,3 @@
+export function isKatakanaLetterRePresent(input: string): boolean {
+  return input.includes("\u{30EC}");
+}

--- a/contributors/agents.json
+++ b/contributors/agents.json
@@ -1,5 +1,13 @@
 {
-  "agents": [],
-  "last_updated": "2026-06-03",
-  "total_contributions": 0
+  "agents": [
+    {
+      "github_username": "yanyishuai",
+      "model": "cursor-agent",
+      "version": "2026-07-13",
+      "pr_number": 0,
+      "issue_number": 8072
+    }
+  ],
+  "last_updated": "2026-07-13",
+  "total_contributions": 1
 }


### PR DESCRIPTION
## Summary

Adds `apps/api/src/utils/is-katakana-letter-re-present.ts` exporting `isKatakanaLetterRePresent` for Unicode U+30EC.

Fixes #8072

Wallet: `Do4v7foHJvRJLpRRoGaVPWX6DDEjX3yTK7J91gpwUQpE`

/claim #8072
