### PR TITLE
[agent] feat: add 13 Katakana letter detection utilities (batch 3)

### DIFF
--- a/apps/api/src/utils/is-katakana-letter-be-present.ts
+++ b/apps/api/src/utils/is-katakana-letter-be-present.ts
@@ -1,0 +1,8 @@
+/**
+ * Checks whether the input string contains the Katakana letter BE (U+30D9) character.
+ * @param input - The string to check.
+ * @returns true if the input contains the character, false otherwise.
+ */
+export function isKatakanaLetterbe(input: string): boolean {
+  return input.includes(String.fromCodePoint(12505));
+}

--- a/apps/api/src/utils/is-katakana-letter-bi-present.ts
+++ b/apps/api/src/utils/is-katakana-letter-bi-present.ts
@@ -1,0 +1,8 @@
+/**
+ * Checks whether the input string contains the Katakana letter BI (U+30D3) character.
+ * @param input - The string to check.
+ * @returns true if the input contains the character, false otherwise.
+ */
+export function isKatakanaLetterbi(input: string): boolean {
+  return input.includes(String.fromCodePoint(12499));
+}

--- a/apps/api/src/utils/is-katakana-letter-bo-present.ts
+++ b/apps/api/src/utils/is-katakana-letter-bo-present.ts
@@ -1,0 +1,8 @@
+/**
+ * Checks whether the input string contains the Katakana letter BO (U+30DC) character.
+ * @param input - The string to check.
+ * @returns true if the input contains the character, false otherwise.
+ */
+export function isKatakanaLetterbo(input: string): boolean {
+  return input.includes(String.fromCodePoint(12508));
+}

--- a/apps/api/src/utils/is-katakana-letter-bu-present.ts
+++ b/apps/api/src/utils/is-katakana-letter-bu-present.ts
@@ -1,0 +1,8 @@
+/**
+ * Checks whether the input string contains the Katakana letter BU (U+30D6) character.
+ * @param input - The string to check.
+ * @returns true if the input contains the character, false otherwise.
+ */
+export function isKatakanaLetterbu(input: string): boolean {
+  return input.includes(String.fromCodePoint(12502));
+}

--- a/apps/api/src/utils/is-katakana-letter-he-present.ts
+++ b/apps/api/src/utils/is-katakana-letter-he-present.ts
@@ -1,0 +1,8 @@
+/**
+ * Checks whether the input string contains the Katakana letter HE (U+30D8) character.
+ * @param input - The string to check.
+ * @returns true if the input contains the character, false otherwise.
+ */
+export function isKatakanaLetterhe(input: string): boolean {
+  return input.includes(String.fromCodePoint(12504));
+}

--- a/apps/api/src/utils/is-katakana-letter-hi-present.ts
+++ b/apps/api/src/utils/is-katakana-letter-hi-present.ts
@@ -1,0 +1,8 @@
+/**
+ * Checks whether the input string contains the Katakana letter HI (U+30D2) character.
+ * @param input - The string to check.
+ * @returns true if the input contains the character, false otherwise.
+ */
+export function isKatakanaLetterhi(input: string): boolean {
+  return input.includes(String.fromCodePoint(12498));
+}

--- a/apps/api/src/utils/is-katakana-letter-ho-present.ts
+++ b/apps/api/src/utils/is-katakana-letter-ho-present.ts
@@ -1,0 +1,8 @@
+/**
+ * Checks whether the input string contains the Katakana letter HO (U+30DB) character.
+ * @param input - The string to check.
+ * @returns true if the input contains the character, false otherwise.
+ */
+export function isKatakanaLetterho(input: string): boolean {
+  return input.includes(String.fromCodePoint(12507));
+}

--- a/apps/api/src/utils/is-katakana-letter-hu-present.ts
+++ b/apps/api/src/utils/is-katakana-letter-hu-present.ts
@@ -1,0 +1,8 @@
+/**
+ * Checks whether the input string contains the Katakana letter HU (U+30D5) character.
+ * @param input - The string to check.
+ * @returns true if the input contains the character, false otherwise.
+ */
+export function isKatakanaLetterhu(input: string): boolean {
+  return input.includes(String.fromCodePoint(12501));
+}

--- a/apps/api/src/utils/is-katakana-letter-pa-present.ts
+++ b/apps/api/src/utils/is-katakana-letter-pa-present.ts
@@ -1,0 +1,8 @@
+/**
+ * Checks whether the input string contains the Katakana letter PA (U+30D1) character.
+ * @param input - The string to check.
+ * @returns true if the input contains the character, false otherwise.
+ */
+export function isKatakanaLetterpa(input: string): boolean {
+  return input.includes(String.fromCodePoint(12497));
+}

--- a/apps/api/src/utils/is-katakana-letter-pe-present.ts
+++ b/apps/api/src/utils/is-katakana-letter-pe-present.ts
@@ -1,0 +1,8 @@
+/**
+ * Checks whether the input string contains the Katakana letter PE (U+30DA) character.
+ * @param input - The string to check.
+ * @returns true if the input contains the character, false otherwise.
+ */
+export function isKatakanaLetterpe(input: string): boolean {
+  return input.includes(String.fromCodePoint(12506));
+}

--- a/apps/api/src/utils/is-katakana-letter-pi-present.ts
+++ b/apps/api/src/utils/is-katakana-letter-pi-present.ts
@@ -1,0 +1,8 @@
+/**
+ * Checks whether the input string contains the Katakana letter PI (U+30D4) character.
+ * @param input - The string to check.
+ * @returns true if the input contains the character, false otherwise.
+ */
+export function isKatakanaLetterpi(input: string): boolean {
+  return input.includes(String.fromCodePoint(12500));
+}

--- a/apps/api/src/utils/is-katakana-letter-po-present.ts
+++ b/apps/api/src/utils/is-katakana-letter-po-present.ts
@@ -1,0 +1,8 @@
+/**
+ * Checks whether the input string contains the Katakana letter PO (U+30DD) character.
+ * @param input - The string to check.
+ * @returns true if the input contains the character, false otherwise.
+ */
+export function isKatakanaLetterpo(input: string): boolean {
+  return input.includes(String.fromCodePoint(12509));
+}

--- a/apps/api/src/utils/is-katakana-letter-pu-present.ts
+++ b/apps/api/src/utils/is-katakana-letter-pu-present.ts
@@ -1,0 +1,8 @@
+/**
+ * Checks whether the input string contains the Katakana letter PU (U+30D7) character.
+ * @param input - The string to check.
+ * @returns true if the input contains the character, false otherwise.
+ */
+export function isKatakanaLetterpu(input: string): boolean {
+  return input.includes(String.fromCodePoint(12503));
+}

--- a/pr-body-katakana2.txt
+++ b/pr-body-katakana2.txt
@@ -1,0 +1,49 @@
+## Katakana Letter Detection Utilities (Batch 2 - 18 utilities)
+
+Closes #8069, #8070, #8071, #8072, #8073, #8081, #8082, #8083, #8084, #8085, #8086, #8087, #8088, #8089, #8090, #8091, #8092, #8093
+
+### Summary
+
+Adds 18 Katakana letter detection API utilities under apps/api/src/utils/. Each utility exports a dependency-free function that returns true only when the input string contains the specified Unicode Katakana character.
+
+### Files Added
+
+| File | Character | Issue |
+|------|-----------|-------|
+| is-katakana-letter-ra-present.ts | U+30E9 | #8069 |
+| is-katakana-letter-ri-present.ts | U+30EA | #8070 |
+| is-katakana-letter-ru-present.ts | U+30EB | #8071 |
+| is-katakana-letter-re-present.ts | U+30EC | #8072 |
+| is-katakana-letter-ro-present.ts | U+30ED | #8073 |
+| is-katakana-letter-small-wa-present.ts | U+30EE | #8081 |
+| is-katakana-letter-wa-present.ts | U+30EF | #8082 |
+| is-katakana-letter-wi-present.ts | U+30F0 | #8083 |
+| is-katakana-letter-we-present.ts | U+30F1 | #8084 |
+| is-katakana-letter-wo-present.ts | U+30F2 | #8085 |
+| is-katakana-letter-n-present.ts | U+30F3 | #8086 |
+| is-katakana-letter-vu-present.ts | U+30F4 | #8087 |
+| is-katakana-letter-small-ka-present.ts | U+30F5 | #8088 |
+| is-katakana-letter-small-ke-present.ts | U+30F6 | #8089 |
+| is-katakana-letter-va-present.ts | U+30F7 | #8090 |
+| is-katakana-letter-vi-present.ts | U+30F8 | #8091 |
+| is-katakana-letter-ve-present.ts | U+30F9 | #8092 |
+| is-katakana-letter-vo-present.ts | U+30FA | #8093 |
+
+/claim #8069
+/claim #8070
+/claim #8071
+/claim #8072
+/claim #8073
+/claim #8081
+/claim #8082
+/claim #8083
+/claim #8084
+/claim #8085
+/claim #8086
+/claim #8087
+/claim #8088
+/claim #8089
+/claim #8090
+/claim #8091
+/claim #8092
+/claim #8093


### PR DESCRIPTION
## Katakana Letter Detection Utilities (Batch 3 - 13 utilities)

Closes #7991, #7992, #7993, #7999, #8000, #8001, #8002, #8003, #8009, #8010, #8011, #8012, #8013

### Summary

Adds 13 Katakana letter detection API utilities under apps/api/src/utils/. Each utility exports a dependency-free function that returns true only when the input string contains the specified Unicode Katakana character.

### Files Added

| File | Character | Issue |
|------|-----------|-------|
| is-katakana-letter-pa-present.ts | U+30D1 | #7991 |
| is-katakana-letter-hi-present.ts | U+30D2 | #7992 |
| is-katakana-letter-bi-present.ts | U+30D3 | #7993 |
| is-katakana-letter-pi-present.ts | U+30D4 | #7999 |
| is-katakana-letter-hu-present.ts | U+30D5 | #8000 |
| is-katakana-letter-bu-present.ts | U+30D6 | #8001 |
| is-katakana-letter-pu-present.ts | U+30D7 | #8002 |
| is-katakana-letter-he-present.ts | U+30D8 | #8003 |
| is-katakana-letter-be-present.ts | U+30D9 | #8009 |
| is-katakana-letter-pe-present.ts | U+30DA | #8010 |
| is-katakana-letter-ho-present.ts | U+30DB | #8011 |
| is-katakana-letter-bo-present.ts | U+30DC | #8012 |
| is-katakana-letter-po-present.ts | U+30DD | #8013 |

/claim #7991
/claim #7992
/claim #7993
/claim #7999
/claim #8000
/claim #8001
/claim #8002
/claim #8003
/claim #8009
/claim #8010
/claim #8011
/claim #8012
/claim #8013
