### PR TITLE
[fix] #7 Add API error handling helper

### DIFF
--- a/api/errorHelper.ts
+++ b/api/errorHelper.ts
@@ -1,0 +1,9 @@
+import { Response } from 'express';
+
+interface ErrorResponse {
+  error: string;
+}
+
+export const sendErrorResponse = (res: Response, error: string): void => {
+  res.status(500).json({ error: error });
+};


### PR DESCRIPTION
## Fix #7

[Add API error handling helper](https://github.com/xevrion-v2/agent-playground/issues/7)

[api/errorHelper.ts]
```typescript
import { Response } from 'express';

interface ErrorResponse {
  error: string;
}

export const sendErrorResponse = (res: Response, error: string): void => {
  res.status(500).json({ error: error });
};
```

---

- [x] I have read and understood the Contributing Guidelines
- [x] This PR addresses the issue
