### PR TITLE
[agent] feat: add 20 Katakana letter detection utilities (batch 5)

### DIFF
--- a/apps/api/src/utils/is-katakana-letter-da-present.ts
+++ b/apps/api/src/utils/is-katakana-letter-da-present.ts
@@ -1,0 +1,8 @@
+/**
+ * Checks whether the input string contains the Katakana letter (U+30C0) character.
+ * @param input - The string to check.
+ * @returns true if the input contains the character, false otherwise.
+ */
+export function isKatakanaLetterda(input: string): boolean {
+  return input.includes(String.fromCodePoint(12480));
+}

--- a/apps/api/src/utils/is-katakana-letter-de-present.ts
+++ b/apps/api/src/utils/is-katakana-letter-de-present.ts
@@ -1,0 +1,8 @@
+/**
+ * Checks whether the input string contains the Katakana letter (U+30C7) character.
+ * @param input - The string to check.
+ * @returns true if the input contains the character, false otherwise.
+ */
+export function isKatakanaLetterde(input: string): boolean {
+  return input.includes(String.fromCodePoint(12487));
+}

--- a/apps/api/src/utils/is-katakana-letter-di-present.ts
+++ b/apps/api/src/utils/is-katakana-letter-di-present.ts
@@ -1,0 +1,8 @@
+/**
+ * Checks whether the input string contains the Katakana letter (U+30C2) character.
+ * @param input - The string to check.
+ * @returns true if the input contains the character, false otherwise.
+ */
+export function isKatakanaLetterdi(input: string): boolean {
+  return input.includes(String.fromCodePoint(12482));
+}

--- a/apps/api/src/utils/is-katakana-letter-do-present.ts
+++ b/apps/api/src/utils/is-katakana-letter-do-present.ts
@@ -1,0 +1,8 @@
+/**
+ * Checks whether the input string contains the Katakana letter (U+30C9) character.
+ * @param input - The string to check.
+ * @returns true if the input contains the character, false otherwise.
+ */
+export function isKatakanaLetterdo(input: string): boolean {
+  return input.includes(String.fromCodePoint(12489));
+}

--- a/apps/api/src/utils/is-katakana-letter-du-present.ts
+++ b/apps/api/src/utils/is-katakana-letter-du-present.ts
@@ -1,0 +1,8 @@
+/**
+ * Checks whether the input string contains the Katakana letter (U+30C5) character.
+ * @param input - The string to check.
+ * @returns true if the input contains the character, false otherwise.
+ */
+export function isKatakanaLetterdu(input: string): boolean {
+  return input.includes(String.fromCodePoint(12485));
+}

--- a/apps/api/src/utils/is-katakana-letter-na-present.ts
+++ b/apps/api/src/utils/is-katakana-letter-na-present.ts
@@ -1,0 +1,8 @@
+/**
+ * Checks whether the input string contains the Katakana letter (U+30CA) character.
+ * @param input - The string to check.
+ * @returns true if the input contains the character, false otherwise.
+ */
+export function isKatakanaLetterna(input: string): boolean {
+  return input.includes(String.fromCodePoint(12490));
+}

--- a/apps/api/src/utils/is-katakana-letter-ni-present.ts
+++ b/apps/api/src/utils/is-katakana-letter-ni-present.ts
@@ -1,0 +1,8 @@
+/**
+ * Checks whether the input string contains the Katakana letter (U+30CB) character.
+ * @param input - The string to check.
+ * @returns true if the input contains the character, false otherwise.
+ */
+export function isKatakanaLetterni(input: string): boolean {
+  return input.includes(String.fromCodePoint(12491));
+}

--- a/apps/api/src/utils/is-katakana-letter-nu-present.ts
+++ b/apps/api/src/utils/is-katakana-letter-nu-present.ts
@@ -1,0 +1,8 @@
+/**
+ * Checks whether the input string contains the Katakana letter (U+30CC) character.
+ * @param input - The string to check.
+ * @returns true if the input contains the character, false otherwise.
+ */
+export function isKatakanaLetternu(input: string): boolean {
+  return input.includes(String.fromCodePoint(12492));
+}

--- a/apps/api/src/utils/is-katakana-letter-se-present.ts
+++ b/apps/api/src/utils/is-katakana-letter-se-present.ts
@@ -1,0 +1,8 @@
+/**
+ * Checks whether the input string contains the Katakana letter (U+30BB) character.
+ * @param input - The string to check.
+ * @returns true if the input contains the character, false otherwise.
+ */
+export function isKatakanaLetterse(input: string): boolean {
+  return input.includes(String.fromCodePoint(12475));
+}

--- a/apps/api/src/utils/is-katakana-letter-small-tu-present.ts
+++ b/apps/api/src/utils/is-katakana-letter-small-tu-present.ts
@@ -1,0 +1,8 @@
+/**
+ * Checks whether the input string contains the Katakana letter (U+30C3) character.
+ * @param input - The string to check.
+ * @returns true if the input contains the character, false otherwise.
+ */
+export function isKatakanaLettersmalltu(input: string): boolean {
+  return input.includes(String.fromCodePoint(12483));
+}

--- a/apps/api/src/utils/is-katakana-letter-so-present.ts
+++ b/apps/api/src/utils/is-katakana-letter-so-present.ts
@@ -1,0 +1,8 @@
+/**
+ * Checks whether the input string contains the Katakana letter (U+30BD) character.
+ * @param input - The string to check.
+ * @returns true if the input contains the character, false otherwise.
+ */
+export function isKatakanaLetterso(input: string): boolean {
+  return input.includes(String.fromCodePoint(12477));
+}

--- a/apps/api/src/utils/is-katakana-letter-su-present.ts
+++ b/apps/api/src/utils/is-katakana-letter-su-present.ts
@@ -1,0 +1,8 @@
+/**
+ * Checks whether the input string contains the Katakana letter (U+30B9) character.
+ * @param input - The string to check.
+ * @returns true if the input contains the character, false otherwise.
+ */
+export function isKatakanaLettersu(input: string): boolean {
+  return input.includes(String.fromCodePoint(12473));
+}

--- a/apps/api/src/utils/is-katakana-letter-ta-present.ts
+++ b/apps/api/src/utils/is-katakana-letter-ta-present.ts
@@ -1,0 +1,8 @@
+/**
+ * Checks whether the input string contains the Katakana letter (U+30BF) character.
+ * @param input - The string to check.
+ * @returns true if the input contains the character, false otherwise.
+ */
+export function isKatakanaLetterta(input: string): boolean {
+  return input.includes(String.fromCodePoint(12479));
+}

--- a/apps/api/src/utils/is-katakana-letter-te-present.ts
+++ b/apps/api/src/utils/is-katakana-letter-te-present.ts
@@ -1,0 +1,8 @@
+/**
+ * Checks whether the input string contains the Katakana letter (U+30C6) character.
+ * @param input - The string to check.
+ * @returns true if the input contains the character, false otherwise.
+ */
+export function isKatakanaLetterte(input: string): boolean {
+  return input.includes(String.fromCodePoint(12486));
+}

--- a/apps/api/src/utils/is-katakana-letter-ti-present.ts
+++ b/apps/api/src/utils/is-katakana-letter-ti-present.ts
@@ -1,0 +1,8 @@
+/**
+ * Checks whether the input string contains the Katakana letter (U+30C1) character.
+ * @param input - The string to check.
+ * @returns true if the input contains the character, false otherwise.
+ */
+export function isKatakanaLetterti(input: string): boolean {
+  return input.includes(String.fromCodePoint(12481));
+}

--- a/apps/api/src/utils/is-katakana-letter-to-present.ts
+++ b/apps/api/src/utils/is-katakana-letter-to-present.ts
@@ -1,0 +1,8 @@
+/**
+ * Checks whether the input string contains the Katakana letter (U+30C8) character.
+ * @param input - The string to check.
+ * @returns true if the input contains the character, false otherwise.
+ */
+export function isKatakanaLetterto(input: string): boolean {
+  return input.includes(String.fromCodePoint(12488));
+}

--- a/apps/api/src/utils/is-katakana-letter-ze-present.ts
+++ b/apps/api/src/utils/is-katakana-letter-ze-present.ts
@@ -1,0 +1,8 @@
+/**
+ * Checks whether the input string contains the Katakana letter (U+30BC) character.
+ * @param input - The string to check.
+ * @returns true if the input contains the character, false otherwise.
+ */
+export function isKatakanaLetterze(input: string): boolean {
+  return input.includes(String.fromCodePoint(12476));
+}

--- a/apps/api/src/utils/is-katakana-letter-zi-present.ts
+++ b/apps/api/src/utils/is-katakana-letter-zi-present.ts
@@ -1,0 +1,8 @@
+/**
+ * Checks whether the input string contains the Katakana letter (U+30B8) character.
+ * @param input - The string to check.
+ * @returns true if the input contains the character, false otherwise.
+ */
+export function isKatakanaLetterzi(input: string): boolean {
+  return input.includes(String.fromCodePoint(12472));
+}

--- a/apps/api/src/utils/is-katakana-letter-zo-present.ts
+++ b/apps/api/src/utils/is-katakana-letter-zo-present.ts
@@ -1,0 +1,8 @@
+/**
+ * Checks whether the input string contains the Katakana letter (U+30BE) character.
+ * @param input - The string to check.
+ * @returns true if the input contains the character, false otherwise.
+ */
+export function isKatakanaLetterzo(input: string): boolean {
+  return input.includes(String.fromCodePoint(12478));
+}

--- a/apps/api/src/utils/is-katakana-letter-zu-present.ts
+++ b/apps/api/src/utils/is-katakana-letter-zu-present.ts
@@ -1,0 +1,8 @@
+/**
+ * Checks whether the input string contains the Katakana letter (U+30BA) character.
+ * @param input - The string to check.
+ * @returns true if the input contains the character, false otherwise.
+ */
+export function isKatakanaLetterzu(input: string): boolean {
+  return input.includes(String.fromCodePoint(12474));
+}

--- a/pr-body-batch4.txt
+++ b/pr-body-batch4.txt
@@ -1,0 +1,53 @@
+## Katakana Letter Detection Utilities (Batch 4 - 20 utilities)
+
+Closes #7669, #7670, #7805, #7806, #7807, #7808, #7809, #7815, #7816, #7817, #7818, #7819, #7825, #7826, #7827, #7828, #7829, #7835, #7836, #7837
+
+### Summary
+
+Adds 20 Katakana letter detection API utilities under apps/api/src/utils/. Each utility exports a dependency-free function that returns true only when the input string contains the specified Unicode Katakana character.
+
+### Files Added
+
+| File | Character | Issue |
+|------|-----------|-------|
+| is-katakana-letter-small-a-present.ts | U+30A1 | #7669 |
+| is-katakana-letter-a-present.ts | U+30A2 | #7670 |
+| is-katakana-letter-small-i-present.ts | U+30A3 | #7805 |
+| is-katakana-letter-i-present.ts | U+30A4 | #7806 |
+| is-katakana-letter-small-e-present.ts | U+30A7 | #7807 |
+| is-katakana-letter-e-present.ts | U+30A8 | #7808 |
+| is-katakana-letter-small-o-present.ts | U+30A9 | #7809 |
+| is-katakana-letter-ka-present.ts | U+30AB | #7815 |
+| is-katakana-letter-ga-present.ts | U+30AC | #7816 |
+| is-katakana-letter-ki-present.ts | U+30AD | #7817 |
+| is-katakana-letter-gi-present.ts | U+30AE | #7818 |
+| is-katakana-letter-ku-present.ts | U+30AF | #7819 |
+| is-katakana-letter-gu-present.ts | U+30B0 | #7825 |
+| is-katakana-letter-ke-present.ts | U+30B1 | #7826 |
+| is-katakana-letter-ge-present.ts | U+30B2 | #7827 |
+| is-katakana-letter-ko-present.ts | U+30B3 | #7828 |
+| is-katakana-letter-go-present.ts | U+30B4 | #7829 |
+| is-katakana-letter-sa-present.ts | U+30B5 | #7835 |
+| is-katakana-letter-za-present.ts | U+30B6 | #7836 |
+| is-katakana-letter-si-present.ts | U+30B7 | #7837 |
+
+/claim #7669
+/claim #7670
+/claim #7805
+/claim #7806
+/claim #7807
+/claim #7808
+/claim #7809
+/claim #7815
+/claim #7816
+/claim #7817
+/claim #7818
+/claim #7819
+/claim #7825
+/claim #7826
+/claim #7827
+/claim #7828
+/claim #7829
+/claim #7835
+/claim #7836
+/claim #7837


### PR DESCRIPTION
## Katakana Letter Detection Utilities (Batch 5 - 20 utilities)

Closes #7838, #7839, #7845, #7846, #7847, #7848, #7849, #7855, #7856, #7857, #7858, #7859, #7867, #7868, #7869, #7870, #7871, #7979, #7980, #7981

### Summary

Adds 20 Katakana letter detection API utilities under apps/api/src/utils/. Each utility exports a dependency-free function that returns true only when the input string contains the specified Unicode Katakana character.

### Files Added

| File | Character | Issue |
|------|-----------|-------|
| is-katakana-letter-zi-present.ts | U+30B8 | #7838 |
| is-katakana-letter-su-present.ts | U+30B9 | #7839 |
| is-katakana-letter-zu-present.ts | U+30BA | #7845 |
| is-katakana-letter-se-present.ts | U+30BB | #7846 |
| is-katakana-letter-ze-present.ts | U+30BC | #7847 |
| is-katakana-letter-so-present.ts | U+30BD | #7848 |
| is-katakana-letter-zo-present.ts | U+30BE | #7849 |
| is-katakana-letter-ta-present.ts | U+30BF | #7855 |
| is-katakana-letter-da-present.ts | U+30C0 | #7856 |
| is-katakana-letter-ti-present.ts | U+30C1 | #7857 |
| is-katakana-letter-di-present.ts | U+30C2 | #7858 |
| is-katakana-letter-small-tu-present.ts | U+30C3 | #7859 |
| is-katakana-letter-du-present.ts | U+30C5 | #7867 |
| is-katakana-letter-te-present.ts | U+30C6 | #7868 |
| is-katakana-letter-de-present.ts | U+30C7 | #7869 |
| is-katakana-letter-to-present.ts | U+30C8 | #7870 |
| is-katakana-letter-do-present.ts | U+30C9 | #7871 |
| is-katakana-letter-na-present.ts | U+30CA | #7979 |
| is-katakana-letter-ni-present.ts | U+30CB | #7980 |
| is-katakana-letter-nu-present.ts | U+30CC | #7981 |

/claim #7838
/claim #7839
/claim #7845
/claim #7846
/claim #7847
/claim #7848
/claim #7849
/claim #7855
/claim #7856
/claim #7857
/claim #7858
/claim #7859
/claim #7867
/claim #7868
/claim #7869
/claim #7870
/claim #7871
/claim #7979
/claim #7980
/claim #7981
