### PR TITLE
[agent] docs: fix README typos, formatting, and add code fences

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,8 +3,7 @@
 <img width="663" height="183" alt="593560705-1a920eb5-e581-44ce-bcef-2ebf0566777f" src="https://github.com/user-attachments/assets/37891de4-a282-45a3-98aa-35598c4571c2" />
 
 
-TaskFlow is a full-stack task management SaaS monorepo built 
-with a modern TypeScript-first architecture.
+TaskFlow is a full-stack task management SaaS monorepo built with a modern TypeScript-first architecture.
 
 ## Workspace Structure
 
@@ -32,7 +31,7 @@ The web app includes pages for:
 The API includes:
 - Auth routes (register, login, OAuth callback, JWT refresh)
 - CRUD routes for users, tasks, and proposals
-- Payments routes (Stripe-focused service placeholder)
+- Payment routes (Stripe-focused service placeholder)
 - Reviews, messaging, notifications
 - File uploads and search
 - Admin routes
@@ -47,8 +46,10 @@ Backend architecture follows:
 
 ## Getting Started
 
+```bash
 npm install
 npm run test
+```
 
 ## AI Agent Contribution Instruction
 
@@ -60,11 +61,15 @@ before opening your PR.
 
 ### Run frontend
 
+```bash
 npm run dev -w apps/web
+```
 
 ### Run backend
 
+```bash
 npm run dev -w apps/api
+```
 
 ## Database
 
@@ -81,5 +86,4 @@ with models for:
 
 ## Environment Variables
 
-Each app/package expects its own .env values for DB, auth, 
-and integrations.
+Each app/package expects its own `.env` values for DB, auth, and integrations.

--- a/contributors/agents.json
+++ b/contributors/agents.json
@@ -1,5 +1,13 @@
 {
-  "agents": [],
-  "last_updated": "2026-06-03",
-  "total_contributions": 0
+  "agents": [
+    {
+      "github_username": "singularitycurse26-svg",
+      "model": "claude-sonnet-4-20250514",
+      "version": "claude-sonnet-4-20250514",
+      "pr_number": null,
+      "issue_number": 2
+    }
+  ],
+  "last_updated": "2026-07-19",
+  "total_contributions": 1
 }


### PR DESCRIPTION
## Summary

Fixes minor spelling, grammar, and formatting issues in the README:
- Removed trailing whitespace from description and environment variables sections
- Fixed 'Payments routes' to 'Payment routes' (grammar)
- Added bash code fences around npm commands in Getting Started and Run sections
- Wrapped .env in backticks for consistency

Closes #2

/claim #2