### PR TITLE
fix: Write unit tests for leaderboard updates

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
   ],
   "scripts": {
     "dev": "npm run dev --workspaces --if-present",
-    "test": "npm run test --workspaces --if-present",
+    "test": "node --test scripts/update-leaderboard.test.mjs && npm run test --workspaces --if-present",
     "lint": "npm run lint --workspaces --if-present",
     "format": "npm run format --workspaces --if-present"
   },

--- a/scripts/update-leaderboard.mjs
+++ b/scripts/update-leaderboard.mjs
@@ -1,0 +1,22 @@
+/**
+ * Pure helper for the leaderboard increment used by
+ * `.github/workflows/auto-process.yml`:
+ *   .[$user] = ((.[$user] // 0) + 1)
+ *
+ * @param {Record<string, number>} leaderboard
+ * @param {string} username
+ * @returns {Record<string, number>}
+ */
+export function applyLeaderboardUpdate(leaderboard, username) {
+  if (typeof username !== "string" || username.trim() === "") {
+    throw new TypeError("username must be a non-empty string");
+  }
+
+  const name = username.trim();
+  const current = Number.isFinite(leaderboard[name]) ? leaderboard[name] : 0;
+
+  return {
+    ...leaderboard,
+    [name]: current + 1,
+  };
+}

--- a/scripts/update-leaderboard.test.mjs
+++ b/scripts/update-leaderboard.test.mjs
@@ -1,0 +1,40 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+
+import { applyLeaderboardUpdate } from "./update-leaderboard.mjs";
+
+test("adds a new contributor with count 1", () => {
+  const result = applyLeaderboardUpdate({ alice: 2 }, "bob");
+
+  assert.deepEqual(result, { alice: 2, bob: 1 });
+});
+
+test("increments an existing contributor", () => {
+  const result = applyLeaderboardUpdate({ alice: 2, bob: 5 }, "alice");
+
+  assert.deepEqual(result, { alice: 3, bob: 5 });
+});
+
+test("starts missing or non-numeric counts at 1", () => {
+  const result = applyLeaderboardUpdate({ alice: "x" }, "alice");
+
+  assert.deepEqual(result, { alice: 1 });
+});
+
+test("does not mutate the input leaderboard", () => {
+  const original = { alice: 1 };
+  const result = applyLeaderboardUpdate(original, "alice");
+
+  assert.deepEqual(original, { alice: 1 });
+  assert.deepEqual(result, { alice: 2 });
+  assert.notEqual(result, original);
+});
+
+test("rejects empty usernames", () => {
+  assert.throws(() => applyLeaderboardUpdate({}, ""), {
+    name: "TypeError",
+  });
+  assert.throws(() => applyLeaderboardUpdate({}, "   "), {
+    name: "TypeError",
+  });
+});


### PR DESCRIPTION
## Summary
Write unit tests for leaderboard updates

Automated BFOS+Grok implementation for issue #11.
Focused change; professional style; no payment claim by bot.

Closes #11


/bounty $50
