### PR TITLE
[agent] feat: add 140 Unicode character detection utilities (batch 7)

### DIFF
--- a/apps/api/src/utils/is-activate-arabic-form-shaping-present.ts
+++ b/apps/api/src/utils/is-activate-arabic-form-shaping-present.ts
@@ -1,0 +1,8 @@
+/**
+ * Checks whether the input string contains the Unicode character U+206D.
+ * @param input - The string to check.
+ * @returns true if the input contains the character, false otherwise.
+ */
+export function isActivateArabicFormShapingPresent(input: string): boolean {
+  return input.includes(String.fromCodePoint(8301));
+}

--- a/apps/api/src/utils/is-activate-symmetric-swapping-present.ts
+++ b/apps/api/src/utils/is-activate-symmetric-swapping-present.ts
@@ -1,0 +1,8 @@
+/**
+ * Checks whether the input string contains the Unicode character U+206B.
+ * @param input - The string to check.
+ * @returns true if the input contains the character, false otherwise.
+ */
+export function isActivateSymmetricSwappingPresent(input: string): boolean {
+  return input.includes(String.fromCodePoint(8299));
+}

--- a/apps/api/src/utils/is-arabic-letter-mark-present.ts
+++ b/apps/api/src/utils/is-arabic-letter-mark-present.ts
@@ -1,0 +1,8 @@
+/**
+ * Checks whether the input string contains the Unicode character U+61C.
+ * @param input - The string to check.
+ * @returns true if the input contains the character, false otherwise.
+ */
+export function isArabicLetterMarkPresent(input: string): boolean {
+  return input.includes(String.fromCodePoint(1564));
+}

--- a/apps/api/src/utils/is-asterism-present.ts
+++ b/apps/api/src/utils/is-asterism-present.ts
@@ -1,0 +1,8 @@
+/**
+ * Checks whether the input string contains the Unicode character U+2042.
+ * @param input - The string to check.
+ * @returns true if the input contains the character, false otherwise.
+ */
+export function isAsterismPresent(input: string): boolean {
+  return input.includes(String.fromCodePoint(8258));
+}

--- a/apps/api/src/utils/is-black-leftwards-bullet-present.ts
+++ b/apps/api/src/utils/is-black-leftwards-bullet-present.ts
@@ -1,0 +1,8 @@
+/**
+ * Checks whether the input string contains the Unicode character U+204C.
+ * @param input - The string to check.
+ * @returns true if the input contains the character, false otherwise.
+ */
+export function isBlackLeftwardsBulletPresent(input: string): boolean {
+  return input.includes(String.fromCodePoint(8268));
+}

--- a/apps/api/src/utils/is-black-rightwards-bullet-present.ts
+++ b/apps/api/src/utils/is-black-rightwards-bullet-present.ts
@@ -1,0 +1,8 @@
+/**
+ * Checks whether the input string contains the Unicode character U+204D.
+ * @param input - The string to check.
+ * @returns true if the input contains the character, false otherwise.
+ */
+export function isBlackRightwardsBulletPresent(input: string): boolean {
+  return input.includes(String.fromCodePoint(8269));
+}

--- a/apps/api/src/utils/is-bottom-half-left-parenthesis-present.ts
+++ b/apps/api/src/utils/is-bottom-half-left-parenthesis-present.ts
@@ -1,0 +1,8 @@
+/**
+ * Checks whether the input string contains the Unicode character U+2E5B.
+ * @param input - The string to check.
+ * @returns true if the input contains the character, false otherwise.
+ */
+export function isBottomHalfLeftParenthesisPresent(input: string): boolean {
+  return input.includes(String.fromCodePoint(11867));
+}

--- a/apps/api/src/utils/is-braille-pattern-blank-present.ts
+++ b/apps/api/src/utils/is-braille-pattern-blank-present.ts
@@ -1,0 +1,8 @@
+/**
+ * Checks whether the input string contains the Unicode character U+2800.
+ * @param input - The string to check.
+ * @returns true if the input contains the character, false otherwise.
+ */
+export function isBraillePatternBlankPresent(input: string): boolean {
+  return input.includes(String.fromCodePoint(10240));
+}

--- a/apps/api/src/utils/is-capitulum-present.ts
+++ b/apps/api/src/utils/is-capitulum-present.ts
@@ -1,0 +1,8 @@
+/**
+ * Checks whether the input string contains the Unicode character U+2E3F.
+ * @param input - The string to check.
+ * @returns true if the input contains the character, false otherwise.
+ */
+export function isCapitulumPresent(input: string): boolean {
+  return input.includes(String.fromCodePoint(11839));
+}

--- a/apps/api/src/utils/is-caret-insertion-point-present.ts
+++ b/apps/api/src/utils/is-caret-insertion-point-present.ts
@@ -1,0 +1,8 @@
+/**
+ * Checks whether the input string contains the Unicode character U+2041.
+ * @param input - The string to check.
+ * @returns true if the input contains the character, false otherwise.
+ */
+export function isCaretInsertionPointPresent(input: string): boolean {
+  return input.includes(String.fromCodePoint(8257));
+}

--- a/apps/api/src/utils/is-character-tie-present.ts
+++ b/apps/api/src/utils/is-character-tie-present.ts
@@ -1,0 +1,8 @@
+/**
+ * Checks whether the input string contains the Unicode character U+2040.
+ * @param input - The string to check.
+ * @returns true if the input contains the character, false otherwise.
+ */
+export function isCharacterTiePresent(input: string): boolean {
+  return input.includes(String.fromCodePoint(8256));
+}

--- a/apps/api/src/utils/is-cjk-radical-cliff-present.ts
+++ b/apps/api/src/utils/is-cjk-radical-cliff-present.ts
@@ -1,0 +1,8 @@
+/**
+ * Checks whether the input string contains the Unicode character U+2E81.
+ * @param input - The string to check.
+ * @returns true if the input contains the character, false otherwise.
+ */
+export function isCjkRadicalCliffPresent(input: string): boolean {
+  return input.includes(String.fromCodePoint(11905));
+}

--- a/apps/api/src/utils/is-cjk-radical-repeat-present.ts
+++ b/apps/api/src/utils/is-cjk-radical-repeat-present.ts
@@ -1,0 +1,8 @@
+/**
+ * Checks whether the input string contains the Unicode character U+2E80.
+ * @param input - The string to check.
+ * @returns true if the input contains the character, false otherwise.
+ */
+export function isCjkRadicalRepeatPresent(input: string): boolean {
+  return input.includes(String.fromCodePoint(11904));
+}

--- a/apps/api/src/utils/is-cjk-radical-second-one-present.ts
+++ b/apps/api/src/utils/is-cjk-radical-second-one-present.ts
@@ -1,0 +1,8 @@
+/**
+ * Checks whether the input string contains the Unicode character U+2E82.
+ * @param input - The string to check.
+ * @returns true if the input contains the character, false otherwise.
+ */
+export function isCjkRadicalSecondOnePresent(input: string): boolean {
+  return input.includes(String.fromCodePoint(11906));
+}

--- a/apps/api/src/utils/is-combining-grapheme-joiner-present.ts
+++ b/apps/api/src/utils/is-combining-grapheme-joiner-present.ts
@@ -1,0 +1,8 @@
+/**
+ * Checks whether the input string contains the Unicode character U+34F.
+ * @param input - The string to check.
+ * @returns true if the input contains the character, false otherwise.
+ */
+export function isCombiningGraphemeJoinerPresent(input: string): boolean {
+  return input.includes(String.fromCodePoint(847));
+}

--- a/apps/api/src/utils/is-commercial-minus-sign-present.ts
+++ b/apps/api/src/utils/is-commercial-minus-sign-present.ts
@@ -1,0 +1,8 @@
+/**
+ * Checks whether the input string contains the Unicode character U+2052.
+ * @param input - The string to check.
+ * @returns true if the input contains the character, false otherwise.
+ */
+export function isCommercialMinusSignPresent(input: string): boolean {
+  return input.includes(String.fromCodePoint(8274));
+}

--- a/apps/api/src/utils/is-cornish-verse-divider-present.ts
+++ b/apps/api/src/utils/is-cornish-verse-divider-present.ts
@@ -1,0 +1,8 @@
+/**
+ * Checks whether the input string contains the Unicode character U+2E4F.
+ * @param input - The string to check.
+ * @returns true if the input contains the character, false otherwise.
+ */
+export function isCornishVerseDividerPresent(input: string): boolean {
+  return input.includes(String.fromCodePoint(11855));
+}

--- a/apps/api/src/utils/is-cross-patty-with-left-crossbar-present.ts
+++ b/apps/api/src/utils/is-cross-patty-with-left-crossbar-present.ts
@@ -1,0 +1,8 @@
+/**
+ * Checks whether the input string contains the Unicode character U+2E51.
+ * @param input - The string to check.
+ * @returns true if the input contains the character, false otherwise.
+ */
+export function isCrossPattyWithLeftCrossbarPresent(input: string): boolean {
+  return input.includes(String.fromCodePoint(11857));
+}

--- a/apps/api/src/utils/is-dagger-with-left-guard-present.ts
+++ b/apps/api/src/utils/is-dagger-with-left-guard-present.ts
@@ -1,0 +1,8 @@
+/**
+ * Checks whether the input string contains the Unicode character U+2E36.
+ * @param input - The string to check.
+ * @returns true if the input contains the character, false otherwise.
+ */
+export function isDaggerWithLeftGuardPresent(input: string): boolean {
+  return input.includes(String.fromCodePoint(11830));
+}

--- a/apps/api/src/utils/is-dagger-with-right-guard-present.ts
+++ b/apps/api/src/utils/is-dagger-with-right-guard-present.ts
@@ -1,0 +1,8 @@
+/**
+ * Checks whether the input string contains the Unicode character U+2E37.
+ * @param input - The string to check.
+ * @returns true if the input contains the character, false otherwise.
+ */
+export function isDaggerWithRightGuardPresent(input: string): boolean {
+  return input.includes(String.fromCodePoint(11831));
+}

--- a/apps/api/src/utils/is-dash-with-left-upturn-present.ts
+++ b/apps/api/src/utils/is-dash-with-left-upturn-present.ts
@@ -1,0 +1,8 @@
+/**
+ * Checks whether the input string contains the Unicode character U+2E43.
+ * @param input - The string to check.
+ * @returns true if the input contains the character, false otherwise.
+ */
+export function isDashWithLeftUpturnPresent(input: string): boolean {
+  return input.includes(String.fromCodePoint(11843));
+}

--- a/apps/api/src/utils/is-dotted-obelos-present.ts
+++ b/apps/api/src/utils/is-dotted-obelos-present.ts
@@ -1,0 +1,8 @@
+/**
+ * Checks whether the input string contains the Unicode character U+2E13.
+ * @param input - The string to check.
+ * @returns true if the input contains the character, false otherwise.
+ */
+export function isDottedObelosPresent(input: string): boolean {
+  return input.includes(String.fromCodePoint(11795));
+}

--- a/apps/api/src/utils/is-dotted-right-pointing-angle-present.ts
+++ b/apps/api/src/utils/is-dotted-right-pointing-angle-present.ts
@@ -1,0 +1,8 @@
+/**
+ * Checks whether the input string contains the Unicode character U+2E16.
+ * @param input - The string to check.
+ * @returns true if the input contains the character, false otherwise.
+ */
+export function isDottedRightPointingAnglePresent(input: string): boolean {
+  return input.includes(String.fromCodePoint(11798));
+}

--- a/apps/api/src/utils/is-dotted-transposition-marker-present.ts
+++ b/apps/api/src/utils/is-dotted-transposition-marker-present.ts
@@ -1,0 +1,8 @@
+/**
+ * Checks whether the input string contains the Unicode character U+2E08.
+ * @param input - The string to check.
+ * @returns true if the input contains the character, false otherwise.
+ */
+export function isDottedTranspositionMarkerPresent(input: string): boolean {
+  return input.includes(String.fromCodePoint(11784));
+}

--- a/apps/api/src/utils/is-double-hyphen-present.ts
+++ b/apps/api/src/utils/is-double-hyphen-present.ts
@@ -1,0 +1,8 @@
+/**
+ * Checks whether the input string contains the Unicode character U+2E40.
+ * @param input - The string to check.
+ * @returns true if the input contains the character, false otherwise.
+ */
+export function isDoubleHyphenPresent(input: string): boolean {
+  return input.includes(String.fromCodePoint(11840));
+}

--- a/apps/api/src/utils/is-double-low-reversed-9-quotation-mark-present.ts
+++ b/apps/api/src/utils/is-double-low-reversed-9-quotation-mark-present.ts
@@ -1,0 +1,8 @@
+/**
+ * Checks whether the input string contains the Unicode character U+2E42.
+ * @param input - The string to check.
+ * @returns true if the input contains the character, false otherwise.
+ */
+export function isDoubleLowReversed9QuotationMarkPresent(input: string): boolean {
+  return input.includes(String.fromCodePoint(11842));
+}

--- a/apps/api/src/utils/is-double-question-mark-present.ts
+++ b/apps/api/src/utils/is-double-question-mark-present.ts
@@ -1,0 +1,8 @@
+/**
+ * Checks whether the input string contains the Unicode character U+2047.
+ * @param input - The string to check.
+ * @returns true if the input contains the character, false otherwise.
+ */
+export function isDoubleQuestionMarkPresent(input: string): boolean {
+  return input.includes(String.fromCodePoint(8263));
+}

--- a/apps/api/src/utils/is-double-stacked-comma-present.ts
+++ b/apps/api/src/utils/is-double-stacked-comma-present.ts
@@ -1,0 +1,8 @@
+/**
+ * Checks whether the input string contains the Unicode character U+2E49.
+ * @param input - The string to check.
+ * @returns true if the input contains the character, false otherwise.
+ */
+export function isDoubleStackedCommaPresent(input: string): boolean {
+  return input.includes(String.fromCodePoint(11849));
+}

--- a/apps/api/src/utils/is-downwards-ancora-present.ts
+++ b/apps/api/src/utils/is-downwards-ancora-present.ts
@@ -1,0 +1,8 @@
+/**
+ * Checks whether the input string contains the Unicode character U+2E14.
+ * @param input - The string to check.
+ * @returns true if the input contains the character, false otherwise.
+ */
+export function isDownwardsAncoraPresent(input: string): boolean {
+  return input.includes(String.fromCodePoint(11796));
+}

--- a/apps/api/src/utils/is-editorial-coronis-present.ts
+++ b/apps/api/src/utils/is-editorial-coronis-present.ts
@@ -1,0 +1,8 @@
+/**
+ * Checks whether the input string contains the Unicode character U+2E0E.
+ * @param input - The string to check.
+ * @returns true if the input contains the character, false otherwise.
+ */
+export function isEditorialCoronisPresent(input: string): boolean {
+  return input.includes(String.fromCodePoint(11790));
+}

--- a/apps/api/src/utils/is-exclamation-question-mark-present.ts
+++ b/apps/api/src/utils/is-exclamation-question-mark-present.ts
@@ -1,0 +1,8 @@
+/**
+ * Checks whether the input string contains the Unicode character U+2049.
+ * @param input - The string to check.
+ * @returns true if the input contains the character, false otherwise.
+ */
+export function isExclamationQuestionMarkPresent(input: string): boolean {
+  return input.includes(String.fromCodePoint(8265));
+}

--- a/apps/api/src/utils/is-first-strong-isolate-present.ts
+++ b/apps/api/src/utils/is-first-strong-isolate-present.ts
@@ -1,0 +1,8 @@
+/**
+ * Checks whether the input string contains the Unicode character U+2068.
+ * @param input - The string to check.
+ * @returns true if the input contains the character, false otherwise.
+ */
+export function isFirstStrongIsolatePresent(input: string): boolean {
+  return input.includes(String.fromCodePoint(8296));
+}

--- a/apps/api/src/utils/is-five-dot-mark-present.ts
+++ b/apps/api/src/utils/is-five-dot-mark-present.ts
@@ -1,0 +1,8 @@
+/**
+ * Checks whether the input string contains the Unicode character U+2E2D.
+ * @param input - The string to check.
+ * @returns true if the input contains the character, false otherwise.
+ */
+export function isFiveDotMarkPresent(input: string): boolean {
+  return input.includes(String.fromCodePoint(11821));
+}

--- a/apps/api/src/utils/is-five-dot-punctuation-present.ts
+++ b/apps/api/src/utils/is-five-dot-punctuation-present.ts
@@ -1,0 +1,8 @@
+/**
+ * Checks whether the input string contains the Unicode character U+2059.
+ * @param input - The string to check.
+ * @returns true if the input contains the character, false otherwise.
+ */
+export function isFiveDotPunctuationPresent(input: string): boolean {
+  return input.includes(String.fromCodePoint(8281));
+}

--- a/apps/api/src/utils/is-flower-punctuation-mark-present.ts
+++ b/apps/api/src/utils/is-flower-punctuation-mark-present.ts
@@ -1,0 +1,8 @@
+/**
+ * Checks whether the input string contains the Unicode character U+2055.
+ * @param input - The string to check.
+ * @returns true if the input contains the character, false otherwise.
+ */
+export function isFlowerPunctuationMarkPresent(input: string): boolean {
+  return input.includes(String.fromCodePoint(8277));
+}

--- a/apps/api/src/utils/is-forked-paragraphos-present.ts
+++ b/apps/api/src/utils/is-forked-paragraphos-present.ts
@@ -1,0 +1,8 @@
+/**
+ * Checks whether the input string contains the Unicode character U+2E10.
+ * @param input - The string to check.
+ * @returns true if the input contains the character, false otherwise.
+ */
+export function isForkedParagraphosPresent(input: string): boolean {
+  return input.includes(String.fromCodePoint(11792));
+}

--- a/apps/api/src/utils/is-four-dot-mark-present.ts
+++ b/apps/api/src/utils/is-four-dot-mark-present.ts
@@ -1,0 +1,8 @@
+/**
+ * Checks whether the input string contains the Unicode character U+205B.
+ * @param input - The string to check.
+ * @returns true if the input contains the character, false otherwise.
+ */
+export function isFourDotMarkPresent(input: string): boolean {
+  return input.includes(String.fromCodePoint(8283));
+}

--- a/apps/api/src/utils/is-four-dot-punctuation-present.ts
+++ b/apps/api/src/utils/is-four-dot-punctuation-present.ts
@@ -1,0 +1,8 @@
+/**
+ * Checks whether the input string contains the Unicode character U+2058.
+ * @param input - The string to check.
+ * @returns true if the input contains the character, false otherwise.
+ */
+export function isFourDotPunctuationPresent(input: string): boolean {
+  return input.includes(String.fromCodePoint(8280));
+}

--- a/apps/api/src/utils/is-fraction-slash-present.ts
+++ b/apps/api/src/utils/is-fraction-slash-present.ts
@@ -1,0 +1,8 @@
+/**
+ * Checks whether the input string contains the Unicode character U+2044.
+ * @param input - The string to check.
+ * @returns true if the input contains the character, false otherwise.
+ */
+export function isFractionSlashPresent(input: string): boolean {
+  return input.includes(String.fromCodePoint(8260));
+}

--- a/apps/api/src/utils/is-halfwidth-hangul-filler-present.ts
+++ b/apps/api/src/utils/is-halfwidth-hangul-filler-present.ts
@@ -1,0 +1,8 @@
+/**
+ * Checks whether the input string contains the Unicode character U+FFA0.
+ * @param input - The string to check.
+ * @returns true if the input contains the character, false otherwise.
+ */
+export function isHalfwidthHangulFillerPresent(input: string): boolean {
+  return input.includes(String.fromCodePoint(65440));
+}

--- a/apps/api/src/utils/is-hangul-filler-present.ts
+++ b/apps/api/src/utils/is-hangul-filler-present.ts
@@ -1,0 +1,8 @@
+/**
+ * Checks whether the input string contains the Unicode character U+3164.
+ * @param input - The string to check.
+ * @returns true if the input contains the character, false otherwise.
+ */
+export function isHangulFillerPresent(input: string): boolean {
+  return input.includes(String.fromCodePoint(12644));
+}

--- a/apps/api/src/utils/is-horizontal-ellipsis-present.ts
+++ b/apps/api/src/utils/is-horizontal-ellipsis-present.ts
@@ -1,0 +1,8 @@
+/**
+ * Checks whether the input string contains the Unicode character U+2026.
+ * @param input - The string to check.
+ * @returns true if the input contains the character, false otherwise.
+ */
+export function isHorizontalEllipsisPresent(input: string): boolean {
+  return input.includes(String.fromCodePoint(8230));
+}

--- a/apps/api/src/utils/is-hyphen-bullet-present.ts
+++ b/apps/api/src/utils/is-hyphen-bullet-present.ts
@@ -1,0 +1,8 @@
+/**
+ * Checks whether the input string contains the Unicode character U+2043.
+ * @param input - The string to check.
+ * @returns true if the input contains the character, false otherwise.
+ */
+export function isHyphenBulletPresent(input: string): boolean {
+  return input.includes(String.fromCodePoint(8259));
+}

--- a/apps/api/src/utils/is-hyphen-with-diaeresis-present.ts
+++ b/apps/api/src/utils/is-hyphen-with-diaeresis-present.ts
@@ -1,0 +1,8 @@
+/**
+ * Checks whether the input string contains the Unicode character U+2E1A.
+ * @param input - The string to check.
+ * @returns true if the input contains the character, false otherwise.
+ */
+export function isHyphenWithDiaeresisPresent(input: string): boolean {
+  return input.includes(String.fromCodePoint(11802));
+}

--- a/apps/api/src/utils/is-hypodiastole-present.ts
+++ b/apps/api/src/utils/is-hypodiastole-present.ts
@@ -1,0 +1,8 @@
+/**
+ * Checks whether the input string contains the Unicode character U+2E12.
+ * @param input - The string to check.
+ * @returns true if the input contains the character, false otherwise.
+ */
+export function isHypodiastolePresent(input: string): boolean {
+  return input.includes(String.fromCodePoint(11794));
+}

--- a/apps/api/src/utils/is-inhibit-arabic-form-shaping-present.ts
+++ b/apps/api/src/utils/is-inhibit-arabic-form-shaping-present.ts
@@ -1,0 +1,8 @@
+/**
+ * Checks whether the input string contains the Unicode character U+206C.
+ * @param input - The string to check.
+ * @returns true if the input contains the character, false otherwise.
+ */
+export function isInhibitArabicFormShapingPresent(input: string): boolean {
+  return input.includes(String.fromCodePoint(8300));
+}

--- a/apps/api/src/utils/is-inhibit-symmetric-swapping-present.ts
+++ b/apps/api/src/utils/is-inhibit-symmetric-swapping-present.ts
@@ -1,0 +1,8 @@
+/**
+ * Checks whether the input string contains the Unicode character U+206A.
+ * @param input - The string to check.
+ * @returns true if the input contains the character, false otherwise.
+ */
+export function isInhibitSymmetricSwappingPresent(input: string): boolean {
+  return input.includes(String.fromCodePoint(8298));
+}

--- a/apps/api/src/utils/is-interlinear-annotation-anchor-present.ts
+++ b/apps/api/src/utils/is-interlinear-annotation-anchor-present.ts
@@ -1,0 +1,8 @@
+/**
+ * Checks whether the input string contains the Unicode character U+FFF9.
+ * @param input - The string to check.
+ * @returns true if the input contains the character, false otherwise.
+ */
+export function isInterlinearAnnotationAnchorPresent(input: string): boolean {
+  return input.includes(String.fromCodePoint(65529));
+}

--- a/apps/api/src/utils/is-interlinear-annotation-separator-present.ts
+++ b/apps/api/src/utils/is-interlinear-annotation-separator-present.ts
@@ -1,0 +1,8 @@
+/**
+ * Checks whether the input string contains the Unicode character U+FFFA.
+ * @param input - The string to check.
+ * @returns true if the input contains the character, false otherwise.
+ */
+export function isInterlinearAnnotationSeparatorPresent(input: string): boolean {
+  return input.includes(String.fromCodePoint(65530));
+}

--- a/apps/api/src/utils/is-interlinear-annotation-terminator-present.ts
+++ b/apps/api/src/utils/is-interlinear-annotation-terminator-present.ts
@@ -1,0 +1,8 @@
+/**
+ * Checks whether the input string contains the Unicode character U+FFFB.
+ * @param input - The string to check.
+ * @returns true if the input contains the character, false otherwise.
+ */
+export function isInterlinearAnnotationTerminatorPresent(input: string): boolean {
+  return input.includes(String.fromCodePoint(65531));
+}

--- a/apps/api/src/utils/is-inverted-low-kavyka-present.ts
+++ b/apps/api/src/utils/is-inverted-low-kavyka-present.ts
@@ -1,0 +1,8 @@
+/**
+ * Checks whether the input string contains the Unicode character U+2E45.
+ * @param input - The string to check.
+ * @returns true if the input contains the character, false otherwise.
+ */
+export function isInvertedLowKavykaPresent(input: string): boolean {
+  return input.includes(String.fromCodePoint(11845));
+}

--- a/apps/api/src/utils/is-inverted-low-kavyka-with-kavyka-above-present.ts
+++ b/apps/api/src/utils/is-inverted-low-kavyka-with-kavyka-above-present.ts
@@ -1,0 +1,8 @@
+/**
+ * Checks whether the input string contains the Unicode character U+2E46.
+ * @param input - The string to check.
+ * @returns true if the input contains the character, false otherwise.
+ */
+export function isInvertedLowKavykaWithKavykaAbovePresent(input: string): boolean {
+  return input.includes(String.fromCodePoint(11846));
+}

--- a/apps/api/src/utils/is-inverted-undertie-present.ts
+++ b/apps/api/src/utils/is-inverted-undertie-present.ts
@@ -1,0 +1,8 @@
+/**
+ * Checks whether the input string contains the Unicode character U+2054.
+ * @param input - The string to check.
+ * @returns true if the input contains the character, false otherwise.
+ */
+export function isInvertedUndertiePresent(input: string): boolean {
+  return input.includes(String.fromCodePoint(8276));
+}

--- a/apps/api/src/utils/is-invisible-operator-present.ts
+++ b/apps/api/src/utils/is-invisible-operator-present.ts
@@ -1,0 +1,8 @@
+/**
+ * Checks whether the input string contains the Unicode character U+2062.
+ * @param input - The string to check.
+ * @returns true if the input contains the character, false otherwise.
+ */
+export function isInvisibleOperatorPresent(input: string): boolean {
+  return input.includes(String.fromCodePoint(8290));
+}

--- a/apps/api/src/utils/is-invisible-plus-present.ts
+++ b/apps/api/src/utils/is-invisible-plus-present.ts
@@ -1,0 +1,8 @@
+/**
+ * Checks whether the input string contains the Unicode character U+2064.
+ * @param input - The string to check.
+ * @returns true if the input contains the character, false otherwise.
+ */
+export function isInvisiblePlusPresent(input: string): boolean {
+  return input.includes(String.fromCodePoint(8292));
+}

--- a/apps/api/src/utils/is-invisible-separator-present.ts
+++ b/apps/api/src/utils/is-invisible-separator-present.ts
@@ -1,0 +1,8 @@
+/**
+ * Checks whether the input string contains the Unicode character U+2063.
+ * @param input - The string to check.
+ * @returns true if the input contains the character, false otherwise.
+ */
+export function isInvisibleSeparatorPresent(input: string): boolean {
+  return input.includes(String.fromCodePoint(8291));
+}

--- a/apps/api/src/utils/is-invisible-times-present.ts
+++ b/apps/api/src/utils/is-invisible-times-present.ts
@@ -1,0 +1,8 @@
+/**
+ * Checks whether the input string contains the Unicode character U+2062.
+ * @param input - The string to check.
+ * @returns true if the input contains the character, false otherwise.
+ */
+export function isInvisibleTimesPresent(input: string): boolean {
+  return input.includes(String.fromCodePoint(8290));
+}

--- a/apps/api/src/utils/is-left-dotted-substitution-bracket-present.ts
+++ b/apps/api/src/utils/is-left-dotted-substitution-bracket-present.ts
@@ -1,0 +1,8 @@
+/**
+ * Checks whether the input string contains the Unicode character U+2E04.
+ * @param input - The string to check.
+ * @returns true if the input contains the character, false otherwise.
+ */
+export function isLeftDottedSubstitutionBracketPresent(input: string): boolean {
+  return input.includes(String.fromCodePoint(11780));
+}

--- a/apps/api/src/utils/is-left-double-parenthesis-present.ts
+++ b/apps/api/src/utils/is-left-double-parenthesis-present.ts
@@ -1,0 +1,8 @@
+/**
+ * Checks whether the input string contains the Unicode character U+2E28.
+ * @param input - The string to check.
+ * @returns true if the input contains the character, false otherwise.
+ */
+export function isLeftDoubleParenthesisPresent(input: string): boolean {
+  return input.includes(String.fromCodePoint(11816));
+}

--- a/apps/api/src/utils/is-left-low-paraphrase-bracket-present.ts
+++ b/apps/api/src/utils/is-left-low-paraphrase-bracket-present.ts
@@ -1,0 +1,8 @@
+/**
+ * Checks whether the input string contains the Unicode character U+2E1C.
+ * @param input - The string to check.
+ * @returns true if the input contains the character, false otherwise.
+ */
+export function isLeftLowParaphraseBracketPresent(input: string): boolean {
+  return input.includes(String.fromCodePoint(11804));
+}

--- a/apps/api/src/utils/is-left-sideways-u-bracket-present.ts
+++ b/apps/api/src/utils/is-left-sideways-u-bracket-present.ts
@@ -1,0 +1,8 @@
+/**
+ * Checks whether the input string contains the Unicode character U+2E26.
+ * @param input - The string to check.
+ * @returns true if the input contains the character, false otherwise.
+ */
+export function isLeftSidewaysUBracketPresent(input: string): boolean {
+  return input.includes(String.fromCodePoint(11814));
+}

--- a/apps/api/src/utils/is-left-square-bracket-with-double-stroke-present.ts
+++ b/apps/api/src/utils/is-left-square-bracket-with-double-stroke-present.ts
@@ -1,0 +1,8 @@
+/**
+ * Checks whether the input string contains the Unicode character U+2E57.
+ * @param input - The string to check.
+ * @returns true if the input contains the character, false otherwise.
+ */
+export function isLeftSquareBracketWithDoubleStrokePresent(input: string): boolean {
+  return input.includes(String.fromCodePoint(11863));
+}

--- a/apps/api/src/utils/is-left-square-bracket-with-quill-present.ts
+++ b/apps/api/src/utils/is-left-square-bracket-with-quill-present.ts
@@ -1,0 +1,8 @@
+/**
+ * Checks whether the input string contains the Unicode character U+2045.
+ * @param input - The string to check.
+ * @returns true if the input contains the character, false otherwise.
+ */
+export function isLeftSquareBracketWithQuillPresent(input: string): boolean {
+  return input.includes(String.fromCodePoint(8261));
+}

--- a/apps/api/src/utils/is-left-square-bracket-with-stroke-present.ts
+++ b/apps/api/src/utils/is-left-square-bracket-with-stroke-present.ts
@@ -1,0 +1,8 @@
+/**
+ * Checks whether the input string contains the Unicode character U+2E55.
+ * @param input - The string to check.
+ * @returns true if the input contains the character, false otherwise.
+ */
+export function isLeftSquareBracketWithStrokePresent(input: string): boolean {
+  return input.includes(String.fromCodePoint(11861));
+}

--- a/apps/api/src/utils/is-left-substitution-bracket-present.ts
+++ b/apps/api/src/utils/is-left-substitution-bracket-present.ts
@@ -1,0 +1,8 @@
+/**
+ * Checks whether the input string contains the Unicode character U+2E02.
+ * @param input - The string to check.
+ * @returns true if the input contains the character, false otherwise.
+ */
+export function isLeftSubstitutionBracketPresent(input: string): boolean {
+  return input.includes(String.fromCodePoint(11778));
+}

--- a/apps/api/src/utils/is-left-to-right-embedding-present.ts
+++ b/apps/api/src/utils/is-left-to-right-embedding-present.ts
@@ -1,0 +1,8 @@
+/**
+ * Checks whether the input string contains the Unicode character U+202A.
+ * @param input - The string to check.
+ * @returns true if the input contains the character, false otherwise.
+ */
+export function isLeftToRightEmbeddingPresent(input: string): boolean {
+  return input.includes(String.fromCodePoint(8234));
+}

--- a/apps/api/src/utils/is-left-to-right-isolate-present.ts
+++ b/apps/api/src/utils/is-left-to-right-isolate-present.ts
@@ -1,0 +1,8 @@
+/**
+ * Checks whether the input string contains the Unicode character U+2066.
+ * @param input - The string to check.
+ * @returns true if the input contains the character, false otherwise.
+ */
+export function isLeftToRightIsolatePresent(input: string): boolean {
+  return input.includes(String.fromCodePoint(8294));
+}

--- a/apps/api/src/utils/is-left-to-right-mark-present.ts
+++ b/apps/api/src/utils/is-left-to-right-mark-present.ts
@@ -1,0 +1,8 @@
+/**
+ * Checks whether the input string contains the Unicode character U+200E.
+ * @param input - The string to check.
+ * @returns true if the input contains the character, false otherwise.
+ */
+export function isLeftToRightMarkPresent(input: string): boolean {
+  return input.includes(String.fromCodePoint(8206));
+}

--- a/apps/api/src/utils/is-left-to-right-override-present.ts
+++ b/apps/api/src/utils/is-left-to-right-override-present.ts
@@ -1,0 +1,8 @@
+/**
+ * Checks whether the input string contains the Unicode character U+202D.
+ * @param input - The string to check.
+ * @returns true if the input contains the character, false otherwise.
+ */
+export function isLeftToRightOverridePresent(input: string): boolean {
+  return input.includes(String.fromCodePoint(8237));
+}

--- a/apps/api/src/utils/is-left-transposition-bracket-present.ts
+++ b/apps/api/src/utils/is-left-transposition-bracket-present.ts
@@ -1,0 +1,8 @@
+/**
+ * Checks whether the input string contains the Unicode character U+2E09.
+ * @param input - The string to check.
+ * @returns true if the input contains the character, false otherwise.
+ */
+export function isLeftTranspositionBracketPresent(input: string): boolean {
+  return input.includes(String.fromCodePoint(11785));
+}

--- a/apps/api/src/utils/is-left-vertical-bar-with-quill-present.ts
+++ b/apps/api/src/utils/is-left-vertical-bar-with-quill-present.ts
@@ -1,0 +1,8 @@
+/**
+ * Checks whether the input string contains the Unicode character U+2E20.
+ * @param input - The string to check.
+ * @returns true if the input contains the character, false otherwise.
+ */
+export function isLeftVerticalBarWithQuillPresent(input: string): boolean {
+  return input.includes(String.fromCodePoint(11808));
+}

--- a/apps/api/src/utils/is-low-asterisk-present.ts
+++ b/apps/api/src/utils/is-low-asterisk-present.ts
@@ -1,0 +1,8 @@
+/**
+ * Checks whether the input string contains the Unicode character U+204E.
+ * @param input - The string to check.
+ * @returns true if the input contains the character, false otherwise.
+ */
+export function isLowAsteriskPresent(input: string): boolean {
+  return input.includes(String.fromCodePoint(8270));
+}

--- a/apps/api/src/utils/is-low-kavyka-present.ts
+++ b/apps/api/src/utils/is-low-kavyka-present.ts
@@ -1,0 +1,8 @@
+/**
+ * Checks whether the input string contains the Unicode character U+2E47.
+ * @param input - The string to check.
+ * @returns true if the input contains the character, false otherwise.
+ */
+export function isLowKavykaPresent(input: string): boolean {
+  return input.includes(String.fromCodePoint(11847));
+}

--- a/apps/api/src/utils/is-low-kavyka-with-dot-present.ts
+++ b/apps/api/src/utils/is-low-kavyka-with-dot-present.ts
@@ -1,0 +1,8 @@
+/**
+ * Checks whether the input string contains the Unicode character U+2E48.
+ * @param input - The string to check.
+ * @returns true if the input contains the character, false otherwise.
+ */
+export function isLowKavykaWithDotPresent(input: string): boolean {
+  return input.includes(String.fromCodePoint(11848));
+}

--- a/apps/api/src/utils/is-math-shift-present.ts
+++ b/apps/api/src/utils/is-math-shift-present.ts
@@ -1,0 +1,8 @@
+/**
+ * Checks whether the input string contains the Unicode character U+205A.
+ * @param input - The string to check.
+ * @returns true if the input contains the character, false otherwise.
+ */
+export function isMathShiftPresent(input: string): boolean {
+  return input.includes(String.fromCodePoint(8282));
+}

--- a/apps/api/src/utils/is-medieval-comma-present.ts
+++ b/apps/api/src/utils/is-medieval-comma-present.ts
@@ -1,0 +1,8 @@
+/**
+ * Checks whether the input string contains the Unicode character U+2E4C.
+ * @param input - The string to check.
+ * @returns true if the input contains the character, false otherwise.
+ */
+export function isMedievalCommaPresent(input: string): boolean {
+  return input.includes(String.fromCodePoint(11852));
+}

--- a/apps/api/src/utils/is-medieval-exclamation-mark-present.ts
+++ b/apps/api/src/utils/is-medieval-exclamation-mark-present.ts
@@ -1,0 +1,8 @@
+/**
+ * Checks whether the input string contains the Unicode character U+2E53.
+ * @param input - The string to check.
+ * @returns true if the input contains the character, false otherwise.
+ */
+export function isMedievalExclamationMarkPresent(input: string): boolean {
+  return input.includes(String.fromCodePoint(11859));
+}

--- a/apps/api/src/utils/is-medieval-question-mark-present.ts
+++ b/apps/api/src/utils/is-medieval-question-mark-present.ts
@@ -1,0 +1,8 @@
+/**
+ * Checks whether the input string contains the Unicode character U+2E54.
+ * @param input - The string to check.
+ * @returns true if the input contains the character, false otherwise.
+ */
+export function isMedievalQuestionMarkPresent(input: string): boolean {
+  return input.includes(String.fromCodePoint(11860));
+}

--- a/apps/api/src/utils/is-national-digit-shapes-present.ts
+++ b/apps/api/src/utils/is-national-digit-shapes-present.ts
@@ -1,0 +1,8 @@
+/**
+ * Checks whether the input string contains the Unicode character U+206E.
+ * @param input - The string to check.
+ * @returns true if the input contains the character, false otherwise.
+ */
+export function isNationalDigitShapesPresent(input: string): boolean {
+  return input.includes(String.fromCodePoint(8302));
+}

--- a/apps/api/src/utils/is-nominal-digit-shapes-present.ts
+++ b/apps/api/src/utils/is-nominal-digit-shapes-present.ts
@@ -1,0 +1,8 @@
+/**
+ * Checks whether the input string contains the Unicode character U+206F.
+ * @param input - The string to check.
+ * @returns true if the input contains the character, false otherwise.
+ */
+export function isNominalDigitShapesPresent(input: string): boolean {
+  return input.includes(String.fromCodePoint(8303));
+}

--- a/apps/api/src/utils/is-object-replacement-character-present.ts
+++ b/apps/api/src/utils/is-object-replacement-character-present.ts
@@ -1,0 +1,8 @@
+/**
+ * Checks whether the input string contains the Unicode character U+FFFC.
+ * @param input - The string to check.
+ * @returns true if the input contains the character, false otherwise.
+ */
+export function isObjectReplacementCharacterPresent(input: string): boolean {
+  return input.includes(String.fromCodePoint(65532));
+}

--- a/apps/api/src/utils/is-oblique-hyphen-present.ts
+++ b/apps/api/src/utils/is-oblique-hyphen-present.ts
@@ -1,0 +1,8 @@
+/**
+ * Checks whether the input string contains the Unicode character U+2E5D.
+ * @param input - The string to check.
+ * @returns true if the input contains the character, false otherwise.
+ */
+export function isObliqueHyphenPresent(input: string): boolean {
+  return input.includes(String.fromCodePoint(11869));
+}

--- a/apps/api/src/utils/is-overline-present.ts
+++ b/apps/api/src/utils/is-overline-present.ts
@@ -1,0 +1,8 @@
+/**
+ * Checks whether the input string contains the Unicode character U+203E.
+ * @param input - The string to check.
+ * @returns true if the input contains the character, false otherwise.
+ */
+export function isOverlinePresent(input: string): boolean {
+  return input.includes(String.fromCodePoint(8254));
+}

--- a/apps/api/src/utils/is-paragraphos-present.ts
+++ b/apps/api/src/utils/is-paragraphos-present.ts
@@ -1,0 +1,8 @@
+/**
+ * Checks whether the input string contains the Unicode character U+2E0F.
+ * @param input - The string to check.
+ * @returns true if the input contains the character, false otherwise.
+ */
+export function isParagraphosPresent(input: string): boolean {
+  return input.includes(String.fromCodePoint(11791));
+}

--- a/apps/api/src/utils/is-paragraphus-mark-present.ts
+++ b/apps/api/src/utils/is-paragraphus-mark-present.ts
@@ -1,0 +1,8 @@
+/**
+ * Checks whether the input string contains the Unicode character U+2E4D.
+ * @param input - The string to check.
+ * @returns true if the input contains the character, false otherwise.
+ */
+export function isParagraphusMarkPresent(input: string): boolean {
+  return input.includes(String.fromCodePoint(11853));
+}

--- a/apps/api/src/utils/is-pop-directional-formatting-present.ts
+++ b/apps/api/src/utils/is-pop-directional-formatting-present.ts
@@ -1,0 +1,8 @@
+/**
+ * Checks whether the input string contains the Unicode character U+202C.
+ * @param input - The string to check.
+ * @returns true if the input contains the character, false otherwise.
+ */
+export function isPopDirectionalFormattingPresent(input: string): boolean {
+  return input.includes(String.fromCodePoint(8236));
+}

--- a/apps/api/src/utils/is-pop-directional-isolate-present.ts
+++ b/apps/api/src/utils/is-pop-directional-isolate-present.ts
@@ -1,0 +1,8 @@
+/**
+ * Checks whether the input string contains the Unicode character U+2069.
+ * @param input - The string to check.
+ * @returns true if the input contains the character, false otherwise.
+ */
+export function isPopDirectionalIsolatePresent(input: string): boolean {
+  return input.includes(String.fromCodePoint(8297));
+}

--- a/apps/api/src/utils/is-punctus-elevatus-mark-present.ts
+++ b/apps/api/src/utils/is-punctus-elevatus-mark-present.ts
@@ -1,0 +1,8 @@
+/**
+ * Checks whether the input string contains the Unicode character U+2E4E.
+ * @param input - The string to check.
+ * @returns true if the input contains the character, false otherwise.
+ */
+export function isPunctusElevatusMarkPresent(input: string): boolean {
+  return input.includes(String.fromCodePoint(11854));
+}

--- a/apps/api/src/utils/is-quadruple-prime-present.ts
+++ b/apps/api/src/utils/is-quadruple-prime-present.ts
@@ -1,0 +1,8 @@
+/**
+ * Checks whether the input string contains the Unicode character U+2057.
+ * @param input - The string to check.
+ * @returns true if the input contains the character, false otherwise.
+ */
+export function isQuadruplePrimePresent(input: string): boolean {
+  return input.includes(String.fromCodePoint(8279));
+}

--- a/apps/api/src/utils/is-question-exclamation-mark-present.ts
+++ b/apps/api/src/utils/is-question-exclamation-mark-present.ts
@@ -1,0 +1,8 @@
+/**
+ * Checks whether the input string contains the Unicode character U+2048.
+ * @param input - The string to check.
+ * @returns true if the input contains the character, false otherwise.
+ */
+export function isQuestionExclamationMarkPresent(input: string): boolean {
+  return input.includes(String.fromCodePoint(8264));
+}

--- a/apps/api/src/utils/is-raised-comma-present.ts
+++ b/apps/api/src/utils/is-raised-comma-present.ts
@@ -1,0 +1,8 @@
+/**
+ * Checks whether the input string contains the Unicode character U+2E34.
+ * @param input - The string to check.
+ * @returns true if the input contains the character, false otherwise.
+ */
+export function isRaisedCommaPresent(input: string): boolean {
+  return input.includes(String.fromCodePoint(11828));
+}

--- a/apps/api/src/utils/is-raised-dotted-interpolation-marker-present.ts
+++ b/apps/api/src/utils/is-raised-dotted-interpolation-marker-present.ts
@@ -1,0 +1,8 @@
+/**
+ * Checks whether the input string contains the Unicode character U+2E07.
+ * @param input - The string to check.
+ * @returns true if the input contains the character, false otherwise.
+ */
+export function isRaisedDottedInterpolationMarkerPresent(input: string): boolean {
+  return input.includes(String.fromCodePoint(11783));
+}

--- a/apps/api/src/utils/is-raised-interpolation-marker-present.ts
+++ b/apps/api/src/utils/is-raised-interpolation-marker-present.ts
@@ -1,0 +1,8 @@
+/**
+ * Checks whether the input string contains the Unicode character U+2E06.
+ * @param input - The string to check.
+ * @returns true if the input contains the character, false otherwise.
+ */
+export function isRaisedInterpolationMarkerPresent(input: string): boolean {
+  return input.includes(String.fromCodePoint(11782));
+}

--- a/apps/api/src/utils/is-replacement-character-present.ts
+++ b/apps/api/src/utils/is-replacement-character-present.ts
@@ -1,0 +1,8 @@
+/**
+ * Checks whether the input string contains the Unicode character U+FFFD.
+ * @param input - The string to check.
+ * @returns true if the input contains the character, false otherwise.
+ */
+export function isReplacementCharacterPresent(input: string): boolean {
+  return input.includes(String.fromCodePoint(65533));
+}

--- a/apps/api/src/utils/is-reversed-comma-present.ts
+++ b/apps/api/src/utils/is-reversed-comma-present.ts
@@ -1,0 +1,8 @@
+/**
+ * Checks whether the input string contains the Unicode character U+2E41.
+ * @param input - The string to check.
+ * @returns true if the input contains the character, false otherwise.
+ */
+export function isReversedCommaPresent(input: string): boolean {
+  return input.includes(String.fromCodePoint(11841));
+}

--- a/apps/api/src/utils/is-reversed-forked-paragraphos-present.ts
+++ b/apps/api/src/utils/is-reversed-forked-paragraphos-present.ts
@@ -1,0 +1,8 @@
+/**
+ * Checks whether the input string contains the Unicode character U+2E11.
+ * @param input - The string to check.
+ * @returns true if the input contains the character, false otherwise.
+ */
+export function isReversedForkedParagraphosPresent(input: string): boolean {
+  return input.includes(String.fromCodePoint(11793));
+}

--- a/apps/api/src/utils/is-reversed-pilcrow-sign-present.ts
+++ b/apps/api/src/utils/is-reversed-pilcrow-sign-present.ts
@@ -1,0 +1,8 @@
+/**
+ * Checks whether the input string contains the Unicode character U+204B.
+ * @param input - The string to check.
+ * @returns true if the input contains the character, false otherwise.
+ */
+export function isReversedPilcrowSignPresent(input: string): boolean {
+  return input.includes(String.fromCodePoint(8267));
+}

--- a/apps/api/src/utils/is-reversed-question-mark-present.ts
+++ b/apps/api/src/utils/is-reversed-question-mark-present.ts
@@ -1,0 +1,8 @@
+/**
+ * Checks whether the input string contains the Unicode character U+2E2E.
+ * @param input - The string to check.
+ * @returns true if the input contains the character, false otherwise.
+ */
+export function isReversedQuestionMarkPresent(input: string): boolean {
+  return input.includes(String.fromCodePoint(11822));
+}

--- a/apps/api/src/utils/is-right-angle-dotted-substitution-marker-present.ts
+++ b/apps/api/src/utils/is-right-angle-dotted-substitution-marker-present.ts
@@ -1,0 +1,8 @@
+/**
+ * Checks whether the input string contains the Unicode character U+2E01.
+ * @param input - The string to check.
+ * @returns true if the input contains the character, false otherwise.
+ */
+export function isRightAngleDottedSubstitutionMarkerPresent(input: string): boolean {
+  return input.includes(String.fromCodePoint(11777));
+}

--- a/apps/api/src/utils/is-right-angle-substitution-marker-present.ts
+++ b/apps/api/src/utils/is-right-angle-substitution-marker-present.ts
@@ -1,0 +1,8 @@
+/**
+ * Checks whether the input string contains the Unicode character U+2E00.
+ * @param input - The string to check.
+ * @returns true if the input contains the character, false otherwise.
+ */
+export function isRightAngleSubstitutionMarkerPresent(input: string): boolean {
+  return input.includes(String.fromCodePoint(11776));
+}

--- a/apps/api/src/utils/is-right-dotted-substitution-bracket-present.ts
+++ b/apps/api/src/utils/is-right-dotted-substitution-bracket-present.ts
@@ -1,0 +1,8 @@
+/**
+ * Checks whether the input string contains the Unicode character U+2E05.
+ * @param input - The string to check.
+ * @returns true if the input contains the character, false otherwise.
+ */
+export function isRightDottedSubstitutionBracketPresent(input: string): boolean {
+  return input.includes(String.fromCodePoint(11781));
+}

--- a/apps/api/src/utils/is-right-double-parenthesis-present.ts
+++ b/apps/api/src/utils/is-right-double-parenthesis-present.ts
@@ -1,0 +1,8 @@
+/**
+ * Checks whether the input string contains the Unicode character U+2E29.
+ * @param input - The string to check.
+ * @returns true if the input contains the character, false otherwise.
+ */
+export function isRightDoubleParenthesisPresent(input: string): boolean {
+  return input.includes(String.fromCodePoint(11817));
+}

--- a/apps/api/src/utils/is-right-low-paraphrase-bracket-present.ts
+++ b/apps/api/src/utils/is-right-low-paraphrase-bracket-present.ts
@@ -1,0 +1,8 @@
+/**
+ * Checks whether the input string contains the Unicode character U+2E1D.
+ * @param input - The string to check.
+ * @returns true if the input contains the character, false otherwise.
+ */
+export function isRightLowParaphraseBracketPresent(input: string): boolean {
+  return input.includes(String.fromCodePoint(11805));
+}

--- a/apps/api/src/utils/is-right-raised-omission-bracket-present.ts
+++ b/apps/api/src/utils/is-right-raised-omission-bracket-present.ts
@@ -1,0 +1,8 @@
+/**
+ * Checks whether the input string contains the Unicode character U+2E0D.
+ * @param input - The string to check.
+ * @returns true if the input contains the character, false otherwise.
+ */
+export function isRightRaisedOmissionBracketPresent(input: string): boolean {
+  return input.includes(String.fromCodePoint(11789));
+}

--- a/apps/api/src/utils/is-right-sideways-u-bracket-present.ts
+++ b/apps/api/src/utils/is-right-sideways-u-bracket-present.ts
@@ -1,0 +1,8 @@
+/**
+ * Checks whether the input string contains the Unicode character U+2E27.
+ * @param input - The string to check.
+ * @returns true if the input contains the character, false otherwise.
+ */
+export function isRightSidewaysUBracketPresent(input: string): boolean {
+  return input.includes(String.fromCodePoint(11815));
+}

--- a/apps/api/src/utils/is-right-square-bracket-with-double-stroke-present.ts
+++ b/apps/api/src/utils/is-right-square-bracket-with-double-stroke-present.ts
@@ -1,0 +1,8 @@
+/**
+ * Checks whether the input string contains the Unicode character U+2E58.
+ * @param input - The string to check.
+ * @returns true if the input contains the character, false otherwise.
+ */
+export function isRightSquareBracketWithDoubleStrokePresent(input: string): boolean {
+  return input.includes(String.fromCodePoint(11864));
+}

--- a/apps/api/src/utils/is-right-square-bracket-with-quill-present.ts
+++ b/apps/api/src/utils/is-right-square-bracket-with-quill-present.ts
@@ -1,0 +1,8 @@
+/**
+ * Checks whether the input string contains the Unicode character U+2046.
+ * @param input - The string to check.
+ * @returns true if the input contains the character, false otherwise.
+ */
+export function isRightSquareBracketWithQuillPresent(input: string): boolean {
+  return input.includes(String.fromCodePoint(8262));
+}

--- a/apps/api/src/utils/is-right-substitution-bracket-present.ts
+++ b/apps/api/src/utils/is-right-substitution-bracket-present.ts
@@ -1,0 +1,8 @@
+/**
+ * Checks whether the input string contains the Unicode character U+2E03.
+ * @param input - The string to check.
+ * @returns true if the input contains the character, false otherwise.
+ */
+export function isRightSubstitutionBracketPresent(input: string): boolean {
+  return input.includes(String.fromCodePoint(11779));
+}

--- a/apps/api/src/utils/is-right-to-left-isolate-present.ts
+++ b/apps/api/src/utils/is-right-to-left-isolate-present.ts
@@ -1,0 +1,8 @@
+/**
+ * Checks whether the input string contains the Unicode character U+2067.
+ * @param input - The string to check.
+ * @returns true if the input contains the character, false otherwise.
+ */
+export function isRightToLeftIsolatePresent(input: string): boolean {
+  return input.includes(String.fromCodePoint(8295));
+}

--- a/apps/api/src/utils/is-right-to-left-mark-present.ts
+++ b/apps/api/src/utils/is-right-to-left-mark-present.ts
@@ -1,0 +1,8 @@
+/**
+ * Checks whether the input string contains the Unicode character U+200F.
+ * @param input - The string to check.
+ * @returns true if the input contains the character, false otherwise.
+ */
+export function isRightToLeftMarkPresent(input: string): boolean {
+  return input.includes(String.fromCodePoint(8207));
+}

--- a/apps/api/src/utils/is-right-to-left-override-present.ts
+++ b/apps/api/src/utils/is-right-to-left-override-present.ts
@@ -1,0 +1,8 @@
+/**
+ * Checks whether the input string contains the Unicode character U+202E.
+ * @param input - The string to check.
+ * @returns true if the input contains the character, false otherwise.
+ */
+export function isRightToLeftOverridePresent(input: string): boolean {
+  return input.includes(String.fromCodePoint(8238));
+}

--- a/apps/api/src/utils/is-right-vertical-bar-with-quill-present.ts
+++ b/apps/api/src/utils/is-right-vertical-bar-with-quill-present.ts
@@ -1,0 +1,8 @@
+/**
+ * Checks whether the input string contains the Unicode character U+2E21.
+ * @param input - The string to check.
+ * @returns true if the input contains the character, false otherwise.
+ */
+export function isRightVerticalBarWithQuillPresent(input: string): boolean {
+  return input.includes(String.fromCodePoint(11809));
+}

--- a/apps/api/src/utils/is-soft-hyphen-present.ts
+++ b/apps/api/src/utils/is-soft-hyphen-present.ts
@@ -1,0 +1,8 @@
+/**
+ * Checks whether the input string contains the Unicode character U+AD.
+ * @param input - The string to check.
+ * @returns true if the input contains the character, false otherwise.
+ */
+export function isSoftHyphenPresent(input: string): boolean {
+  return input.includes(String.fromCodePoint(173));
+}

--- a/apps/api/src/utils/is-squared-four-dot-punctuation-present.ts
+++ b/apps/api/src/utils/is-squared-four-dot-punctuation-present.ts
@@ -1,0 +1,8 @@
+/**
+ * Checks whether the input string contains the Unicode character U+2E2C.
+ * @param input - The string to check.
+ * @returns true if the input contains the character, false otherwise.
+ */
+export function isSquaredFourDotPunctuationPresent(input: string): boolean {
+  return input.includes(String.fromCodePoint(11820));
+}

--- a/apps/api/src/utils/is-stenographic-full-stop-present.ts
+++ b/apps/api/src/utils/is-stenographic-full-stop-present.ts
@@ -1,0 +1,8 @@
+/**
+ * Checks whether the input string contains the Unicode character U+2E3C.
+ * @param input - The string to check.
+ * @returns true if the input contains the character, false otherwise.
+ */
+export function isStenographicFullStopPresent(input: string): boolean {
+  return input.includes(String.fromCodePoint(11836));
+}

--- a/apps/api/src/utils/is-swung-dash-present.ts
+++ b/apps/api/src/utils/is-swung-dash-present.ts
@@ -1,0 +1,8 @@
+/**
+ * Checks whether the input string contains the Unicode character U+2053.
+ * @param input - The string to check.
+ * @returns true if the input contains the character, false otherwise.
+ */
+export function isSwungDashPresent(input: string): boolean {
+  return input.includes(String.fromCodePoint(8275));
+}

--- a/apps/api/src/utils/is-three-dot-punctuation-present.ts
+++ b/apps/api/src/utils/is-three-dot-punctuation-present.ts
@@ -1,0 +1,8 @@
+/**
+ * Checks whether the input string contains the Unicode character U+2056.
+ * @param input - The string to check.
+ * @returns true if the input contains the character, false otherwise.
+ */
+export function isThreeDotPunctuationPresent(input: string): boolean {
+  return input.includes(String.fromCodePoint(8278));
+}

--- a/apps/api/src/utils/is-three-em-dash-present.ts
+++ b/apps/api/src/utils/is-three-em-dash-present.ts
@@ -1,0 +1,8 @@
+/**
+ * Checks whether the input string contains the Unicode character U+2E3B.
+ * @param input - The string to check.
+ * @returns true if the input contains the character, false otherwise.
+ */
+export function isThreeEmDashPresent(input: string): boolean {
+  return input.includes(String.fromCodePoint(11835));
+}

--- a/apps/api/src/utils/is-tilde-with-dot-above-present.ts
+++ b/apps/api/src/utils/is-tilde-with-dot-above-present.ts
@@ -1,0 +1,8 @@
+/**
+ * Checks whether the input string contains the Unicode character U+2E1E.
+ * @param input - The string to check.
+ * @returns true if the input contains the character, false otherwise.
+ */
+export function isTildeWithDotAbovePresent(input: string): boolean {
+  return input.includes(String.fromCodePoint(11806));
+}

--- a/apps/api/src/utils/is-tilde-with-dot-below-present.ts
+++ b/apps/api/src/utils/is-tilde-with-dot-below-present.ts
@@ -1,0 +1,8 @@
+/**
+ * Checks whether the input string contains the Unicode character U+2E1F.
+ * @param input - The string to check.
+ * @returns true if the input contains the character, false otherwise.
+ */
+export function isTildeWithDotBelowPresent(input: string): boolean {
+  return input.includes(String.fromCodePoint(11807));
+}

--- a/apps/api/src/utils/is-tilde-with-ring-above-present.ts
+++ b/apps/api/src/utils/is-tilde-with-ring-above-present.ts
@@ -1,0 +1,8 @@
+/**
+ * Checks whether the input string contains the Unicode character U+2E1B.
+ * @param input - The string to check.
+ * @returns true if the input contains the character, false otherwise.
+ */
+export function isTildeWithRingAbovePresent(input: string): boolean {
+  return input.includes(String.fromCodePoint(11803));
+}

--- a/apps/api/src/utils/is-tironian-sign-capital-et-present.ts
+++ b/apps/api/src/utils/is-tironian-sign-capital-et-present.ts
@@ -1,0 +1,8 @@
+/**
+ * Checks whether the input string contains the Unicode character U+2E52.
+ * @param input - The string to check.
+ * @returns true if the input contains the character, false otherwise.
+ */
+export function isTironianSignCapitalEtPresent(input: string): boolean {
+  return input.includes(String.fromCodePoint(11858));
+}

--- a/apps/api/src/utils/is-tironian-sign-et-present.ts
+++ b/apps/api/src/utils/is-tironian-sign-et-present.ts
@@ -1,0 +1,8 @@
+/**
+ * Checks whether the input string contains the Unicode character U+204A.
+ * @param input - The string to check.
+ * @returns true if the input contains the character, false otherwise.
+ */
+export function isTironianSignEtPresent(input: string): boolean {
+  return input.includes(String.fromCodePoint(8266));
+}

--- a/apps/api/src/utils/is-top-half-left-parenthesis-present.ts
+++ b/apps/api/src/utils/is-top-half-left-parenthesis-present.ts
@@ -1,0 +1,8 @@
+/**
+ * Checks whether the input string contains the Unicode character U+2E59.
+ * @param input - The string to check.
+ * @returns true if the input contains the character, false otherwise.
+ */
+export function isTopHalfLeftParenthesisPresent(input: string): boolean {
+  return input.includes(String.fromCodePoint(11865));
+}

--- a/apps/api/src/utils/is-top-half-right-parenthesis-present.ts
+++ b/apps/api/src/utils/is-top-half-right-parenthesis-present.ts
@@ -1,0 +1,8 @@
+/**
+ * Checks whether the input string contains the Unicode character U+2E5A.
+ * @param input - The string to check.
+ * @returns true if the input contains the character, false otherwise.
+ */
+export function isTopHalfRightParenthesisPresent(input: string): boolean {
+  return input.includes(String.fromCodePoint(11866));
+}

--- a/apps/api/src/utils/is-top-half-section-sign-present.ts
+++ b/apps/api/src/utils/is-top-half-section-sign-present.ts
@@ -1,0 +1,8 @@
+/**
+ * Checks whether the input string contains the Unicode character U+2E39.
+ * @param input - The string to check.
+ * @returns true if the input contains the character, false otherwise.
+ */
+export function isTopHalfSectionSignPresent(input: string): boolean {
+  return input.includes(String.fromCodePoint(11833));
+}

--- a/apps/api/src/utils/is-top-left-half-bracket-present.ts
+++ b/apps/api/src/utils/is-top-left-half-bracket-present.ts
@@ -1,0 +1,8 @@
+/**
+ * Checks whether the input string contains the Unicode character U+2E22.
+ * @param input - The string to check.
+ * @returns true if the input contains the character, false otherwise.
+ */
+export function isTopLeftHalfBracketPresent(input: string): boolean {
+  return input.includes(String.fromCodePoint(11810));
+}

--- a/apps/api/src/utils/is-top-right-half-bracket-present.ts
+++ b/apps/api/src/utils/is-top-right-half-bracket-present.ts
@@ -1,0 +1,8 @@
+/**
+ * Checks whether the input string contains the Unicode character U+2E23.
+ * @param input - The string to check.
+ * @returns true if the input contains the character, false otherwise.
+ */
+export function isTopRightHalfBracketPresent(input: string): boolean {
+  return input.includes(String.fromCodePoint(11811));
+}

--- a/apps/api/src/utils/is-triple-dagger-present.ts
+++ b/apps/api/src/utils/is-triple-dagger-present.ts
@@ -1,0 +1,8 @@
+/**
+ * Checks whether the input string contains the Unicode character U+2E4B.
+ * @param input - The string to check.
+ * @returns true if the input contains the character, false otherwise.
+ */
+export function isTripleDaggerPresent(input: string): boolean {
+  return input.includes(String.fromCodePoint(11851));
+}

--- a/apps/api/src/utils/is-turned-comma-present.ts
+++ b/apps/api/src/utils/is-turned-comma-present.ts
@@ -1,0 +1,8 @@
+/**
+ * Checks whether the input string contains the Unicode character U+2E32.
+ * @param input - The string to check.
+ * @returns true if the input contains the character, false otherwise.
+ */
+export function isTurnedCommaPresent(input: string): boolean {
+  return input.includes(String.fromCodePoint(11826));
+}

--- a/apps/api/src/utils/is-turned-semicolon-present.ts
+++ b/apps/api/src/utils/is-turned-semicolon-present.ts
@@ -1,0 +1,8 @@
+/**
+ * Checks whether the input string contains the Unicode character U+2E35.
+ * @param input - The string to check.
+ * @returns true if the input contains the character, false otherwise.
+ */
+export function isTurnedSemicolonPresent(input: string): boolean {
+  return input.includes(String.fromCodePoint(11829));
+}

--- a/apps/api/src/utils/is-two-asterisks-aligned-vertically-present.ts
+++ b/apps/api/src/utils/is-two-asterisks-aligned-vertically-present.ts
@@ -1,0 +1,8 @@
+/**
+ * Checks whether the input string contains the Unicode character U+2051.
+ * @param input - The string to check.
+ * @returns true if the input contains the character, false otherwise.
+ */
+export function isTwoAsterisksAlignedVerticallyPresent(input: string): boolean {
+  return input.includes(String.fromCodePoint(8273));
+}

--- a/apps/api/src/utils/is-two-dot-punctuation-present.ts
+++ b/apps/api/src/utils/is-two-dot-punctuation-present.ts
@@ -1,0 +1,8 @@
+/**
+ * Checks whether the input string contains the Unicode character U+205A.
+ * @param input - The string to check.
+ * @returns true if the input contains the character, false otherwise.
+ */
+export function isTwoDotPunctuationPresent(input: string): boolean {
+  return input.includes(String.fromCodePoint(8282));
+}

--- a/apps/api/src/utils/is-two-dots-over-one-dot-punctuation-present.ts
+++ b/apps/api/src/utils/is-two-dots-over-one-dot-punctuation-present.ts
@@ -1,0 +1,8 @@
+/**
+ * Checks whether the input string contains the Unicode character U+2E2A.
+ * @param input - The string to check.
+ * @returns true if the input contains the character, false otherwise.
+ */
+export function isTwoDotsOverOneDotPunctuationPresent(input: string): boolean {
+  return input.includes(String.fromCodePoint(11818));
+}

--- a/apps/api/src/utils/is-two-em-dash-present.ts
+++ b/apps/api/src/utils/is-two-em-dash-present.ts
@@ -1,0 +1,8 @@
+/**
+ * Checks whether the input string contains the Unicode character U+2E3A.
+ * @param input - The string to check.
+ * @returns true if the input contains the character, false otherwise.
+ */
+export function isTwoEmDashPresent(input: string): boolean {
+  return input.includes(String.fromCodePoint(11834));
+}

--- a/apps/api/src/utils/is-upwards-ancora-present.ts
+++ b/apps/api/src/utils/is-upwards-ancora-present.ts
@@ -1,0 +1,8 @@
+/**
+ * Checks whether the input string contains the Unicode character U+2E15.
+ * @param input - The string to check.
+ * @returns true if the input contains the character, false otherwise.
+ */
+export function isUpwardsAncoraPresent(input: string): boolean {
+  return input.includes(String.fromCodePoint(11797));
+}

--- a/apps/api/src/utils/is-vertical-six-dots-present.ts
+++ b/apps/api/src/utils/is-vertical-six-dots-present.ts
@@ -1,0 +1,8 @@
+/**
+ * Checks whether the input string contains the Unicode character U+2E3D.
+ * @param input - The string to check.
+ * @returns true if the input contains the character, false otherwise.
+ */
+export function isVerticalSixDotsPresent(input: string): boolean {
+  return input.includes(String.fromCodePoint(11837));
+}

--- a/apps/api/src/utils/is-vertical-tilde-present.ts
+++ b/apps/api/src/utils/is-vertical-tilde-present.ts
@@ -1,0 +1,8 @@
+/**
+ * Checks whether the input string contains the Unicode character U+2E2F.
+ * @param input - The string to check.
+ * @returns true if the input contains the character, false otherwise.
+ */
+export function isVerticalTildePresent(input: string): boolean {
+  return input.includes(String.fromCodePoint(11823));
+}

--- a/apps/api/src/utils/is-word-joiner-present.ts
+++ b/apps/api/src/utils/is-word-joiner-present.ts
@@ -1,0 +1,8 @@
+/**
+ * Checks whether the input string contains the Unicode character U+2060.
+ * @param input - The string to check.
+ * @returns true if the input contains the character, false otherwise.
+ */
+export function isWordJoinerPresent(input: string): boolean {
+  return input.includes(String.fromCodePoint(8288));
+}

--- a/apps/api/src/utils/is-word-separator-middle-dot-present.ts
+++ b/apps/api/src/utils/is-word-separator-middle-dot-present.ts
@@ -1,0 +1,8 @@
+/**
+ * Checks whether the input string contains the Unicode character U+2E31.
+ * @param input - The string to check.
+ * @returns true if the input contains the character, false otherwise.
+ */
+export function isWordSeparatorMiddleDotPresent(input: string): boolean {
+  return input.includes(String.fromCodePoint(11825));
+}

--- a/pr-body-batch4.txt
+++ b/pr-body-batch4.txt
@@ -1,0 +1,53 @@
+## Katakana Letter Detection Utilities (Batch 4 - 20 utilities)
+
+Closes #7669, #7670, #7805, #7806, #7807, #7808, #7809, #7815, #7816, #7817, #7818, #7819, #7825, #7826, #7827, #7828, #7829, #7835, #7836, #7837
+
+### Summary
+
+Adds 20 Katakana letter detection API utilities under apps/api/src/utils/. Each utility exports a dependency-free function that returns true only when the input string contains the specified Unicode Katakana character.
+
+### Files Added
+
+| File | Character | Issue |
+|------|-----------|-------|
+| is-katakana-letter-small-a-present.ts | U+30A1 | #7669 |
+| is-katakana-letter-a-present.ts | U+30A2 | #7670 |
+| is-katakana-letter-small-i-present.ts | U+30A3 | #7805 |
+| is-katakana-letter-i-present.ts | U+30A4 | #7806 |
+| is-katakana-letter-small-e-present.ts | U+30A7 | #7807 |
+| is-katakana-letter-e-present.ts | U+30A8 | #7808 |
+| is-katakana-letter-small-o-present.ts | U+30A9 | #7809 |
+| is-katakana-letter-ka-present.ts | U+30AB | #7815 |
+| is-katakana-letter-ga-present.ts | U+30AC | #7816 |
+| is-katakana-letter-ki-present.ts | U+30AD | #7817 |
+| is-katakana-letter-gi-present.ts | U+30AE | #7818 |
+| is-katakana-letter-ku-present.ts | U+30AF | #7819 |
+| is-katakana-letter-gu-present.ts | U+30B0 | #7825 |
+| is-katakana-letter-ke-present.ts | U+30B1 | #7826 |
+| is-katakana-letter-ge-present.ts | U+30B2 | #7827 |
+| is-katakana-letter-ko-present.ts | U+30B3 | #7828 |
+| is-katakana-letter-go-present.ts | U+30B4 | #7829 |
+| is-katakana-letter-sa-present.ts | U+30B5 | #7835 |
+| is-katakana-letter-za-present.ts | U+30B6 | #7836 |
+| is-katakana-letter-si-present.ts | U+30B7 | #7837 |
+
+/claim #7669
+/claim #7670
+/claim #7805
+/claim #7806
+/claim #7807
+/claim #7808
+/claim #7809
+/claim #7815
+/claim #7816
+/claim #7817
+/claim #7818
+/claim #7819
+/claim #7825
+/claim #7826
+/claim #7827
+/claim #7828
+/claim #7829
+/claim #7835
+/claim #7836
+/claim #7837

--- a/pr-body-batch6.txt
+++ b/pr-body-batch6.txt
@@ -1,0 +1,21 @@
+## Katakana Letter Detection Utilities (Batch 6 - 4 utilities)
+
+Closes #7982, #7983, #7989, #7990
+
+### Summary
+
+Adds 4 Katakana letter detection API utilities under apps/api/src/utils/. Each utility exports a dependency-free function that returns true only when the input string contains the specified Unicode Katakana character.
+
+### Files Added
+
+| File | Character | Issue |
+|------|-----------|-------|
+| is-katakana-letter-ne-present.ts | U+30CD | #7982 |
+| is-katakana-letter-no-present.ts | U+30CE | #7983 |
+| is-katakana-letter-ha-present.ts | U+30CF | #7989 |
+| is-katakana-letter-ba-present.ts | U+30D0 | #7990 |
+
+/claim #7982
+/claim #7983
+/claim #7989
+/claim #7990


### PR DESCRIPTION
## Unicode Character Detection Utilities (Batch 7 - 140 utilities)

Closes #5005, #5013, #5014, #5015, #5016, #5084, #5085, #5086, #5087, #5088, #5111, #5112, #5113, #5114, #5115, #5121, #5122, #5123, #5124, #5125, #5131, #5132, #5133, #5134, #5135, #5147, #5148, #5149, #5150, #5151, #5400, #5401, #5402, #5403, #5404, #5415, #5416, #5417, #5418, #5419, #5427, #5428, #5429, #5430, #5431, #5437, #5438, #5439, #5440, #5441, #5448, #5449, #5450, #5451, #5452, #5458, #5459, #5460, #5461, #5462, #5468, #5469, #5470, #5471, #5472, #5478, #5479, #5480, #5481, #5482, #5490, #5491, #5492, #5493, #5494, #5573, #5574, #5575, #5576, #5577, #5589, #5590, #5591, #5592, #5593, #5604, #5605, #5606, #5607, #5608, #5629, #5630, #5631, #5632, #5633, #5639, #5640, #5641, #5642, #5643, #5679, #5680, #5681, #5682, #5683, #5695, #5696, #5697, #5698, #5699, #5705, #5720, #5721, #5722, #5723, #5724, #5735, #5736, #5737, #5738, #5739, #5754, #5755, #5756, #5757, #5758, #5764, #5765, #5766, #5767, #5768, #5774, #5775, #5776, #5777, #5778, #5784, #5785, #5786, #5787

### Summary

Adds 140 Unicode character detection API utilities under apps/api/src/utils/. Each utility exports a dependency-free function that returns true only when the input string contains the specified Unicode character.

### Files Added

| File | Character | Issue |
|------|-----------|-------|
| is-word-joiner-present.ts | U+2060 | #5005 |
| is-invisible-times-present.ts | U+2062 | #5013 |
| is-invisible-separator-present.ts | U+2063 | #5014 |
| is-invisible-plus-present.ts | U+2064 | #5015 |
| is-left-to-right-embedding-present.ts | U+202A | #5016 |
| is-pop-directional-formatting-present.ts | U+202C | #5084 |
| is-left-to-right-override-present.ts | U+202D | #5085 |
| is-right-to-left-override-present.ts | U+202E | #5086 |
| is-left-to-right-mark-present.ts | U+200E | #5087 |
| is-right-to-left-mark-present.ts | U+200F | #5088 |
| is-arabic-letter-mark-present.ts | U+61C | #5111 |
| is-left-to-right-isolate-present.ts | U+2066 | #5112 |
| is-right-to-left-isolate-present.ts | U+2067 | #5113 |
| is-first-strong-isolate-present.ts | U+2068 | #5114 |
| is-pop-directional-isolate-present.ts | U+2069 | #5115 |
| is-inhibit-symmetric-swapping-present.ts | U+206A | #5121 |
| is-activate-symmetric-swapping-present.ts | U+206B | #5122 |
| is-inhibit-arabic-form-shaping-present.ts | U+206C | #5123 |
| is-activate-arabic-form-shaping-present.ts | U+206D | #5124 |
| is-national-digit-shapes-present.ts | U+206E | #5125 |
| is-nominal-digit-shapes-present.ts | U+206F | #5131 |
| is-object-replacement-character-present.ts | U+FFFC | #5132 |
| is-replacement-character-present.ts | U+FFFD | #5133 |
| is-soft-hyphen-present.ts | U+AD | #5134 |
| is-combining-grapheme-joiner-present.ts | U+34F | #5135 |
| is-hangul-filler-present.ts | U+3164 | #5147 |
| is-halfwidth-hangul-filler-present.ts | U+FFA0 | #5148 |
| is-braille-pattern-blank-present.ts | U+2800 | #5149 |
| is-interlinear-annotation-anchor-present.ts | U+FFF9 | #5150 |
| is-interlinear-annotation-separator-present.ts | U+FFFA | #5151 |
| is-interlinear-annotation-terminator-present.ts | U+FFFB | #5400 |
| is-invisible-operator-present.ts | U+2062 | #5401 |
| is-math-shift-present.ts | U+205A | #5402 |
| is-inverted-undertie-present.ts | U+2054 | #5403 |
| is-character-tie-present.ts | U+2040 | #5404 |
| is-overline-present.ts | U+203E | #5415 |
| is-caret-insertion-point-present.ts | U+2041 | #5416 |
| is-asterism-present.ts | U+2042 | #5417 |
| is-hyphen-bullet-present.ts | U+2043 | #5418 |
| is-fraction-slash-present.ts | U+2044 | #5419 |
| is-left-square-bracket-with-quill-present.ts | U+2045 | #5427 |
| is-right-square-bracket-with-quill-present.ts | U+2046 | #5428 |
| is-double-question-mark-present.ts | U+2047 | #5429 |
| is-question-exclamation-mark-present.ts | U+2048 | #5430 |
| is-exclamation-question-mark-present.ts | U+2049 | #5431 |
| is-tironian-sign-et-present.ts | U+204A | #5437 |
| is-reversed-pilcrow-sign-present.ts | U+204B | #5438 |
| is-black-leftwards-bullet-present.ts | U+204C | #5439 |
| is-black-rightwards-bullet-present.ts | U+204D | #5440 |
| is-low-asterisk-present.ts | U+204E | #5441 |
| is-two-asterisks-aligned-vertically-present.ts | U+2051 | #5448 |
| is-commercial-minus-sign-present.ts | U+2052 | #5449 |
| is-swung-dash-present.ts | U+2053 | #5450 |
| is-flower-punctuation-mark-present.ts | U+2055 | #5451 |
| is-three-dot-punctuation-present.ts | U+2056 | #5452 |
| is-quadruple-prime-present.ts | U+2057 | #5458 |
| is-four-dot-punctuation-present.ts | U+2058 | #5459 |
| is-five-dot-punctuation-present.ts | U+2059 | #5460 |
| is-two-dot-punctuation-present.ts | U+205A | #5461 |
| is-four-dot-mark-present.ts | U+205B | #5462 |
| is-right-angle-substitution-marker-present.ts | U+2E00 | #5468 |
| is-right-angle-dotted-substitution-marker-present.ts | U+2E01 | #5469 |
| is-left-substitution-bracket-present.ts | U+2E02 | #5470 |
| is-right-substitution-bracket-present.ts | U+2E03 | #5471 |
| is-left-dotted-substitution-bracket-present.ts | U+2E04 | #5472 |
| is-right-dotted-substitution-bracket-present.ts | U+2E05 | #5478 |
| is-raised-interpolation-marker-present.ts | U+2E06 | #5479 |
| is-raised-dotted-interpolation-marker-present.ts | U+2E07 | #5480 |
| is-dotted-transposition-marker-present.ts | U+2E08 | #5481 |
| is-left-transposition-bracket-present.ts | U+2E09 | #5482 |
| is-right-raised-omission-bracket-present.ts | U+2E0D | #5490 |
| is-editorial-coronis-present.ts | U+2E0E | #5491 |
| is-paragraphos-present.ts | U+2E0F | #5492 |
| is-forked-paragraphos-present.ts | U+2E10 | #5493 |
| is-reversed-forked-paragraphos-present.ts | U+2E11 | #5494 |
| is-hypodiastole-present.ts | U+2E12 | #5573 |
| is-dotted-obelos-present.ts | U+2E13 | #5574 |
| is-downwards-ancora-present.ts | U+2E14 | #5575 |
| is-upwards-ancora-present.ts | U+2E15 | #5576 |
| is-dotted-right-pointing-angle-present.ts | U+2E16 | #5577 |
| is-hyphen-with-diaeresis-present.ts | U+2E1A | #5589 |
| is-tilde-with-ring-above-present.ts | U+2E1B | #5590 |
| is-left-low-paraphrase-bracket-present.ts | U+2E1C | #5591 |
| is-right-low-paraphrase-bracket-present.ts | U+2E1D | #5592 |
| is-tilde-with-dot-above-present.ts | U+2E1E | #5593 |
| is-tilde-with-dot-below-present.ts | U+2E1F | #5604 |
| is-left-vertical-bar-with-quill-present.ts | U+2E20 | #5605 |
| is-right-vertical-bar-with-quill-present.ts | U+2E21 | #5606 |
| is-top-left-half-bracket-present.ts | U+2E22 | #5607 |
| is-top-right-half-bracket-present.ts | U+2E23 | #5608 |
| is-left-sideways-u-bracket-present.ts | U+2E26 | #5629 |
| is-right-sideways-u-bracket-present.ts | U+2E27 | #5630 |
| is-left-double-parenthesis-present.ts | U+2E28 | #5631 |
| is-right-double-parenthesis-present.ts | U+2E29 | #5632 |
| is-two-dots-over-one-dot-punctuation-present.ts | U+2E2A | #5633 |
| is-squared-four-dot-punctuation-present.ts | U+2E2C | #5639 |
| is-five-dot-mark-present.ts | U+2E2D | #5640 |
| is-reversed-question-mark-present.ts | U+2E2E | #5641 |
| is-vertical-tilde-present.ts | U+2E2F | #5642 |
| is-word-separator-middle-dot-present.ts | U+2E31 | #5643 |
| is-turned-comma-present.ts | U+2E32 | #5679 |
| is-raised-comma-present.ts | U+2E34 | #5680 |
| is-turned-semicolon-present.ts | U+2E35 | #5681 |
| is-dagger-with-left-guard-present.ts | U+2E36 | #5682 |
| is-dagger-with-right-guard-present.ts | U+2E37 | #5683 |
| is-top-half-section-sign-present.ts | U+2E39 | #5695 |
| is-two-em-dash-present.ts | U+2E3A | #5696 |
| is-three-em-dash-present.ts | U+2E3B | #5697 |
| is-stenographic-full-stop-present.ts | U+2E3C | #5698 |
| is-vertical-six-dots-present.ts | U+2E3D | #5699 |
| is-horizontal-ellipsis-present.ts | U+2026 | #5705 |
| is-capitulum-present.ts | U+2E3F | #5720 |
| is-double-hyphen-present.ts | U+2E40 | #5721 |
| is-reversed-comma-present.ts | U+2E41 | #5722 |
| is-double-low-reversed-9-quotation-mark-present.ts | U+2E42 | #5723 |
| is-dash-with-left-upturn-present.ts | U+2E43 | #5724 |
| is-inverted-low-kavyka-present.ts | U+2E45 | #5735 |
| is-inverted-low-kavyka-with-kavyka-above-present.ts | U+2E46 | #5736 |
| is-low-kavyka-present.ts | U+2E47 | #5737 |
| is-low-kavyka-with-dot-present.ts | U+2E48 | #5738 |
| is-double-stacked-comma-present.ts | U+2E49 | #5739 |
| is-triple-dagger-present.ts | U+2E4B | #5754 |
| is-medieval-comma-present.ts | U+2E4C | #5755 |
| is-paragraphus-mark-present.ts | U+2E4D | #5756 |
| is-punctus-elevatus-mark-present.ts | U+2E4E | #5757 |
| is-cornish-verse-divider-present.ts | U+2E4F | #5758 |
| is-cross-patty-with-left-crossbar-present.ts | U+2E51 | #5764 |
| is-tironian-sign-capital-et-present.ts | U+2E52 | #5765 |
| is-medieval-exclamation-mark-present.ts | U+2E53 | #5766 |
| is-medieval-question-mark-present.ts | U+2E54 | #5767 |
| is-left-square-bracket-with-stroke-present.ts | U+2E55 | #5768 |
| is-left-square-bracket-with-double-stroke-present.ts | U+2E57 | #5774 |
| is-right-square-bracket-with-double-stroke-present.ts | U+2E58 | #5775 |
| is-top-half-left-parenthesis-present.ts | U+2E59 | #5776 |
| is-top-half-right-parenthesis-present.ts | U+2E5A | #5777 |
| is-bottom-half-left-parenthesis-present.ts | U+2E5B | #5778 |
| is-oblique-hyphen-present.ts | U+2E5D | #5784 |
| is-cjk-radical-repeat-present.ts | U+2E80 | #5785 |
| is-cjk-radical-cliff-present.ts | U+2E81 | #5786 |
| is-cjk-radical-second-one-present.ts | U+2E82 | #5787 |

/claim #5005
/claim #5013
/claim #5014
/claim #5015
/claim #5016
/claim #5084
/claim #5085
/claim #5086
/claim #5087
/claim #5088
/claim #5111
/claim #5112
/claim #5113
/claim #5114
/claim #5115
/claim #5121
/claim #5122
/claim #5123
/claim #5124
/claim #5125
/claim #5131
/claim #5132
/claim #5133
/claim #5134
/claim #5135
/claim #5147
/claim #5148
/claim #5149
/claim #5150
/claim #5151
/claim #5400
/claim #5401
/claim #5402
/claim #5403
/claim #5404
/claim #5415
/claim #5416
/claim #5417
/claim #5418
/claim #5419
/claim #5427
/claim #5428
/claim #5429
/claim #5430
/claim #5431
/claim #5437
/claim #5438
/claim #5439
/claim #5440
/claim #5441
/claim #5448
/claim #5449
/claim #5450
/claim #5451
/claim #5452
/claim #5458
/claim #5459
/claim #5460
/claim #5461
/claim #5462
/claim #5468
/claim #5469
/claim #5470
/claim #5471
/claim #5472
/claim #5478
/claim #5479
/claim #5480
/claim #5481
/claim #5482
/claim #5490
/claim #5491
/claim #5492
/claim #5493
/claim #5494
/claim #5573
/claim #5574
/claim #5575
/claim #5576
/claim #5577
/claim #5589
/claim #5590
/claim #5591
/claim #5592
/claim #5593
/claim #5604
/claim #5605
/claim #5606
/claim #5607
/claim #5608
/claim #5629
/claim #5630
/claim #5631
/claim #5632
/claim #5633
/claim #5639
/claim #5640
/claim #5641
/claim #5642
/claim #5643
/claim #5679
/claim #5680
/claim #5681
/claim #5682
/claim #5683
/claim #5695
/claim #5696
/claim #5697
/claim #5698
/claim #5699
/claim #5705
/claim #5720
/claim #5721
/claim #5722
/claim #5723
/claim #5724
/claim #5735
/claim #5736
/claim #5737
/claim #5738
/claim #5739
/claim #5754
/claim #5755
/claim #5756
/claim #5757
/claim #5758
/claim #5764
/claim #5765
/claim #5766
/claim #5767
/claim #5768
/claim #5774
/claim #5775
/claim #5776
/claim #5777
/claim #5778
/claim #5784
/claim #5785
/claim #5786
/claim #5787
