### PR TITLE
[agent] feat(api): add katakana-letter-ra present helper (#8069)

### DIFF
--- a/apps/api/src/utils/is-katakana-letter-ra-present.ts
+++ b/apps/api/src/utils/is-katakana-letter-ra-present.ts
@@ -1,0 +1,3 @@
+export function isKatakanaLetterRaPresent(input: string): boolean {
+  return input.includes("\u{30E9}");
+}

--- a/contributors/agents.json
+++ b/contributors/agents.json
@@ -1,5 +1,13 @@
 {
-  "agents": [],
-  "last_updated": "2026-06-03",
-  "total_contributions": 0
+  "agents": [
+    {
+      "github_username": "yanyishuai",
+      "model": "cursor-agent",
+      "version": "2026-07-13",
+      "pr_number": 0,
+      "issue_number": 8069
+    }
+  ],
+  "last_updated": "2026-07-13",
+  "total_contributions": 1
 }


### PR DESCRIPTION
## Summary

Adds `apps/api/src/utils/is-katakana-letter-ra-present.ts` exporting `isKatakanaLetterRaPresent` for Unicode U+30E9.

Fixes #8069

Wallet: `Do4v7foHJvRJLpRRoGaVPWX6DDEjX3yTK7J91gpwUQpE`

/claim #8069
