### PR TITLE
[agent] feat: add 140 Unicode character detection utilities (batch 9)

### DIFF
--- a/apps/api/src/utils/is-ditto-mark-present.ts
+++ b/apps/api/src/utils/is-ditto-mark-present.ts
@@ -1,0 +1,8 @@
+/**
+ * Checks whether the input string contains the Unicode character U+3003.
+ * @param input - The string to check.
+ * @returns true if the input contains the character, false otherwise.
+ */
+export function isDittoMarkPresent(input: string): boolean {
+  return input.includes(String.fromCodePoint(12291));
+}

--- a/apps/api/src/utils/is-ideographic-closing-mark-present.ts
+++ b/apps/api/src/utils/is-ideographic-closing-mark-present.ts
@@ -1,0 +1,8 @@
+/**
+ * Checks whether the input string contains the Unicode character U+3006.
+ * @param input - The string to check.
+ * @returns true if the input contains the character, false otherwise.
+ */
+export function isIdeographicClosingMarkPresent(input: string): boolean {
+  return input.includes(String.fromCodePoint(12294));
+}

--- a/apps/api/src/utils/is-ideographic-comma-present.ts
+++ b/apps/api/src/utils/is-ideographic-comma-present.ts
@@ -1,0 +1,8 @@
+/**
+ * Checks whether the input string contains the Unicode character U+3001.
+ * @param input - The string to check.
+ * @returns true if the input contains the character, false otherwise.
+ */
+export function isIdeographicCommaPresent(input: string): boolean {
+  return input.includes(String.fromCodePoint(12289));
+}

--- a/apps/api/src/utils/is-ideographic-description-character-above-to-below-present.ts
+++ b/apps/api/src/utils/is-ideographic-description-character-above-to-below-present.ts
@@ -1,0 +1,8 @@
+/**
+ * Checks whether the input string contains the Unicode character U+2FF1.
+ * @param input - The string to check.
+ * @returns true if the input contains the character, false otherwise.
+ */
+export function isIdeographicDescriptionCharacterAboveToBelowPresent(input: string): boolean {
+  return input.includes(String.fromCodePoint(12273));
+}

--- a/apps/api/src/utils/is-ideographic-description-character-above-to-middle-and-below-present.ts
+++ b/apps/api/src/utils/is-ideographic-description-character-above-to-middle-and-below-present.ts
@@ -1,0 +1,8 @@
+/**
+ * Checks whether the input string contains the Unicode character U+2FF3.
+ * @param input - The string to check.
+ * @returns true if the input contains the character, false otherwise.
+ */
+export function isIdeographicDescriptionCharacterAboveToMiddleAndBelowPresent(input: string): boolean {
+  return input.includes(String.fromCodePoint(12275));
+}

--- a/apps/api/src/utils/is-ideographic-description-character-full-surround-present.ts
+++ b/apps/api/src/utils/is-ideographic-description-character-full-surround-present.ts
@@ -1,0 +1,8 @@
+/**
+ * Checks whether the input string contains the Unicode character U+2FF4.
+ * @param input - The string to check.
+ * @returns true if the input contains the character, false otherwise.
+ */
+export function isIdeographicDescriptionCharacterFullSurroundPresent(input: string): boolean {
+  return input.includes(String.fromCodePoint(12276));
+}

--- a/apps/api/src/utils/is-ideographic-description-character-left-to-middle-and-right-present.ts
+++ b/apps/api/src/utils/is-ideographic-description-character-left-to-middle-and-right-present.ts
@@ -1,0 +1,8 @@
+/**
+ * Checks whether the input string contains the Unicode character U+2FF2.
+ * @param input - The string to check.
+ * @returns true if the input contains the character, false otherwise.
+ */
+export function isIdeographicDescriptionCharacterLeftToMiddleAndRightPresent(input: string): boolean {
+  return input.includes(String.fromCodePoint(12274));
+}

--- a/apps/api/src/utils/is-ideographic-description-character-left-to-right-present.ts
+++ b/apps/api/src/utils/is-ideographic-description-character-left-to-right-present.ts
@@ -1,0 +1,8 @@
+/**
+ * Checks whether the input string contains the Unicode character U+2FF0.
+ * @param input - The string to check.
+ * @returns true if the input contains the character, false otherwise.
+ */
+export function isIdeographicDescriptionCharacterLeftToRightPresent(input: string): boolean {
+  return input.includes(String.fromCodePoint(12272));
+}

--- a/apps/api/src/utils/is-ideographic-description-character-overlaid-present.ts
+++ b/apps/api/src/utils/is-ideographic-description-character-overlaid-present.ts
@@ -1,0 +1,8 @@
+/**
+ * Checks whether the input string contains the Unicode character U+2FFB.
+ * @param input - The string to check.
+ * @returns true if the input contains the character, false otherwise.
+ */
+export function isIdeographicDescriptionCharacterOverlaidPresent(input: string): boolean {
+  return input.includes(String.fromCodePoint(12283));
+}

--- a/apps/api/src/utils/is-ideographic-description-character-surround-from-lower-left-present.ts
+++ b/apps/api/src/utils/is-ideographic-description-character-surround-from-lower-left-present.ts
@@ -1,0 +1,8 @@
+/**
+ * Checks whether the input string contains the Unicode character U+2FFA.
+ * @param input - The string to check.
+ * @returns true if the input contains the character, false otherwise.
+ */
+export function isIdeographicDescriptionCharacterSurroundFromLowerLeftPresent(input: string): boolean {
+  return input.includes(String.fromCodePoint(12282));
+}

--- a/apps/api/src/utils/is-ideographic-description-character-surround-from-lower-right-present.ts
+++ b/apps/api/src/utils/is-ideographic-description-character-surround-from-lower-right-present.ts
@@ -1,0 +1,8 @@
+/**
+ * Checks whether the input string contains the Unicode character U+2FFD.
+ * @param input - The string to check.
+ * @returns true if the input contains the character, false otherwise.
+ */
+export function isIdeographicDescriptionCharacterSurroundFromLowerRightPresent(input: string): boolean {
+  return input.includes(String.fromCodePoint(12285));
+}

--- a/apps/api/src/utils/is-ideographic-description-character-surround-from-right-present.ts
+++ b/apps/api/src/utils/is-ideographic-description-character-surround-from-right-present.ts
@@ -1,0 +1,8 @@
+/**
+ * Checks whether the input string contains the Unicode character U+2FFC.
+ * @param input - The string to check.
+ * @returns true if the input contains the character, false otherwise.
+ */
+export function isIdeographicDescriptionCharacterSurroundFromRightPresent(input: string): boolean {
+  return input.includes(String.fromCodePoint(12284));
+}

--- a/apps/api/src/utils/is-ideographic-description-character-surround-from-upper-right-present.ts
+++ b/apps/api/src/utils/is-ideographic-description-character-surround-from-upper-right-present.ts
@@ -1,0 +1,8 @@
+/**
+ * Checks whether the input string contains the Unicode character U+2FF9.
+ * @param input - The string to check.
+ * @returns true if the input contains the character, false otherwise.
+ */
+export function isIdeographicDescriptionCharacterSurroundFromUpperRightPresent(input: string): boolean {
+  return input.includes(String.fromCodePoint(12281));
+}

--- a/apps/api/src/utils/is-ideographic-full-stop-present.ts
+++ b/apps/api/src/utils/is-ideographic-full-stop-present.ts
@@ -1,0 +1,8 @@
+/**
+ * Checks whether the input string contains the Unicode character U+3002.
+ * @param input - The string to check.
+ * @returns true if the input contains the character, false otherwise.
+ */
+export function isIdeographicFullStopPresent(input: string): boolean {
+  return input.includes(String.fromCodePoint(12290));
+}

--- a/apps/api/src/utils/is-ideographic-iteration-mark-present.ts
+++ b/apps/api/src/utils/is-ideographic-iteration-mark-present.ts
@@ -1,0 +1,8 @@
+/**
+ * Checks whether the input string contains the Unicode character U+3005.
+ * @param input - The string to check.
+ * @returns true if the input contains the character, false otherwise.
+ */
+export function isIdeographicIterationMarkPresent(input: string): boolean {
+  return input.includes(String.fromCodePoint(12293));
+}

--- a/apps/api/src/utils/is-ideographic-number-zero-present.ts
+++ b/apps/api/src/utils/is-ideographic-number-zero-present.ts
@@ -1,0 +1,8 @@
+/**
+ * Checks whether the input string contains the Unicode character U+3007.
+ * @param input - The string to check.
+ * @returns true if the input contains the character, false otherwise.
+ */
+export function isIdeographicNumberZeroPresent(input: string): boolean {
+  return input.includes(String.fromCodePoint(12295));
+}

--- a/apps/api/src/utils/is-japanese-industrial-standard-symbol-present.ts
+++ b/apps/api/src/utils/is-japanese-industrial-standard-symbol-present.ts
@@ -1,0 +1,8 @@
+/**
+ * Checks whether the input string contains the Unicode character U+3004.
+ * @param input - The string to check.
+ * @returns true if the input contains the character, false otherwise.
+ */
+export function isJapaneseIndustrialStandardSymbolPresent(input: string): boolean {
+  return input.includes(String.fromCodePoint(12292));
+}

--- a/apps/api/src/utils/is-kangxi-radical-arrive-present.ts
+++ b/apps/api/src/utils/is-kangxi-radical-arrive-present.ts
@@ -1,0 +1,8 @@
+/**
+ * Checks whether the input string contains the Unicode character U+2F84.
+ * @param input - The string to check.
+ * @returns true if the input contains the character, false otherwise.
+ */
+export function isKangxiRadicalArrivePresent(input: string): boolean {
+  return input.includes(String.fromCodePoint(12164));
+}

--- a/apps/api/src/utils/is-kangxi-radical-arrow-present.ts
+++ b/apps/api/src/utils/is-kangxi-radical-arrow-present.ts
@@ -1,0 +1,8 @@
+/**
+ * Checks whether the input string contains the Unicode character U+2F6E.
+ * @param input - The string to check.
+ * @returns true if the input contains the character, false otherwise.
+ */
+export function isKangxiRadicalArrowPresent(input: string): boolean {
+  return input.includes(String.fromCodePoint(12142));
+}

--- a/apps/api/src/utils/is-kangxi-radical-axe-present.ts
+++ b/apps/api/src/utils/is-kangxi-radical-axe-present.ts
@@ -1,0 +1,8 @@
+/**
+ * Checks whether the input string contains the Unicode character U+2F44.
+ * @param input - The string to check.
+ * @returns true if the input contains the character, false otherwise.
+ */
+export function isKangxiRadicalAxePresent(input: string): boolean {
+  return input.includes(String.fromCodePoint(12100));
+}

--- a/apps/api/src/utils/is-kangxi-radical-badger-present.ts
+++ b/apps/api/src/utils/is-kangxi-radical-badger-present.ts
@@ -1,0 +1,8 @@
+/**
+ * Checks whether the input string contains the Unicode character U+2F98.
+ * @param input - The string to check.
+ * @returns true if the input contains the character, false otherwise.
+ */
+export function isKangxiRadicalBadgerPresent(input: string): boolean {
+  return input.includes(String.fromCodePoint(12184));
+}

--- a/apps/api/src/utils/is-kangxi-radical-bamboo-present.ts
+++ b/apps/api/src/utils/is-kangxi-radical-bamboo-present.ts
@@ -1,0 +1,8 @@
+/**
+ * Checks whether the input string contains the Unicode character U+2F75.
+ * @param input - The string to check.
+ * @returns true if the input contains the character, false otherwise.
+ */
+export function isKangxiRadicalBambooPresent(input: string): boolean {
+  return input.includes(String.fromCodePoint(12149));
+}

--- a/apps/api/src/utils/is-kangxi-radical-bean-present.ts
+++ b/apps/api/src/utils/is-kangxi-radical-bean-present.ts
@@ -1,0 +1,8 @@
+/**
+ * Checks whether the input string contains the Unicode character U+2F96.
+ * @param input - The string to check.
+ * @returns true if the input contains the character, false otherwise.
+ */
+export function isKangxiRadicalBeanPresent(input: string): boolean {
+  return input.includes(String.fromCodePoint(12182));
+}

--- a/apps/api/src/utils/is-kangxi-radical-bitter-present.ts
+++ b/apps/api/src/utils/is-kangxi-radical-bitter-present.ts
@@ -1,0 +1,8 @@
+/**
+ * Checks whether the input string contains the Unicode character U+2F9F.
+ * @param input - The string to check.
+ * @returns true if the input contains the character, false otherwise.
+ */
+export function isKangxiRadicalBitterPresent(input: string): boolean {
+  return input.includes(String.fromCodePoint(12191));
+}

--- a/apps/api/src/utils/is-kangxi-radical-blood-present.ts
+++ b/apps/api/src/utils/is-kangxi-radical-blood-present.ts
@@ -1,0 +1,8 @@
+/**
+ * Checks whether the input string contains the Unicode character U+2F8E.
+ * @param input - The string to check.
+ * @returns true if the input contains the character, false otherwise.
+ */
+export function isKangxiRadicalBloodPresent(input: string): boolean {
+  return input.includes(String.fromCodePoint(12174));
+}

--- a/apps/api/src/utils/is-kangxi-radical-boat-present.ts
+++ b/apps/api/src/utils/is-kangxi-radical-boat-present.ts
@@ -1,0 +1,8 @@
+/**
+ * Checks whether the input string contains the Unicode character U+2F88.
+ * @param input - The string to check.
+ * @returns true if the input contains the character, false otherwise.
+ */
+export function isKangxiRadicalBoatPresent(input: string): boolean {
+  return input.includes(String.fromCodePoint(12168));
+}

--- a/apps/api/src/utils/is-kangxi-radical-body-present.ts
+++ b/apps/api/src/utils/is-kangxi-radical-body-present.ts
@@ -1,0 +1,8 @@
+/**
+ * Checks whether the input string contains the Unicode character U+2F9D.
+ * @param input - The string to check.
+ * @returns true if the input contains the character, false otherwise.
+ */
+export function isKangxiRadicalBodyPresent(input: string): boolean {
+  return input.includes(String.fromCodePoint(12189));
+}

--- a/apps/api/src/utils/is-kangxi-radical-bolt-of-cloth-present.ts
+++ b/apps/api/src/utils/is-kangxi-radical-bolt-of-cloth-present.ts
@@ -1,0 +1,8 @@
+/**
+ * Checks whether the input string contains the Unicode character U+2F66.
+ * @param input - The string to check.
+ * @returns true if the input contains the character, false otherwise.
+ */
+export function isKangxiRadicalBoltOfClothPresent(input: string): boolean {
+  return input.includes(String.fromCodePoint(12134));
+}

--- a/apps/api/src/utils/is-kangxi-radical-brush-present.ts
+++ b/apps/api/src/utils/is-kangxi-radical-brush-present.ts
@@ -1,0 +1,8 @@
+/**
+ * Checks whether the input string contains the Unicode character U+2F80.
+ * @param input - The string to check.
+ * @returns true if the input contains the character, false otherwise.
+ */
+export function isKangxiRadicalBrushPresent(input: string): boolean {
+  return input.includes(String.fromCodePoint(12160));
+}

--- a/apps/api/src/utils/is-kangxi-radical-cart-present.ts
+++ b/apps/api/src/utils/is-kangxi-radical-cart-present.ts
@@ -1,0 +1,8 @@
+/**
+ * Checks whether the input string contains the Unicode character U+2F9E.
+ * @param input - The string to check.
+ * @returns true if the input contains the character, false otherwise.
+ */
+export function isKangxiRadicalCartPresent(input: string): boolean {
+  return input.includes(String.fromCodePoint(12190));
+}

--- a/apps/api/src/utils/is-kangxi-radical-cauldron-present.ts
+++ b/apps/api/src/utils/is-kangxi-radical-cauldron-present.ts
@@ -1,0 +1,8 @@
+/**
+ * Checks whether the input string contains the Unicode character U+2FC0.
+ * @param input - The string to check.
+ * @returns true if the input contains the character, false otherwise.
+ */
+export function isKangxiRadicalCauldronPresent(input: string): boolean {
+  return input.includes(String.fromCodePoint(12224));
+}

--- a/apps/api/src/utils/is-kangxi-radical-cave-present.ts
+++ b/apps/api/src/utils/is-kangxi-radical-cave-present.ts
@@ -1,0 +1,8 @@
+/**
+ * Checks whether the input string contains the Unicode character U+2F73.
+ * @param input - The string to check.
+ * @returns true if the input contains the character, false otherwise.
+ */
+export function isKangxiRadicalCavePresent(input: string): boolean {
+  return input.includes(String.fromCodePoint(12147));
+}

--- a/apps/api/src/utils/is-kangxi-radical-city-present.ts
+++ b/apps/api/src/utils/is-kangxi-radical-city-present.ts
@@ -1,0 +1,8 @@
+/**
+ * Checks whether the input string contains the Unicode character U+2FA2.
+ * @param input - The string to check.
+ * @returns true if the input contains the character, false otherwise.
+ */
+export function isKangxiRadicalCityPresent(input: string): boolean {
+  return input.includes(String.fromCodePoint(12194));
+}

--- a/apps/api/src/utils/is-kangxi-radical-clan-present.ts
+++ b/apps/api/src/utils/is-kangxi-radical-clan-present.ts
@@ -1,0 +1,8 @@
+/**
+ * Checks whether the input string contains the Unicode character U+2F52.
+ * @param input - The string to check.
+ * @returns true if the input contains the character, false otherwise.
+ */
+export function isKangxiRadicalClanPresent(input: string): boolean {
+  return input.includes(String.fromCodePoint(12114));
+}

--- a/apps/api/src/utils/is-kangxi-radical-claw-present.ts
+++ b/apps/api/src/utils/is-kangxi-radical-claw-present.ts
@@ -1,0 +1,8 @@
+/**
+ * Checks whether the input string contains the Unicode character U+2F56.
+ * @param input - The string to check.
+ * @returns true if the input contains the character, false otherwise.
+ */
+export function isKangxiRadicalClawPresent(input: string): boolean {
+  return input.includes(String.fromCodePoint(12118));
+}

--- a/apps/api/src/utils/is-kangxi-radical-color-present.ts
+++ b/apps/api/src/utils/is-kangxi-radical-color-present.ts
@@ -1,0 +1,8 @@
+/**
+ * Checks whether the input string contains the Unicode character U+2F8A.
+ * @param input - The string to check.
+ * @returns true if the input contains the character, false otherwise.
+ */
+export function isKangxiRadicalColorPresent(input: string): boolean {
+  return input.includes(String.fromCodePoint(12170));
+}

--- a/apps/api/src/utils/is-kangxi-radical-compare-present.ts
+++ b/apps/api/src/utils/is-kangxi-radical-compare-present.ts
@@ -1,0 +1,8 @@
+/**
+ * Checks whether the input string contains the Unicode character U+2F50.
+ * @param input - The string to check.
+ * @returns true if the input contains the character, false otherwise.
+ */
+export function isKangxiRadicalComparePresent(input: string): boolean {
+  return input.includes(String.fromCodePoint(12112));
+}

--- a/apps/api/src/utils/is-kangxi-radical-cow-present.ts
+++ b/apps/api/src/utils/is-kangxi-radical-cow-present.ts
@@ -1,0 +1,8 @@
+/**
+ * Checks whether the input string contains the Unicode character U+2F5C.
+ * @param input - The string to check.
+ * @returns true if the input contains the character, false otherwise.
+ */
+export function isKangxiRadicalCowPresent(input: string): boolean {
+  return input.includes(String.fromCodePoint(12124));
+}

--- a/apps/api/src/utils/is-kangxi-radical-death-present.ts
+++ b/apps/api/src/utils/is-kangxi-radical-death-present.ts
@@ -1,0 +1,8 @@
+/**
+ * Checks whether the input string contains the Unicode character U+2F4D.
+ * @param input - The string to check.
+ * @returns true if the input contains the character, false otherwise.
+ */
+export function isKangxiRadicalDeathPresent(input: string): boolean {
+  return input.includes(String.fromCodePoint(12109));
+}

--- a/apps/api/src/utils/is-kangxi-radical-deer-present.ts
+++ b/apps/api/src/utils/is-kangxi-radical-deer-present.ts
@@ -1,0 +1,8 @@
+/**
+ * Checks whether the input string contains the Unicode character U+2FC5.
+ * @param input - The string to check.
+ * @returns true if the input contains the character, false otherwise.
+ */
+export function isKangxiRadicalDeerPresent(input: string): boolean {
+  return input.includes(String.fromCodePoint(12229));
+}

--- a/apps/api/src/utils/is-kangxi-radical-dipper-present.ts
+++ b/apps/api/src/utils/is-kangxi-radical-dipper-present.ts
@@ -1,0 +1,8 @@
+/**
+ * Checks whether the input string contains the Unicode character U+2F43.
+ * @param input - The string to check.
+ * @returns true if the input contains the character, false otherwise.
+ */
+export function isKangxiRadicalDipperPresent(input: string): boolean {
+  return input.includes(String.fromCodePoint(12099));
+}

--- a/apps/api/src/utils/is-kangxi-radical-dish-present.ts
+++ b/apps/api/src/utils/is-kangxi-radical-dish-present.ts
@@ -1,0 +1,8 @@
+/**
+ * Checks whether the input string contains the Unicode character U+2F6B.
+ * @param input - The string to check.
+ * @returns true if the input contains the character, false otherwise.
+ */
+export function isKangxiRadicalDishPresent(input: string): boolean {
+  return input.includes(String.fromCodePoint(12139));
+}

--- a/apps/api/src/utils/is-kangxi-radical-do-not-present.ts
+++ b/apps/api/src/utils/is-kangxi-radical-do-not-present.ts
@@ -1,0 +1,8 @@
+/**
+ * Checks whether the input string contains the Unicode character U+2F4F.
+ * @param input - The string to check.
+ * @returns true if the input contains the character, false otherwise.
+ */
+export function isKangxiRadicalDoNotPresent(input: string): boolean {
+  return input.includes(String.fromCodePoint(12111));
+}

--- a/apps/api/src/utils/is-kangxi-radical-dog-present.ts
+++ b/apps/api/src/utils/is-kangxi-radical-dog-present.ts
@@ -1,0 +1,8 @@
+/**
+ * Checks whether the input string contains the Unicode character U+2F5D.
+ * @param input - The string to check.
+ * @returns true if the input contains the character, false otherwise.
+ */
+export function isKangxiRadicalDogPresent(input: string): boolean {
+  return input.includes(String.fromCodePoint(12125));
+}

--- a/apps/api/src/utils/is-kangxi-radical-dotted-tent-present.ts
+++ b/apps/api/src/utils/is-kangxi-radical-dotted-tent-present.ts
@@ -1,0 +1,8 @@
+/**
+ * Checks whether the input string contains the Unicode character U+2F68.
+ * @param input - The string to check.
+ * @returns true if the input contains the character, false otherwise.
+ */
+export function isKangxiRadicalDottedTentPresent(input: string): boolean {
+  return input.includes(String.fromCodePoint(12136));
+}

--- a/apps/api/src/utils/is-kangxi-radical-double-x-present.ts
+++ b/apps/api/src/utils/is-kangxi-radical-double-x-present.ts
@@ -1,0 +1,8 @@
+/**
+ * Checks whether the input string contains the Unicode character U+2F58.
+ * @param input - The string to check.
+ * @returns true if the input contains the character, false otherwise.
+ */
+export function isKangxiRadicalDoubleXPresent(input: string): boolean {
+  return input.includes(String.fromCodePoint(12120));
+}

--- a/apps/api/src/utils/is-kangxi-radical-drum-present.ts
+++ b/apps/api/src/utils/is-kangxi-radical-drum-present.ts
@@ -1,0 +1,8 @@
+/**
+ * Checks whether the input string contains the Unicode character U+2FCE.
+ * @param input - The string to check.
+ * @returns true if the input contains the character, false otherwise.
+ */
+export function isKangxiRadicalDrumPresent(input: string): boolean {
+  return input.includes(String.fromCodePoint(12238));
+}

--- a/apps/api/src/utils/is-kangxi-radical-ear-present.ts
+++ b/apps/api/src/utils/is-kangxi-radical-ear-present.ts
@@ -1,0 +1,8 @@
+/**
+ * Checks whether the input string contains the Unicode character U+2F7F.
+ * @param input - The string to check.
+ * @returns true if the input contains the character, false otherwise.
+ */
+export function isKangxiRadicalEarPresent(input: string): boolean {
+  return input.includes(String.fromCodePoint(12159));
+}

--- a/apps/api/src/utils/is-kangxi-radical-eat-present.ts
+++ b/apps/api/src/utils/is-kangxi-radical-eat-present.ts
@@ -1,0 +1,8 @@
+/**
+ * Checks whether the input string contains the Unicode character U+2FB7.
+ * @param input - The string to check.
+ * @returns true if the input contains the character, false otherwise.
+ */
+export function isKangxiRadicalEatPresent(input: string): boolean {
+  return input.includes(String.fromCodePoint(12215));
+}

--- a/apps/api/src/utils/is-kangxi-radical-even-present.ts
+++ b/apps/api/src/utils/is-kangxi-radical-even-present.ts
@@ -1,0 +1,8 @@
+/**
+ * Checks whether the input string contains the Unicode character U+2FD1.
+ * @param input - The string to check.
+ * @returns true if the input contains the character, false otherwise.
+ */
+export function isKangxiRadicalEvenPresent(input: string): boolean {
+  return input.includes(String.fromCodePoint(12241));
+}

--- a/apps/api/src/utils/is-kangxi-radical-eye-present.ts
+++ b/apps/api/src/utils/is-kangxi-radical-eye-present.ts
@@ -1,0 +1,8 @@
+/**
+ * Checks whether the input string contains the Unicode character U+2F6C.
+ * @param input - The string to check.
+ * @returns true if the input contains the character, false otherwise.
+ */
+export function isKangxiRadicalEyePresent(input: string): boolean {
+  return input.includes(String.fromCodePoint(12140));
+}

--- a/apps/api/src/utils/is-kangxi-radical-face-present.ts
+++ b/apps/api/src/utils/is-kangxi-radical-face-present.ts
@@ -1,0 +1,8 @@
+/**
+ * Checks whether the input string contains the Unicode character U+2FAF.
+ * @param input - The string to check.
+ * @returns true if the input contains the character, false otherwise.
+ */
+export function isKangxiRadicalFacePresent(input: string): boolean {
+  return input.includes(String.fromCodePoint(12207));
+}

--- a/apps/api/src/utils/is-kangxi-radical-fang-present.ts
+++ b/apps/api/src/utils/is-kangxi-radical-fang-present.ts
@@ -1,0 +1,8 @@
+/**
+ * Checks whether the input string contains the Unicode character U+2F5B.
+ * @param input - The string to check.
+ * @returns true if the input contains the character, false otherwise.
+ */
+export function isKangxiRadicalFangPresent(input: string): boolean {
+  return input.includes(String.fromCodePoint(12123));
+}

--- a/apps/api/src/utils/is-kangxi-radical-father-present.ts
+++ b/apps/api/src/utils/is-kangxi-radical-father-present.ts
@@ -1,0 +1,8 @@
+/**
+ * Checks whether the input string contains the Unicode character U+2F57.
+ * @param input - The string to check.
+ * @returns true if the input contains the character, false otherwise.
+ */
+export function isKangxiRadicalFatherPresent(input: string): boolean {
+  return input.includes(String.fromCodePoint(12119));
+}

--- a/apps/api/src/utils/is-kangxi-radical-feather-present.ts
+++ b/apps/api/src/utils/is-kangxi-radical-feather-present.ts
@@ -1,0 +1,8 @@
+/**
+ * Checks whether the input string contains the Unicode character U+2F7B.
+ * @param input - The string to check.
+ * @returns true if the input contains the character, false otherwise.
+ */
+export function isKangxiRadicalFeatherPresent(input: string): boolean {
+  return input.includes(String.fromCodePoint(12155));
+}

--- a/apps/api/src/utils/is-kangxi-radical-field-present.ts
+++ b/apps/api/src/utils/is-kangxi-radical-field-present.ts
@@ -1,0 +1,8 @@
+/**
+ * Checks whether the input string contains the Unicode character U+2F65.
+ * @param input - The string to check.
+ * @returns true if the input contains the character, false otherwise.
+ */
+export function isKangxiRadicalFieldPresent(input: string): boolean {
+  return input.includes(String.fromCodePoint(12133));
+}

--- a/apps/api/src/utils/is-kangxi-radical-fight-present.ts
+++ b/apps/api/src/utils/is-kangxi-radical-fight-present.ts
@@ -1,0 +1,8 @@
+/**
+ * Checks whether the input string contains the Unicode character U+2FBE.
+ * @param input - The string to check.
+ * @returns true if the input contains the character, false otherwise.
+ */
+export function isKangxiRadicalFightPresent(input: string): boolean {
+  return input.includes(String.fromCodePoint(12222));
+}

--- a/apps/api/src/utils/is-kangxi-radical-fire-present.ts
+++ b/apps/api/src/utils/is-kangxi-radical-fire-present.ts
@@ -1,0 +1,8 @@
+/**
+ * Checks whether the input string contains the Unicode character U+2F55.
+ * @param input - The string to check.
+ * @returns true if the input contains the character, false otherwise.
+ */
+export function isKangxiRadicalFirePresent(input: string): boolean {
+  return input.includes(String.fromCodePoint(12117));
+}

--- a/apps/api/src/utils/is-kangxi-radical-fish-present.ts
+++ b/apps/api/src/utils/is-kangxi-radical-fish-present.ts
@@ -1,0 +1,8 @@
+/**
+ * Checks whether the input string contains the Unicode character U+2FC2.
+ * @param input - The string to check.
+ * @returns true if the input contains the character, false otherwise.
+ */
+export function isKangxiRadicalFishPresent(input: string): boolean {
+  return input.includes(String.fromCodePoint(12226));
+}

--- a/apps/api/src/utils/is-kangxi-radical-fly-present.ts
+++ b/apps/api/src/utils/is-kangxi-radical-fly-present.ts
@@ -1,0 +1,8 @@
+/**
+ * Checks whether the input string contains the Unicode character U+2FB6.
+ * @param input - The string to check.
+ * @returns true if the input contains the character, false otherwise.
+ */
+export function isKangxiRadicalFlyPresent(input: string): boolean {
+  return input.includes(String.fromCodePoint(12214));
+}

--- a/apps/api/src/utils/is-kangxi-radical-foot-present.ts
+++ b/apps/api/src/utils/is-kangxi-radical-foot-present.ts
@@ -1,0 +1,8 @@
+/**
+ * Checks whether the input string contains the Unicode character U+2F9C.
+ * @param input - The string to check.
+ * @returns true if the input contains the character, false otherwise.
+ */
+export function isKangxiRadicalFootPresent(input: string): boolean {
+  return input.includes(String.fromCodePoint(12188));
+}

--- a/apps/api/src/utils/is-kangxi-radical-fragrant-present.ts
+++ b/apps/api/src/utils/is-kangxi-radical-fragrant-present.ts
@@ -1,0 +1,8 @@
+/**
+ * Checks whether the input string contains the Unicode character U+2FB9.
+ * @param input - The string to check.
+ * @returns true if the input contains the character, false otherwise.
+ */
+export function isKangxiRadicalFragrantPresent(input: string): boolean {
+  return input.includes(String.fromCodePoint(12217));
+}

--- a/apps/api/src/utils/is-kangxi-radical-fur-present.ts
+++ b/apps/api/src/utils/is-kangxi-radical-fur-present.ts
@@ -1,0 +1,8 @@
+/**
+ * Checks whether the input string contains the Unicode character U+2F51.
+ * @param input - The string to check.
+ * @returns true if the input contains the character, false otherwise.
+ */
+export function isKangxiRadicalFurPresent(input: string): boolean {
+  return input.includes(String.fromCodePoint(12113));
+}

--- a/apps/api/src/utils/is-kangxi-radical-ghost-present.ts
+++ b/apps/api/src/utils/is-kangxi-radical-ghost-present.ts
@@ -1,0 +1,8 @@
+/**
+ * Checks whether the input string contains the Unicode character U+2FC1.
+ * @param input - The string to check.
+ * @returns true if the input contains the character, false otherwise.
+ */
+export function isKangxiRadicalGhostPresent(input: string): boolean {
+  return input.includes(String.fromCodePoint(12225));
+}

--- a/apps/api/src/utils/is-kangxi-radical-gold-present.ts
+++ b/apps/api/src/utils/is-kangxi-radical-gold-present.ts
@@ -1,0 +1,8 @@
+/**
+ * Checks whether the input string contains the Unicode character U+2FA6.
+ * @param input - The string to check.
+ * @returns true if the input contains the character, false otherwise.
+ */
+export function isKangxiRadicalGoldPresent(input: string): boolean {
+  return input.includes(String.fromCodePoint(12198));
+}

--- a/apps/api/src/utils/is-kangxi-radical-grain-present.ts
+++ b/apps/api/src/utils/is-kangxi-radical-grain-present.ts
@@ -1,0 +1,8 @@
+/**
+ * Checks whether the input string contains the Unicode character U+2F72.
+ * @param input - The string to check.
+ * @returns true if the input contains the character, false otherwise.
+ */
+export function isKangxiRadicalGrainPresent(input: string): boolean {
+  return input.includes(String.fromCodePoint(12146));
+}

--- a/apps/api/src/utils/is-kangxi-radical-grass-present.ts
+++ b/apps/api/src/utils/is-kangxi-radical-grass-present.ts
@@ -1,0 +1,8 @@
+/**
+ * Checks whether the input string contains the Unicode character U+2F8B.
+ * @param input - The string to check.
+ * @returns true if the input contains the character, false otherwise.
+ */
+export function isKangxiRadicalGrassPresent(input: string): boolean {
+  return input.includes(String.fromCodePoint(12171));
+}

--- a/apps/api/src/utils/is-kangxi-radical-half-tree-trunk-present.ts
+++ b/apps/api/src/utils/is-kangxi-radical-half-tree-trunk-present.ts
@@ -1,0 +1,8 @@
+/**
+ * Checks whether the input string contains the Unicode character U+2F59.
+ * @param input - The string to check.
+ * @returns true if the input contains the character, false otherwise.
+ */
+export function isKangxiRadicalHalfTreeTrunkPresent(input: string): boolean {
+  return input.includes(String.fromCodePoint(12121));
+}

--- a/apps/api/src/utils/is-kangxi-radical-head-present.ts
+++ b/apps/api/src/utils/is-kangxi-radical-head-present.ts
@@ -1,0 +1,8 @@
+/**
+ * Checks whether the input string contains the Unicode character U+2FB8.
+ * @param input - The string to check.
+ * @returns true if the input contains the character, false otherwise.
+ */
+export function isKangxiRadicalHeadPresent(input: string): boolean {
+  return input.includes(String.fromCodePoint(12216));
+}

--- a/apps/api/src/utils/is-kangxi-radical-hemp-present.ts
+++ b/apps/api/src/utils/is-kangxi-radical-hemp-present.ts
@@ -1,0 +1,8 @@
+/**
+ * Checks whether the input string contains the Unicode character U+2FC7.
+ * @param input - The string to check.
+ * @returns true if the input contains the character, false otherwise.
+ */
+export function isKangxiRadicalHempPresent(input: string): boolean {
+  return input.includes(String.fromCodePoint(12231));
+}

--- a/apps/api/src/utils/is-kangxi-radical-horn-present.ts
+++ b/apps/api/src/utils/is-kangxi-radical-horn-present.ts
@@ -1,0 +1,8 @@
+/**
+ * Checks whether the input string contains the Unicode character U+2F93.
+ * @param input - The string to check.
+ * @returns true if the input contains the character, false otherwise.
+ */
+export function isKangxiRadicalHornPresent(input: string): boolean {
+  return input.includes(String.fromCodePoint(12179));
+}

--- a/apps/api/src/utils/is-kangxi-radical-horse-present.ts
+++ b/apps/api/src/utils/is-kangxi-radical-horse-present.ts
@@ -1,0 +1,8 @@
+/**
+ * Checks whether the input string contains the Unicode character U+2FBA.
+ * @param input - The string to check.
+ * @returns true if the input contains the character, false otherwise.
+ */
+export function isKangxiRadicalHorsePresent(input: string): boolean {
+  return input.includes(String.fromCodePoint(12218));
+}

--- a/apps/api/src/utils/is-kangxi-radical-insect-present.ts
+++ b/apps/api/src/utils/is-kangxi-radical-insect-present.ts
@@ -1,0 +1,8 @@
+/**
+ * Checks whether the input string contains the Unicode character U+2F8D.
+ * @param input - The string to check.
+ * @returns true if the input contains the character, false otherwise.
+ */
+export function isKangxiRadicalInsectPresent(input: string): boolean {
+  return input.includes(String.fromCodePoint(12173));
+}

--- a/apps/api/src/utils/is-kangxi-radical-jade-present.ts
+++ b/apps/api/src/utils/is-kangxi-radical-jade-present.ts
@@ -1,0 +1,8 @@
+/**
+ * Checks whether the input string contains the Unicode character U+2F5F.
+ * @param input - The string to check.
+ * @returns true if the input contains the character, false otherwise.
+ */
+export function isKangxiRadicalJadePresent(input: string): boolean {
+  return input.includes(String.fromCodePoint(12127));
+}

--- a/apps/api/src/utils/is-kangxi-radical-jar-present.ts
+++ b/apps/api/src/utils/is-kangxi-radical-jar-present.ts
@@ -1,0 +1,8 @@
+/**
+ * Checks whether the input string contains the Unicode character U+2F78.
+ * @param input - The string to check.
+ * @returns true if the input contains the character, false otherwise.
+ */
+export function isKangxiRadicalJarPresent(input: string): boolean {
+  return input.includes(String.fromCodePoint(12152));
+}

--- a/apps/api/src/utils/is-kangxi-radical-lack-present.ts
+++ b/apps/api/src/utils/is-kangxi-radical-lack-present.ts
@@ -1,0 +1,8 @@
+/**
+ * Checks whether the input string contains the Unicode character U+2F4B.
+ * @param input - The string to check.
+ * @returns true if the input contains the character, false otherwise.
+ */
+export function isKangxiRadicalLackPresent(input: string): boolean {
+  return input.includes(String.fromCodePoint(12107));
+}

--- a/apps/api/src/utils/is-kangxi-radical-leather-present.ts
+++ b/apps/api/src/utils/is-kangxi-radical-leather-present.ts
@@ -1,0 +1,8 @@
+/**
+ * Checks whether the input string contains the Unicode character U+2FB0.
+ * @param input - The string to check.
+ * @returns true if the input contains the character, false otherwise.
+ */
+export function isKangxiRadicalLeatherPresent(input: string): boolean {
+  return input.includes(String.fromCodePoint(12208));
+}

--- a/apps/api/src/utils/is-kangxi-radical-leek-present.ts
+++ b/apps/api/src/utils/is-kangxi-radical-leek-present.ts
@@ -1,0 +1,8 @@
+/**
+ * Checks whether the input string contains the Unicode character U+2FB2.
+ * @param input - The string to check.
+ * @returns true if the input contains the character, false otherwise.
+ */
+export function isKangxiRadicalLeekPresent(input: string): boolean {
+  return input.includes(String.fromCodePoint(12210));
+}

--- a/apps/api/src/utils/is-kangxi-radical-life-present.ts
+++ b/apps/api/src/utils/is-kangxi-radical-life-present.ts
@@ -1,0 +1,8 @@
+/**
+ * Checks whether the input string contains the Unicode character U+2F63.
+ * @param input - The string to check.
+ * @returns true if the input contains the character, false otherwise.
+ */
+export function isKangxiRadicalLifePresent(input: string): boolean {
+  return input.includes(String.fromCodePoint(12131));
+}

--- a/apps/api/src/utils/is-kangxi-radical-meat-present.ts
+++ b/apps/api/src/utils/is-kangxi-radical-meat-present.ts
@@ -1,0 +1,8 @@
+/**
+ * Checks whether the input string contains the Unicode character U+2F81.
+ * @param input - The string to check.
+ * @returns true if the input contains the character, false otherwise.
+ */
+export function isKangxiRadicalMeatPresent(input: string): boolean {
+  return input.includes(String.fromCodePoint(12161));
+}

--- a/apps/api/src/utils/is-kangxi-radical-melon-present.ts
+++ b/apps/api/src/utils/is-kangxi-radical-melon-present.ts
@@ -1,0 +1,8 @@
+/**
+ * Checks whether the input string contains the Unicode character U+2F60.
+ * @param input - The string to check.
+ * @returns true if the input contains the character, false otherwise.
+ */
+export function isKangxiRadicalMelonPresent(input: string): boolean {
+  return input.includes(String.fromCodePoint(12128));
+}

--- a/apps/api/src/utils/is-kangxi-radical-millet-present.ts
+++ b/apps/api/src/utils/is-kangxi-radical-millet-present.ts
@@ -1,0 +1,8 @@
+/**
+ * Checks whether the input string contains the Unicode character U+2FC9.
+ * @param input - The string to check.
+ * @returns true if the input contains the character, false otherwise.
+ */
+export function isKangxiRadicalMilletPresent(input: string): boolean {
+  return input.includes(String.fromCodePoint(12233));
+}

--- a/apps/api/src/utils/is-kangxi-radical-minister-present.ts
+++ b/apps/api/src/utils/is-kangxi-radical-minister-present.ts
@@ -1,0 +1,8 @@
+/**
+ * Checks whether the input string contains the Unicode character U+2F82.
+ * @param input - The string to check.
+ * @returns true if the input contains the character, false otherwise.
+ */
+export function isKangxiRadicalMinisterPresent(input: string): boolean {
+  return input.includes(String.fromCodePoint(12162));
+}

--- a/apps/api/src/utils/is-kangxi-radical-moon-present.ts
+++ b/apps/api/src/utils/is-kangxi-radical-moon-present.ts
@@ -1,0 +1,8 @@
+/**
+ * Checks whether the input string contains the Unicode character U+2F49.
+ * @param input - The string to check.
+ * @returns true if the input contains the character, false otherwise.
+ */
+export function isKangxiRadicalMoonPresent(input: string): boolean {
+  return input.includes(String.fromCodePoint(12105));
+}

--- a/apps/api/src/utils/is-kangxi-radical-morning-present.ts
+++ b/apps/api/src/utils/is-kangxi-radical-morning-present.ts
@@ -1,0 +1,8 @@
+/**
+ * Checks whether the input string contains the Unicode character U+2FA0.
+ * @param input - The string to check.
+ * @returns true if the input contains the character, false otherwise.
+ */
+export function isKangxiRadicalMorningPresent(input: string): boolean {
+  return input.includes(String.fromCodePoint(12192));
+}

--- a/apps/api/src/utils/is-kangxi-radical-mound-present.ts
+++ b/apps/api/src/utils/is-kangxi-radical-mound-present.ts
@@ -1,0 +1,8 @@
+/**
+ * Checks whether the input string contains the Unicode character U+2FA9.
+ * @param input - The string to check.
+ * @returns true if the input contains the character, false otherwise.
+ */
+export function isKangxiRadicalMoundPresent(input: string): boolean {
+  return input.includes(String.fromCodePoint(12201));
+}

--- a/apps/api/src/utils/is-kangxi-radical-net-present.ts
+++ b/apps/api/src/utils/is-kangxi-radical-net-present.ts
@@ -1,0 +1,8 @@
+/**
+ * Checks whether the input string contains the Unicode character U+2F79.
+ * @param input - The string to check.
+ * @returns true if the input contains the character, false otherwise.
+ */
+export function isKangxiRadicalNetPresent(input: string): boolean {
+  return input.includes(String.fromCodePoint(12153));
+}

--- a/apps/api/src/utils/is-kangxi-radical-nose-present.ts
+++ b/apps/api/src/utils/is-kangxi-radical-nose-present.ts
@@ -1,0 +1,8 @@
+/**
+ * Checks whether the input string contains the Unicode character U+2FD0.
+ * @param input - The string to check.
+ * @returns true if the input contains the character, false otherwise.
+ */
+export function isKangxiRadicalNosePresent(input: string): boolean {
+  return input.includes(String.fromCodePoint(12240));
+}

--- a/apps/api/src/utils/is-kangxi-radical-not-present.ts
+++ b/apps/api/src/utils/is-kangxi-radical-not-present.ts
@@ -1,0 +1,8 @@
+/**
+ * Checks whether the input string contains the Unicode character U+2F46.
+ * @param input - The string to check.
+ * @returns true if the input contains the character, false otherwise.
+ */
+export function isKangxiRadicalNotPresent(input: string): boolean {
+  return input.includes(String.fromCodePoint(12102));
+}

--- a/apps/api/src/utils/is-kangxi-radical-old-present.ts
+++ b/apps/api/src/utils/is-kangxi-radical-old-present.ts
@@ -1,0 +1,8 @@
+/**
+ * Checks whether the input string contains the Unicode character U+2F7C.
+ * @param input - The string to check.
+ * @returns true if the input contains the character, false otherwise.
+ */
+export function isKangxiRadicalOldPresent(input: string): boolean {
+  return input.includes(String.fromCodePoint(12156));
+}

--- a/apps/api/src/utils/is-kangxi-radical-oppose-present.ts
+++ b/apps/api/src/utils/is-kangxi-radical-oppose-present.ts
@@ -1,0 +1,8 @@
+/**
+ * Checks whether the input string contains the Unicode character U+2F87.
+ * @param input - The string to check.
+ * @returns true if the input contains the character, false otherwise.
+ */
+export function isKangxiRadicalOpposePresent(input: string): boolean {
+  return input.includes(String.fromCodePoint(12167));
+}

--- a/apps/api/src/utils/is-kangxi-radical-pig-present.ts
+++ b/apps/api/src/utils/is-kangxi-radical-pig-present.ts
@@ -1,0 +1,8 @@
+/**
+ * Checks whether the input string contains the Unicode character U+2F97.
+ * @param input - The string to check.
+ * @returns true if the input contains the character, false otherwise.
+ */
+export function isKangxiRadicalPigPresent(input: string): boolean {
+  return input.includes(String.fromCodePoint(12183));
+}

--- a/apps/api/src/utils/is-kangxi-radical-plow-present.ts
+++ b/apps/api/src/utils/is-kangxi-radical-plow-present.ts
@@ -1,0 +1,8 @@
+/**
+ * Checks whether the input string contains the Unicode character U+2F7E.
+ * @param input - The string to check.
+ * @returns true if the input contains the character, false otherwise.
+ */
+export function isKangxiRadicalPlowPresent(input: string): boolean {
+  return input.includes(String.fromCodePoint(12158));
+}

--- a/apps/api/src/utils/is-kangxi-radical-profound-present.ts
+++ b/apps/api/src/utils/is-kangxi-radical-profound-present.ts
@@ -1,0 +1,8 @@
+/**
+ * Checks whether the input string contains the Unicode character U+2F5E.
+ * @param input - The string to check.
+ * @returns true if the input contains the character, false otherwise.
+ */
+export function isKangxiRadicalProfoundPresent(input: string): boolean {
+  return input.includes(String.fromCodePoint(12126));
+}

--- a/apps/api/src/utils/is-kangxi-radical-rap-present.ts
+++ b/apps/api/src/utils/is-kangxi-radical-rap-present.ts
@@ -1,0 +1,8 @@
+/**
+ * Checks whether the input string contains the Unicode character U+2F41.
+ * @param input - The string to check.
+ * @returns true if the input contains the character, false otherwise.
+ */
+export function isKangxiRadicalRapPresent(input: string): boolean {
+  return input.includes(String.fromCodePoint(12097));
+}

--- a/apps/api/src/utils/is-kangxi-radical-rat-present.ts
+++ b/apps/api/src/utils/is-kangxi-radical-rat-present.ts
@@ -1,0 +1,8 @@
+/**
+ * Checks whether the input string contains the Unicode character U+2FCF.
+ * @param input - The string to check.
+ * @returns true if the input contains the character, false otherwise.
+ */
+export function isKangxiRadicalRatPresent(input: string): boolean {
+  return input.includes(String.fromCodePoint(12239));
+}

--- a/apps/api/src/utils/is-kangxi-radical-rice-present.ts
+++ b/apps/api/src/utils/is-kangxi-radical-rice-present.ts
@@ -1,0 +1,8 @@
+/**
+ * Checks whether the input string contains the Unicode character U+2F76.
+ * @param input - The string to check.
+ * @returns true if the input contains the character, false otherwise.
+ */
+export function isKangxiRadicalRicePresent(input: string): boolean {
+  return input.includes(String.fromCodePoint(12150));
+}

--- a/apps/api/src/utils/is-kangxi-radical-sacrificial-wine-present.ts
+++ b/apps/api/src/utils/is-kangxi-radical-sacrificial-wine-present.ts
@@ -1,0 +1,8 @@
+/**
+ * Checks whether the input string contains the Unicode character U+2FBF.
+ * @param input - The string to check.
+ * @returns true if the input contains the character, false otherwise.
+ */
+export function isKangxiRadicalSacrificialWinePresent(input: string): boolean {
+  return input.includes(String.fromCodePoint(12223));
+}

--- a/apps/api/src/utils/is-kangxi-radical-say-present.ts
+++ b/apps/api/src/utils/is-kangxi-radical-say-present.ts
@@ -1,0 +1,8 @@
+/**
+ * Checks whether the input string contains the Unicode character U+2F48.
+ * @param input - The string to check.
+ * @returns true if the input contains the character, false otherwise.
+ */
+export function isKangxiRadicalSayPresent(input: string): boolean {
+  return input.includes(String.fromCodePoint(12104));
+}

--- a/apps/api/src/utils/is-kangxi-radical-script-present.ts
+++ b/apps/api/src/utils/is-kangxi-radical-script-present.ts
@@ -1,0 +1,8 @@
+/**
+ * Checks whether the input string contains the Unicode character U+2F42.
+ * @param input - The string to check.
+ * @returns true if the input contains the character, false otherwise.
+ */
+export function isKangxiRadicalScriptPresent(input: string): boolean {
+  return input.includes(String.fromCodePoint(12098));
+}

--- a/apps/api/src/utils/is-kangxi-radical-see-present.ts
+++ b/apps/api/src/utils/is-kangxi-radical-see-present.ts
@@ -1,0 +1,8 @@
+/**
+ * Checks whether the input string contains the Unicode character U+2F92.
+ * @param input - The string to check.
+ * @returns true if the input contains the character, false otherwise.
+ */
+export function isKangxiRadicalSeePresent(input: string): boolean {
+  return input.includes(String.fromCodePoint(12178));
+}

--- a/apps/api/src/utils/is-kangxi-radical-self-present.ts
+++ b/apps/api/src/utils/is-kangxi-radical-self-present.ts
@@ -1,0 +1,8 @@
+/**
+ * Checks whether the input string contains the Unicode character U+2F83.
+ * @param input - The string to check.
+ * @returns true if the input contains the character, false otherwise.
+ */
+export function isKangxiRadicalSelfPresent(input: string): boolean {
+  return input.includes(String.fromCodePoint(12163));
+}

--- a/apps/api/src/utils/is-kangxi-radical-sheep-present.ts
+++ b/apps/api/src/utils/is-kangxi-radical-sheep-present.ts
@@ -1,0 +1,8 @@
+/**
+ * Checks whether the input string contains the Unicode character U+2F7A.
+ * @param input - The string to check.
+ * @returns true if the input contains the character, false otherwise.
+ */
+export function isKangxiRadicalSheepPresent(input: string): boolean {
+  return input.includes(String.fromCodePoint(12154));
+}

--- a/apps/api/src/utils/is-kangxi-radical-shell-present.ts
+++ b/apps/api/src/utils/is-kangxi-radical-shell-present.ts
@@ -1,0 +1,8 @@
+/**
+ * Checks whether the input string contains the Unicode character U+2F99.
+ * @param input - The string to check.
+ * @returns true if the input contains the character, false otherwise.
+ */
+export function isKangxiRadicalShellPresent(input: string): boolean {
+  return input.includes(String.fromCodePoint(12185));
+}

--- a/apps/api/src/utils/is-kangxi-radical-short-tailed-bird-present.ts
+++ b/apps/api/src/utils/is-kangxi-radical-short-tailed-bird-present.ts
@@ -1,0 +1,8 @@
+/**
+ * Checks whether the input string contains the Unicode character U+2FAB.
+ * @param input - The string to check.
+ * @returns true if the input contains the character, false otherwise.
+ */
+export function isKangxiRadicalShortTailedBirdPresent(input: string): boolean {
+  return input.includes(String.fromCodePoint(12203));
+}

--- a/apps/api/src/utils/is-kangxi-radical-sickness-present.ts
+++ b/apps/api/src/utils/is-kangxi-radical-sickness-present.ts
@@ -1,0 +1,8 @@
+/**
+ * Checks whether the input string contains the Unicode character U+2F67.
+ * @param input - The string to check.
+ * @returns true if the input contains the character, false otherwise.
+ */
+export function isKangxiRadicalSicknessPresent(input: string): boolean {
+  return input.includes(String.fromCodePoint(12135));
+}

--- a/apps/api/src/utils/is-kangxi-radical-silk-present.ts
+++ b/apps/api/src/utils/is-kangxi-radical-silk-present.ts
@@ -1,0 +1,8 @@
+/**
+ * Checks whether the input string contains the Unicode character U+2F77.
+ * @param input - The string to check.
+ * @returns true if the input contains the character, false otherwise.
+ */
+export function isKangxiRadicalSilkPresent(input: string): boolean {
+  return input.includes(String.fromCodePoint(12151));
+}

--- a/apps/api/src/utils/is-kangxi-radical-skin-present.ts
+++ b/apps/api/src/utils/is-kangxi-radical-skin-present.ts
@@ -1,0 +1,8 @@
+/**
+ * Checks whether the input string contains the Unicode character U+2F6A.
+ * @param input - The string to check.
+ * @returns true if the input contains the character, false otherwise.
+ */
+export function isKangxiRadicalSkinPresent(input: string): boolean {
+  return input.includes(String.fromCodePoint(12138));
+}

--- a/apps/api/src/utils/is-kangxi-radical-slave-present.ts
+++ b/apps/api/src/utils/is-kangxi-radical-slave-present.ts
@@ -1,0 +1,8 @@
+/**
+ * Checks whether the input string contains the Unicode character U+2FAA.
+ * @param input - The string to check.
+ * @returns true if the input contains the character, false otherwise.
+ */
+export function isKangxiRadicalSlavePresent(input: string): boolean {
+  return input.includes(String.fromCodePoint(12202));
+}

--- a/apps/api/src/utils/is-kangxi-radical-slice-present.ts
+++ b/apps/api/src/utils/is-kangxi-radical-slice-present.ts
@@ -1,0 +1,8 @@
+/**
+ * Checks whether the input string contains the Unicode character U+2F5A.
+ * @param input - The string to check.
+ * @returns true if the input contains the character, false otherwise.
+ */
+export function isKangxiRadicalSlicePresent(input: string): boolean {
+  return input.includes(String.fromCodePoint(12122));
+}

--- a/apps/api/src/utils/is-kangxi-radical-sound-present.ts
+++ b/apps/api/src/utils/is-kangxi-radical-sound-present.ts
@@ -1,0 +1,8 @@
+/**
+ * Checks whether the input string contains the Unicode character U+2FB3.
+ * @param input - The string to check.
+ * @returns true if the input contains the character, false otherwise.
+ */
+export function isKangxiRadicalSoundPresent(input: string): boolean {
+  return input.includes(String.fromCodePoint(12211));
+}

--- a/apps/api/src/utils/is-kangxi-radical-spear-present.ts
+++ b/apps/api/src/utils/is-kangxi-radical-spear-present.ts
@@ -1,0 +1,8 @@
+/**
+ * Checks whether the input string contains the Unicode character U+2F6D.
+ * @param input - The string to check.
+ * @returns true if the input contains the character, false otherwise.
+ */
+export function isKangxiRadicalSpearPresent(input: string): boolean {
+  return input.includes(String.fromCodePoint(12141));
+}

--- a/apps/api/src/utils/is-kangxi-radical-speech-present.ts
+++ b/apps/api/src/utils/is-kangxi-radical-speech-present.ts
@@ -1,0 +1,8 @@
+/**
+ * Checks whether the input string contains the Unicode character U+2F94.
+ * @param input - The string to check.
+ * @returns true if the input contains the character, false otherwise.
+ */
+export function isKangxiRadicalSpeechPresent(input: string): boolean {
+  return input.includes(String.fromCodePoint(12180));
+}

--- a/apps/api/src/utils/is-kangxi-radical-spirit-present.ts
+++ b/apps/api/src/utils/is-kangxi-radical-spirit-present.ts
@@ -1,0 +1,8 @@
+/**
+ * Checks whether the input string contains the Unicode character U+2F70.
+ * @param input - The string to check.
+ * @returns true if the input contains the character, false otherwise.
+ */
+export function isKangxiRadicalSpiritPresent(input: string): boolean {
+  return input.includes(String.fromCodePoint(12144));
+}

--- a/apps/api/src/utils/is-kangxi-radical-square-present.ts
+++ b/apps/api/src/utils/is-kangxi-radical-square-present.ts
@@ -1,0 +1,8 @@
+/**
+ * Checks whether the input string contains the Unicode character U+2F45.
+ * @param input - The string to check.
+ * @returns true if the input contains the character, false otherwise.
+ */
+export function isKangxiRadicalSquarePresent(input: string): boolean {
+  return input.includes(String.fromCodePoint(12101));
+}

--- a/apps/api/src/utils/is-kangxi-radical-stand-present.ts
+++ b/apps/api/src/utils/is-kangxi-radical-stand-present.ts
@@ -1,0 +1,8 @@
+/**
+ * Checks whether the input string contains the Unicode character U+2F74.
+ * @param input - The string to check.
+ * @returns true if the input contains the character, false otherwise.
+ */
+export function isKangxiRadicalStandPresent(input: string): boolean {
+  return input.includes(String.fromCodePoint(12148));
+}

--- a/apps/api/src/utils/is-kangxi-radical-steam-present.ts
+++ b/apps/api/src/utils/is-kangxi-radical-steam-present.ts
@@ -1,0 +1,8 @@
+/**
+ * Checks whether the input string contains the Unicode character U+2F53.
+ * @param input - The string to check.
+ * @returns true if the input contains the character, false otherwise.
+ */
+export function isKangxiRadicalSteamPresent(input: string): boolean {
+  return input.includes(String.fromCodePoint(12115));
+}

--- a/apps/api/src/utils/is-kangxi-radical-stone-present.ts
+++ b/apps/api/src/utils/is-kangxi-radical-stone-present.ts
@@ -1,0 +1,8 @@
+/**
+ * Checks whether the input string contains the Unicode character U+2F6F.
+ * @param input - The string to check.
+ * @returns true if the input contains the character, false otherwise.
+ */
+export function isKangxiRadicalStonePresent(input: string): boolean {
+  return input.includes(String.fromCodePoint(12143));
+}

--- a/apps/api/src/utils/is-kangxi-radical-stop-present.ts
+++ b/apps/api/src/utils/is-kangxi-radical-stop-present.ts
@@ -1,0 +1,8 @@
+/**
+ * Checks whether the input string contains the Unicode character U+2F4C.
+ * @param input - The string to check.
+ * @returns true if the input contains the character, false otherwise.
+ */
+export function isKangxiRadicalStopPresent(input: string): boolean {
+  return input.includes(String.fromCodePoint(12108));
+}

--- a/apps/api/src/utils/is-kangxi-radical-stopping-present.ts
+++ b/apps/api/src/utils/is-kangxi-radical-stopping-present.ts
@@ -1,0 +1,8 @@
+/**
+ * Checks whether the input string contains the Unicode character U+2F89.
+ * @param input - The string to check.
+ * @returns true if the input contains the character, false otherwise.
+ */
+export function isKangxiRadicalStoppingPresent(input: string): boolean {
+  return input.includes(String.fromCodePoint(12169));
+}

--- a/apps/api/src/utils/is-kangxi-radical-sun-present.ts
+++ b/apps/api/src/utils/is-kangxi-radical-sun-present.ts
@@ -1,0 +1,8 @@
+/**
+ * Checks whether the input string contains the Unicode character U+2F47.
+ * @param input - The string to check.
+ * @returns true if the input contains the character, false otherwise.
+ */
+export function isKangxiRadicalSunPresent(input: string): boolean {
+  return input.includes(String.fromCodePoint(12103));
+}

--- a/apps/api/src/utils/is-kangxi-radical-sweet-present.ts
+++ b/apps/api/src/utils/is-kangxi-radical-sweet-present.ts
@@ -1,0 +1,8 @@
+/**
+ * Checks whether the input string contains the Unicode character U+2F62.
+ * @param input - The string to check.
+ * @returns true if the input contains the character, false otherwise.
+ */
+export function isKangxiRadicalSweetPresent(input: string): boolean {
+  return input.includes(String.fromCodePoint(12130));
+}

--- a/apps/api/src/utils/is-kangxi-radical-tanned-leather-present.ts
+++ b/apps/api/src/utils/is-kangxi-radical-tanned-leather-present.ts
@@ -1,0 +1,8 @@
+/**
+ * Checks whether the input string contains the Unicode character U+2FB1.
+ * @param input - The string to check.
+ * @returns true if the input contains the character, false otherwise.
+ */
+export function isKangxiRadicalTannedLeatherPresent(input: string): boolean {
+  return input.includes(String.fromCodePoint(12209));
+}

--- a/apps/api/src/utils/is-kangxi-radical-tiger-present.ts
+++ b/apps/api/src/utils/is-kangxi-radical-tiger-present.ts
@@ -1,0 +1,8 @@
+/**
+ * Checks whether the input string contains the Unicode character U+2F8C.
+ * @param input - The string to check.
+ * @returns true if the input contains the character, false otherwise.
+ */
+export function isKangxiRadicalTigerPresent(input: string): boolean {
+  return input.includes(String.fromCodePoint(12172));
+}

--- a/apps/api/src/utils/is-kangxi-radical-tile-present.ts
+++ b/apps/api/src/utils/is-kangxi-radical-tile-present.ts
@@ -1,0 +1,8 @@
+/**
+ * Checks whether the input string contains the Unicode character U+2F61.
+ * @param input - The string to check.
+ * @returns true if the input contains the character, false otherwise.
+ */
+export function isKangxiRadicalTilePresent(input: string): boolean {
+  return input.includes(String.fromCodePoint(12129));
+}

--- a/apps/api/src/utils/is-kangxi-radical-tongue-present.ts
+++ b/apps/api/src/utils/is-kangxi-radical-tongue-present.ts
@@ -1,0 +1,8 @@
+/**
+ * Checks whether the input string contains the Unicode character U+2F86.
+ * @param input - The string to check.
+ * @returns true if the input contains the character, false otherwise.
+ */
+export function isKangxiRadicalTonguePresent(input: string): boolean {
+  return input.includes(String.fromCodePoint(12166));
+}

--- a/apps/api/src/utils/is-kangxi-radical-tooth-present.ts
+++ b/apps/api/src/utils/is-kangxi-radical-tooth-present.ts
@@ -1,0 +1,8 @@
+/**
+ * Checks whether the input string contains the Unicode character U+2FD2.
+ * @param input - The string to check.
+ * @returns true if the input contains the character, false otherwise.
+ */
+export function isKangxiRadicalToothPresent(input: string): boolean {
+  return input.includes(String.fromCodePoint(12242));
+}

--- a/apps/api/src/utils/is-kangxi-radical-track-present.ts
+++ b/apps/api/src/utils/is-kangxi-radical-track-present.ts
@@ -1,0 +1,8 @@
+/**
+ * Checks whether the input string contains the Unicode character U+2F71.
+ * @param input - The string to check.
+ * @returns true if the input contains the character, false otherwise.
+ */
+export function isKangxiRadicalTrackPresent(input: string): boolean {
+  return input.includes(String.fromCodePoint(12145));
+}

--- a/apps/api/src/utils/is-kangxi-radical-tree-present.ts
+++ b/apps/api/src/utils/is-kangxi-radical-tree-present.ts
@@ -1,0 +1,8 @@
+/**
+ * Checks whether the input string contains the Unicode character U+2F4A.
+ * @param input - The string to check.
+ * @returns true if the input contains the character, false otherwise.
+ */
+export function isKangxiRadicalTreePresent(input: string): boolean {
+  return input.includes(String.fromCodePoint(12106));
+}

--- a/apps/api/src/utils/is-kangxi-radical-valley-present.ts
+++ b/apps/api/src/utils/is-kangxi-radical-valley-present.ts
@@ -1,0 +1,8 @@
+/**
+ * Checks whether the input string contains the Unicode character U+2F95.
+ * @param input - The string to check.
+ * @returns true if the input contains the character, false otherwise.
+ */
+export function isKangxiRadicalValleyPresent(input: string): boolean {
+  return input.includes(String.fromCodePoint(12181));
+}

--- a/apps/api/src/utils/is-kangxi-radical-village-present.ts
+++ b/apps/api/src/utils/is-kangxi-radical-village-present.ts
@@ -1,0 +1,8 @@
+/**
+ * Checks whether the input string contains the Unicode character U+2FA5.
+ * @param input - The string to check.
+ * @returns true if the input contains the character, false otherwise.
+ */
+export function isKangxiRadicalVillagePresent(input: string): boolean {
+  return input.includes(String.fromCodePoint(12197));
+}

--- a/apps/api/src/utils/is-kangxi-radical-walk-enclosure-present.ts
+++ b/apps/api/src/utils/is-kangxi-radical-walk-enclosure-present.ts
@@ -1,0 +1,8 @@
+/**
+ * Checks whether the input string contains the Unicode character U+2F8F.
+ * @param input - The string to check.
+ * @returns true if the input contains the character, false otherwise.
+ */
+export function isKangxiRadicalWalkEnclosurePresent(input: string): boolean {
+  return input.includes(String.fromCodePoint(12175));
+}

--- a/apps/api/src/utils/is-kangxi-radical-water-present.ts
+++ b/apps/api/src/utils/is-kangxi-radical-water-present.ts
@@ -1,0 +1,8 @@
+/**
+ * Checks whether the input string contains the Unicode character U+2F54.
+ * @param input - The string to check.
+ * @returns true if the input contains the character, false otherwise.
+ */
+export function isKangxiRadicalWaterPresent(input: string): boolean {
+  return input.includes(String.fromCodePoint(12116));
+}

--- a/apps/api/src/utils/is-kangxi-radical-weapon-present.ts
+++ b/apps/api/src/utils/is-kangxi-radical-weapon-present.ts
@@ -1,0 +1,8 @@
+/**
+ * Checks whether the input string contains the Unicode character U+2F4E.
+ * @param input - The string to check.
+ * @returns true if the input contains the character, false otherwise.
+ */
+export function isKangxiRadicalWeaponPresent(input: string): boolean {
+  return input.includes(String.fromCodePoint(12110));
+}

--- a/apps/api/src/utils/is-kangxi-radical-west-present.ts
+++ b/apps/api/src/utils/is-kangxi-radical-west-present.ts
@@ -1,0 +1,8 @@
+/**
+ * Checks whether the input string contains the Unicode character U+2F91.
+ * @param input - The string to check.
+ * @returns true if the input contains the character, false otherwise.
+ */
+export function isKangxiRadicalWestPresent(input: string): boolean {
+  return input.includes(String.fromCodePoint(12177));
+}

--- a/apps/api/src/utils/is-kangxi-radical-wheat-present.ts
+++ b/apps/api/src/utils/is-kangxi-radical-wheat-present.ts
@@ -1,0 +1,8 @@
+/**
+ * Checks whether the input string contains the Unicode character U+2FC6.
+ * @param input - The string to check.
+ * @returns true if the input contains the character, false otherwise.
+ */
+export function isKangxiRadicalWheatPresent(input: string): boolean {
+  return input.includes(String.fromCodePoint(12230));
+}

--- a/apps/api/src/utils/is-kangxi-radical-white-present.ts
+++ b/apps/api/src/utils/is-kangxi-radical-white-present.ts
@@ -1,0 +1,8 @@
+/**
+ * Checks whether the input string contains the Unicode character U+2F69.
+ * @param input - The string to check.
+ * @returns true if the input contains the character, false otherwise.
+ */
+export function isKangxiRadicalWhitePresent(input: string): boolean {
+  return input.includes(String.fromCodePoint(12137));
+}

--- a/apps/api/src/utils/is-kangxi-radical-yellow-present.ts
+++ b/apps/api/src/utils/is-kangxi-radical-yellow-present.ts
@@ -1,0 +1,8 @@
+/**
+ * Checks whether the input string contains the Unicode character U+2FC8.
+ * @param input - The string to check.
+ * @returns true if the input contains the character, false otherwise.
+ */
+export function isKangxiRadicalYellowPresent(input: string): boolean {
+  return input.includes(String.fromCodePoint(12232));
+}

--- a/apps/api/src/utils/is-left-angle-bracket-present.ts
+++ b/apps/api/src/utils/is-left-angle-bracket-present.ts
@@ -1,0 +1,8 @@
+/**
+ * Checks whether the input string contains the Unicode character U+3008.
+ * @param input - The string to check.
+ * @returns true if the input contains the character, false otherwise.
+ */
+export function isLeftAngleBracketPresent(input: string): boolean {
+  return input.includes(String.fromCodePoint(12296));
+}

--- a/apps/api/src/utils/is-right-angle-bracket-present.ts
+++ b/apps/api/src/utils/is-right-angle-bracket-present.ts
@@ -1,0 +1,8 @@
+/**
+ * Checks whether the input string contains the Unicode character U+3009.
+ * @param input - The string to check.
+ * @returns true if the input contains the character, false otherwise.
+ */
+export function isRightAngleBracketPresent(input: string): boolean {
+  return input.includes(String.fromCodePoint(12297));
+}


### PR DESCRIPTION
## Unicode Character Detection Utilities (Batch 9 - 140 utilities)

Closes #6256, #6262, #6263, #6264, #6265, #6266, #6273, #6274, #6275, #6276, #6277, #6283, #6284, #6285, #6286, #6287, #6306, #6307, #6308, #6309, #6310, #6316, #6317, #6318, #6319, #6320, #6327, #6328, #6329, #6330, #6331, #6338, #6339, #6340, #6341, #6342, #6376, #6377, #6378, #6379, #6380, #6424, #6425, #6426, #6427, #6428, #6434, #6435, #6436, #6437, #6438, #6445, #6446, #6447, #6448, #6449, #6455, #6456, #6457, #6458, #6459, #6465, #6466, #6467, #6468, #6469, #6475, #6476, #6477, #6478, #6479, #6535, #6536, #6537, #6538, #6539, #6545, #6546, #6547, #6548, #6549, #6555, #6556, #6557, #6558, #6559, #6565, #6566, #6567, #6568, #6569, #6575, #6576, #6577, #6578, #6579, #6585, #6586, #6587, #6588, #6589, #6599, #6600, #6601, #6602, #6603, #6659, #6660, #6661, #6662, #6663, #6669, #6670, #6671, #6672, #6673, #6679, #6680, #6681, #6682, #6683, #6689, #6690, #6691, #6692, #6693, #6699, #6700, #6701, #6702, #6703, #6709, #6710, #6711, #6712, #6713, #6719, #6720, #6721, #6722

### Summary

Adds 140 Unicode character detection API utilities under apps/api/src/utils/. Each utility exports a dependency-free function that returns true only when the input string contains the specified Unicode character.

### Files Added

| File | Character | Issue |
|------|-----------|-------|
| is-kangxi-radical-rap-present.ts | U+2F41 | #6256 |
| is-kangxi-radical-script-present.ts | U+2F42 | #6262 |
| is-kangxi-radical-dipper-present.ts | U+2F43 | #6263 |
| is-kangxi-radical-axe-present.ts | U+2F44 | #6264 |
| is-kangxi-radical-square-present.ts | U+2F45 | #6265 |
| is-kangxi-radical-not-present.ts | U+2F46 | #6266 |
| is-kangxi-radical-sun-present.ts | U+2F47 | #6273 |
| is-kangxi-radical-say-present.ts | U+2F48 | #6274 |
| is-kangxi-radical-moon-present.ts | U+2F49 | #6275 |
| is-kangxi-radical-tree-present.ts | U+2F4A | #6276 |
| is-kangxi-radical-lack-present.ts | U+2F4B | #6277 |
| is-kangxi-radical-stop-present.ts | U+2F4C | #6283 |
| is-kangxi-radical-death-present.ts | U+2F4D | #6284 |
| is-kangxi-radical-weapon-present.ts | U+2F4E | #6285 |
| is-kangxi-radical-do-not-present.ts | U+2F4F | #6286 |
| is-kangxi-radical-compare-present.ts | U+2F50 | #6287 |
| is-kangxi-radical-fur-present.ts | U+2F51 | #6306 |
| is-kangxi-radical-clan-present.ts | U+2F52 | #6307 |
| is-kangxi-radical-steam-present.ts | U+2F53 | #6308 |
| is-kangxi-radical-water-present.ts | U+2F54 | #6309 |
| is-kangxi-radical-fire-present.ts | U+2F55 | #6310 |
| is-kangxi-radical-claw-present.ts | U+2F56 | #6316 |
| is-kangxi-radical-father-present.ts | U+2F57 | #6317 |
| is-kangxi-radical-double-x-present.ts | U+2F58 | #6318 |
| is-kangxi-radical-half-tree-trunk-present.ts | U+2F59 | #6319 |
| is-kangxi-radical-slice-present.ts | U+2F5A | #6320 |
| is-kangxi-radical-fang-present.ts | U+2F5B | #6327 |
| is-kangxi-radical-cow-present.ts | U+2F5C | #6328 |
| is-kangxi-radical-dog-present.ts | U+2F5D | #6329 |
| is-kangxi-radical-profound-present.ts | U+2F5E | #6330 |
| is-kangxi-radical-jade-present.ts | U+2F5F | #6331 |
| is-kangxi-radical-melon-present.ts | U+2F60 | #6338 |
| is-kangxi-radical-tile-present.ts | U+2F61 | #6339 |
| is-kangxi-radical-sweet-present.ts | U+2F62 | #6340 |
| is-kangxi-radical-life-present.ts | U+2F63 | #6341 |
| is-kangxi-radical-field-present.ts | U+2F65 | #6342 |
| is-kangxi-radical-bolt-of-cloth-present.ts | U+2F66 | #6376 |
| is-kangxi-radical-sickness-present.ts | U+2F67 | #6377 |
| is-kangxi-radical-dotted-tent-present.ts | U+2F68 | #6378 |
| is-kangxi-radical-white-present.ts | U+2F69 | #6379 |
| is-kangxi-radical-skin-present.ts | U+2F6A | #6380 |
| is-kangxi-radical-dish-present.ts | U+2F6B | #6424 |
| is-kangxi-radical-eye-present.ts | U+2F6C | #6425 |
| is-kangxi-radical-spear-present.ts | U+2F6D | #6426 |
| is-kangxi-radical-arrow-present.ts | U+2F6E | #6427 |
| is-kangxi-radical-stone-present.ts | U+2F6F | #6428 |
| is-kangxi-radical-spirit-present.ts | U+2F70 | #6434 |
| is-kangxi-radical-track-present.ts | U+2F71 | #6435 |
| is-kangxi-radical-grain-present.ts | U+2F72 | #6436 |
| is-kangxi-radical-cave-present.ts | U+2F73 | #6437 |
| is-kangxi-radical-stand-present.ts | U+2F74 | #6438 |
| is-kangxi-radical-bamboo-present.ts | U+2F75 | #6445 |
| is-kangxi-radical-rice-present.ts | U+2F76 | #6446 |
| is-kangxi-radical-silk-present.ts | U+2F77 | #6447 |
| is-kangxi-radical-jar-present.ts | U+2F78 | #6448 |
| is-kangxi-radical-net-present.ts | U+2F79 | #6449 |
| is-kangxi-radical-sheep-present.ts | U+2F7A | #6455 |
| is-kangxi-radical-feather-present.ts | U+2F7B | #6456 |
| is-kangxi-radical-old-present.ts | U+2F7C | #6457 |
| is-kangxi-radical-plow-present.ts | U+2F7E | #6458 |
| is-kangxi-radical-ear-present.ts | U+2F7F | #6459 |
| is-kangxi-radical-brush-present.ts | U+2F80 | #6465 |
| is-kangxi-radical-meat-present.ts | U+2F81 | #6466 |
| is-kangxi-radical-minister-present.ts | U+2F82 | #6467 |
| is-kangxi-radical-self-present.ts | U+2F83 | #6468 |
| is-kangxi-radical-arrive-present.ts | U+2F84 | #6469 |
| is-kangxi-radical-tongue-present.ts | U+2F86 | #6475 |
| is-kangxi-radical-oppose-present.ts | U+2F87 | #6476 |
| is-kangxi-radical-boat-present.ts | U+2F88 | #6477 |
| is-kangxi-radical-stopping-present.ts | U+2F89 | #6478 |
| is-kangxi-radical-color-present.ts | U+2F8A | #6479 |
| is-kangxi-radical-grass-present.ts | U+2F8B | #6535 |
| is-kangxi-radical-tiger-present.ts | U+2F8C | #6536 |
| is-kangxi-radical-insect-present.ts | U+2F8D | #6537 |
| is-kangxi-radical-blood-present.ts | U+2F8E | #6538 |
| is-kangxi-radical-walk-enclosure-present.ts | U+2F8F | #6539 |
| is-kangxi-radical-west-present.ts | U+2F91 | #6545 |
| is-kangxi-radical-see-present.ts | U+2F92 | #6546 |
| is-kangxi-radical-horn-present.ts | U+2F93 | #6547 |
| is-kangxi-radical-speech-present.ts | U+2F94 | #6548 |
| is-kangxi-radical-valley-present.ts | U+2F95 | #6549 |
| is-kangxi-radical-bean-present.ts | U+2F96 | #6555 |
| is-kangxi-radical-pig-present.ts | U+2F97 | #6556 |
| is-kangxi-radical-badger-present.ts | U+2F98 | #6557 |
| is-kangxi-radical-shell-present.ts | U+2F99 | #6558 |
| is-kangxi-radical-foot-present.ts | U+2F9C | #6559 |
| is-kangxi-radical-body-present.ts | U+2F9D | #6565 |
| is-kangxi-radical-cart-present.ts | U+2F9E | #6566 |
| is-kangxi-radical-bitter-present.ts | U+2F9F | #6567 |
| is-kangxi-radical-morning-present.ts | U+2FA0 | #6568 |
| is-kangxi-radical-city-present.ts | U+2FA2 | #6569 |
| is-kangxi-radical-village-present.ts | U+2FA5 | #6575 |
| is-kangxi-radical-gold-present.ts | U+2FA6 | #6576 |
| is-kangxi-radical-mound-present.ts | U+2FA9 | #6577 |
| is-kangxi-radical-slave-present.ts | U+2FAA | #6578 |
| is-kangxi-radical-short-tailed-bird-present.ts | U+2FAB | #6579 |
| is-kangxi-radical-face-present.ts | U+2FAF | #6585 |
| is-kangxi-radical-leather-present.ts | U+2FB0 | #6586 |
| is-kangxi-radical-tanned-leather-present.ts | U+2FB1 | #6587 |
| is-kangxi-radical-leek-present.ts | U+2FB2 | #6588 |
| is-kangxi-radical-sound-present.ts | U+2FB3 | #6589 |
| is-kangxi-radical-fly-present.ts | U+2FB6 | #6599 |
| is-kangxi-radical-eat-present.ts | U+2FB7 | #6600 |
| is-kangxi-radical-head-present.ts | U+2FB8 | #6601 |
| is-kangxi-radical-fragrant-present.ts | U+2FB9 | #6602 |
| is-kangxi-radical-horse-present.ts | U+2FBA | #6603 |
| is-kangxi-radical-fight-present.ts | U+2FBE | #6659 |
| is-kangxi-radical-sacrificial-wine-present.ts | U+2FBF | #6660 |
| is-kangxi-radical-cauldron-present.ts | U+2FC0 | #6661 |
| is-kangxi-radical-ghost-present.ts | U+2FC1 | #6662 |
| is-kangxi-radical-fish-present.ts | U+2FC2 | #6663 |
| is-kangxi-radical-deer-present.ts | U+2FC5 | #6669 |
| is-kangxi-radical-wheat-present.ts | U+2FC6 | #6670 |
| is-kangxi-radical-hemp-present.ts | U+2FC7 | #6671 |
| is-kangxi-radical-yellow-present.ts | U+2FC8 | #6672 |
| is-kangxi-radical-millet-present.ts | U+2FC9 | #6673 |
| is-kangxi-radical-drum-present.ts | U+2FCE | #6679 |
| is-kangxi-radical-rat-present.ts | U+2FCF | #6680 |
| is-kangxi-radical-nose-present.ts | U+2FD0 | #6681 |
| is-kangxi-radical-even-present.ts | U+2FD1 | #6682 |
| is-kangxi-radical-tooth-present.ts | U+2FD2 | #6683 |
| is-ideographic-description-character-left-to-right-present.ts | U+2FF0 | #6689 |
| is-ideographic-description-character-above-to-below-present.ts | U+2FF1 | #6690 |
| is-ideographic-description-character-left-to-middle-and-right-present.ts | U+2FF2 | #6691 |
| is-ideographic-description-character-above-to-middle-and-below-present.ts | U+2FF3 | #6692 |
| is-ideographic-description-character-full-surround-present.ts | U+2FF4 | #6693 |
| is-ideographic-description-character-surround-from-upper-right-present.ts | U+2FF9 | #6699 |
| is-ideographic-description-character-surround-from-lower-left-present.ts | U+2FFA | #6700 |
| is-ideographic-description-character-overlaid-present.ts | U+2FFB | #6701 |
| is-ideographic-description-character-surround-from-right-present.ts | U+2FFC | #6702 |
| is-ideographic-description-character-surround-from-lower-right-present.ts | U+2FFD | #6703 |
| is-ideographic-comma-present.ts | U+3001 | #6709 |
| is-ideographic-full-stop-present.ts | U+3002 | #6710 |
| is-ditto-mark-present.ts | U+3003 | #6711 |
| is-japanese-industrial-standard-symbol-present.ts | U+3004 | #6712 |
| is-ideographic-iteration-mark-present.ts | U+3005 | #6713 |
| is-ideographic-closing-mark-present.ts | U+3006 | #6719 |
| is-ideographic-number-zero-present.ts | U+3007 | #6720 |
| is-left-angle-bracket-present.ts | U+3008 | #6721 |
| is-right-angle-bracket-present.ts | U+3009 | #6722 |

/claim #6256
/claim #6262
/claim #6263
/claim #6264
/claim #6265
/claim #6266
/claim #6273
/claim #6274
/claim #6275
/claim #6276
/claim #6277
/claim #6283
/claim #6284
/claim #6285
/claim #6286
/claim #6287
/claim #6306
/claim #6307
/claim #6308
/claim #6309
/claim #6310
/claim #6316
/claim #6317
/claim #6318
/claim #6319
/claim #6320
/claim #6327
/claim #6328
/claim #6329
/claim #6330
/claim #6331
/claim #6338
/claim #6339
/claim #6340
/claim #6341
/claim #6342
/claim #6376
/claim #6377
/claim #6378
/claim #6379
/claim #6380
/claim #6424
/claim #6425
/claim #6426
/claim #6427
/claim #6428
/claim #6434
/claim #6435
/claim #6436
/claim #6437
/claim #6438
/claim #6445
/claim #6446
/claim #6447
/claim #6448
/claim #6449
/claim #6455
/claim #6456
/claim #6457
/claim #6458
/claim #6459
/claim #6465
/claim #6466
/claim #6467
/claim #6468
/claim #6469
/claim #6475
/claim #6476
/claim #6477
/claim #6478
/claim #6479
/claim #6535
/claim #6536
/claim #6537
/claim #6538
/claim #6539
/claim #6545
/claim #6546
/claim #6547
/claim #6548
/claim #6549
/claim #6555
/claim #6556
/claim #6557
/claim #6558
/claim #6559
/claim #6565
/claim #6566
/claim #6567
/claim #6568
/claim #6569
/claim #6575
/claim #6576
/claim #6577
/claim #6578
/claim #6579
/claim #6585
/claim #6586
/claim #6587
/claim #6588
/claim #6589
/claim #6599
/claim #6600
/claim #6601
/claim #6602
/claim #6603
/claim #6659
/claim #6660
/claim #6661
/claim #6662
/claim #6663
/claim #6669
/claim #6670
/claim #6671
/claim #6672
/claim #6673
/claim #6679
/claim #6680
/claim #6681
/claim #6682
/claim #6683
/claim #6689
/claim #6690
/claim #6691
/claim #6692
/claim #6693
/claim #6699
/claim #6700
/claim #6701
/claim #6702
/claim #6703
/claim #6709
/claim #6710
/claim #6711
/claim #6712
/claim #6713
/claim #6719
/claim #6720
/claim #6721
/claim #6722
