### PR TITLE
[agent] feat: add 20 Katakana letter detection utilities (batch 4)

### DIFF
--- a/apps/api/src/utils/is-katakana-letter-a-present.ts
+++ b/apps/api/src/utils/is-katakana-letter-a-present.ts
@@ -1,0 +1,8 @@
+/**
+ * Checks whether the input string contains the Katakana letter (U+30A2) character.
+ * @param input - The string to check.
+ * @returns true if the input contains the character, false otherwise.
+ */
+export function isKatakanaLettera(input: string): boolean {
+  return input.includes(String.fromCodePoint(12450));
+}

--- a/apps/api/src/utils/is-katakana-letter-e-present.ts
+++ b/apps/api/src/utils/is-katakana-letter-e-present.ts
@@ -1,0 +1,8 @@
+/**
+ * Checks whether the input string contains the Katakana letter (U+30A8) character.
+ * @param input - The string to check.
+ * @returns true if the input contains the character, false otherwise.
+ */
+export function isKatakanaLettere(input: string): boolean {
+  return input.includes(String.fromCodePoint(12456));
+}

--- a/apps/api/src/utils/is-katakana-letter-ga-present.ts
+++ b/apps/api/src/utils/is-katakana-letter-ga-present.ts
@@ -1,0 +1,8 @@
+/**
+ * Checks whether the input string contains the Katakana letter (U+30AC) character.
+ * @param input - The string to check.
+ * @returns true if the input contains the character, false otherwise.
+ */
+export function isKatakanaLetterga(input: string): boolean {
+  return input.includes(String.fromCodePoint(12460));
+}

--- a/apps/api/src/utils/is-katakana-letter-ge-present.ts
+++ b/apps/api/src/utils/is-katakana-letter-ge-present.ts
@@ -1,0 +1,8 @@
+/**
+ * Checks whether the input string contains the Katakana letter (U+30B2) character.
+ * @param input - The string to check.
+ * @returns true if the input contains the character, false otherwise.
+ */
+export function isKatakanaLetterge(input: string): boolean {
+  return input.includes(String.fromCodePoint(12466));
+}

--- a/apps/api/src/utils/is-katakana-letter-gi-present.ts
+++ b/apps/api/src/utils/is-katakana-letter-gi-present.ts
@@ -1,0 +1,8 @@
+/**
+ * Checks whether the input string contains the Katakana letter (U+30AE) character.
+ * @param input - The string to check.
+ * @returns true if the input contains the character, false otherwise.
+ */
+export function isKatakanaLettergi(input: string): boolean {
+  return input.includes(String.fromCodePoint(12462));
+}

--- a/apps/api/src/utils/is-katakana-letter-go-present.ts
+++ b/apps/api/src/utils/is-katakana-letter-go-present.ts
@@ -1,0 +1,8 @@
+/**
+ * Checks whether the input string contains the Katakana letter (U+30B4) character.
+ * @param input - The string to check.
+ * @returns true if the input contains the character, false otherwise.
+ */
+export function isKatakanaLettergo(input: string): boolean {
+  return input.includes(String.fromCodePoint(12468));
+}

--- a/apps/api/src/utils/is-katakana-letter-gu-present.ts
+++ b/apps/api/src/utils/is-katakana-letter-gu-present.ts
@@ -1,0 +1,8 @@
+/**
+ * Checks whether the input string contains the Katakana letter (U+30B0) character.
+ * @param input - The string to check.
+ * @returns true if the input contains the character, false otherwise.
+ */
+export function isKatakanaLettergu(input: string): boolean {
+  return input.includes(String.fromCodePoint(12464));
+}

--- a/apps/api/src/utils/is-katakana-letter-i-present.ts
+++ b/apps/api/src/utils/is-katakana-letter-i-present.ts
@@ -1,0 +1,8 @@
+/**
+ * Checks whether the input string contains the Katakana letter (U+30A4) character.
+ * @param input - The string to check.
+ * @returns true if the input contains the character, false otherwise.
+ */
+export function isKatakanaLetteri(input: string): boolean {
+  return input.includes(String.fromCodePoint(12452));
+}

--- a/apps/api/src/utils/is-katakana-letter-ka-present.ts
+++ b/apps/api/src/utils/is-katakana-letter-ka-present.ts
@@ -1,0 +1,8 @@
+/**
+ * Checks whether the input string contains the Katakana letter (U+30AB) character.
+ * @param input - The string to check.
+ * @returns true if the input contains the character, false otherwise.
+ */
+export function isKatakanaLetterka(input: string): boolean {
+  return input.includes(String.fromCodePoint(12459));
+}

--- a/apps/api/src/utils/is-katakana-letter-ke-present.ts
+++ b/apps/api/src/utils/is-katakana-letter-ke-present.ts
@@ -1,0 +1,8 @@
+/**
+ * Checks whether the input string contains the Katakana letter (U+30B1) character.
+ * @param input - The string to check.
+ * @returns true if the input contains the character, false otherwise.
+ */
+export function isKatakanaLetterke(input: string): boolean {
+  return input.includes(String.fromCodePoint(12465));
+}

--- a/apps/api/src/utils/is-katakana-letter-ki-present.ts
+++ b/apps/api/src/utils/is-katakana-letter-ki-present.ts
@@ -1,0 +1,8 @@
+/**
+ * Checks whether the input string contains the Katakana letter (U+30AD) character.
+ * @param input - The string to check.
+ * @returns true if the input contains the character, false otherwise.
+ */
+export function isKatakanaLetterki(input: string): boolean {
+  return input.includes(String.fromCodePoint(12461));
+}

--- a/apps/api/src/utils/is-katakana-letter-ko-present.ts
+++ b/apps/api/src/utils/is-katakana-letter-ko-present.ts
@@ -1,0 +1,8 @@
+/**
+ * Checks whether the input string contains the Katakana letter (U+30B3) character.
+ * @param input - The string to check.
+ * @returns true if the input contains the character, false otherwise.
+ */
+export function isKatakanaLetterko(input: string): boolean {
+  return input.includes(String.fromCodePoint(12467));
+}

--- a/apps/api/src/utils/is-katakana-letter-ku-present.ts
+++ b/apps/api/src/utils/is-katakana-letter-ku-present.ts
@@ -1,0 +1,8 @@
+/**
+ * Checks whether the input string contains the Katakana letter (U+30AF) character.
+ * @param input - The string to check.
+ * @returns true if the input contains the character, false otherwise.
+ */
+export function isKatakanaLetterku(input: string): boolean {
+  return input.includes(String.fromCodePoint(12463));
+}

--- a/apps/api/src/utils/is-katakana-letter-sa-present.ts
+++ b/apps/api/src/utils/is-katakana-letter-sa-present.ts
@@ -1,0 +1,8 @@
+/**
+ * Checks whether the input string contains the Katakana letter (U+30B5) character.
+ * @param input - The string to check.
+ * @returns true if the input contains the character, false otherwise.
+ */
+export function isKatakanaLettersa(input: string): boolean {
+  return input.includes(String.fromCodePoint(12469));
+}

--- a/apps/api/src/utils/is-katakana-letter-si-present.ts
+++ b/apps/api/src/utils/is-katakana-letter-si-present.ts
@@ -1,0 +1,8 @@
+/**
+ * Checks whether the input string contains the Katakana letter (U+30B7) character.
+ * @param input - The string to check.
+ * @returns true if the input contains the character, false otherwise.
+ */
+export function isKatakanaLettersi(input: string): boolean {
+  return input.includes(String.fromCodePoint(12471));
+}

--- a/apps/api/src/utils/is-katakana-letter-small-a-present.ts
+++ b/apps/api/src/utils/is-katakana-letter-small-a-present.ts
@@ -1,0 +1,8 @@
+/**
+ * Checks whether the input string contains the Katakana letter (U+30A1) character.
+ * @param input - The string to check.
+ * @returns true if the input contains the character, false otherwise.
+ */
+export function isKatakanaLettersmalla(input: string): boolean {
+  return input.includes(String.fromCodePoint(12449));
+}

--- a/apps/api/src/utils/is-katakana-letter-small-e-present.ts
+++ b/apps/api/src/utils/is-katakana-letter-small-e-present.ts
@@ -1,0 +1,8 @@
+/**
+ * Checks whether the input string contains the Katakana letter (U+30A7) character.
+ * @param input - The string to check.
+ * @returns true if the input contains the character, false otherwise.
+ */
+export function isKatakanaLettersmalle(input: string): boolean {
+  return input.includes(String.fromCodePoint(12455));
+}

--- a/apps/api/src/utils/is-katakana-letter-small-i-present.ts
+++ b/apps/api/src/utils/is-katakana-letter-small-i-present.ts
@@ -1,0 +1,8 @@
+/**
+ * Checks whether the input string contains the Katakana letter (U+30A3) character.
+ * @param input - The string to check.
+ * @returns true if the input contains the character, false otherwise.
+ */
+export function isKatakanaLettersmalli(input: string): boolean {
+  return input.includes(String.fromCodePoint(12451));
+}

--- a/apps/api/src/utils/is-katakana-letter-small-o-present.ts
+++ b/apps/api/src/utils/is-katakana-letter-small-o-present.ts
@@ -1,0 +1,8 @@
+/**
+ * Checks whether the input string contains the Katakana letter (U+30A9) character.
+ * @param input - The string to check.
+ * @returns true if the input contains the character, false otherwise.
+ */
+export function isKatakanaLettersmallo(input: string): boolean {
+  return input.includes(String.fromCodePoint(12457));
+}

--- a/apps/api/src/utils/is-katakana-letter-za-present.ts
+++ b/apps/api/src/utils/is-katakana-letter-za-present.ts
@@ -1,0 +1,8 @@
+/**
+ * Checks whether the input string contains the Katakana letter (U+30B6) character.
+ * @param input - The string to check.
+ * @returns true if the input contains the character, false otherwise.
+ */
+export function isKatakanaLetterza(input: string): boolean {
+  return input.includes(String.fromCodePoint(12470));
+}

--- a/pr-body-katakana3.txt
+++ b/pr-body-katakana3.txt
@@ -1,0 +1,39 @@
+## Katakana Letter Detection Utilities (Batch 3 - 13 utilities)
+
+Closes #7991, #7992, #7993, #7999, #8000, #8001, #8002, #8003, #8009, #8010, #8011, #8012, #8013
+
+### Summary
+
+Adds 13 Katakana letter detection API utilities under apps/api/src/utils/. Each utility exports a dependency-free function that returns true only when the input string contains the specified Unicode Katakana character.
+
+### Files Added
+
+| File | Character | Issue |
+|------|-----------|-------|
+| is-katakana-letter-pa-present.ts | U+30D1 | #7991 |
+| is-katakana-letter-hi-present.ts | U+30D2 | #7992 |
+| is-katakana-letter-bi-present.ts | U+30D3 | #7993 |
+| is-katakana-letter-pi-present.ts | U+30D4 | #7999 |
+| is-katakana-letter-hu-present.ts | U+30D5 | #8000 |
+| is-katakana-letter-bu-present.ts | U+30D6 | #8001 |
+| is-katakana-letter-pu-present.ts | U+30D7 | #8002 |
+| is-katakana-letter-he-present.ts | U+30D8 | #8003 |
+| is-katakana-letter-be-present.ts | U+30D9 | #8009 |
+| is-katakana-letter-pe-present.ts | U+30DA | #8010 |
+| is-katakana-letter-ho-present.ts | U+30DB | #8011 |
+| is-katakana-letter-bo-present.ts | U+30DC | #8012 |
+| is-katakana-letter-po-present.ts | U+30DD | #8013 |
+
+/claim #7991
+/claim #7992
+/claim #7993
+/claim #7999
+/claim #8000
+/claim #8001
+/claim #8002
+/claim #8003
+/claim #8009
+/claim #8010
+/claim #8011
+/claim #8012
+/claim #8013


### PR DESCRIPTION
## Katakana Letter Detection Utilities (Batch 4 - 20 utilities)

Closes #7669, #7670, #7805, #7806, #7807, #7808, #7809, #7815, #7816, #7817, #7818, #7819, #7825, #7826, #7827, #7828, #7829, #7835, #7836, #7837

### Summary

Adds 20 Katakana letter detection API utilities under apps/api/src/utils/. Each utility exports a dependency-free function that returns true only when the input string contains the specified Unicode Katakana character.

### Files Added

| File | Character | Issue |
|------|-----------|-------|
| is-katakana-letter-small-a-present.ts | U+30A1 | #7669 |
| is-katakana-letter-a-present.ts | U+30A2 | #7670 |
| is-katakana-letter-small-i-present.ts | U+30A3 | #7805 |
| is-katakana-letter-i-present.ts | U+30A4 | #7806 |
| is-katakana-letter-small-e-present.ts | U+30A7 | #7807 |
| is-katakana-letter-e-present.ts | U+30A8 | #7808 |
| is-katakana-letter-small-o-present.ts | U+30A9 | #7809 |
| is-katakana-letter-ka-present.ts | U+30AB | #7815 |
| is-katakana-letter-ga-present.ts | U+30AC | #7816 |
| is-katakana-letter-ki-present.ts | U+30AD | #7817 |
| is-katakana-letter-gi-present.ts | U+30AE | #7818 |
| is-katakana-letter-ku-present.ts | U+30AF | #7819 |
| is-katakana-letter-gu-present.ts | U+30B0 | #7825 |
| is-katakana-letter-ke-present.ts | U+30B1 | #7826 |
| is-katakana-letter-ge-present.ts | U+30B2 | #7827 |
| is-katakana-letter-ko-present.ts | U+30B3 | #7828 |
| is-katakana-letter-go-present.ts | U+30B4 | #7829 |
| is-katakana-letter-sa-present.ts | U+30B5 | #7835 |
| is-katakana-letter-za-present.ts | U+30B6 | #7836 |
| is-katakana-letter-si-present.ts | U+30B7 | #7837 |

/claim #7669
/claim #7670
/claim #7805
/claim #7806
/claim #7807
/claim #7808
/claim #7809
/claim #7815
/claim #7816
/claim #7817
/claim #7818
/claim #7819
/claim #7825
/claim #7826
/claim #7827
/claim #7828
/claim #7829
/claim #7835
/claim #7836
/claim #7837
