### PR TITLE
[agent] feat: add 140 Unicode character detection utilities (batch 8)

### DIFF
--- a/apps/api/src/utils/is-cjk-radical-bolt-of-cloth-present.ts
+++ b/apps/api/src/utils/is-cjk-radical-bolt-of-cloth-present.ts
@@ -1,0 +1,8 @@
+/**
+ * Checks whether the input string contains the Unicode character U+2EAA.
+ * @param input - The string to check.
+ * @returns true if the input contains the character, false otherwise.
+ */
+export function isCjkRadicalBoltOfClothPresent(input: string): boolean {
+  return input.includes(String.fromCodePoint(11946));
+}

--- a/apps/api/src/utils/is-cjk-radical-bone-present.ts
+++ b/apps/api/src/utils/is-cjk-radical-bone-present.ts
@@ -1,0 +1,8 @@
+/**
+ * Checks whether the input string contains the Unicode character U+2EE3.
+ * @param input - The string to check.
+ * @returns true if the input contains the character, false otherwise.
+ */
+export function isCjkRadicalBonePresent(input: string): boolean {
+  return input.includes(String.fromCodePoint(12003));
+}

--- a/apps/api/src/utils/is-cjk-radical-box-present.ts
+++ b/apps/api/src/utils/is-cjk-radical-box-present.ts
@@ -1,0 +1,8 @@
+/**
+ * Checks whether the input string contains the Unicode character U+2E86.
+ * @param input - The string to check.
+ * @returns true if the input contains the character, false otherwise.
+ */
+export function isCjkRadicalBoxPresent(input: string): boolean {
+  return input.includes(String.fromCodePoint(11910));
+}

--- a/apps/api/src/utils/is-cjk-radical-brush-one-present.ts
+++ b/apps/api/src/utils/is-cjk-radical-brush-one-present.ts
@@ -1,0 +1,8 @@
+/**
+ * Checks whether the input string contains the Unicode character U+2EBA.
+ * @param input - The string to check.
+ * @returns true if the input contains the character, false otherwise.
+ */
+export function isCjkRadicalBrushOnePresent(input: string): boolean {
+  return input.includes(String.fromCodePoint(11962));
+}

--- a/apps/api/src/utils/is-cjk-radical-brush-two-present.ts
+++ b/apps/api/src/utils/is-cjk-radical-brush-two-present.ts
@@ -1,0 +1,8 @@
+/**
+ * Checks whether the input string contains the Unicode character U+2EBB.
+ * @param input - The string to check.
+ * @returns true if the input contains the character, false otherwise.
+ */
+export function isCjkRadicalBrushTwoPresent(input: string): boolean {
+  return input.includes(String.fromCodePoint(11963));
+}

--- a/apps/api/src/utils/is-cjk-radical-c-simplified-bird-present.ts
+++ b/apps/api/src/utils/is-cjk-radical-c-simplified-bird-present.ts
@@ -1,0 +1,8 @@
+/**
+ * Checks whether the input string contains the Unicode character U+2EE6.
+ * @param input - The string to check.
+ * @returns true if the input contains the character, false otherwise.
+ */
+export function isCjkRadicalCSimplifiedBirdPresent(input: string): boolean {
+  return input.includes(String.fromCodePoint(12006));
+}

--- a/apps/api/src/utils/is-cjk-radical-c-simplified-cart-present.ts
+++ b/apps/api/src/utils/is-cjk-radical-c-simplified-cart-present.ts
@@ -1,0 +1,8 @@
+/**
+ * Checks whether the input string contains the Unicode character U+2ECB.
+ * @param input - The string to check.
+ * @returns true if the input contains the character, false otherwise.
+ */
+export function isCjkRadicalCSimplifiedCartPresent(input: string): boolean {
+  return input.includes(String.fromCodePoint(11979));
+}

--- a/apps/api/src/utils/is-cjk-radical-c-simplified-dragon-present.ts
+++ b/apps/api/src/utils/is-cjk-radical-c-simplified-dragon-present.ts
@@ -1,0 +1,8 @@
+/**
+ * Checks whether the input string contains the Unicode character U+2EF0.
+ * @param input - The string to check.
+ * @returns true if the input contains the character, false otherwise.
+ */
+export function isCjkRadicalCSimplifiedDragonPresent(input: string): boolean {
+  return input.includes(String.fromCodePoint(12016));
+}

--- a/apps/api/src/utils/is-cjk-radical-c-simplified-even-present.ts
+++ b/apps/api/src/utils/is-cjk-radical-c-simplified-even-present.ts
@@ -1,0 +1,8 @@
+/**
+ * Checks whether the input string contains the Unicode character U+2EEC.
+ * @param input - The string to check.
+ * @returns true if the input contains the character, false otherwise.
+ */
+export function isCjkRadicalCSimplifiedEvenPresent(input: string): boolean {
+  return input.includes(String.fromCodePoint(12012));
+}

--- a/apps/api/src/utils/is-cjk-radical-c-simplified-fish-present.ts
+++ b/apps/api/src/utils/is-cjk-radical-c-simplified-fish-present.ts
@@ -1,0 +1,8 @@
+/**
+ * Checks whether the input string contains the Unicode character U+2EE5.
+ * @param input - The string to check.
+ * @returns true if the input contains the character, false otherwise.
+ */
+export function isCjkRadicalCSimplifiedFishPresent(input: string): boolean {
+  return input.includes(String.fromCodePoint(12005));
+}

--- a/apps/api/src/utils/is-cjk-radical-c-simplified-fly-present.ts
+++ b/apps/api/src/utils/is-cjk-radical-c-simplified-fly-present.ts
@@ -1,0 +1,8 @@
+/**
+ * Checks whether the input string contains the Unicode character U+2EDC.
+ * @param input - The string to check.
+ * @returns true if the input contains the character, false otherwise.
+ */
+export function isCjkRadicalCSimplifiedFlyPresent(input: string): boolean {
+  return input.includes(String.fromCodePoint(11996));
+}

--- a/apps/api/src/utils/is-cjk-radical-c-simplified-frog-present.ts
+++ b/apps/api/src/utils/is-cjk-radical-c-simplified-frog-present.ts
@@ -1,0 +1,8 @@
+/**
+ * Checks whether the input string contains the Unicode character U+2EEA.
+ * @param input - The string to check.
+ * @returns true if the input contains the character, false otherwise.
+ */
+export function isCjkRadicalCSimplifiedFrogPresent(input: string): boolean {
+  return input.includes(String.fromCodePoint(12010));
+}

--- a/apps/api/src/utils/is-cjk-radical-c-simplified-gate-present.ts
+++ b/apps/api/src/utils/is-cjk-radical-c-simplified-gate-present.ts
@@ -1,0 +1,8 @@
+/**
+ * Checks whether the input string contains the Unicode character U+2ED4.
+ * @param input - The string to check.
+ * @returns true if the input contains the character, false otherwise.
+ */
+export function isCjkRadicalCSimplifiedGatePresent(input: string): boolean {
+  return input.includes(String.fromCodePoint(11988));
+}

--- a/apps/api/src/utils/is-cjk-radical-c-simplified-horse-present.ts
+++ b/apps/api/src/utils/is-cjk-radical-c-simplified-horse-present.ts
@@ -1,0 +1,8 @@
+/**
+ * Checks whether the input string contains the Unicode character U+2EE2.
+ * @param input - The string to check.
+ * @returns true if the input contains the character, false otherwise.
+ */
+export function isCjkRadicalCSimplifiedHorsePresent(input: string): boolean {
+  return input.includes(String.fromCodePoint(12002));
+}

--- a/apps/api/src/utils/is-cjk-radical-c-simplified-leaf-present.ts
+++ b/apps/api/src/utils/is-cjk-radical-c-simplified-leaf-present.ts
@@ -1,0 +1,8 @@
+/**
+ * Checks whether the input string contains the Unicode character U+2EDA.
+ * @param input - The string to check.
+ * @returns true if the input contains the character, false otherwise.
+ */
+export function isCjkRadicalCSimplifiedLeafPresent(input: string): boolean {
+  return input.includes(String.fromCodePoint(11994));
+}

--- a/apps/api/src/utils/is-cjk-radical-c-simplified-long-present.ts
+++ b/apps/api/src/utils/is-cjk-radical-c-simplified-long-present.ts
@@ -1,0 +1,8 @@
+/**
+ * Checks whether the input string contains the Unicode character U+2ED3.
+ * @param input - The string to check.
+ * @returns true if the input contains the character, false otherwise.
+ */
+export function isCjkRadicalCSimplifiedLongPresent(input: string): boolean {
+  return input.includes(String.fromCodePoint(11987));
+}

--- a/apps/api/src/utils/is-cjk-radical-c-simplified-salt-present.ts
+++ b/apps/api/src/utils/is-cjk-radical-c-simplified-salt-present.ts
@@ -1,0 +1,8 @@
+/**
+ * Checks whether the input string contains the Unicode character U+2EE7.
+ * @param input - The string to check.
+ * @returns true if the input contains the character, false otherwise.
+ */
+export function isCjkRadicalCSimplifiedSaltPresent(input: string): boolean {
+  return input.includes(String.fromCodePoint(12007));
+}

--- a/apps/api/src/utils/is-cjk-radical-c-simplified-see-present.ts
+++ b/apps/api/src/utils/is-cjk-radical-c-simplified-see-present.ts
@@ -1,0 +1,8 @@
+/**
+ * Checks whether the input string contains the Unicode character U+2EC5.
+ * @param input - The string to check.
+ * @returns true if the input contains the character, false otherwise.
+ */
+export function isCjkRadicalCSimplifiedSeePresent(input: string): boolean {
+  return input.includes(String.fromCodePoint(11973));
+}

--- a/apps/api/src/utils/is-cjk-radical-c-simplified-shell-present.ts
+++ b/apps/api/src/utils/is-cjk-radical-c-simplified-shell-present.ts
@@ -1,0 +1,8 @@
+/**
+ * Checks whether the input string contains the Unicode character U+2EC9.
+ * @param input - The string to check.
+ * @returns true if the input contains the character, false otherwise.
+ */
+export function isCjkRadicalCSimplifiedShellPresent(input: string): boolean {
+  return input.includes(String.fromCodePoint(11977));
+}

--- a/apps/api/src/utils/is-cjk-radical-c-simplified-tooth-present.ts
+++ b/apps/api/src/utils/is-cjk-radical-c-simplified-tooth-present.ts
@@ -1,0 +1,8 @@
+/**
+ * Checks whether the input string contains the Unicode character U+2EEE.
+ * @param input - The string to check.
+ * @returns true if the input contains the character, false otherwise.
+ */
+export function isCjkRadicalCSimplifiedToothPresent(input: string): boolean {
+  return input.includes(String.fromCodePoint(12014));
+}

--- a/apps/api/src/utils/is-cjk-radical-c-simplified-turtle-present.ts
+++ b/apps/api/src/utils/is-cjk-radical-c-simplified-turtle-present.ts
@@ -1,0 +1,8 @@
+/**
+ * Checks whether the input string contains the Unicode character U+2EF3.
+ * @param input - The string to check.
+ * @returns true if the input contains the character, false otherwise.
+ */
+export function isCjkRadicalCSimplifiedTurtlePresent(input: string): boolean {
+  return input.includes(String.fromCodePoint(12019));
+}

--- a/apps/api/src/utils/is-cjk-radical-c-simplified-wind-present.ts
+++ b/apps/api/src/utils/is-cjk-radical-c-simplified-wind-present.ts
@@ -1,0 +1,8 @@
+/**
+ * Checks whether the input string contains the Unicode character U+2EDB.
+ * @param input - The string to check.
+ * @returns true if the input contains the character, false otherwise.
+ */
+export function isCjkRadicalCSimplifiedWindPresent(input: string): boolean {
+  return input.includes(String.fromCodePoint(11995));
+}

--- a/apps/api/src/utils/is-cjk-radical-choke-present.ts
+++ b/apps/api/src/utils/is-cjk-radical-choke-present.ts
@@ -1,0 +1,8 @@
+/**
+ * Checks whether the input string contains the Unicode character U+2E9B.
+ * @param input - The string to check.
+ * @returns true if the input contains the character, false otherwise.
+ */
+export function isCjkRadicalChokePresent(input: string): boolean {
+  return input.includes(String.fromCodePoint(11931));
+}

--- a/apps/api/src/utils/is-cjk-radical-clothes-present.ts
+++ b/apps/api/src/utils/is-cjk-radical-clothes-present.ts
@@ -1,0 +1,8 @@
+/**
+ * Checks whether the input string contains the Unicode character U+2EC2.
+ * @param input - The string to check.
+ * @returns true if the input contains the character, false otherwise.
+ */
+export function isCjkRadicalClothesPresent(input: string): boolean {
+  return input.includes(String.fromCodePoint(11970));
+}

--- a/apps/api/src/utils/is-cjk-radical-death-present.ts
+++ b/apps/api/src/utils/is-cjk-radical-death-present.ts
@@ -1,0 +1,8 @@
+/**
+ * Checks whether the input string contains the Unicode character U+2E9E.
+ * @param input - The string to check.
+ * @returns true if the input contains the character, false otherwise.
+ */
+export function isCjkRadicalDeathPresent(input: string): boolean {
+  return input.includes(String.fromCodePoint(11934));
+}

--- a/apps/api/src/utils/is-cjk-radical-eat-one-present.ts
+++ b/apps/api/src/utils/is-cjk-radical-eat-one-present.ts
@@ -1,0 +1,8 @@
+/**
+ * Checks whether the input string contains the Unicode character U+2EDD.
+ * @param input - The string to check.
+ * @returns true if the input contains the character, false otherwise.
+ */
+export function isCjkRadicalEatOnePresent(input: string): boolean {
+  return input.includes(String.fromCodePoint(11997));
+}

--- a/apps/api/src/utils/is-cjk-radical-eye-present.ts
+++ b/apps/api/src/utils/is-cjk-radical-eye-present.ts
@@ -1,0 +1,8 @@
+/**
+ * Checks whether the input string contains the Unicode character U+2EAB.
+ * @param input - The string to check.
+ * @returns true if the input contains the character, false otherwise.
+ */
+export function isCjkRadicalEyePresent(input: string): boolean {
+  return input.includes(String.fromCodePoint(11947));
+}

--- a/apps/api/src/utils/is-cjk-radical-fire-present.ts
+++ b/apps/api/src/utils/is-cjk-radical-fire-present.ts
@@ -1,0 +1,8 @@
+/**
+ * Checks whether the input string contains the Unicode character U+2EA3.
+ * @param input - The string to check.
+ * @returns true if the input contains the character, false otherwise.
+ */
+export function isCjkRadicalFirePresent(input: string): boolean {
+  return input.includes(String.fromCodePoint(11939));
+}

--- a/apps/api/src/utils/is-cjk-radical-foot-present.ts
+++ b/apps/api/src/utils/is-cjk-radical-foot-present.ts
@@ -1,0 +1,8 @@
+/**
+ * Checks whether the input string contains the Unicode character U+2ECA.
+ * @param input - The string to check.
+ * @returns true if the input contains the character, false otherwise.
+ */
+export function isCjkRadicalFootPresent(input: string): boolean {
+  return input.includes(String.fromCodePoint(11978));
+}

--- a/apps/api/src/utils/is-cjk-radical-ghost-present.ts
+++ b/apps/api/src/utils/is-cjk-radical-ghost-present.ts
@@ -1,0 +1,8 @@
+/**
+ * Checks whether the input string contains the Unicode character U+2EE4.
+ * @param input - The string to check.
+ * @returns true if the input contains the character, false otherwise.
+ */
+export function isCjkRadicalGhostPresent(input: string): boolean {
+  return input.includes(String.fromCodePoint(12004));
+}

--- a/apps/api/src/utils/is-cjk-radical-heart-one-present.ts
+++ b/apps/api/src/utils/is-cjk-radical-heart-one-present.ts
@@ -1,0 +1,8 @@
+/**
+ * Checks whether the input string contains the Unicode character U+2E96.
+ * @param input - The string to check.
+ * @returns true if the input contains the character, false otherwise.
+ */
+export function isCjkRadicalHeartOnePresent(input: string): boolean {
+  return input.includes(String.fromCodePoint(11926));
+}

--- a/apps/api/src/utils/is-cjk-radical-heart-two-present.ts
+++ b/apps/api/src/utils/is-cjk-radical-heart-two-present.ts
@@ -1,0 +1,8 @@
+/**
+ * Checks whether the input string contains the Unicode character U+2E97.
+ * @param input - The string to check.
+ * @returns true if the input contains the character, false otherwise.
+ */
+export function isCjkRadicalHeartTwoPresent(input: string): boolean {
+  return input.includes(String.fromCodePoint(11927));
+}

--- a/apps/api/src/utils/is-cjk-radical-j-simplified-dragon-present.ts
+++ b/apps/api/src/utils/is-cjk-radical-j-simplified-dragon-present.ts
@@ -1,0 +1,8 @@
+/**
+ * Checks whether the input string contains the Unicode character U+2EEF.
+ * @param input - The string to check.
+ * @returns true if the input contains the character, false otherwise.
+ */
+export function isCjkRadicalJSimplifiedDragonPresent(input: string): boolean {
+  return input.includes(String.fromCodePoint(12015));
+}

--- a/apps/api/src/utils/is-cjk-radical-j-simplified-even-present.ts
+++ b/apps/api/src/utils/is-cjk-radical-j-simplified-even-present.ts
@@ -1,0 +1,8 @@
+/**
+ * Checks whether the input string contains the Unicode character U+2EEB.
+ * @param input - The string to check.
+ * @returns true if the input contains the character, false otherwise.
+ */
+export function isCjkRadicalJSimplifiedEvenPresent(input: string): boolean {
+  return input.includes(String.fromCodePoint(12011));
+}

--- a/apps/api/src/utils/is-cjk-radical-j-simplified-tooth-present.ts
+++ b/apps/api/src/utils/is-cjk-radical-j-simplified-tooth-present.ts
@@ -1,0 +1,8 @@
+/**
+ * Checks whether the input string contains the Unicode character U+2EED.
+ * @param input - The string to check.
+ * @returns true if the input contains the character, false otherwise.
+ */
+export function isCjkRadicalJSimplifiedToothPresent(input: string): boolean {
+  return input.includes(String.fromCodePoint(12013));
+}

--- a/apps/api/src/utils/is-cjk-radical-j-simplified-turtle-present.ts
+++ b/apps/api/src/utils/is-cjk-radical-j-simplified-turtle-present.ts
@@ -1,0 +1,8 @@
+/**
+ * Checks whether the input string contains the Unicode character U+2EF2.
+ * @param input - The string to check.
+ * @returns true if the input contains the character, false otherwise.
+ */
+export function isCjkRadicalJSimplifiedTurtlePresent(input: string): boolean {
+  return input.includes(String.fromCodePoint(12018));
+}

--- a/apps/api/src/utils/is-cjk-radical-jade-present.ts
+++ b/apps/api/src/utils/is-cjk-radical-jade-present.ts
@@ -1,0 +1,8 @@
+/**
+ * Checks whether the input string contains the Unicode character U+2EA9.
+ * @param input - The string to check.
+ * @returns true if the input contains the character, false otherwise.
+ */
+export function isCjkRadicalJadePresent(input: string): boolean {
+  return input.includes(String.fromCodePoint(11945));
+}

--- a/apps/api/src/utils/is-cjk-radical-knife-one-present.ts
+++ b/apps/api/src/utils/is-cjk-radical-knife-one-present.ts
@@ -1,0 +1,8 @@
+/**
+ * Checks whether the input string contains the Unicode character U+2E88.
+ * @param input - The string to check.
+ * @returns true if the input contains the character, false otherwise.
+ */
+export function isCjkRadicalKnifeOnePresent(input: string): boolean {
+  return input.includes(String.fromCodePoint(11912));
+}

--- a/apps/api/src/utils/is-cjk-radical-knife-two-present.ts
+++ b/apps/api/src/utils/is-cjk-radical-knife-two-present.ts
@@ -1,0 +1,8 @@
+/**
+ * Checks whether the input string contains the Unicode character U+2E89.
+ * @param input - The string to check.
+ * @returns true if the input contains the character, false otherwise.
+ */
+export function isCjkRadicalKnifeTwoPresent(input: string): boolean {
+  return input.includes(String.fromCodePoint(11913));
+}

--- a/apps/api/src/utils/is-cjk-radical-lame-four-present.ts
+++ b/apps/api/src/utils/is-cjk-radical-lame-four-present.ts
@@ -1,0 +1,8 @@
+/**
+ * Checks whether the input string contains the Unicode character U+2E91.
+ * @param input - The string to check.
+ * @returns true if the input contains the character, false otherwise.
+ */
+export function isCjkRadicalLameFourPresent(input: string): boolean {
+  return input.includes(String.fromCodePoint(11921));
+}

--- a/apps/api/src/utils/is-cjk-radical-lame-one-present.ts
+++ b/apps/api/src/utils/is-cjk-radical-lame-one-present.ts
@@ -1,0 +1,8 @@
+/**
+ * Checks whether the input string contains the Unicode character U+2E8E.
+ * @param input - The string to check.
+ * @returns true if the input contains the character, false otherwise.
+ */
+export function isCjkRadicalLameOnePresent(input: string): boolean {
+  return input.includes(String.fromCodePoint(11918));
+}

--- a/apps/api/src/utils/is-cjk-radical-lame-three-present.ts
+++ b/apps/api/src/utils/is-cjk-radical-lame-three-present.ts
@@ -1,0 +1,8 @@
+/**
+ * Checks whether the input string contains the Unicode character U+2E90.
+ * @param input - The string to check.
+ * @returns true if the input contains the character, false otherwise.
+ */
+export function isCjkRadicalLameThreePresent(input: string): boolean {
+  return input.includes(String.fromCodePoint(11920));
+}

--- a/apps/api/src/utils/is-cjk-radical-lame-two-present.ts
+++ b/apps/api/src/utils/is-cjk-radical-lame-two-present.ts
@@ -1,0 +1,8 @@
+/**
+ * Checks whether the input string contains the Unicode character U+2E8F.
+ * @param input - The string to check.
+ * @returns true if the input contains the character, false otherwise.
+ */
+export function isCjkRadicalLameTwoPresent(input: string): boolean {
+  return input.includes(String.fromCodePoint(11919));
+}

--- a/apps/api/src/utils/is-cjk-radical-leaf-present.ts
+++ b/apps/api/src/utils/is-cjk-radical-leaf-present.ts
@@ -1,0 +1,8 @@
+/**
+ * Checks whether the input string contains the Unicode character U+2ED9.
+ * @param input - The string to check.
+ * @returns true if the input contains the character, false otherwise.
+ */
+export function isCjkRadicalLeafPresent(input: string): boolean {
+  return input.includes(String.fromCodePoint(11993));
+}

--- a/apps/api/src/utils/is-cjk-radical-long-one-present.ts
+++ b/apps/api/src/utils/is-cjk-radical-long-one-present.ts
@@ -1,0 +1,8 @@
+/**
+ * Checks whether the input string contains the Unicode character U+2ED1.
+ * @param input - The string to check.
+ * @returns true if the input contains the character, false otherwise.
+ */
+export function isCjkRadicalLongOnePresent(input: string): boolean {
+  return input.includes(String.fromCodePoint(11985));
+}

--- a/apps/api/src/utils/is-cjk-radical-long-two-present.ts
+++ b/apps/api/src/utils/is-cjk-radical-long-two-present.ts
@@ -1,0 +1,8 @@
+/**
+ * Checks whether the input string contains the Unicode character U+2ED2.
+ * @param input - The string to check.
+ * @returns true if the input contains the character, false otherwise.
+ */
+export function isCjkRadicalLongTwoPresent(input: string): boolean {
+  return input.includes(String.fromCodePoint(11986));
+}

--- a/apps/api/src/utils/is-cjk-radical-meat-present.ts
+++ b/apps/api/src/utils/is-cjk-radical-meat-present.ts
@@ -1,0 +1,8 @@
+/**
+ * Checks whether the input string contains the Unicode character U+2EBC.
+ * @param input - The string to check.
+ * @returns true if the input contains the character, false otherwise.
+ */
+export function isCjkRadicalMeatPresent(input: string): boolean {
+  return input.includes(String.fromCodePoint(11964));
+}

--- a/apps/api/src/utils/is-cjk-radical-mesh-present.ts
+++ b/apps/api/src/utils/is-cjk-radical-mesh-present.ts
@@ -1,0 +1,8 @@
+/**
+ * Checks whether the input string contains the Unicode character U+2EB5.
+ * @param input - The string to check.
+ * @returns true if the input contains the character, false otherwise.
+ */
+export function isCjkRadicalMeshPresent(input: string): boolean {
+  return input.includes(String.fromCodePoint(11957));
+}

--- a/apps/api/src/utils/is-cjk-radical-moon-present.ts
+++ b/apps/api/src/utils/is-cjk-radical-moon-present.ts
@@ -1,0 +1,8 @@
+/**
+ * Checks whether the input string contains the Unicode character U+2E9D.
+ * @param input - The string to check.
+ * @returns true if the input contains the character, false otherwise.
+ */
+export function isCjkRadicalMoonPresent(input: string): boolean {
+  return input.includes(String.fromCodePoint(11933));
+}

--- a/apps/api/src/utils/is-cjk-radical-mortar-present.ts
+++ b/apps/api/src/utils/is-cjk-radical-mortar-present.ts
@@ -1,0 +1,8 @@
+/**
+ * Checks whether the input string contains the Unicode character U+2EBD.
+ * @param input - The string to check.
+ * @returns true if the input contains the character, false otherwise.
+ */
+export function isCjkRadicalMortarPresent(input: string): boolean {
+  return input.includes(String.fromCodePoint(11965));
+}

--- a/apps/api/src/utils/is-cjk-radical-mound-two-present.ts
+++ b/apps/api/src/utils/is-cjk-radical-mound-two-present.ts
@@ -1,0 +1,8 @@
+/**
+ * Checks whether the input string contains the Unicode character U+2ED5.
+ * @param input - The string to check.
+ * @returns true if the input contains the character, false otherwise.
+ */
+export function isCjkRadicalMoundTwoPresent(input: string): boolean {
+  return input.includes(String.fromCodePoint(11989));
+}

--- a/apps/api/src/utils/is-cjk-radical-net-four-present.ts
+++ b/apps/api/src/utils/is-cjk-radical-net-four-present.ts
@@ -1,0 +1,8 @@
+/**
+ * Checks whether the input string contains the Unicode character U+2EB4.
+ * @param input - The string to check.
+ * @returns true if the input contains the character, false otherwise.
+ */
+export function isCjkRadicalNetFourPresent(input: string): boolean {
+  return input.includes(String.fromCodePoint(11956));
+}

--- a/apps/api/src/utils/is-cjk-radical-net-one-present.ts
+++ b/apps/api/src/utils/is-cjk-radical-net-one-present.ts
@@ -1,0 +1,8 @@
+/**
+ * Checks whether the input string contains the Unicode character U+2EB1.
+ * @param input - The string to check.
+ * @returns true if the input contains the character, false otherwise.
+ */
+export function isCjkRadicalNetOnePresent(input: string): boolean {
+  return input.includes(String.fromCodePoint(11953));
+}

--- a/apps/api/src/utils/is-cjk-radical-net-three-present.ts
+++ b/apps/api/src/utils/is-cjk-radical-net-three-present.ts
@@ -1,0 +1,8 @@
+/**
+ * Checks whether the input string contains the Unicode character U+2EB3.
+ * @param input - The string to check.
+ * @returns true if the input contains the character, false otherwise.
+ */
+export function isCjkRadicalNetThreePresent(input: string): boolean {
+  return input.includes(String.fromCodePoint(11955));
+}

--- a/apps/api/src/utils/is-cjk-radical-net-two-present.ts
+++ b/apps/api/src/utils/is-cjk-radical-net-two-present.ts
@@ -1,0 +1,8 @@
+/**
+ * Checks whether the input string contains the Unicode character U+2EB2.
+ * @param input - The string to check.
+ * @returns true if the input contains the character, false otherwise.
+ */
+export function isCjkRadicalNetTwoPresent(input: string): boolean {
+  return input.includes(String.fromCodePoint(11954));
+}

--- a/apps/api/src/utils/is-cjk-radical-old-present.ts
+++ b/apps/api/src/utils/is-cjk-radical-old-present.ts
@@ -1,0 +1,8 @@
+/**
+ * Checks whether the input string contains the Unicode character U+2EB9.
+ * @param input - The string to check.
+ * @returns true if the input contains the character, false otherwise.
+ */
+export function isCjkRadicalOldPresent(input: string): boolean {
+  return input.includes(String.fromCodePoint(11961));
+}

--- a/apps/api/src/utils/is-cjk-radical-paw-one-present.ts
+++ b/apps/api/src/utils/is-cjk-radical-paw-one-present.ts
@@ -1,0 +1,8 @@
+/**
+ * Checks whether the input string contains the Unicode character U+2EA4.
+ * @param input - The string to check.
+ * @returns true if the input contains the character, false otherwise.
+ */
+export function isCjkRadicalPawOnePresent(input: string): boolean {
+  return input.includes(String.fromCodePoint(11940));
+}

--- a/apps/api/src/utils/is-cjk-radical-paw-two-present.ts
+++ b/apps/api/src/utils/is-cjk-radical-paw-two-present.ts
@@ -1,0 +1,8 @@
+/**
+ * Checks whether the input string contains the Unicode character U+2EA5.
+ * @param input - The string to check.
+ * @returns true if the input contains the character, false otherwise.
+ */
+export function isCjkRadicalPawTwoPresent(input: string): boolean {
+  return input.includes(String.fromCodePoint(11941));
+}

--- a/apps/api/src/utils/is-cjk-radical-person-present.ts
+++ b/apps/api/src/utils/is-cjk-radical-person-present.ts
@@ -1,0 +1,8 @@
+/**
+ * Checks whether the input string contains the Unicode character U+2E85.
+ * @param input - The string to check.
+ * @returns true if the input contains the character, false otherwise.
+ */
+export function isCjkRadicalPersonPresent(input: string): boolean {
+  return input.includes(String.fromCodePoint(11909));
+}

--- a/apps/api/src/utils/is-cjk-radical-rap-present.ts
+++ b/apps/api/src/utils/is-cjk-radical-rap-present.ts
@@ -1,0 +1,8 @@
+/**
+ * Checks whether the input string contains the Unicode character U+2E99.
+ * @param input - The string to check.
+ * @returns true if the input contains the character, false otherwise.
+ */
+export function isCjkRadicalRapPresent(input: string): boolean {
+  return input.includes(String.fromCodePoint(11929));
+}

--- a/apps/api/src/utils/is-cjk-radical-seal-present.ts
+++ b/apps/api/src/utils/is-cjk-radical-seal-present.ts
@@ -1,0 +1,8 @@
+/**
+ * Checks whether the input string contains the Unicode character U+2E8B.
+ * @param input - The string to check.
+ * @returns true if the input contains the character, false otherwise.
+ */
+export function isCjkRadicalSealPresent(input: string): boolean {
+  return input.includes(String.fromCodePoint(11915));
+}

--- a/apps/api/src/utils/is-cjk-radical-second-two-present.ts
+++ b/apps/api/src/utils/is-cjk-radical-second-two-present.ts
@@ -1,0 +1,8 @@
+/**
+ * Checks whether the input string contains the Unicode character U+2E83.
+ * @param input - The string to check.
+ * @returns true if the input contains the character, false otherwise.
+ */
+export function isCjkRadicalSecondTwoPresent(input: string): boolean {
+  return input.includes(String.fromCodePoint(11907));
+}

--- a/apps/api/src/utils/is-cjk-radical-simplified-walk-present.ts
+++ b/apps/api/src/utils/is-cjk-radical-simplified-walk-present.ts
@@ -1,0 +1,8 @@
+/**
+ * Checks whether the input string contains the Unicode character U+2ECC.
+ * @param input - The string to check.
+ * @returns true if the input contains the character, false otherwise.
+ */
+export function isCjkRadicalSimplifiedWalkPresent(input: string): boolean {
+  return input.includes(String.fromCodePoint(11980));
+}

--- a/apps/api/src/utils/is-cjk-radical-simplified-wheat-present.ts
+++ b/apps/api/src/utils/is-cjk-radical-simplified-wheat-present.ts
@@ -1,0 +1,8 @@
+/**
+ * Checks whether the input string contains the Unicode character U+2EE8.
+ * @param input - The string to check.
+ * @returns true if the input contains the character, false otherwise.
+ */
+export function isCjkRadicalSimplifiedWheatPresent(input: string): boolean {
+  return input.includes(String.fromCodePoint(12008));
+}

--- a/apps/api/src/utils/is-cjk-radical-simplified-yellow-present.ts
+++ b/apps/api/src/utils/is-cjk-radical-simplified-yellow-present.ts
@@ -1,0 +1,8 @@
+/**
+ * Checks whether the input string contains the Unicode character U+2EE9.
+ * @param input - The string to check.
+ * @returns true if the input contains the character, false otherwise.
+ */
+export function isCjkRadicalSimplifiedYellowPresent(input: string): boolean {
+  return input.includes(String.fromCodePoint(12009));
+}

--- a/apps/api/src/utils/is-cjk-radical-snout-one-present.ts
+++ b/apps/api/src/utils/is-cjk-radical-snout-one-present.ts
@@ -1,0 +1,8 @@
+/**
+ * Checks whether the input string contains the Unicode character U+2E94.
+ * @param input - The string to check.
+ * @returns true if the input contains the character, false otherwise.
+ */
+export function isCjkRadicalSnoutOnePresent(input: string): boolean {
+  return input.includes(String.fromCodePoint(11924));
+}

--- a/apps/api/src/utils/is-cjk-radical-snout-two-present.ts
+++ b/apps/api/src/utils/is-cjk-radical-snout-two-present.ts
@@ -1,0 +1,8 @@
+/**
+ * Checks whether the input string contains the Unicode character U+2E95.
+ * @param input - The string to check.
+ * @returns true if the input contains the character, false otherwise.
+ */
+export function isCjkRadicalSnoutTwoPresent(input: string): boolean {
+  return input.includes(String.fromCodePoint(11925));
+}

--- a/apps/api/src/utils/is-cjk-radical-spirit-one-present.ts
+++ b/apps/api/src/utils/is-cjk-radical-spirit-one-present.ts
@@ -1,0 +1,8 @@
+/**
+ * Checks whether the input string contains the Unicode character U+2EAC.
+ * @param input - The string to check.
+ * @returns true if the input contains the character, false otherwise.
+ */
+export function isCjkRadicalSpiritOnePresent(input: string): boolean {
+  return input.includes(String.fromCodePoint(11948));
+}

--- a/apps/api/src/utils/is-cjk-radical-spirit-two-present.ts
+++ b/apps/api/src/utils/is-cjk-radical-spirit-two-present.ts
@@ -1,0 +1,8 @@
+/**
+ * Checks whether the input string contains the Unicode character U+2EAD.
+ * @param input - The string to check.
+ * @returns true if the input contains the character, false otherwise.
+ */
+export function isCjkRadicalSpiritTwoPresent(input: string): boolean {
+  return input.includes(String.fromCodePoint(11949));
+}

--- a/apps/api/src/utils/is-cjk-radical-sun-present.ts
+++ b/apps/api/src/utils/is-cjk-radical-sun-present.ts
@@ -1,0 +1,8 @@
+/**
+ * Checks whether the input string contains the Unicode character U+2E9C.
+ * @param input - The string to check.
+ * @returns true if the input contains the character, false otherwise.
+ */
+export function isCjkRadicalSunPresent(input: string): boolean {
+  return input.includes(String.fromCodePoint(11932));
+}

--- a/apps/api/src/utils/is-cjk-radical-table-present.ts
+++ b/apps/api/src/utils/is-cjk-radical-table-present.ts
@@ -1,0 +1,8 @@
+/**
+ * Checks whether the input string contains the Unicode character U+2E87.
+ * @param input - The string to check.
+ * @returns true if the input contains the character, false otherwise.
+ */
+export function isCjkRadicalTablePresent(input: string): boolean {
+  return input.includes(String.fromCodePoint(11911));
+}

--- a/apps/api/src/utils/is-cjk-radical-thread-present.ts
+++ b/apps/api/src/utils/is-cjk-radical-thread-present.ts
@@ -1,0 +1,8 @@
+/**
+ * Checks whether the input string contains the Unicode character U+2E93.
+ * @param input - The string to check.
+ * @returns true if the input contains the character, false otherwise.
+ */
+export function isCjkRadicalThreadPresent(input: string): boolean {
+  return input.includes(String.fromCodePoint(11923));
+}

--- a/apps/api/src/utils/is-cjk-radical-tiger-present.ts
+++ b/apps/api/src/utils/is-cjk-radical-tiger-present.ts
@@ -1,0 +1,8 @@
+/**
+ * Checks whether the input string contains the Unicode character U+2EC1.
+ * @param input - The string to check.
+ * @returns true if the input contains the character, false otherwise.
+ */
+export function isCjkRadicalTigerPresent(input: string): boolean {
+  return input.includes(String.fromCodePoint(11969));
+}

--- a/apps/api/src/utils/is-cjk-radical-turtle-present.ts
+++ b/apps/api/src/utils/is-cjk-radical-turtle-present.ts
@@ -1,0 +1,8 @@
+/**
+ * Checks whether the input string contains the Unicode character U+2EF1.
+ * @param input - The string to check.
+ * @returns true if the input contains the character, false otherwise.
+ */
+export function isCjkRadicalTurtlePresent(input: string): boolean {
+  return input.includes(String.fromCodePoint(12017));
+}

--- a/apps/api/src/utils/is-cjk-radical-walk-one-present.ts
+++ b/apps/api/src/utils/is-cjk-radical-walk-one-present.ts
@@ -1,0 +1,8 @@
+/**
+ * Checks whether the input string contains the Unicode character U+2ECD.
+ * @param input - The string to check.
+ * @returns true if the input contains the character, false otherwise.
+ */
+export function isCjkRadicalWalkOnePresent(input: string): boolean {
+  return input.includes(String.fromCodePoint(11981));
+}

--- a/apps/api/src/utils/is-cjk-radical-water-one-present.ts
+++ b/apps/api/src/utils/is-cjk-radical-water-one-present.ts
@@ -1,0 +1,8 @@
+/**
+ * Checks whether the input string contains the Unicode character U+2EA1.
+ * @param input - The string to check.
+ * @returns true if the input contains the character, false otherwise.
+ */
+export function isCjkRadicalWaterOnePresent(input: string): boolean {
+  return input.includes(String.fromCodePoint(11937));
+}

--- a/apps/api/src/utils/is-cjk-radical-water-two-present.ts
+++ b/apps/api/src/utils/is-cjk-radical-water-two-present.ts
@@ -1,0 +1,8 @@
+/**
+ * Checks whether the input string contains the Unicode character U+2EA2.
+ * @param input - The string to check.
+ * @returns true if the input contains the character, false otherwise.
+ */
+export function isCjkRadicalWaterTwoPresent(input: string): boolean {
+  return input.includes(String.fromCodePoint(11938));
+}

--- a/apps/api/src/utils/is-cjk-radical-west-one-present.ts
+++ b/apps/api/src/utils/is-cjk-radical-west-one-present.ts
@@ -1,0 +1,8 @@
+/**
+ * Checks whether the input string contains the Unicode character U+2EC3.
+ * @param input - The string to check.
+ * @returns true if the input contains the character, false otherwise.
+ */
+export function isCjkRadicalWestOnePresent(input: string): boolean {
+  return input.includes(String.fromCodePoint(11971));
+}

--- a/apps/api/src/utils/is-cjk-radical-west-two-present.ts
+++ b/apps/api/src/utils/is-cjk-radical-west-two-present.ts
@@ -1,0 +1,8 @@
+/**
+ * Checks whether the input string contains the Unicode character U+2EC4.
+ * @param input - The string to check.
+ * @returns true if the input contains the character, false otherwise.
+ */
+export function isCjkRadicalWestTwoPresent(input: string): boolean {
+  return input.includes(String.fromCodePoint(11972));
+}

--- a/apps/api/src/utils/is-kangxi-radical-again-present.ts
+++ b/apps/api/src/utils/is-kangxi-radical-again-present.ts
@@ -1,0 +1,8 @@
+/**
+ * Checks whether the input string contains the Unicode character U+2F1C.
+ * @param input - The string to check.
+ * @returns true if the input contains the character, false otherwise.
+ */
+export function isKangxiRadicalAgainPresent(input: string): boolean {
+  return input.includes(String.fromCodePoint(12060));
+}

--- a/apps/api/src/utils/is-kangxi-radical-big-present.ts
+++ b/apps/api/src/utils/is-kangxi-radical-big-present.ts
@@ -1,0 +1,8 @@
+/**
+ * Checks whether the input string contains the Unicode character U+2F24.
+ * @param input - The string to check.
+ * @returns true if the input contains the character, false otherwise.
+ */
+export function isKangxiRadicalBigPresent(input: string): boolean {
+  return input.includes(String.fromCodePoint(12068));
+}

--- a/apps/api/src/utils/is-kangxi-radical-bow-present.ts
+++ b/apps/api/src/utils/is-kangxi-radical-bow-present.ts
@@ -1,0 +1,8 @@
+/**
+ * Checks whether the input string contains the Unicode character U+2F38.
+ * @param input - The string to check.
+ * @returns true if the input contains the character, false otherwise.
+ */
+export function isKangxiRadicalBowPresent(input: string): boolean {
+  return input.includes(String.fromCodePoint(12088));
+}

--- a/apps/api/src/utils/is-kangxi-radical-branch-present.ts
+++ b/apps/api/src/utils/is-kangxi-radical-branch-present.ts
@@ -1,0 +1,8 @@
+/**
+ * Checks whether the input string contains the Unicode character U+2F40.
+ * @param input - The string to check.
+ * @returns true if the input contains the character, false otherwise.
+ */
+export function isKangxiRadicalBranchPresent(input: string): boolean {
+  return input.includes(String.fromCodePoint(12096));
+}

--- a/apps/api/src/utils/is-kangxi-radical-bristle-present.ts
+++ b/apps/api/src/utils/is-kangxi-radical-bristle-present.ts
@@ -1,0 +1,8 @@
+/**
+ * Checks whether the input string contains the Unicode character U+2F3A.
+ * @param input - The string to check.
+ * @returns true if the input contains the character, false otherwise.
+ */
+export function isKangxiRadicalBristlePresent(input: string): boolean {
+  return input.includes(String.fromCodePoint(12090));
+}

--- a/apps/api/src/utils/is-kangxi-radical-child-present.ts
+++ b/apps/api/src/utils/is-kangxi-radical-child-present.ts
@@ -1,0 +1,8 @@
+/**
+ * Checks whether the input string contains the Unicode character U+2F26.
+ * @param input - The string to check.
+ * @returns true if the input contains the character, false otherwise.
+ */
+export function isKangxiRadicalChildPresent(input: string): boolean {
+  return input.includes(String.fromCodePoint(12070));
+}

--- a/apps/api/src/utils/is-kangxi-radical-cliff-present.ts
+++ b/apps/api/src/utils/is-kangxi-radical-cliff-present.ts
@@ -1,0 +1,8 @@
+/**
+ * Checks whether the input string contains the Unicode character U+2F1A.
+ * @param input - The string to check.
+ * @returns true if the input contains the character, false otherwise.
+ */
+export function isKangxiRadicalCliffPresent(input: string): boolean {
+  return input.includes(String.fromCodePoint(12058));
+}

--- a/apps/api/src/utils/is-kangxi-radical-corpse-present.ts
+++ b/apps/api/src/utils/is-kangxi-radical-corpse-present.ts
@@ -1,0 +1,8 @@
+/**
+ * Checks whether the input string contains the Unicode character U+2F2B.
+ * @param input - The string to check.
+ * @returns true if the input contains the character, false otherwise.
+ */
+export function isKangxiRadicalCorpsePresent(input: string): boolean {
+  return input.includes(String.fromCodePoint(12075));
+}

--- a/apps/api/src/utils/is-kangxi-radical-divination-present.ts
+++ b/apps/api/src/utils/is-kangxi-radical-divination-present.ts
@@ -1,0 +1,8 @@
+/**
+ * Checks whether the input string contains the Unicode character U+2F18.
+ * @param input - The string to check.
+ * @returns true if the input contains the character, false otherwise.
+ */
+export function isKangxiRadicalDivinationPresent(input: string): boolean {
+  return input.includes(String.fromCodePoint(12056));
+}

--- a/apps/api/src/utils/is-kangxi-radical-door-present.ts
+++ b/apps/api/src/utils/is-kangxi-radical-door-present.ts
@@ -1,0 +1,8 @@
+/**
+ * Checks whether the input string contains the Unicode character U+2F3E.
+ * @param input - The string to check.
+ * @returns true if the input contains the character, false otherwise.
+ */
+export function isKangxiRadicalDoorPresent(input: string): boolean {
+  return input.includes(String.fromCodePoint(12094));
+}

--- a/apps/api/src/utils/is-kangxi-radical-dot-present.ts
+++ b/apps/api/src/utils/is-kangxi-radical-dot-present.ts
@@ -1,0 +1,8 @@
+/**
+ * Checks whether the input string contains the Unicode character U+2F02.
+ * @param input - The string to check.
+ * @returns true if the input contains the character, false otherwise.
+ */
+export function isKangxiRadicalDotPresent(input: string): boolean {
+  return input.includes(String.fromCodePoint(12034));
+}

--- a/apps/api/src/utils/is-kangxi-radical-dotted-cliff-present.ts
+++ b/apps/api/src/utils/is-kangxi-radical-dotted-cliff-present.ts
@@ -1,0 +1,8 @@
+/**
+ * Checks whether the input string contains the Unicode character U+2F34.
+ * @param input - The string to check.
+ * @returns true if the input contains the character, false otherwise.
+ */
+export function isKangxiRadicalDottedCliffPresent(input: string): boolean {
+  return input.includes(String.fromCodePoint(12084));
+}

--- a/apps/api/src/utils/is-kangxi-radical-down-box-present.ts
+++ b/apps/api/src/utils/is-kangxi-radical-down-box-present.ts
@@ -1,0 +1,8 @@
+/**
+ * Checks whether the input string contains the Unicode character U+2F0C.
+ * @param input - The string to check.
+ * @returns true if the input contains the character, false otherwise.
+ */
+export function isKangxiRadicalDownBoxPresent(input: string): boolean {
+  return input.includes(String.fromCodePoint(12044));
+}

--- a/apps/api/src/utils/is-kangxi-radical-dry-present.ts
+++ b/apps/api/src/utils/is-kangxi-radical-dry-present.ts
@@ -1,0 +1,8 @@
+/**
+ * Checks whether the input string contains the Unicode character U+2F32.
+ * @param input - The string to check.
+ * @returns true if the input contains the character, false otherwise.
+ */
+export function isKangxiRadicalDryPresent(input: string): boolean {
+  return input.includes(String.fromCodePoint(12082));
+}

--- a/apps/api/src/utils/is-kangxi-radical-earth-present.ts
+++ b/apps/api/src/utils/is-kangxi-radical-earth-present.ts
@@ -1,0 +1,8 @@
+/**
+ * Checks whether the input string contains the Unicode character U+2F1F.
+ * @param input - The string to check.
+ * @returns true if the input contains the character, false otherwise.
+ */
+export function isKangxiRadicalEarthPresent(input: string): boolean {
+  return input.includes(String.fromCodePoint(12063));
+}

--- a/apps/api/src/utils/is-kangxi-radical-eight-present.ts
+++ b/apps/api/src/utils/is-kangxi-radical-eight-present.ts
@@ -1,0 +1,8 @@
+/**
+ * Checks whether the input string contains the Unicode character U+2F0B.
+ * @param input - The string to check.
+ * @returns true if the input contains the character, false otherwise.
+ */
+export function isKangxiRadicalEightPresent(input: string): boolean {
+  return input.includes(String.fromCodePoint(12043));
+}

--- a/apps/api/src/utils/is-kangxi-radical-enter-present.ts
+++ b/apps/api/src/utils/is-kangxi-radical-enter-present.ts
@@ -1,0 +1,8 @@
+/**
+ * Checks whether the input string contains the Unicode character U+2F0A.
+ * @param input - The string to check.
+ * @returns true if the input contains the character, false otherwise.
+ */
+export function isKangxiRadicalEnterPresent(input: string): boolean {
+  return input.includes(String.fromCodePoint(12042));
+}

--- a/apps/api/src/utils/is-kangxi-radical-evening-present.ts
+++ b/apps/api/src/utils/is-kangxi-radical-evening-present.ts
@@ -1,0 +1,8 @@
+/**
+ * Checks whether the input string contains the Unicode character U+2F23.
+ * @param input - The string to check.
+ * @returns true if the input contains the character, false otherwise.
+ */
+export function isKangxiRadicalEveningPresent(input: string): boolean {
+  return input.includes(String.fromCodePoint(12067));
+}

--- a/apps/api/src/utils/is-kangxi-radical-go-present.ts
+++ b/apps/api/src/utils/is-kangxi-radical-go-present.ts
@@ -1,0 +1,8 @@
+/**
+ * Checks whether the input string contains the Unicode character U+2F21.
+ * @param input - The string to check.
+ * @returns true if the input contains the character, false otherwise.
+ */
+export function isKangxiRadicalGoPresent(input: string): boolean {
+  return input.includes(String.fromCodePoint(12065));
+}

--- a/apps/api/src/utils/is-kangxi-radical-go-slowly-present.ts
+++ b/apps/api/src/utils/is-kangxi-radical-go-slowly-present.ts
@@ -1,0 +1,8 @@
+/**
+ * Checks whether the input string contains the Unicode character U+2F22.
+ * @param input - The string to check.
+ * @returns true if the input contains the character, false otherwise.
+ */
+export function isKangxiRadicalGoSlowlyPresent(input: string): boolean {
+  return input.includes(String.fromCodePoint(12066));
+}

--- a/apps/api/src/utils/is-kangxi-radical-halberd-present.ts
+++ b/apps/api/src/utils/is-kangxi-radical-halberd-present.ts
@@ -1,0 +1,8 @@
+/**
+ * Checks whether the input string contains the Unicode character U+2F3D.
+ * @param input - The string to check.
+ * @returns true if the input contains the character, false otherwise.
+ */
+export function isKangxiRadicalHalberdPresent(input: string): boolean {
+  return input.includes(String.fromCodePoint(12093));
+}

--- a/apps/api/src/utils/is-kangxi-radical-heart-present.ts
+++ b/apps/api/src/utils/is-kangxi-radical-heart-present.ts
@@ -1,0 +1,8 @@
+/**
+ * Checks whether the input string contains the Unicode character U+2F3C.
+ * @param input - The string to check.
+ * @returns true if the input contains the character, false otherwise.
+ */
+export function isKangxiRadicalHeartPresent(input: string): boolean {
+  return input.includes(String.fromCodePoint(12092));
+}

--- a/apps/api/src/utils/is-kangxi-radical-hiding-enclosure-present.ts
+++ b/apps/api/src/utils/is-kangxi-radical-hiding-enclosure-present.ts
@@ -1,0 +1,8 @@
+/**
+ * Checks whether the input string contains the Unicode character U+2F16.
+ * @param input - The string to check.
+ * @returns true if the input contains the character, false otherwise.
+ */
+export function isKangxiRadicalHidingEnclosurePresent(input: string): boolean {
+  return input.includes(String.fromCodePoint(12054));
+}

--- a/apps/api/src/utils/is-kangxi-radical-hook-present.ts
+++ b/apps/api/src/utils/is-kangxi-radical-hook-present.ts
@@ -1,0 +1,8 @@
+/**
+ * Checks whether the input string contains the Unicode character U+2F05.
+ * @param input - The string to check.
+ * @returns true if the input contains the character, false otherwise.
+ */
+export function isKangxiRadicalHookPresent(input: string): boolean {
+  return input.includes(String.fromCodePoint(12037));
+}

--- a/apps/api/src/utils/is-kangxi-radical-ice-present.ts
+++ b/apps/api/src/utils/is-kangxi-radical-ice-present.ts
@@ -1,0 +1,8 @@
+/**
+ * Checks whether the input string contains the Unicode character U+2F0E.
+ * @param input - The string to check.
+ * @returns true if the input contains the character, false otherwise.
+ */
+export function isKangxiRadicalIcePresent(input: string): boolean {
+  return input.includes(String.fromCodePoint(12046));
+}

--- a/apps/api/src/utils/is-kangxi-radical-inch-present.ts
+++ b/apps/api/src/utils/is-kangxi-radical-inch-present.ts
@@ -1,0 +1,8 @@
+/**
+ * Checks whether the input string contains the Unicode character U+2F28.
+ * @param input - The string to check.
+ * @returns true if the input contains the character, false otherwise.
+ */
+export function isKangxiRadicalInchPresent(input: string): boolean {
+  return input.includes(String.fromCodePoint(12072));
+}

--- a/apps/api/src/utils/is-kangxi-radical-knife-present.ts
+++ b/apps/api/src/utils/is-kangxi-radical-knife-present.ts
@@ -1,0 +1,8 @@
+/**
+ * Checks whether the input string contains the Unicode character U+2F11.
+ * @param input - The string to check.
+ * @returns true if the input contains the character, false otherwise.
+ */
+export function isKangxiRadicalKnifePresent(input: string): boolean {
+  return input.includes(String.fromCodePoint(12049));
+}

--- a/apps/api/src/utils/is-kangxi-radical-lame-present.ts
+++ b/apps/api/src/utils/is-kangxi-radical-lame-present.ts
@@ -1,0 +1,8 @@
+/**
+ * Checks whether the input string contains the Unicode character U+2F2A.
+ * @param input - The string to check.
+ * @returns true if the input contains the character, false otherwise.
+ */
+export function isKangxiRadicalLamePresent(input: string): boolean {
+  return input.includes(String.fromCodePoint(12074));
+}

--- a/apps/api/src/utils/is-kangxi-radical-legs-present.ts
+++ b/apps/api/src/utils/is-kangxi-radical-legs-present.ts
@@ -1,0 +1,8 @@
+/**
+ * Checks whether the input string contains the Unicode character U+2F09.
+ * @param input - The string to check.
+ * @returns true if the input contains the character, false otherwise.
+ */
+export function isKangxiRadicalLegsPresent(input: string): boolean {
+  return input.includes(String.fromCodePoint(12041));
+}

--- a/apps/api/src/utils/is-kangxi-radical-lid-present.ts
+++ b/apps/api/src/utils/is-kangxi-radical-lid-present.ts
@@ -1,0 +1,8 @@
+/**
+ * Checks whether the input string contains the Unicode character U+2F07.
+ * @param input - The string to check.
+ * @returns true if the input contains the character, false otherwise.
+ */
+export function isKangxiRadicalLidPresent(input: string): boolean {
+  return input.includes(String.fromCodePoint(12039));
+}

--- a/apps/api/src/utils/is-kangxi-radical-line-present.ts
+++ b/apps/api/src/utils/is-kangxi-radical-line-present.ts
@@ -1,0 +1,8 @@
+/**
+ * Checks whether the input string contains the Unicode character U+2F01.
+ * @param input - The string to check.
+ * @returns true if the input contains the character, false otherwise.
+ */
+export function isKangxiRadicalLinePresent(input: string): boolean {
+  return input.includes(String.fromCodePoint(12033));
+}

--- a/apps/api/src/utils/is-kangxi-radical-long-stride-present.ts
+++ b/apps/api/src/utils/is-kangxi-radical-long-stride-present.ts
@@ -1,0 +1,8 @@
+/**
+ * Checks whether the input string contains the Unicode character U+2F35.
+ * @param input - The string to check.
+ * @returns true if the input contains the character, false otherwise.
+ */
+export function isKangxiRadicalLongStridePresent(input: string): boolean {
+  return input.includes(String.fromCodePoint(12085));
+}

--- a/apps/api/src/utils/is-kangxi-radical-mountain-present.ts
+++ b/apps/api/src/utils/is-kangxi-radical-mountain-present.ts
@@ -1,0 +1,8 @@
+/**
+ * Checks whether the input string contains the Unicode character U+2F2D.
+ * @param input - The string to check.
+ * @returns true if the input contains the character, false otherwise.
+ */
+export function isKangxiRadicalMountainPresent(input: string): boolean {
+  return input.includes(String.fromCodePoint(12077));
+}

--- a/apps/api/src/utils/is-kangxi-radical-mouth-present.ts
+++ b/apps/api/src/utils/is-kangxi-radical-mouth-present.ts
@@ -1,0 +1,8 @@
+/**
+ * Checks whether the input string contains the Unicode character U+2F1D.
+ * @param input - The string to check.
+ * @returns true if the input contains the character, false otherwise.
+ */
+export function isKangxiRadicalMouthPresent(input: string): boolean {
+  return input.includes(String.fromCodePoint(12061));
+}

--- a/apps/api/src/utils/is-kangxi-radical-one-present.ts
+++ b/apps/api/src/utils/is-kangxi-radical-one-present.ts
@@ -1,0 +1,8 @@
+/**
+ * Checks whether the input string contains the Unicode character U+2F00.
+ * @param input - The string to check.
+ * @returns true if the input contains the character, false otherwise.
+ */
+export function isKangxiRadicalOnePresent(input: string): boolean {
+  return input.includes(String.fromCodePoint(12032));
+}

--- a/apps/api/src/utils/is-kangxi-radical-oneself-present.ts
+++ b/apps/api/src/utils/is-kangxi-radical-oneself-present.ts
@@ -1,0 +1,8 @@
+/**
+ * Checks whether the input string contains the Unicode character U+2F30.
+ * @param input - The string to check.
+ * @returns true if the input contains the character, false otherwise.
+ */
+export function isKangxiRadicalOneselfPresent(input: string): boolean {
+  return input.includes(String.fromCodePoint(12080));
+}

--- a/apps/api/src/utils/is-kangxi-radical-open-box-present.ts
+++ b/apps/api/src/utils/is-kangxi-radical-open-box-present.ts
@@ -1,0 +1,8 @@
+/**
+ * Checks whether the input string contains the Unicode character U+2F10.
+ * @param input - The string to check.
+ * @returns true if the input contains the character, false otherwise.
+ */
+export function isKangxiRadicalOpenBoxPresent(input: string): boolean {
+  return input.includes(String.fromCodePoint(12048));
+}

--- a/apps/api/src/utils/is-kangxi-radical-person-present.ts
+++ b/apps/api/src/utils/is-kangxi-radical-person-present.ts
@@ -1,0 +1,8 @@
+/**
+ * Checks whether the input string contains the Unicode character U+2F08.
+ * @param input - The string to check.
+ * @returns true if the input contains the character, false otherwise.
+ */
+export function isKangxiRadicalPersonPresent(input: string): boolean {
+  return input.includes(String.fromCodePoint(12040));
+}

--- a/apps/api/src/utils/is-kangxi-radical-power-present.ts
+++ b/apps/api/src/utils/is-kangxi-radical-power-present.ts
@@ -1,0 +1,8 @@
+/**
+ * Checks whether the input string contains the Unicode character U+2F12.
+ * @param input - The string to check.
+ * @returns true if the input contains the character, false otherwise.
+ */
+export function isKangxiRadicalPowerPresent(input: string): boolean {
+  return input.includes(String.fromCodePoint(12050));
+}

--- a/apps/api/src/utils/is-kangxi-radical-private-present.ts
+++ b/apps/api/src/utils/is-kangxi-radical-private-present.ts
@@ -1,0 +1,8 @@
+/**
+ * Checks whether the input string contains the Unicode character U+2F1B.
+ * @param input - The string to check.
+ * @returns true if the input contains the character, false otherwise.
+ */
+export function isKangxiRadicalPrivatePresent(input: string): boolean {
+  return input.includes(String.fromCodePoint(12059));
+}

--- a/apps/api/src/utils/is-kangxi-radical-right-open-box-present.ts
+++ b/apps/api/src/utils/is-kangxi-radical-right-open-box-present.ts
@@ -1,0 +1,8 @@
+/**
+ * Checks whether the input string contains the Unicode character U+2F15.
+ * @param input - The string to check.
+ * @returns true if the input contains the character, false otherwise.
+ */
+export function isKangxiRadicalRightOpenBoxPresent(input: string): boolean {
+  return input.includes(String.fromCodePoint(12053));
+}

--- a/apps/api/src/utils/is-kangxi-radical-river-present.ts
+++ b/apps/api/src/utils/is-kangxi-radical-river-present.ts
@@ -1,0 +1,8 @@
+/**
+ * Checks whether the input string contains the Unicode character U+2F2E.
+ * @param input - The string to check.
+ * @returns true if the input contains the character, false otherwise.
+ */
+export function isKangxiRadicalRiverPresent(input: string): boolean {
+  return input.includes(String.fromCodePoint(12078));
+}

--- a/apps/api/src/utils/is-kangxi-radical-roof-present.ts
+++ b/apps/api/src/utils/is-kangxi-radical-roof-present.ts
@@ -1,0 +1,8 @@
+/**
+ * Checks whether the input string contains the Unicode character U+2F27.
+ * @param input - The string to check.
+ * @returns true if the input contains the character, false otherwise.
+ */
+export function isKangxiRadicalRoofPresent(input: string): boolean {
+  return input.includes(String.fromCodePoint(12071));
+}

--- a/apps/api/src/utils/is-kangxi-radical-scholar-present.ts
+++ b/apps/api/src/utils/is-kangxi-radical-scholar-present.ts
@@ -1,0 +1,8 @@
+/**
+ * Checks whether the input string contains the Unicode character U+2F20.
+ * @param input - The string to check.
+ * @returns true if the input contains the character, false otherwise.
+ */
+export function isKangxiRadicalScholarPresent(input: string): boolean {
+  return input.includes(String.fromCodePoint(12064));
+}

--- a/apps/api/src/utils/is-kangxi-radical-seal-present.ts
+++ b/apps/api/src/utils/is-kangxi-radical-seal-present.ts
@@ -1,0 +1,8 @@
+/**
+ * Checks whether the input string contains the Unicode character U+2F19.
+ * @param input - The string to check.
+ * @returns true if the input contains the character, false otherwise.
+ */
+export function isKangxiRadicalSealPresent(input: string): boolean {
+  return input.includes(String.fromCodePoint(12057));
+}

--- a/apps/api/src/utils/is-kangxi-radical-second-present.ts
+++ b/apps/api/src/utils/is-kangxi-radical-second-present.ts
@@ -1,0 +1,8 @@
+/**
+ * Checks whether the input string contains the Unicode character U+2F04.
+ * @param input - The string to check.
+ * @returns true if the input contains the character, false otherwise.
+ */
+export function isKangxiRadicalSecondPresent(input: string): boolean {
+  return input.includes(String.fromCodePoint(12036));
+}

--- a/apps/api/src/utils/is-kangxi-radical-shoot-present.ts
+++ b/apps/api/src/utils/is-kangxi-radical-shoot-present.ts
@@ -1,0 +1,8 @@
+/**
+ * Checks whether the input string contains the Unicode character U+2F37.
+ * @param input - The string to check.
+ * @returns true if the input contains the character, false otherwise.
+ */
+export function isKangxiRadicalShootPresent(input: string): boolean {
+  return input.includes(String.fromCodePoint(12087));
+}

--- a/apps/api/src/utils/is-kangxi-radical-short-thread-present.ts
+++ b/apps/api/src/utils/is-kangxi-radical-short-thread-present.ts
@@ -1,0 +1,8 @@
+/**
+ * Checks whether the input string contains the Unicode character U+2F33.
+ * @param input - The string to check.
+ * @returns true if the input contains the character, false otherwise.
+ */
+export function isKangxiRadicalShortThreadPresent(input: string): boolean {
+  return input.includes(String.fromCodePoint(12083));
+}

--- a/apps/api/src/utils/is-kangxi-radical-slash-present.ts
+++ b/apps/api/src/utils/is-kangxi-radical-slash-present.ts
@@ -1,0 +1,8 @@
+/**
+ * Checks whether the input string contains the Unicode character U+2F03.
+ * @param input - The string to check.
+ * @returns true if the input contains the character, false otherwise.
+ */
+export function isKangxiRadicalSlashPresent(input: string): boolean {
+  return input.includes(String.fromCodePoint(12035));
+}

--- a/apps/api/src/utils/is-kangxi-radical-snout-present.ts
+++ b/apps/api/src/utils/is-kangxi-radical-snout-present.ts
@@ -1,0 +1,8 @@
+/**
+ * Checks whether the input string contains the Unicode character U+2F39.
+ * @param input - The string to check.
+ * @returns true if the input contains the character, false otherwise.
+ */
+export function isKangxiRadicalSnoutPresent(input: string): boolean {
+  return input.includes(String.fromCodePoint(12089));
+}

--- a/apps/api/src/utils/is-kangxi-radical-spoon-present.ts
+++ b/apps/api/src/utils/is-kangxi-radical-spoon-present.ts
@@ -1,0 +1,8 @@
+/**
+ * Checks whether the input string contains the Unicode character U+2F14.
+ * @param input - The string to check.
+ * @returns true if the input contains the character, false otherwise.
+ */
+export function isKangxiRadicalSpoonPresent(input: string): boolean {
+  return input.includes(String.fromCodePoint(12052));
+}

--- a/apps/api/src/utils/is-kangxi-radical-sprout-present.ts
+++ b/apps/api/src/utils/is-kangxi-radical-sprout-present.ts
@@ -1,0 +1,8 @@
+/**
+ * Checks whether the input string contains the Unicode character U+2F2C.
+ * @param input - The string to check.
+ * @returns true if the input contains the character, false otherwise.
+ */
+export function isKangxiRadicalSproutPresent(input: string): boolean {
+  return input.includes(String.fromCodePoint(12076));
+}

--- a/apps/api/src/utils/is-kangxi-radical-step-present.ts
+++ b/apps/api/src/utils/is-kangxi-radical-step-present.ts
@@ -1,0 +1,8 @@
+/**
+ * Checks whether the input string contains the Unicode character U+2F3B.
+ * @param input - The string to check.
+ * @returns true if the input contains the character, false otherwise.
+ */
+export function isKangxiRadicalStepPresent(input: string): boolean {
+  return input.includes(String.fromCodePoint(12091));
+}

--- a/apps/api/src/utils/is-kangxi-radical-table-present.ts
+++ b/apps/api/src/utils/is-kangxi-radical-table-present.ts
@@ -1,0 +1,8 @@
+/**
+ * Checks whether the input string contains the Unicode character U+2F0F.
+ * @param input - The string to check.
+ * @returns true if the input contains the character, false otherwise.
+ */
+export function isKangxiRadicalTablePresent(input: string): boolean {
+  return input.includes(String.fromCodePoint(12047));
+}

--- a/apps/api/src/utils/is-kangxi-radical-ten-present.ts
+++ b/apps/api/src/utils/is-kangxi-radical-ten-present.ts
@@ -1,0 +1,8 @@
+/**
+ * Checks whether the input string contains the Unicode character U+2F17.
+ * @param input - The string to check.
+ * @returns true if the input contains the character, false otherwise.
+ */
+export function isKangxiRadicalTenPresent(input: string): boolean {
+  return input.includes(String.fromCodePoint(12055));
+}

--- a/apps/api/src/utils/is-kangxi-radical-turban-present.ts
+++ b/apps/api/src/utils/is-kangxi-radical-turban-present.ts
@@ -1,0 +1,8 @@
+/**
+ * Checks whether the input string contains the Unicode character U+2F31.
+ * @param input - The string to check.
+ * @returns true if the input contains the character, false otherwise.
+ */
+export function isKangxiRadicalTurbanPresent(input: string): boolean {
+  return input.includes(String.fromCodePoint(12081));
+}

--- a/apps/api/src/utils/is-kangxi-radical-two-hands-present.ts
+++ b/apps/api/src/utils/is-kangxi-radical-two-hands-present.ts
@@ -1,0 +1,8 @@
+/**
+ * Checks whether the input string contains the Unicode character U+2F36.
+ * @param input - The string to check.
+ * @returns true if the input contains the character, false otherwise.
+ */
+export function isKangxiRadicalTwoHandsPresent(input: string): boolean {
+  return input.includes(String.fromCodePoint(12086));
+}

--- a/apps/api/src/utils/is-kangxi-radical-two-present.ts
+++ b/apps/api/src/utils/is-kangxi-radical-two-present.ts
@@ -1,0 +1,8 @@
+/**
+ * Checks whether the input string contains the Unicode character U+2F06.
+ * @param input - The string to check.
+ * @returns true if the input contains the character, false otherwise.
+ */
+export function isKangxiRadicalTwoPresent(input: string): boolean {
+  return input.includes(String.fromCodePoint(12038));
+}

--- a/apps/api/src/utils/is-kangxi-radical-woman-present.ts
+++ b/apps/api/src/utils/is-kangxi-radical-woman-present.ts
@@ -1,0 +1,8 @@
+/**
+ * Checks whether the input string contains the Unicode character U+2F25.
+ * @param input - The string to check.
+ * @returns true if the input contains the character, false otherwise.
+ */
+export function isKangxiRadicalWomanPresent(input: string): boolean {
+  return input.includes(String.fromCodePoint(12069));
+}

--- a/apps/api/src/utils/is-kangxi-radical-work-present.ts
+++ b/apps/api/src/utils/is-kangxi-radical-work-present.ts
@@ -1,0 +1,8 @@
+/**
+ * Checks whether the input string contains the Unicode character U+2F2F.
+ * @param input - The string to check.
+ * @returns true if the input contains the character, false otherwise.
+ */
+export function isKangxiRadicalWorkPresent(input: string): boolean {
+  return input.includes(String.fromCodePoint(12079));
+}

--- a/apps/api/src/utils/is-kangxi-radical-wrap-present.ts
+++ b/apps/api/src/utils/is-kangxi-radical-wrap-present.ts
@@ -1,0 +1,8 @@
+/**
+ * Checks whether the input string contains the Unicode character U+2F13.
+ * @param input - The string to check.
+ * @returns true if the input contains the character, false otherwise.
+ */
+export function isKangxiRadicalWrapPresent(input: string): boolean {
+  return input.includes(String.fromCodePoint(12051));
+}


### PR DESCRIPTION
## Unicode Character Detection Utilities (Batch 8 - 140 utilities)

Closes #5788, #5794, #5795, #5796, #5797, #5798, #5840, #5841, #5842, #5843, #5844, #5863, #5864, #5865, #5866, #5867, #5876, #5877, #5878, #5879, #5880, #5886, #5887, #5888, #5889, #5890, #5898, #5899, #5900, #5901, #5902, #5909, #5910, #5911, #5912, #5913, #5926, #5927, #5928, #5929, #5930, #5957, #5958, #5959, #5960, #5961, #5967, #5968, #5969, #5970, #5971, #5977, #5978, #5979, #5980, #5981, #6032, #6033, #6034, #6035, #6036, #6047, #6048, #6049, #6050, #6051, #6077, #6078, #6079, #6080, #6081, #6092, #6093, #6094, #6095, #6096, #6102, #6103, #6104, #6105, #6106, #6115, #6116, #6117, #6118, #6119, #6125, #6126, #6127, #6128, #6129, #6135, #6136, #6137, #6138, #6139, #6145, #6146, #6147, #6148, #6149, #6155, #6156, #6157, #6158, #6159, #6165, #6166, #6167, #6168, #6169, #6175, #6176, #6177, #6178, #6179, #6186, #6187, #6188, #6189, #6190, #6197, #6198, #6199, #6200, #6201, #6208, #6209, #6210, #6211, #6212, #6219, #6220, #6221, #6222, #6223, #6252, #6253, #6254, #6255

### Summary

Adds 140 Unicode character detection API utilities under apps/api/src/utils/. Each utility exports a dependency-free function that returns true only when the input string contains the specified Unicode character.

### Files Added

| File | Character | Issue |
|------|-----------|-------|
| is-cjk-radical-second-two-present.ts | U+2E83 | #5788 |
| is-cjk-radical-person-present.ts | U+2E85 | #5794 |
| is-cjk-radical-box-present.ts | U+2E86 | #5795 |
| is-cjk-radical-table-present.ts | U+2E87 | #5796 |
| is-cjk-radical-knife-one-present.ts | U+2E88 | #5797 |
| is-cjk-radical-knife-two-present.ts | U+2E89 | #5798 |
| is-cjk-radical-seal-present.ts | U+2E8B | #5840 |
| is-cjk-radical-lame-one-present.ts | U+2E8E | #5841 |
| is-cjk-radical-lame-two-present.ts | U+2E8F | #5842 |
| is-cjk-radical-lame-three-present.ts | U+2E90 | #5843 |
| is-cjk-radical-lame-four-present.ts | U+2E91 | #5844 |
| is-cjk-radical-thread-present.ts | U+2E93 | #5863 |
| is-cjk-radical-snout-one-present.ts | U+2E94 | #5864 |
| is-cjk-radical-snout-two-present.ts | U+2E95 | #5865 |
| is-cjk-radical-heart-one-present.ts | U+2E96 | #5866 |
| is-cjk-radical-heart-two-present.ts | U+2E97 | #5867 |
| is-cjk-radical-rap-present.ts | U+2E99 | #5876 |
| is-cjk-radical-choke-present.ts | U+2E9B | #5877 |
| is-cjk-radical-sun-present.ts | U+2E9C | #5878 |
| is-cjk-radical-moon-present.ts | U+2E9D | #5879 |
| is-cjk-radical-death-present.ts | U+2E9E | #5880 |
| is-cjk-radical-water-one-present.ts | U+2EA1 | #5886 |
| is-cjk-radical-water-two-present.ts | U+2EA2 | #5887 |
| is-cjk-radical-fire-present.ts | U+2EA3 | #5888 |
| is-cjk-radical-paw-one-present.ts | U+2EA4 | #5889 |
| is-cjk-radical-paw-two-present.ts | U+2EA5 | #5890 |
| is-cjk-radical-jade-present.ts | U+2EA9 | #5898 |
| is-cjk-radical-bolt-of-cloth-present.ts | U+2EAA | #5899 |
| is-cjk-radical-eye-present.ts | U+2EAB | #5900 |
| is-cjk-radical-spirit-one-present.ts | U+2EAC | #5901 |
| is-cjk-radical-spirit-two-present.ts | U+2EAD | #5902 |
| is-cjk-radical-net-one-present.ts | U+2EB1 | #5909 |
| is-cjk-radical-net-two-present.ts | U+2EB2 | #5910 |
| is-cjk-radical-net-three-present.ts | U+2EB3 | #5911 |
| is-cjk-radical-net-four-present.ts | U+2EB4 | #5912 |
| is-cjk-radical-mesh-present.ts | U+2EB5 | #5913 |
| is-cjk-radical-old-present.ts | U+2EB9 | #5926 |
| is-cjk-radical-brush-one-present.ts | U+2EBA | #5927 |
| is-cjk-radical-brush-two-present.ts | U+2EBB | #5928 |
| is-cjk-radical-meat-present.ts | U+2EBC | #5929 |
| is-cjk-radical-mortar-present.ts | U+2EBD | #5930 |
| is-cjk-radical-tiger-present.ts | U+2EC1 | #5957 |
| is-cjk-radical-clothes-present.ts | U+2EC2 | #5958 |
| is-cjk-radical-west-one-present.ts | U+2EC3 | #5959 |
| is-cjk-radical-west-two-present.ts | U+2EC4 | #5960 |
| is-cjk-radical-c-simplified-see-present.ts | U+2EC5 | #5961 |
| is-cjk-radical-c-simplified-shell-present.ts | U+2EC9 | #5967 |
| is-cjk-radical-foot-present.ts | U+2ECA | #5968 |
| is-cjk-radical-c-simplified-cart-present.ts | U+2ECB | #5969 |
| is-cjk-radical-simplified-walk-present.ts | U+2ECC | #5970 |
| is-cjk-radical-walk-one-present.ts | U+2ECD | #5971 |
| is-cjk-radical-long-one-present.ts | U+2ED1 | #5977 |
| is-cjk-radical-long-two-present.ts | U+2ED2 | #5978 |
| is-cjk-radical-c-simplified-long-present.ts | U+2ED3 | #5979 |
| is-cjk-radical-c-simplified-gate-present.ts | U+2ED4 | #5980 |
| is-cjk-radical-mound-two-present.ts | U+2ED5 | #5981 |
| is-cjk-radical-leaf-present.ts | U+2ED9 | #6032 |
| is-cjk-radical-c-simplified-leaf-present.ts | U+2EDA | #6033 |
| is-cjk-radical-c-simplified-wind-present.ts | U+2EDB | #6034 |
| is-cjk-radical-c-simplified-fly-present.ts | U+2EDC | #6035 |
| is-cjk-radical-eat-one-present.ts | U+2EDD | #6036 |
| is-cjk-radical-c-simplified-horse-present.ts | U+2EE2 | #6047 |
| is-cjk-radical-bone-present.ts | U+2EE3 | #6048 |
| is-cjk-radical-ghost-present.ts | U+2EE4 | #6049 |
| is-cjk-radical-c-simplified-fish-present.ts | U+2EE5 | #6050 |
| is-cjk-radical-c-simplified-bird-present.ts | U+2EE6 | #6051 |
| is-cjk-radical-c-simplified-salt-present.ts | U+2EE7 | #6077 |
| is-cjk-radical-simplified-wheat-present.ts | U+2EE8 | #6078 |
| is-cjk-radical-simplified-yellow-present.ts | U+2EE9 | #6079 |
| is-cjk-radical-c-simplified-frog-present.ts | U+2EEA | #6080 |
| is-cjk-radical-j-simplified-even-present.ts | U+2EEB | #6081 |
| is-cjk-radical-c-simplified-even-present.ts | U+2EEC | #6092 |
| is-cjk-radical-j-simplified-tooth-present.ts | U+2EED | #6093 |
| is-cjk-radical-c-simplified-tooth-present.ts | U+2EEE | #6094 |
| is-cjk-radical-j-simplified-dragon-present.ts | U+2EEF | #6095 |
| is-cjk-radical-c-simplified-dragon-present.ts | U+2EF0 | #6096 |
| is-cjk-radical-turtle-present.ts | U+2EF1 | #6102 |
| is-cjk-radical-j-simplified-turtle-present.ts | U+2EF2 | #6103 |
| is-cjk-radical-c-simplified-turtle-present.ts | U+2EF3 | #6104 |
| is-kangxi-radical-one-present.ts | U+2F00 | #6105 |
| is-kangxi-radical-line-present.ts | U+2F01 | #6106 |
| is-kangxi-radical-dot-present.ts | U+2F02 | #6115 |
| is-kangxi-radical-slash-present.ts | U+2F03 | #6116 |
| is-kangxi-radical-second-present.ts | U+2F04 | #6117 |
| is-kangxi-radical-hook-present.ts | U+2F05 | #6118 |
| is-kangxi-radical-two-present.ts | U+2F06 | #6119 |
| is-kangxi-radical-lid-present.ts | U+2F07 | #6125 |
| is-kangxi-radical-person-present.ts | U+2F08 | #6126 |
| is-kangxi-radical-legs-present.ts | U+2F09 | #6127 |
| is-kangxi-radical-enter-present.ts | U+2F0A | #6128 |
| is-kangxi-radical-eight-present.ts | U+2F0B | #6129 |
| is-kangxi-radical-down-box-present.ts | U+2F0C | #6135 |
| is-kangxi-radical-ice-present.ts | U+2F0E | #6136 |
| is-kangxi-radical-table-present.ts | U+2F0F | #6137 |
| is-kangxi-radical-open-box-present.ts | U+2F10 | #6138 |
| is-kangxi-radical-knife-present.ts | U+2F11 | #6139 |
| is-kangxi-radical-power-present.ts | U+2F12 | #6145 |
| is-kangxi-radical-wrap-present.ts | U+2F13 | #6146 |
| is-kangxi-radical-spoon-present.ts | U+2F14 | #6147 |
| is-kangxi-radical-right-open-box-present.ts | U+2F15 | #6148 |
| is-kangxi-radical-hiding-enclosure-present.ts | U+2F16 | #6149 |
| is-kangxi-radical-ten-present.ts | U+2F17 | #6155 |
| is-kangxi-radical-divination-present.ts | U+2F18 | #6156 |
| is-kangxi-radical-seal-present.ts | U+2F19 | #6157 |
| is-kangxi-radical-cliff-present.ts | U+2F1A | #6158 |
| is-kangxi-radical-private-present.ts | U+2F1B | #6159 |
| is-kangxi-radical-again-present.ts | U+2F1C | #6165 |
| is-kangxi-radical-mouth-present.ts | U+2F1D | #6166 |
| is-kangxi-radical-earth-present.ts | U+2F1F | #6167 |
| is-kangxi-radical-scholar-present.ts | U+2F20 | #6168 |
| is-kangxi-radical-go-present.ts | U+2F21 | #6169 |
| is-kangxi-radical-go-slowly-present.ts | U+2F22 | #6175 |
| is-kangxi-radical-evening-present.ts | U+2F23 | #6176 |
| is-kangxi-radical-big-present.ts | U+2F24 | #6177 |
| is-kangxi-radical-woman-present.ts | U+2F25 | #6178 |
| is-kangxi-radical-child-present.ts | U+2F26 | #6179 |
| is-kangxi-radical-roof-present.ts | U+2F27 | #6186 |
| is-kangxi-radical-inch-present.ts | U+2F28 | #6187 |
| is-kangxi-radical-lame-present.ts | U+2F2A | #6188 |
| is-kangxi-radical-corpse-present.ts | U+2F2B | #6189 |
| is-kangxi-radical-sprout-present.ts | U+2F2C | #6190 |
| is-kangxi-radical-mountain-present.ts | U+2F2D | #6197 |
| is-kangxi-radical-river-present.ts | U+2F2E | #6198 |
| is-kangxi-radical-work-present.ts | U+2F2F | #6199 |
| is-kangxi-radical-oneself-present.ts | U+2F30 | #6200 |
| is-kangxi-radical-turban-present.ts | U+2F31 | #6201 |
| is-kangxi-radical-dry-present.ts | U+2F32 | #6208 |
| is-kangxi-radical-short-thread-present.ts | U+2F33 | #6209 |
| is-kangxi-radical-dotted-cliff-present.ts | U+2F34 | #6210 |
| is-kangxi-radical-long-stride-present.ts | U+2F35 | #6211 |
| is-kangxi-radical-two-hands-present.ts | U+2F36 | #6212 |
| is-kangxi-radical-shoot-present.ts | U+2F37 | #6219 |
| is-kangxi-radical-bow-present.ts | U+2F38 | #6220 |
| is-kangxi-radical-snout-present.ts | U+2F39 | #6221 |
| is-kangxi-radical-bristle-present.ts | U+2F3A | #6222 |
| is-kangxi-radical-step-present.ts | U+2F3B | #6223 |
| is-kangxi-radical-heart-present.ts | U+2F3C | #6252 |
| is-kangxi-radical-halberd-present.ts | U+2F3D | #6253 |
| is-kangxi-radical-door-present.ts | U+2F3E | #6254 |
| is-kangxi-radical-branch-present.ts | U+2F40 | #6255 |

/claim #5788
/claim #5794
/claim #5795
/claim #5796
/claim #5797
/claim #5798
/claim #5840
/claim #5841
/claim #5842
/claim #5843
/claim #5844
/claim #5863
/claim #5864
/claim #5865
/claim #5866
/claim #5867
/claim #5876
/claim #5877
/claim #5878
/claim #5879
/claim #5880
/claim #5886
/claim #5887
/claim #5888
/claim #5889
/claim #5890
/claim #5898
/claim #5899
/claim #5900
/claim #5901
/claim #5902
/claim #5909
/claim #5910
/claim #5911
/claim #5912
/claim #5913
/claim #5926
/claim #5927
/claim #5928
/claim #5929
/claim #5930
/claim #5957
/claim #5958
/claim #5959
/claim #5960
/claim #5961
/claim #5967
/claim #5968
/claim #5969
/claim #5970
/claim #5971
/claim #5977
/claim #5978
/claim #5979
/claim #5980
/claim #5981
/claim #6032
/claim #6033
/claim #6034
/claim #6035
/claim #6036
/claim #6047
/claim #6048
/claim #6049
/claim #6050
/claim #6051
/claim #6077
/claim #6078
/claim #6079
/claim #6080
/claim #6081
/claim #6092
/claim #6093
/claim #6094
/claim #6095
/claim #6096
/claim #6102
/claim #6103
/claim #6104
/claim #6105
/claim #6106
/claim #6115
/claim #6116
/claim #6117
/claim #6118
/claim #6119
/claim #6125
/claim #6126
/claim #6127
/claim #6128
/claim #6129
/claim #6135
/claim #6136
/claim #6137
/claim #6138
/claim #6139
/claim #6145
/claim #6146
/claim #6147
/claim #6148
/claim #6149
/claim #6155
/claim #6156
/claim #6157
/claim #6158
/claim #6159
/claim #6165
/claim #6166
/claim #6167
/claim #6168
/claim #6169
/claim #6175
/claim #6176
/claim #6177
/claim #6178
/claim #6179
/claim #6186
/claim #6187
/claim #6188
/claim #6189
/claim #6190
/claim #6197
/claim #6198
/claim #6199
/claim #6200
/claim #6201
/claim #6208
/claim #6209
/claim #6210
/claim #6211
/claim #6212
/claim #6219
/claim #6220
/claim #6221
/claim #6222
/claim #6223
/claim #6252
/claim #6253
/claim #6254
/claim #6255
