### PR TITLE
[agent] feat: add 139 Unicode character detection utilities (batch 10)

### DIFF
--- a/apps/api/src/utils/is-circled-postal-mark-present.ts
+++ b/apps/api/src/utils/is-circled-postal-mark-present.ts
@@ -1,0 +1,8 @@
+/**
+ * Checks whether the input string contains the Unicode character U+3036.
+ * @param input - The string to check.
+ * @returns true if the input contains the character, false otherwise.
+ */
+export function isCircledPostalMarkPresent(input: string): boolean {
+  return input.includes(String.fromCodePoint(12342));
+}

--- a/apps/api/src/utils/is-double-prime-quotation-mark-present.ts
+++ b/apps/api/src/utils/is-double-prime-quotation-mark-present.ts
@@ -1,0 +1,8 @@
+/**
+ * Checks whether the input string contains the Unicode character U+301E.
+ * @param input - The string to check.
+ * @returns true if the input contains the character, false otherwise.
+ */
+export function isDoublePrimeQuotationMarkPresent(input: string): boolean {
+  return input.includes(String.fromCodePoint(12318));
+}

--- a/apps/api/src/utils/is-geta-mark-present.ts
+++ b/apps/api/src/utils/is-geta-mark-present.ts
@@ -1,0 +1,8 @@
+/**
+ * Checks whether the input string contains the Unicode character U+3013.
+ * @param input - The string to check.
+ * @returns true if the input contains the character, false otherwise.
+ */
+export function isGetaMarkPresent(input: string): boolean {
+  return input.includes(String.fromCodePoint(12307));
+}

--- a/apps/api/src/utils/is-hangul-double-dot-tone-mark-present.ts
+++ b/apps/api/src/utils/is-hangul-double-dot-tone-mark-present.ts
@@ -1,0 +1,8 @@
+/**
+ * Checks whether the input string contains the Unicode character U+302F.
+ * @param input - The string to check.
+ * @returns true if the input contains the character, false otherwise.
+ */
+export function isHangulDoubleDotToneMarkPresent(input: string): boolean {
+  return input.includes(String.fromCodePoint(12335));
+}

--- a/apps/api/src/utils/is-hangul-single-dot-tone-mark-present.ts
+++ b/apps/api/src/utils/is-hangul-single-dot-tone-mark-present.ts
@@ -1,0 +1,8 @@
+/**
+ * Checks whether the input string contains the Unicode character U+302E.
+ * @param input - The string to check.
+ * @returns true if the input contains the character, false otherwise.
+ */
+export function isHangulSingleDotToneMarkPresent(input: string): boolean {
+  return input.includes(String.fromCodePoint(12334));
+}

--- a/apps/api/src/utils/is-hangzhou-numeral-eight-present.ts
+++ b/apps/api/src/utils/is-hangzhou-numeral-eight-present.ts
@@ -1,0 +1,8 @@
+/**
+ * Checks whether the input string contains the Unicode character U+3028.
+ * @param input - The string to check.
+ * @returns true if the input contains the character, false otherwise.
+ */
+export function isHangzhouNumeralEightPresent(input: string): boolean {
+  return input.includes(String.fromCodePoint(12328));
+}

--- a/apps/api/src/utils/is-hangzhou-numeral-five-present.ts
+++ b/apps/api/src/utils/is-hangzhou-numeral-five-present.ts
@@ -1,0 +1,8 @@
+/**
+ * Checks whether the input string contains the Unicode character U+3025.
+ * @param input - The string to check.
+ * @returns true if the input contains the character, false otherwise.
+ */
+export function isHangzhouNumeralFivePresent(input: string): boolean {
+  return input.includes(String.fromCodePoint(12325));
+}

--- a/apps/api/src/utils/is-hangzhou-numeral-four-present.ts
+++ b/apps/api/src/utils/is-hangzhou-numeral-four-present.ts
@@ -1,0 +1,8 @@
+/**
+ * Checks whether the input string contains the Unicode character U+3024.
+ * @param input - The string to check.
+ * @returns true if the input contains the character, false otherwise.
+ */
+export function isHangzhouNumeralFourPresent(input: string): boolean {
+  return input.includes(String.fromCodePoint(12324));
+}

--- a/apps/api/src/utils/is-hangzhou-numeral-nine-present.ts
+++ b/apps/api/src/utils/is-hangzhou-numeral-nine-present.ts
@@ -1,0 +1,8 @@
+/**
+ * Checks whether the input string contains the Unicode character U+3029.
+ * @param input - The string to check.
+ * @returns true if the input contains the character, false otherwise.
+ */
+export function isHangzhouNumeralNinePresent(input: string): boolean {
+  return input.includes(String.fromCodePoint(12329));
+}

--- a/apps/api/src/utils/is-hangzhou-numeral-one-present.ts
+++ b/apps/api/src/utils/is-hangzhou-numeral-one-present.ts
@@ -1,0 +1,8 @@
+/**
+ * Checks whether the input string contains the Unicode character U+3021.
+ * @param input - The string to check.
+ * @returns true if the input contains the character, false otherwise.
+ */
+export function isHangzhouNumeralOnePresent(input: string): boolean {
+  return input.includes(String.fromCodePoint(12321));
+}

--- a/apps/api/src/utils/is-hangzhou-numeral-seven-present.ts
+++ b/apps/api/src/utils/is-hangzhou-numeral-seven-present.ts
@@ -1,0 +1,8 @@
+/**
+ * Checks whether the input string contains the Unicode character U+3027.
+ * @param input - The string to check.
+ * @returns true if the input contains the character, false otherwise.
+ */
+export function isHangzhouNumeralSevenPresent(input: string): boolean {
+  return input.includes(String.fromCodePoint(12327));
+}

--- a/apps/api/src/utils/is-hangzhou-numeral-six-present.ts
+++ b/apps/api/src/utils/is-hangzhou-numeral-six-present.ts
@@ -1,0 +1,8 @@
+/**
+ * Checks whether the input string contains the Unicode character U+3026.
+ * @param input - The string to check.
+ * @returns true if the input contains the character, false otherwise.
+ */
+export function isHangzhouNumeralSixPresent(input: string): boolean {
+  return input.includes(String.fromCodePoint(12326));
+}

--- a/apps/api/src/utils/is-hangzhou-numeral-ten-present.ts
+++ b/apps/api/src/utils/is-hangzhou-numeral-ten-present.ts
@@ -1,0 +1,8 @@
+/**
+ * Checks whether the input string contains the Unicode character U+3038.
+ * @param input - The string to check.
+ * @returns true if the input contains the character, false otherwise.
+ */
+export function isHangzhouNumeralTenPresent(input: string): boolean {
+  return input.includes(String.fromCodePoint(12344));
+}

--- a/apps/api/src/utils/is-hangzhou-numeral-thirty-present.ts
+++ b/apps/api/src/utils/is-hangzhou-numeral-thirty-present.ts
@@ -1,0 +1,8 @@
+/**
+ * Checks whether the input string contains the Unicode character U+303A.
+ * @param input - The string to check.
+ * @returns true if the input contains the character, false otherwise.
+ */
+export function isHangzhouNumeralThirtyPresent(input: string): boolean {
+  return input.includes(String.fromCodePoint(12346));
+}

--- a/apps/api/src/utils/is-hangzhou-numeral-three-present.ts
+++ b/apps/api/src/utils/is-hangzhou-numeral-three-present.ts
@@ -1,0 +1,8 @@
+/**
+ * Checks whether the input string contains the Unicode character U+3023.
+ * @param input - The string to check.
+ * @returns true if the input contains the character, false otherwise.
+ */
+export function isHangzhouNumeralThreePresent(input: string): boolean {
+  return input.includes(String.fromCodePoint(12323));
+}

--- a/apps/api/src/utils/is-hangzhou-numeral-twenty-present.ts
+++ b/apps/api/src/utils/is-hangzhou-numeral-twenty-present.ts
@@ -1,0 +1,8 @@
+/**
+ * Checks whether the input string contains the Unicode character U+3039.
+ * @param input - The string to check.
+ * @returns true if the input contains the character, false otherwise.
+ */
+export function isHangzhouNumeralTwentyPresent(input: string): boolean {
+  return input.includes(String.fromCodePoint(12345));
+}

--- a/apps/api/src/utils/is-hangzhou-numeral-two-present.ts
+++ b/apps/api/src/utils/is-hangzhou-numeral-two-present.ts
@@ -1,0 +1,8 @@
+/**
+ * Checks whether the input string contains the Unicode character U+3022.
+ * @param input - The string to check.
+ * @returns true if the input contains the character, false otherwise.
+ */
+export function isHangzhouNumeralTwoPresent(input: string): boolean {
+  return input.includes(String.fromCodePoint(12322));
+}

--- a/apps/api/src/utils/is-hiragana-combining-semi-voiced-sound-mark-present.ts
+++ b/apps/api/src/utils/is-hiragana-combining-semi-voiced-sound-mark-present.ts
@@ -1,0 +1,8 @@
+/**
+ * Checks whether the input string contains the Unicode character U+309A.
+ * @param input - The string to check.
+ * @returns true if the input contains the character, false otherwise.
+ */
+export function isHiraganaCombiningSemiVoicedSoundMarkPresent(input: string): boolean {
+  return input.includes(String.fromCodePoint(12442));
+}

--- a/apps/api/src/utils/is-hiragana-combining-voiced-sound-mark-present.ts
+++ b/apps/api/src/utils/is-hiragana-combining-voiced-sound-mark-present.ts
@@ -1,0 +1,8 @@
+/**
+ * Checks whether the input string contains the Unicode character U+3099.
+ * @param input - The string to check.
+ * @returns true if the input contains the character, false otherwise.
+ */
+export function isHiraganaCombiningVoicedSoundMarkPresent(input: string): boolean {
+  return input.includes(String.fromCodePoint(12441));
+}

--- a/apps/api/src/utils/is-hiragana-digraph-yori-present.ts
+++ b/apps/api/src/utils/is-hiragana-digraph-yori-present.ts
@@ -1,0 +1,8 @@
+/**
+ * Checks whether the input string contains the Unicode character U+309F.
+ * @param input - The string to check.
+ * @returns true if the input contains the character, false otherwise.
+ */
+export function isHiraganaDigraphYoriPresent(input: string): boolean {
+  return input.includes(String.fromCodePoint(12447));
+}

--- a/apps/api/src/utils/is-hiragana-iteration-mark-present.ts
+++ b/apps/api/src/utils/is-hiragana-iteration-mark-present.ts
@@ -1,0 +1,8 @@
+/**
+ * Checks whether the input string contains the Unicode character U+309D.
+ * @param input - The string to check.
+ * @returns true if the input contains the character, false otherwise.
+ */
+export function isHiraganaIterationMarkPresent(input: string): boolean {
+  return input.includes(String.fromCodePoint(12445));
+}

--- a/apps/api/src/utils/is-hiragana-letter-a-present.ts
+++ b/apps/api/src/utils/is-hiragana-letter-a-present.ts
@@ -1,0 +1,8 @@
+/**
+ * Checks whether the input string contains the Unicode character U+3042.
+ * @param input - The string to check.
+ * @returns true if the input contains the character, false otherwise.
+ */
+export function isHiraganaLetterAPresent(input: string): boolean {
+  return input.includes(String.fromCodePoint(12354));
+}

--- a/apps/api/src/utils/is-hiragana-letter-ba-present.ts
+++ b/apps/api/src/utils/is-hiragana-letter-ba-present.ts
@@ -1,0 +1,8 @@
+/**
+ * Checks whether the input string contains the Unicode character U+3070.
+ * @param input - The string to check.
+ * @returns true if the input contains the character, false otherwise.
+ */
+export function isHiraganaLetterBaPresent(input: string): boolean {
+  return input.includes(String.fromCodePoint(12400));
+}

--- a/apps/api/src/utils/is-hiragana-letter-be-present.ts
+++ b/apps/api/src/utils/is-hiragana-letter-be-present.ts
@@ -1,0 +1,8 @@
+/**
+ * Checks whether the input string contains the Unicode character U+3079.
+ * @param input - The string to check.
+ * @returns true if the input contains the character, false otherwise.
+ */
+export function isHiraganaLetterBePresent(input: string): boolean {
+  return input.includes(String.fromCodePoint(12409));
+}

--- a/apps/api/src/utils/is-hiragana-letter-bi-present.ts
+++ b/apps/api/src/utils/is-hiragana-letter-bi-present.ts
@@ -1,0 +1,8 @@
+/**
+ * Checks whether the input string contains the Unicode character U+3073.
+ * @param input - The string to check.
+ * @returns true if the input contains the character, false otherwise.
+ */
+export function isHiraganaLetterBiPresent(input: string): boolean {
+  return input.includes(String.fromCodePoint(12403));
+}

--- a/apps/api/src/utils/is-hiragana-letter-bo-present.ts
+++ b/apps/api/src/utils/is-hiragana-letter-bo-present.ts
@@ -1,0 +1,8 @@
+/**
+ * Checks whether the input string contains the Unicode character U+307C.
+ * @param input - The string to check.
+ * @returns true if the input contains the character, false otherwise.
+ */
+export function isHiraganaLetterBoPresent(input: string): boolean {
+  return input.includes(String.fromCodePoint(12412));
+}

--- a/apps/api/src/utils/is-hiragana-letter-bu-present.ts
+++ b/apps/api/src/utils/is-hiragana-letter-bu-present.ts
@@ -1,0 +1,8 @@
+/**
+ * Checks whether the input string contains the Unicode character U+3076.
+ * @param input - The string to check.
+ * @returns true if the input contains the character, false otherwise.
+ */
+export function isHiraganaLetterBuPresent(input: string): boolean {
+  return input.includes(String.fromCodePoint(12406));
+}

--- a/apps/api/src/utils/is-hiragana-letter-da-present.ts
+++ b/apps/api/src/utils/is-hiragana-letter-da-present.ts
@@ -1,0 +1,8 @@
+/**
+ * Checks whether the input string contains the Unicode character U+3060.
+ * @param input - The string to check.
+ * @returns true if the input contains the character, false otherwise.
+ */
+export function isHiraganaLetterDaPresent(input: string): boolean {
+  return input.includes(String.fromCodePoint(12384));
+}

--- a/apps/api/src/utils/is-hiragana-letter-de-present.ts
+++ b/apps/api/src/utils/is-hiragana-letter-de-present.ts
@@ -1,0 +1,8 @@
+/**
+ * Checks whether the input string contains the Unicode character U+3067.
+ * @param input - The string to check.
+ * @returns true if the input contains the character, false otherwise.
+ */
+export function isHiraganaLetterDePresent(input: string): boolean {
+  return input.includes(String.fromCodePoint(12391));
+}

--- a/apps/api/src/utils/is-hiragana-letter-di-present.ts
+++ b/apps/api/src/utils/is-hiragana-letter-di-present.ts
@@ -1,0 +1,8 @@
+/**
+ * Checks whether the input string contains the Unicode character U+3062.
+ * @param input - The string to check.
+ * @returns true if the input contains the character, false otherwise.
+ */
+export function isHiraganaLetterDiPresent(input: string): boolean {
+  return input.includes(String.fromCodePoint(12386));
+}

--- a/apps/api/src/utils/is-hiragana-letter-do-present.ts
+++ b/apps/api/src/utils/is-hiragana-letter-do-present.ts
@@ -1,0 +1,8 @@
+/**
+ * Checks whether the input string contains the Unicode character U+3069.
+ * @param input - The string to check.
+ * @returns true if the input contains the character, false otherwise.
+ */
+export function isHiraganaLetterDoPresent(input: string): boolean {
+  return input.includes(String.fromCodePoint(12393));
+}

--- a/apps/api/src/utils/is-hiragana-letter-du-present.ts
+++ b/apps/api/src/utils/is-hiragana-letter-du-present.ts
@@ -1,0 +1,8 @@
+/**
+ * Checks whether the input string contains the Unicode character U+3065.
+ * @param input - The string to check.
+ * @returns true if the input contains the character, false otherwise.
+ */
+export function isHiraganaLetterDuPresent(input: string): boolean {
+  return input.includes(String.fromCodePoint(12389));
+}

--- a/apps/api/src/utils/is-hiragana-letter-e-present.ts
+++ b/apps/api/src/utils/is-hiragana-letter-e-present.ts
@@ -1,0 +1,8 @@
+/**
+ * Checks whether the input string contains the Unicode character U+3048.
+ * @param input - The string to check.
+ * @returns true if the input contains the character, false otherwise.
+ */
+export function isHiraganaLetterEPresent(input: string): boolean {
+  return input.includes(String.fromCodePoint(12360));
+}

--- a/apps/api/src/utils/is-hiragana-letter-ga-present.ts
+++ b/apps/api/src/utils/is-hiragana-letter-ga-present.ts
@@ -1,0 +1,8 @@
+/**
+ * Checks whether the input string contains the Unicode character U+304C.
+ * @param input - The string to check.
+ * @returns true if the input contains the character, false otherwise.
+ */
+export function isHiraganaLetterGaPresent(input: string): boolean {
+  return input.includes(String.fromCodePoint(12364));
+}

--- a/apps/api/src/utils/is-hiragana-letter-ge-present.ts
+++ b/apps/api/src/utils/is-hiragana-letter-ge-present.ts
@@ -1,0 +1,8 @@
+/**
+ * Checks whether the input string contains the Unicode character U+3052.
+ * @param input - The string to check.
+ * @returns true if the input contains the character, false otherwise.
+ */
+export function isHiraganaLetterGePresent(input: string): boolean {
+  return input.includes(String.fromCodePoint(12370));
+}

--- a/apps/api/src/utils/is-hiragana-letter-gi-present.ts
+++ b/apps/api/src/utils/is-hiragana-letter-gi-present.ts
@@ -1,0 +1,8 @@
+/**
+ * Checks whether the input string contains the Unicode character U+304E.
+ * @param input - The string to check.
+ * @returns true if the input contains the character, false otherwise.
+ */
+export function isHiraganaLetterGiPresent(input: string): boolean {
+  return input.includes(String.fromCodePoint(12366));
+}

--- a/apps/api/src/utils/is-hiragana-letter-go-present.ts
+++ b/apps/api/src/utils/is-hiragana-letter-go-present.ts
@@ -1,0 +1,8 @@
+/**
+ * Checks whether the input string contains the Unicode character U+3054.
+ * @param input - The string to check.
+ * @returns true if the input contains the character, false otherwise.
+ */
+export function isHiraganaLetterGoPresent(input: string): boolean {
+  return input.includes(String.fromCodePoint(12372));
+}

--- a/apps/api/src/utils/is-hiragana-letter-gu-present.ts
+++ b/apps/api/src/utils/is-hiragana-letter-gu-present.ts
@@ -1,0 +1,8 @@
+/**
+ * Checks whether the input string contains the Unicode character U+3050.
+ * @param input - The string to check.
+ * @returns true if the input contains the character, false otherwise.
+ */
+export function isHiraganaLetterGuPresent(input: string): boolean {
+  return input.includes(String.fromCodePoint(12368));
+}

--- a/apps/api/src/utils/is-hiragana-letter-ha-present.ts
+++ b/apps/api/src/utils/is-hiragana-letter-ha-present.ts
@@ -1,0 +1,8 @@
+/**
+ * Checks whether the input string contains the Unicode character U+306F.
+ * @param input - The string to check.
+ * @returns true if the input contains the character, false otherwise.
+ */
+export function isHiraganaLetterHaPresent(input: string): boolean {
+  return input.includes(String.fromCodePoint(12399));
+}

--- a/apps/api/src/utils/is-hiragana-letter-he-present.ts
+++ b/apps/api/src/utils/is-hiragana-letter-he-present.ts
@@ -1,0 +1,8 @@
+/**
+ * Checks whether the input string contains the Unicode character U+3078.
+ * @param input - The string to check.
+ * @returns true if the input contains the character, false otherwise.
+ */
+export function isHiraganaLetterHePresent(input: string): boolean {
+  return input.includes(String.fromCodePoint(12408));
+}

--- a/apps/api/src/utils/is-hiragana-letter-ho-present.ts
+++ b/apps/api/src/utils/is-hiragana-letter-ho-present.ts
@@ -1,0 +1,8 @@
+/**
+ * Checks whether the input string contains the Unicode character U+307B.
+ * @param input - The string to check.
+ * @returns true if the input contains the character, false otherwise.
+ */
+export function isHiraganaLetterHoPresent(input: string): boolean {
+  return input.includes(String.fromCodePoint(12411));
+}

--- a/apps/api/src/utils/is-hiragana-letter-hu-present.ts
+++ b/apps/api/src/utils/is-hiragana-letter-hu-present.ts
@@ -1,0 +1,8 @@
+/**
+ * Checks whether the input string contains the Unicode character U+3075.
+ * @param input - The string to check.
+ * @returns true if the input contains the character, false otherwise.
+ */
+export function isHiraganaLetterHuPresent(input: string): boolean {
+  return input.includes(String.fromCodePoint(12405));
+}

--- a/apps/api/src/utils/is-hiragana-letter-i-present.ts
+++ b/apps/api/src/utils/is-hiragana-letter-i-present.ts
@@ -1,0 +1,8 @@
+/**
+ * Checks whether the input string contains the Unicode character U+3044.
+ * @param input - The string to check.
+ * @returns true if the input contains the character, false otherwise.
+ */
+export function isHiraganaLetterIPresent(input: string): boolean {
+  return input.includes(String.fromCodePoint(12356));
+}

--- a/apps/api/src/utils/is-hiragana-letter-ka-present.ts
+++ b/apps/api/src/utils/is-hiragana-letter-ka-present.ts
@@ -1,0 +1,8 @@
+/**
+ * Checks whether the input string contains the Unicode character U+304B.
+ * @param input - The string to check.
+ * @returns true if the input contains the character, false otherwise.
+ */
+export function isHiraganaLetterKaPresent(input: string): boolean {
+  return input.includes(String.fromCodePoint(12363));
+}

--- a/apps/api/src/utils/is-hiragana-letter-ke-present.ts
+++ b/apps/api/src/utils/is-hiragana-letter-ke-present.ts
@@ -1,0 +1,8 @@
+/**
+ * Checks whether the input string contains the Unicode character U+3051.
+ * @param input - The string to check.
+ * @returns true if the input contains the character, false otherwise.
+ */
+export function isHiraganaLetterKePresent(input: string): boolean {
+  return input.includes(String.fromCodePoint(12369));
+}

--- a/apps/api/src/utils/is-hiragana-letter-ki-present.ts
+++ b/apps/api/src/utils/is-hiragana-letter-ki-present.ts
@@ -1,0 +1,8 @@
+/**
+ * Checks whether the input string contains the Unicode character U+304D.
+ * @param input - The string to check.
+ * @returns true if the input contains the character, false otherwise.
+ */
+export function isHiraganaLetterKiPresent(input: string): boolean {
+  return input.includes(String.fromCodePoint(12365));
+}

--- a/apps/api/src/utils/is-hiragana-letter-ko-present.ts
+++ b/apps/api/src/utils/is-hiragana-letter-ko-present.ts
@@ -1,0 +1,8 @@
+/**
+ * Checks whether the input string contains the Unicode character U+3053.
+ * @param input - The string to check.
+ * @returns true if the input contains the character, false otherwise.
+ */
+export function isHiraganaLetterKoPresent(input: string): boolean {
+  return input.includes(String.fromCodePoint(12371));
+}

--- a/apps/api/src/utils/is-hiragana-letter-ku-present.ts
+++ b/apps/api/src/utils/is-hiragana-letter-ku-present.ts
@@ -1,0 +1,8 @@
+/**
+ * Checks whether the input string contains the Unicode character U+304F.
+ * @param input - The string to check.
+ * @returns true if the input contains the character, false otherwise.
+ */
+export function isHiraganaLetterKuPresent(input: string): boolean {
+  return input.includes(String.fromCodePoint(12367));
+}

--- a/apps/api/src/utils/is-hiragana-letter-ma-present.ts
+++ b/apps/api/src/utils/is-hiragana-letter-ma-present.ts
@@ -1,0 +1,8 @@
+/**
+ * Checks whether the input string contains the Unicode character U+307E.
+ * @param input - The string to check.
+ * @returns true if the input contains the character, false otherwise.
+ */
+export function isHiraganaLetterMaPresent(input: string): boolean {
+  return input.includes(String.fromCodePoint(12414));
+}

--- a/apps/api/src/utils/is-hiragana-letter-me-present.ts
+++ b/apps/api/src/utils/is-hiragana-letter-me-present.ts
@@ -1,0 +1,8 @@
+/**
+ * Checks whether the input string contains the Unicode character U+3081.
+ * @param input - The string to check.
+ * @returns true if the input contains the character, false otherwise.
+ */
+export function isHiraganaLetterMePresent(input: string): boolean {
+  return input.includes(String.fromCodePoint(12417));
+}

--- a/apps/api/src/utils/is-hiragana-letter-mi-present.ts
+++ b/apps/api/src/utils/is-hiragana-letter-mi-present.ts
@@ -1,0 +1,8 @@
+/**
+ * Checks whether the input string contains the Unicode character U+307F.
+ * @param input - The string to check.
+ * @returns true if the input contains the character, false otherwise.
+ */
+export function isHiraganaLetterMiPresent(input: string): boolean {
+  return input.includes(String.fromCodePoint(12415));
+}

--- a/apps/api/src/utils/is-hiragana-letter-mo-present.ts
+++ b/apps/api/src/utils/is-hiragana-letter-mo-present.ts
@@ -1,0 +1,8 @@
+/**
+ * Checks whether the input string contains the Unicode character U+3082.
+ * @param input - The string to check.
+ * @returns true if the input contains the character, false otherwise.
+ */
+export function isHiraganaLetterMoPresent(input: string): boolean {
+  return input.includes(String.fromCodePoint(12418));
+}

--- a/apps/api/src/utils/is-hiragana-letter-mu-present.ts
+++ b/apps/api/src/utils/is-hiragana-letter-mu-present.ts
@@ -1,0 +1,8 @@
+/**
+ * Checks whether the input string contains the Unicode character U+3080.
+ * @param input - The string to check.
+ * @returns true if the input contains the character, false otherwise.
+ */
+export function isHiraganaLetterMuPresent(input: string): boolean {
+  return input.includes(String.fromCodePoint(12416));
+}

--- a/apps/api/src/utils/is-hiragana-letter-n-present.ts
+++ b/apps/api/src/utils/is-hiragana-letter-n-present.ts
@@ -1,0 +1,8 @@
+/**
+ * Checks whether the input string contains the Unicode character U+3093.
+ * @param input - The string to check.
+ * @returns true if the input contains the character, false otherwise.
+ */
+export function isHiraganaLetterNPresent(input: string): boolean {
+  return input.includes(String.fromCodePoint(12435));
+}

--- a/apps/api/src/utils/is-hiragana-letter-na-present.ts
+++ b/apps/api/src/utils/is-hiragana-letter-na-present.ts
@@ -1,0 +1,8 @@
+/**
+ * Checks whether the input string contains the Unicode character U+306A.
+ * @param input - The string to check.
+ * @returns true if the input contains the character, false otherwise.
+ */
+export function isHiraganaLetterNaPresent(input: string): boolean {
+  return input.includes(String.fromCodePoint(12394));
+}

--- a/apps/api/src/utils/is-hiragana-letter-ne-present.ts
+++ b/apps/api/src/utils/is-hiragana-letter-ne-present.ts
@@ -1,0 +1,8 @@
+/**
+ * Checks whether the input string contains the Unicode character U+306D.
+ * @param input - The string to check.
+ * @returns true if the input contains the character, false otherwise.
+ */
+export function isHiraganaLetterNePresent(input: string): boolean {
+  return input.includes(String.fromCodePoint(12397));
+}

--- a/apps/api/src/utils/is-hiragana-letter-ni-present.ts
+++ b/apps/api/src/utils/is-hiragana-letter-ni-present.ts
@@ -1,0 +1,8 @@
+/**
+ * Checks whether the input string contains the Unicode character U+306B.
+ * @param input - The string to check.
+ * @returns true if the input contains the character, false otherwise.
+ */
+export function isHiraganaLetterNiPresent(input: string): boolean {
+  return input.includes(String.fromCodePoint(12395));
+}

--- a/apps/api/src/utils/is-hiragana-letter-no-present.ts
+++ b/apps/api/src/utils/is-hiragana-letter-no-present.ts
@@ -1,0 +1,8 @@
+/**
+ * Checks whether the input string contains the Unicode character U+306E.
+ * @param input - The string to check.
+ * @returns true if the input contains the character, false otherwise.
+ */
+export function isHiraganaLetterNoPresent(input: string): boolean {
+  return input.includes(String.fromCodePoint(12398));
+}

--- a/apps/api/src/utils/is-hiragana-letter-nu-present.ts
+++ b/apps/api/src/utils/is-hiragana-letter-nu-present.ts
@@ -1,0 +1,8 @@
+/**
+ * Checks whether the input string contains the Unicode character U+306C.
+ * @param input - The string to check.
+ * @returns true if the input contains the character, false otherwise.
+ */
+export function isHiraganaLetterNuPresent(input: string): boolean {
+  return input.includes(String.fromCodePoint(12396));
+}

--- a/apps/api/src/utils/is-hiragana-letter-pa-present.ts
+++ b/apps/api/src/utils/is-hiragana-letter-pa-present.ts
@@ -1,0 +1,8 @@
+/**
+ * Checks whether the input string contains the Unicode character U+3071.
+ * @param input - The string to check.
+ * @returns true if the input contains the character, false otherwise.
+ */
+export function isHiraganaLetterPaPresent(input: string): boolean {
+  return input.includes(String.fromCodePoint(12401));
+}

--- a/apps/api/src/utils/is-hiragana-letter-pe-present.ts
+++ b/apps/api/src/utils/is-hiragana-letter-pe-present.ts
@@ -1,0 +1,8 @@
+/**
+ * Checks whether the input string contains the Unicode character U+307A.
+ * @param input - The string to check.
+ * @returns true if the input contains the character, false otherwise.
+ */
+export function isHiraganaLetterPePresent(input: string): boolean {
+  return input.includes(String.fromCodePoint(12410));
+}

--- a/apps/api/src/utils/is-hiragana-letter-pi-present.ts
+++ b/apps/api/src/utils/is-hiragana-letter-pi-present.ts
@@ -1,0 +1,8 @@
+/**
+ * Checks whether the input string contains the Unicode character U+3074.
+ * @param input - The string to check.
+ * @returns true if the input contains the character, false otherwise.
+ */
+export function isHiraganaLetterPiPresent(input: string): boolean {
+  return input.includes(String.fromCodePoint(12404));
+}

--- a/apps/api/src/utils/is-hiragana-letter-po-present.ts
+++ b/apps/api/src/utils/is-hiragana-letter-po-present.ts
@@ -1,0 +1,8 @@
+/**
+ * Checks whether the input string contains the Unicode character U+307D.
+ * @param input - The string to check.
+ * @returns true if the input contains the character, false otherwise.
+ */
+export function isHiraganaLetterPoPresent(input: string): boolean {
+  return input.includes(String.fromCodePoint(12413));
+}

--- a/apps/api/src/utils/is-hiragana-letter-pu-present.ts
+++ b/apps/api/src/utils/is-hiragana-letter-pu-present.ts
@@ -1,0 +1,8 @@
+/**
+ * Checks whether the input string contains the Unicode character U+3077.
+ * @param input - The string to check.
+ * @returns true if the input contains the character, false otherwise.
+ */
+export function isHiraganaLetterPuPresent(input: string): boolean {
+  return input.includes(String.fromCodePoint(12407));
+}

--- a/apps/api/src/utils/is-hiragana-letter-ra-present.ts
+++ b/apps/api/src/utils/is-hiragana-letter-ra-present.ts
@@ -1,0 +1,8 @@
+/**
+ * Checks whether the input string contains the Unicode character U+3089.
+ * @param input - The string to check.
+ * @returns true if the input contains the character, false otherwise.
+ */
+export function isHiraganaLetterRaPresent(input: string): boolean {
+  return input.includes(String.fromCodePoint(12425));
+}

--- a/apps/api/src/utils/is-hiragana-letter-re-present.ts
+++ b/apps/api/src/utils/is-hiragana-letter-re-present.ts
@@ -1,0 +1,8 @@
+/**
+ * Checks whether the input string contains the Unicode character U+308C.
+ * @param input - The string to check.
+ * @returns true if the input contains the character, false otherwise.
+ */
+export function isHiraganaLetterRePresent(input: string): boolean {
+  return input.includes(String.fromCodePoint(12428));
+}

--- a/apps/api/src/utils/is-hiragana-letter-ri-present.ts
+++ b/apps/api/src/utils/is-hiragana-letter-ri-present.ts
@@ -1,0 +1,8 @@
+/**
+ * Checks whether the input string contains the Unicode character U+308A.
+ * @param input - The string to check.
+ * @returns true if the input contains the character, false otherwise.
+ */
+export function isHiraganaLetterRiPresent(input: string): boolean {
+  return input.includes(String.fromCodePoint(12426));
+}

--- a/apps/api/src/utils/is-hiragana-letter-ro-present.ts
+++ b/apps/api/src/utils/is-hiragana-letter-ro-present.ts
@@ -1,0 +1,8 @@
+/**
+ * Checks whether the input string contains the Unicode character U+308D.
+ * @param input - The string to check.
+ * @returns true if the input contains the character, false otherwise.
+ */
+export function isHiraganaLetterRoPresent(input: string): boolean {
+  return input.includes(String.fromCodePoint(12429));
+}

--- a/apps/api/src/utils/is-hiragana-letter-ru-present.ts
+++ b/apps/api/src/utils/is-hiragana-letter-ru-present.ts
@@ -1,0 +1,8 @@
+/**
+ * Checks whether the input string contains the Unicode character U+308B.
+ * @param input - The string to check.
+ * @returns true if the input contains the character, false otherwise.
+ */
+export function isHiraganaLetterRuPresent(input: string): boolean {
+  return input.includes(String.fromCodePoint(12427));
+}

--- a/apps/api/src/utils/is-hiragana-letter-sa-present.ts
+++ b/apps/api/src/utils/is-hiragana-letter-sa-present.ts
@@ -1,0 +1,8 @@
+/**
+ * Checks whether the input string contains the Unicode character U+3055.
+ * @param input - The string to check.
+ * @returns true if the input contains the character, false otherwise.
+ */
+export function isHiraganaLetterSaPresent(input: string): boolean {
+  return input.includes(String.fromCodePoint(12373));
+}

--- a/apps/api/src/utils/is-hiragana-letter-se-present.ts
+++ b/apps/api/src/utils/is-hiragana-letter-se-present.ts
@@ -1,0 +1,8 @@
+/**
+ * Checks whether the input string contains the Unicode character U+305B.
+ * @param input - The string to check.
+ * @returns true if the input contains the character, false otherwise.
+ */
+export function isHiraganaLetterSePresent(input: string): boolean {
+  return input.includes(String.fromCodePoint(12379));
+}

--- a/apps/api/src/utils/is-hiragana-letter-si-present.ts
+++ b/apps/api/src/utils/is-hiragana-letter-si-present.ts
@@ -1,0 +1,8 @@
+/**
+ * Checks whether the input string contains the Unicode character U+3057.
+ * @param input - The string to check.
+ * @returns true if the input contains the character, false otherwise.
+ */
+export function isHiraganaLetterSiPresent(input: string): boolean {
+  return input.includes(String.fromCodePoint(12375));
+}

--- a/apps/api/src/utils/is-hiragana-letter-small-a-present.ts
+++ b/apps/api/src/utils/is-hiragana-letter-small-a-present.ts
@@ -1,0 +1,8 @@
+/**
+ * Checks whether the input string contains the Unicode character U+3041.
+ * @param input - The string to check.
+ * @returns true if the input contains the character, false otherwise.
+ */
+export function isHiraganaLetterSmallAPresent(input: string): boolean {
+  return input.includes(String.fromCodePoint(12353));
+}

--- a/apps/api/src/utils/is-hiragana-letter-small-e-present.ts
+++ b/apps/api/src/utils/is-hiragana-letter-small-e-present.ts
@@ -1,0 +1,8 @@
+/**
+ * Checks whether the input string contains the Unicode character U+3047.
+ * @param input - The string to check.
+ * @returns true if the input contains the character, false otherwise.
+ */
+export function isHiraganaLetterSmallEPresent(input: string): boolean {
+  return input.includes(String.fromCodePoint(12359));
+}

--- a/apps/api/src/utils/is-hiragana-letter-small-i-present.ts
+++ b/apps/api/src/utils/is-hiragana-letter-small-i-present.ts
@@ -1,0 +1,8 @@
+/**
+ * Checks whether the input string contains the Unicode character U+3043.
+ * @param input - The string to check.
+ * @returns true if the input contains the character, false otherwise.
+ */
+export function isHiraganaLetterSmallIPresent(input: string): boolean {
+  return input.includes(String.fromCodePoint(12355));
+}

--- a/apps/api/src/utils/is-hiragana-letter-small-o-present.ts
+++ b/apps/api/src/utils/is-hiragana-letter-small-o-present.ts
@@ -1,0 +1,8 @@
+/**
+ * Checks whether the input string contains the Unicode character U+3049.
+ * @param input - The string to check.
+ * @returns true if the input contains the character, false otherwise.
+ */
+export function isHiraganaLetterSmallOPresent(input: string): boolean {
+  return input.includes(String.fromCodePoint(12361));
+}

--- a/apps/api/src/utils/is-hiragana-letter-small-tu-present.ts
+++ b/apps/api/src/utils/is-hiragana-letter-small-tu-present.ts
@@ -1,0 +1,8 @@
+/**
+ * Checks whether the input string contains the Unicode character U+3063.
+ * @param input - The string to check.
+ * @returns true if the input contains the character, false otherwise.
+ */
+export function isHiraganaLetterSmallTuPresent(input: string): boolean {
+  return input.includes(String.fromCodePoint(12387));
+}

--- a/apps/api/src/utils/is-hiragana-letter-small-wa-present.ts
+++ b/apps/api/src/utils/is-hiragana-letter-small-wa-present.ts
@@ -1,0 +1,8 @@
+/**
+ * Checks whether the input string contains the Unicode character U+308E.
+ * @param input - The string to check.
+ * @returns true if the input contains the character, false otherwise.
+ */
+export function isHiraganaLetterSmallWaPresent(input: string): boolean {
+  return input.includes(String.fromCodePoint(12430));
+}

--- a/apps/api/src/utils/is-hiragana-letter-small-ya-present.ts
+++ b/apps/api/src/utils/is-hiragana-letter-small-ya-present.ts
@@ -1,0 +1,8 @@
+/**
+ * Checks whether the input string contains the Unicode character U+3083.
+ * @param input - The string to check.
+ * @returns true if the input contains the character, false otherwise.
+ */
+export function isHiraganaLetterSmallYaPresent(input: string): boolean {
+  return input.includes(String.fromCodePoint(12419));
+}

--- a/apps/api/src/utils/is-hiragana-letter-small-yo-present.ts
+++ b/apps/api/src/utils/is-hiragana-letter-small-yo-present.ts
@@ -1,0 +1,8 @@
+/**
+ * Checks whether the input string contains the Unicode character U+3087.
+ * @param input - The string to check.
+ * @returns true if the input contains the character, false otherwise.
+ */
+export function isHiraganaLetterSmallYoPresent(input: string): boolean {
+  return input.includes(String.fromCodePoint(12423));
+}

--- a/apps/api/src/utils/is-hiragana-letter-small-yu-present.ts
+++ b/apps/api/src/utils/is-hiragana-letter-small-yu-present.ts
@@ -1,0 +1,8 @@
+/**
+ * Checks whether the input string contains the Unicode character U+3085.
+ * @param input - The string to check.
+ * @returns true if the input contains the character, false otherwise.
+ */
+export function isHiraganaLetterSmallYuPresent(input: string): boolean {
+  return input.includes(String.fromCodePoint(12421));
+}

--- a/apps/api/src/utils/is-hiragana-letter-so-present.ts
+++ b/apps/api/src/utils/is-hiragana-letter-so-present.ts
@@ -1,0 +1,8 @@
+/**
+ * Checks whether the input string contains the Unicode character U+305D.
+ * @param input - The string to check.
+ * @returns true if the input contains the character, false otherwise.
+ */
+export function isHiraganaLetterSoPresent(input: string): boolean {
+  return input.includes(String.fromCodePoint(12381));
+}

--- a/apps/api/src/utils/is-hiragana-letter-su-present.ts
+++ b/apps/api/src/utils/is-hiragana-letter-su-present.ts
@@ -1,0 +1,8 @@
+/**
+ * Checks whether the input string contains the Unicode character U+3059.
+ * @param input - The string to check.
+ * @returns true if the input contains the character, false otherwise.
+ */
+export function isHiraganaLetterSuPresent(input: string): boolean {
+  return input.includes(String.fromCodePoint(12377));
+}

--- a/apps/api/src/utils/is-hiragana-letter-ta-present.ts
+++ b/apps/api/src/utils/is-hiragana-letter-ta-present.ts
@@ -1,0 +1,8 @@
+/**
+ * Checks whether the input string contains the Unicode character U+305F.
+ * @param input - The string to check.
+ * @returns true if the input contains the character, false otherwise.
+ */
+export function isHiraganaLetterTaPresent(input: string): boolean {
+  return input.includes(String.fromCodePoint(12383));
+}

--- a/apps/api/src/utils/is-hiragana-letter-te-present.ts
+++ b/apps/api/src/utils/is-hiragana-letter-te-present.ts
@@ -1,0 +1,8 @@
+/**
+ * Checks whether the input string contains the Unicode character U+3066.
+ * @param input - The string to check.
+ * @returns true if the input contains the character, false otherwise.
+ */
+export function isHiraganaLetterTePresent(input: string): boolean {
+  return input.includes(String.fromCodePoint(12390));
+}

--- a/apps/api/src/utils/is-hiragana-letter-ti-present.ts
+++ b/apps/api/src/utils/is-hiragana-letter-ti-present.ts
@@ -1,0 +1,8 @@
+/**
+ * Checks whether the input string contains the Unicode character U+3061.
+ * @param input - The string to check.
+ * @returns true if the input contains the character, false otherwise.
+ */
+export function isHiraganaLetterTiPresent(input: string): boolean {
+  return input.includes(String.fromCodePoint(12385));
+}

--- a/apps/api/src/utils/is-hiragana-letter-vu-present.ts
+++ b/apps/api/src/utils/is-hiragana-letter-vu-present.ts
@@ -1,0 +1,8 @@
+/**
+ * Checks whether the input string contains the Unicode character U+3094.
+ * @param input - The string to check.
+ * @returns true if the input contains the character, false otherwise.
+ */
+export function isHiraganaLetterVuPresent(input: string): boolean {
+  return input.includes(String.fromCodePoint(12436));
+}

--- a/apps/api/src/utils/is-hiragana-letter-we-present.ts
+++ b/apps/api/src/utils/is-hiragana-letter-we-present.ts
@@ -1,0 +1,8 @@
+/**
+ * Checks whether the input string contains the Unicode character U+3091.
+ * @param input - The string to check.
+ * @returns true if the input contains the character, false otherwise.
+ */
+export function isHiraganaLetterWePresent(input: string): boolean {
+  return input.includes(String.fromCodePoint(12433));
+}

--- a/apps/api/src/utils/is-hiragana-letter-wi-present.ts
+++ b/apps/api/src/utils/is-hiragana-letter-wi-present.ts
@@ -1,0 +1,8 @@
+/**
+ * Checks whether the input string contains the Unicode character U+3090.
+ * @param input - The string to check.
+ * @returns true if the input contains the character, false otherwise.
+ */
+export function isHiraganaLetterWiPresent(input: string): boolean {
+  return input.includes(String.fromCodePoint(12432));
+}

--- a/apps/api/src/utils/is-hiragana-letter-wo-present.ts
+++ b/apps/api/src/utils/is-hiragana-letter-wo-present.ts
@@ -1,0 +1,8 @@
+/**
+ * Checks whether the input string contains the Unicode character U+3092.
+ * @param input - The string to check.
+ * @returns true if the input contains the character, false otherwise.
+ */
+export function isHiraganaLetterWoPresent(input: string): boolean {
+  return input.includes(String.fromCodePoint(12434));
+}

--- a/apps/api/src/utils/is-hiragana-letter-ya-present.ts
+++ b/apps/api/src/utils/is-hiragana-letter-ya-present.ts
@@ -1,0 +1,8 @@
+/**
+ * Checks whether the input string contains the Unicode character U+3084.
+ * @param input - The string to check.
+ * @returns true if the input contains the character, false otherwise.
+ */
+export function isHiraganaLetterYaPresent(input: string): boolean {
+  return input.includes(String.fromCodePoint(12420));
+}

--- a/apps/api/src/utils/is-hiragana-letter-yo-present.ts
+++ b/apps/api/src/utils/is-hiragana-letter-yo-present.ts
@@ -1,0 +1,8 @@
+/**
+ * Checks whether the input string contains the Unicode character U+3088.
+ * @param input - The string to check.
+ * @returns true if the input contains the character, false otherwise.
+ */
+export function isHiraganaLetterYoPresent(input: string): boolean {
+  return input.includes(String.fromCodePoint(12424));
+}

--- a/apps/api/src/utils/is-hiragana-letter-yu-present.ts
+++ b/apps/api/src/utils/is-hiragana-letter-yu-present.ts
@@ -1,0 +1,8 @@
+/**
+ * Checks whether the input string contains the Unicode character U+3086.
+ * @param input - The string to check.
+ * @returns true if the input contains the character, false otherwise.
+ */
+export function isHiraganaLetterYuPresent(input: string): boolean {
+  return input.includes(String.fromCodePoint(12422));
+}

--- a/apps/api/src/utils/is-hiragana-letter-za-present.ts
+++ b/apps/api/src/utils/is-hiragana-letter-za-present.ts
@@ -1,0 +1,8 @@
+/**
+ * Checks whether the input string contains the Unicode character U+3056.
+ * @param input - The string to check.
+ * @returns true if the input contains the character, false otherwise.
+ */
+export function isHiraganaLetterZaPresent(input: string): boolean {
+  return input.includes(String.fromCodePoint(12374));
+}

--- a/apps/api/src/utils/is-hiragana-letter-ze-present.ts
+++ b/apps/api/src/utils/is-hiragana-letter-ze-present.ts
@@ -1,0 +1,8 @@
+/**
+ * Checks whether the input string contains the Unicode character U+305C.
+ * @param input - The string to check.
+ * @returns true if the input contains the character, false otherwise.
+ */
+export function isHiraganaLetterZePresent(input: string): boolean {
+  return input.includes(String.fromCodePoint(12380));
+}

--- a/apps/api/src/utils/is-hiragana-letter-zi-present.ts
+++ b/apps/api/src/utils/is-hiragana-letter-zi-present.ts
@@ -1,0 +1,8 @@
+/**
+ * Checks whether the input string contains the Unicode character U+3058.
+ * @param input - The string to check.
+ * @returns true if the input contains the character, false otherwise.
+ */
+export function isHiraganaLetterZiPresent(input: string): boolean {
+  return input.includes(String.fromCodePoint(12376));
+}

--- a/apps/api/src/utils/is-hiragana-letter-zo-present.ts
+++ b/apps/api/src/utils/is-hiragana-letter-zo-present.ts
@@ -1,0 +1,8 @@
+/**
+ * Checks whether the input string contains the Unicode character U+305E.
+ * @param input - The string to check.
+ * @returns true if the input contains the character, false otherwise.
+ */
+export function isHiraganaLetterZoPresent(input: string): boolean {
+  return input.includes(String.fromCodePoint(12382));
+}

--- a/apps/api/src/utils/is-hiragana-letter-zu-present.ts
+++ b/apps/api/src/utils/is-hiragana-letter-zu-present.ts
@@ -1,0 +1,8 @@
+/**
+ * Checks whether the input string contains the Unicode character U+305A.
+ * @param input - The string to check.
+ * @returns true if the input contains the character, false otherwise.
+ */
+export function isHiraganaLetterZuPresent(input: string): boolean {
+  return input.includes(String.fromCodePoint(12378));
+}

--- a/apps/api/src/utils/is-hiragana-semi-voiced-sound-mark-present.ts
+++ b/apps/api/src/utils/is-hiragana-semi-voiced-sound-mark-present.ts
@@ -1,0 +1,8 @@
+/**
+ * Checks whether the input string contains the Unicode character U+309C.
+ * @param input - The string to check.
+ * @returns true if the input contains the character, false otherwise.
+ */
+export function isHiraganaSemiVoicedSoundMarkPresent(input: string): boolean {
+  return input.includes(String.fromCodePoint(12444));
+}

--- a/apps/api/src/utils/is-hiragana-voiced-iteration-mark-present.ts
+++ b/apps/api/src/utils/is-hiragana-voiced-iteration-mark-present.ts
@@ -1,0 +1,8 @@
+/**
+ * Checks whether the input string contains the Unicode character U+309E.
+ * @param input - The string to check.
+ * @returns true if the input contains the character, false otherwise.
+ */
+export function isHiraganaVoicedIterationMarkPresent(input: string): boolean {
+  return input.includes(String.fromCodePoint(12446));
+}

--- a/apps/api/src/utils/is-hiragana-voiced-sound-mark-present.ts
+++ b/apps/api/src/utils/is-hiragana-voiced-sound-mark-present.ts
@@ -1,0 +1,8 @@
+/**
+ * Checks whether the input string contains the Unicode character U+309B.
+ * @param input - The string to check.
+ * @returns true if the input contains the character, false otherwise.
+ */
+export function isHiraganaVoicedSoundMarkPresent(input: string): boolean {
+  return input.includes(String.fromCodePoint(12443));
+}

--- a/apps/api/src/utils/is-ideographic-departing-tone-mark-present.ts
+++ b/apps/api/src/utils/is-ideographic-departing-tone-mark-present.ts
@@ -1,0 +1,8 @@
+/**
+ * Checks whether the input string contains the Unicode character U+302C.
+ * @param input - The string to check.
+ * @returns true if the input contains the character, false otherwise.
+ */
+export function isIdeographicDepartingToneMarkPresent(input: string): boolean {
+  return input.includes(String.fromCodePoint(12332));
+}

--- a/apps/api/src/utils/is-ideographic-entering-tone-mark-present.ts
+++ b/apps/api/src/utils/is-ideographic-entering-tone-mark-present.ts
@@ -1,0 +1,8 @@
+/**
+ * Checks whether the input string contains the Unicode character U+302D.
+ * @param input - The string to check.
+ * @returns true if the input contains the character, false otherwise.
+ */
+export function isIdeographicEnteringToneMarkPresent(input: string): boolean {
+  return input.includes(String.fromCodePoint(12333));
+}

--- a/apps/api/src/utils/is-ideographic-half-fill-space-present.ts
+++ b/apps/api/src/utils/is-ideographic-half-fill-space-present.ts
@@ -1,0 +1,8 @@
+/**
+ * Checks whether the input string contains the Unicode character U+303F.
+ * @param input - The string to check.
+ * @returns true if the input contains the character, false otherwise.
+ */
+export function isIdeographicHalfFillSpacePresent(input: string): boolean {
+  return input.includes(String.fromCodePoint(12351));
+}

--- a/apps/api/src/utils/is-ideographic-level-tone-mark-present.ts
+++ b/apps/api/src/utils/is-ideographic-level-tone-mark-present.ts
@@ -1,0 +1,8 @@
+/**
+ * Checks whether the input string contains the Unicode character U+302A.
+ * @param input - The string to check.
+ * @returns true if the input contains the character, false otherwise.
+ */
+export function isIdeographicLevelToneMarkPresent(input: string): boolean {
+  return input.includes(String.fromCodePoint(12330));
+}

--- a/apps/api/src/utils/is-ideographic-rising-tone-mark-present.ts
+++ b/apps/api/src/utils/is-ideographic-rising-tone-mark-present.ts
@@ -1,0 +1,8 @@
+/**
+ * Checks whether the input string contains the Unicode character U+302B.
+ * @param input - The string to check.
+ * @returns true if the input contains the character, false otherwise.
+ */
+export function isIdeographicRisingToneMarkPresent(input: string): boolean {
+  return input.includes(String.fromCodePoint(12331));
+}

--- a/apps/api/src/utils/is-ideographic-telegraph-line-feed-separator-symbol-present.ts
+++ b/apps/api/src/utils/is-ideographic-telegraph-line-feed-separator-symbol-present.ts
@@ -1,0 +1,8 @@
+/**
+ * Checks whether the input string contains the Unicode character U+3037.
+ * @param input - The string to check.
+ * @returns true if the input contains the character, false otherwise.
+ */
+export function isIdeographicTelegraphLineFeedSeparatorSymbolPresent(input: string): boolean {
+  return input.includes(String.fromCodePoint(12343));
+}

--- a/apps/api/src/utils/is-ideographic-variation-indicator-present.ts
+++ b/apps/api/src/utils/is-ideographic-variation-indicator-present.ts
@@ -1,0 +1,8 @@
+/**
+ * Checks whether the input string contains the Unicode character U+303E.
+ * @param input - The string to check.
+ * @returns true if the input contains the character, false otherwise.
+ */
+export function isIdeographicVariationIndicatorPresent(input: string): boolean {
+  return input.includes(String.fromCodePoint(12350));
+}

--- a/apps/api/src/utils/is-katakana-hiragana-double-hyphen-present.ts
+++ b/apps/api/src/utils/is-katakana-hiragana-double-hyphen-present.ts
@@ -1,0 +1,8 @@
+/**
+ * Checks whether the input string contains the Unicode character U+30A0.
+ * @param input - The string to check.
+ * @returns true if the input contains the character, false otherwise.
+ */
+export function isKatakanaHiraganaDoubleHyphenPresent(input: string): boolean {
+  return input.includes(String.fromCodePoint(12448));
+}

--- a/apps/api/src/utils/is-left-black-lenticular-bracket-present.ts
+++ b/apps/api/src/utils/is-left-black-lenticular-bracket-present.ts
@@ -1,0 +1,8 @@
+/**
+ * Checks whether the input string contains the Unicode character U+3010.
+ * @param input - The string to check.
+ * @returns true if the input contains the character, false otherwise.
+ */
+export function isLeftBlackLenticularBracketPresent(input: string): boolean {
+  return input.includes(String.fromCodePoint(12304));
+}

--- a/apps/api/src/utils/is-left-corner-bracket-present.ts
+++ b/apps/api/src/utils/is-left-corner-bracket-present.ts
@@ -1,0 +1,8 @@
+/**
+ * Checks whether the input string contains the Unicode character U+300C.
+ * @param input - The string to check.
+ * @returns true if the input contains the character, false otherwise.
+ */
+export function isLeftCornerBracketPresent(input: string): boolean {
+  return input.includes(String.fromCodePoint(12300));
+}

--- a/apps/api/src/utils/is-left-double-angle-bracket-present.ts
+++ b/apps/api/src/utils/is-left-double-angle-bracket-present.ts
@@ -1,0 +1,8 @@
+/**
+ * Checks whether the input string contains the Unicode character U+300A.
+ * @param input - The string to check.
+ * @returns true if the input contains the character, false otherwise.
+ */
+export function isLeftDoubleAngleBracketPresent(input: string): boolean {
+  return input.includes(String.fromCodePoint(12298));
+}

--- a/apps/api/src/utils/is-left-tortoise-shell-bracket-present.ts
+++ b/apps/api/src/utils/is-left-tortoise-shell-bracket-present.ts
@@ -1,0 +1,8 @@
+/**
+ * Checks whether the input string contains the Unicode character U+3014.
+ * @param input - The string to check.
+ * @returns true if the input contains the character, false otherwise.
+ */
+export function isLeftTortoiseShellBracketPresent(input: string): boolean {
+  return input.includes(String.fromCodePoint(12308));
+}

--- a/apps/api/src/utils/is-left-white-corner-bracket-present.ts
+++ b/apps/api/src/utils/is-left-white-corner-bracket-present.ts
@@ -1,0 +1,8 @@
+/**
+ * Checks whether the input string contains the Unicode character U+300E.
+ * @param input - The string to check.
+ * @returns true if the input contains the character, false otherwise.
+ */
+export function isLeftWhiteCornerBracketPresent(input: string): boolean {
+  return input.includes(String.fromCodePoint(12302));
+}

--- a/apps/api/src/utils/is-left-white-lenticular-bracket-present.ts
+++ b/apps/api/src/utils/is-left-white-lenticular-bracket-present.ts
@@ -1,0 +1,8 @@
+/**
+ * Checks whether the input string contains the Unicode character U+3016.
+ * @param input - The string to check.
+ * @returns true if the input contains the character, false otherwise.
+ */
+export function isLeftWhiteLenticularBracketPresent(input: string): boolean {
+  return input.includes(String.fromCodePoint(12310));
+}

--- a/apps/api/src/utils/is-left-white-square-bracket-present.ts
+++ b/apps/api/src/utils/is-left-white-square-bracket-present.ts
@@ -1,0 +1,8 @@
+/**
+ * Checks whether the input string contains the Unicode character U+301A.
+ * @param input - The string to check.
+ * @returns true if the input contains the character, false otherwise.
+ */
+export function isLeftWhiteSquareBracketPresent(input: string): boolean {
+  return input.includes(String.fromCodePoint(12314));
+}

--- a/apps/api/src/utils/is-left-white-tortoise-shell-bracket-present.ts
+++ b/apps/api/src/utils/is-left-white-tortoise-shell-bracket-present.ts
@@ -1,0 +1,8 @@
+/**
+ * Checks whether the input string contains the Unicode character U+3018.
+ * @param input - The string to check.
+ * @returns true if the input contains the character, false otherwise.
+ */
+export function isLeftWhiteTortoiseShellBracketPresent(input: string): boolean {
+  return input.includes(String.fromCodePoint(12312));
+}

--- a/apps/api/src/utils/is-low-double-prime-quotation-mark-present.ts
+++ b/apps/api/src/utils/is-low-double-prime-quotation-mark-present.ts
@@ -1,0 +1,8 @@
+/**
+ * Checks whether the input string contains the Unicode character U+301F.
+ * @param input - The string to check.
+ * @returns true if the input contains the character, false otherwise.
+ */
+export function isLowDoublePrimeQuotationMarkPresent(input: string): boolean {
+  return input.includes(String.fromCodePoint(12319));
+}

--- a/apps/api/src/utils/is-masu-mark-present.ts
+++ b/apps/api/src/utils/is-masu-mark-present.ts
@@ -1,0 +1,8 @@
+/**
+ * Checks whether the input string contains the Unicode character U+303C.
+ * @param input - The string to check.
+ * @returns true if the input contains the character, false otherwise.
+ */
+export function isMasuMarkPresent(input: string): boolean {
+  return input.includes(String.fromCodePoint(12348));
+}

--- a/apps/api/src/utils/is-part-alternation-mark-present.ts
+++ b/apps/api/src/utils/is-part-alternation-mark-present.ts
@@ -1,0 +1,8 @@
+/**
+ * Checks whether the input string contains the Unicode character U+303D.
+ * @param input - The string to check.
+ * @returns true if the input contains the character, false otherwise.
+ */
+export function isPartAlternationMarkPresent(input: string): boolean {
+  return input.includes(String.fromCodePoint(12349));
+}

--- a/apps/api/src/utils/is-postal-mark-face-present.ts
+++ b/apps/api/src/utils/is-postal-mark-face-present.ts
@@ -1,0 +1,8 @@
+/**
+ * Checks whether the input string contains the Unicode character U+3020.
+ * @param input - The string to check.
+ * @returns true if the input contains the character, false otherwise.
+ */
+export function isPostalMarkFacePresent(input: string): boolean {
+  return input.includes(String.fromCodePoint(12320));
+}

--- a/apps/api/src/utils/is-postal-mark-present.ts
+++ b/apps/api/src/utils/is-postal-mark-present.ts
@@ -1,0 +1,8 @@
+/**
+ * Checks whether the input string contains the Unicode character U+3012.
+ * @param input - The string to check.
+ * @returns true if the input contains the character, false otherwise.
+ */
+export function isPostalMarkPresent(input: string): boolean {
+  return input.includes(String.fromCodePoint(12306));
+}

--- a/apps/api/src/utils/is-reversed-double-prime-quotation-mark-present.ts
+++ b/apps/api/src/utils/is-reversed-double-prime-quotation-mark-present.ts
@@ -1,0 +1,8 @@
+/**
+ * Checks whether the input string contains the Unicode character U+301D.
+ * @param input - The string to check.
+ * @returns true if the input contains the character, false otherwise.
+ */
+export function isReversedDoublePrimeQuotationMarkPresent(input: string): boolean {
+  return input.includes(String.fromCodePoint(12317));
+}

--- a/apps/api/src/utils/is-right-black-lenticular-bracket-present.ts
+++ b/apps/api/src/utils/is-right-black-lenticular-bracket-present.ts
@@ -1,0 +1,8 @@
+/**
+ * Checks whether the input string contains the Unicode character U+3011.
+ * @param input - The string to check.
+ * @returns true if the input contains the character, false otherwise.
+ */
+export function isRightBlackLenticularBracketPresent(input: string): boolean {
+  return input.includes(String.fromCodePoint(12305));
+}

--- a/apps/api/src/utils/is-right-corner-bracket-present.ts
+++ b/apps/api/src/utils/is-right-corner-bracket-present.ts
@@ -1,0 +1,8 @@
+/**
+ * Checks whether the input string contains the Unicode character U+300D.
+ * @param input - The string to check.
+ * @returns true if the input contains the character, false otherwise.
+ */
+export function isRightCornerBracketPresent(input: string): boolean {
+  return input.includes(String.fromCodePoint(12301));
+}

--- a/apps/api/src/utils/is-right-double-angle-bracket-present.ts
+++ b/apps/api/src/utils/is-right-double-angle-bracket-present.ts
@@ -1,0 +1,8 @@
+/**
+ * Checks whether the input string contains the Unicode character U+300B.
+ * @param input - The string to check.
+ * @returns true if the input contains the character, false otherwise.
+ */
+export function isRightDoubleAngleBracketPresent(input: string): boolean {
+  return input.includes(String.fromCodePoint(12299));
+}

--- a/apps/api/src/utils/is-right-tortoise-shell-bracket-present.ts
+++ b/apps/api/src/utils/is-right-tortoise-shell-bracket-present.ts
@@ -1,0 +1,8 @@
+/**
+ * Checks whether the input string contains the Unicode character U+3015.
+ * @param input - The string to check.
+ * @returns true if the input contains the character, false otherwise.
+ */
+export function isRightTortoiseShellBracketPresent(input: string): boolean {
+  return input.includes(String.fromCodePoint(12309));
+}

--- a/apps/api/src/utils/is-right-white-corner-bracket-present.ts
+++ b/apps/api/src/utils/is-right-white-corner-bracket-present.ts
@@ -1,0 +1,8 @@
+/**
+ * Checks whether the input string contains the Unicode character U+300F.
+ * @param input - The string to check.
+ * @returns true if the input contains the character, false otherwise.
+ */
+export function isRightWhiteCornerBracketPresent(input: string): boolean {
+  return input.includes(String.fromCodePoint(12303));
+}

--- a/apps/api/src/utils/is-right-white-lenticular-bracket-present.ts
+++ b/apps/api/src/utils/is-right-white-lenticular-bracket-present.ts
@@ -1,0 +1,8 @@
+/**
+ * Checks whether the input string contains the Unicode character U+3017.
+ * @param input - The string to check.
+ * @returns true if the input contains the character, false otherwise.
+ */
+export function isRightWhiteLenticularBracketPresent(input: string): boolean {
+  return input.includes(String.fromCodePoint(12311));
+}

--- a/apps/api/src/utils/is-right-white-square-bracket-present.ts
+++ b/apps/api/src/utils/is-right-white-square-bracket-present.ts
@@ -1,0 +1,8 @@
+/**
+ * Checks whether the input string contains the Unicode character U+301B.
+ * @param input - The string to check.
+ * @returns true if the input contains the character, false otherwise.
+ */
+export function isRightWhiteSquareBracketPresent(input: string): boolean {
+  return input.includes(String.fromCodePoint(12315));
+}

--- a/apps/api/src/utils/is-right-white-tortoise-shell-bracket-present.ts
+++ b/apps/api/src/utils/is-right-white-tortoise-shell-bracket-present.ts
@@ -1,0 +1,8 @@
+/**
+ * Checks whether the input string contains the Unicode character U+3019.
+ * @param input - The string to check.
+ * @returns true if the input contains the character, false otherwise.
+ */
+export function isRightWhiteTortoiseShellBracketPresent(input: string): boolean {
+  return input.includes(String.fromCodePoint(12313));
+}

--- a/apps/api/src/utils/is-vertical-ideographic-iteration-mark-present.ts
+++ b/apps/api/src/utils/is-vertical-ideographic-iteration-mark-present.ts
@@ -1,0 +1,8 @@
+/**
+ * Checks whether the input string contains the Unicode character U+303B.
+ * @param input - The string to check.
+ * @returns true if the input contains the character, false otherwise.
+ */
+export function isVerticalIdeographicIterationMarkPresent(input: string): boolean {
+  return input.includes(String.fromCodePoint(12347));
+}

--- a/apps/api/src/utils/is-vertical-kana-repeat-mark-lower-half-present.ts
+++ b/apps/api/src/utils/is-vertical-kana-repeat-mark-lower-half-present.ts
@@ -1,0 +1,8 @@
+/**
+ * Checks whether the input string contains the Unicode character U+3035.
+ * @param input - The string to check.
+ * @returns true if the input contains the character, false otherwise.
+ */
+export function isVerticalKanaRepeatMarkLowerHalfPresent(input: string): boolean {
+  return input.includes(String.fromCodePoint(12341));
+}

--- a/apps/api/src/utils/is-vertical-kana-repeat-mark-present.ts
+++ b/apps/api/src/utils/is-vertical-kana-repeat-mark-present.ts
@@ -1,0 +1,8 @@
+/**
+ * Checks whether the input string contains the Unicode character U+3031.
+ * @param input - The string to check.
+ * @returns true if the input contains the character, false otherwise.
+ */
+export function isVerticalKanaRepeatMarkPresent(input: string): boolean {
+  return input.includes(String.fromCodePoint(12337));
+}

--- a/apps/api/src/utils/is-vertical-kana-repeat-mark-upper-half-present.ts
+++ b/apps/api/src/utils/is-vertical-kana-repeat-mark-upper-half-present.ts
@@ -1,0 +1,8 @@
+/**
+ * Checks whether the input string contains the Unicode character U+3033.
+ * @param input - The string to check.
+ * @returns true if the input contains the character, false otherwise.
+ */
+export function isVerticalKanaRepeatMarkUpperHalfPresent(input: string): boolean {
+  return input.includes(String.fromCodePoint(12339));
+}

--- a/apps/api/src/utils/is-vertical-kana-repeat-with-voiced-sound-mark-present.ts
+++ b/apps/api/src/utils/is-vertical-kana-repeat-with-voiced-sound-mark-present.ts
@@ -1,0 +1,8 @@
+/**
+ * Checks whether the input string contains the Unicode character U+3032.
+ * @param input - The string to check.
+ * @returns true if the input contains the character, false otherwise.
+ */
+export function isVerticalKanaRepeatWithVoicedSoundMarkPresent(input: string): boolean {
+  return input.includes(String.fromCodePoint(12338));
+}

--- a/apps/api/src/utils/is-vertical-kana-repeat-with-voiced-sound-mark-upper-half-present.ts
+++ b/apps/api/src/utils/is-vertical-kana-repeat-with-voiced-sound-mark-upper-half-present.ts
@@ -1,0 +1,8 @@
+/**
+ * Checks whether the input string contains the Unicode character U+3034.
+ * @param input - The string to check.
+ * @returns true if the input contains the character, false otherwise.
+ */
+export function isVerticalKanaRepeatWithVoicedSoundMarkUpperHalfPresent(input: string): boolean {
+  return input.includes(String.fromCodePoint(12340));
+}

--- a/apps/api/src/utils/is-wave-dash-present.ts
+++ b/apps/api/src/utils/is-wave-dash-present.ts
@@ -1,0 +1,8 @@
+/**
+ * Checks whether the input string contains the Unicode character U+301C.
+ * @param input - The string to check.
+ * @returns true if the input contains the character, false otherwise.
+ */
+export function isWaveDashPresent(input: string): boolean {
+  return input.includes(String.fromCodePoint(12316));
+}

--- a/apps/api/src/utils/is-wavy-dash-present.ts
+++ b/apps/api/src/utils/is-wavy-dash-present.ts
@@ -1,0 +1,8 @@
+/**
+ * Checks whether the input string contains the Unicode character U+3030.
+ * @param input - The string to check.
+ * @returns true if the input contains the character, false otherwise.
+ */
+export function isWavyDashPresent(input: string): boolean {
+  return input.includes(String.fromCodePoint(12336));
+}


### PR DESCRIPTION
## Unicode Character Detection Utilities (Batch 10 - 139 utilities)

Closes #6723, #6730, #6731, #6732, #6733, #6734, #6741, #6742, #6743, #6744, #6745, #6751, #6752, #6753, #6754, #6755, #6761, #6762, #6763, #6764, #6765, #6771, #6772, #6773, #6774, #6775, #6788, #6789, #6790, #6791, #6792, #6798, #6799, #6800, #6801, #6802, #6808, #6809, #6810, #6811, #6812, #6856, #6857, #6858, #6859, #6860, #6869, #6870, #6871, #6872, #6873, #6879, #6880, #6881, #6882, #6883, #6889, #6890, #6891, #6892, #6893, #6954, #6955, #6956, #6957, #6958, #6969, #6970, #6971, #6972, #6973, #6979, #6980, #6981, #6982, #6983, #7182, #7183, #7184, #7185, #7186, #7192, #7193, #7194, #7195, #7196, #7202, #7203, #7204, #7205, #7206, #7212, #7213, #7214, #7215, #7216, #7222, #7223, #7224, #7225, #7226, #7247, #7248, #7249, #7250, #7251, #7258, #7259, #7260, #7261, #7262, #7272, #7273, #7274, #7275, #7276, #7283, #7284, #7285, #7286, #7287, #7294, #7295, #7296, #7297, #7298, #7546, #7547, #7548, #7549, #7550, #7619, #7620, #7621, #7622, #7623, #7666, #7667, #7668

### Summary

Adds 139 Unicode character detection API utilities under apps/api/src/utils/. Each utility exports a dependency-free function that returns true only when the input string contains the specified Unicode character.

### Files Added

| File | Character | Issue |
|------|-----------|-------|
| is-left-double-angle-bracket-present.ts | U+300A | #6723 |
| is-right-double-angle-bracket-present.ts | U+300B | #6730 |
| is-left-corner-bracket-present.ts | U+300C | #6731 |
| is-right-corner-bracket-present.ts | U+300D | #6732 |
| is-left-white-corner-bracket-present.ts | U+300E | #6733 |
| is-right-white-corner-bracket-present.ts | U+300F | #6734 |
| is-left-black-lenticular-bracket-present.ts | U+3010 | #6741 |
| is-right-black-lenticular-bracket-present.ts | U+3011 | #6742 |
| is-postal-mark-present.ts | U+3012 | #6743 |
| is-geta-mark-present.ts | U+3013 | #6744 |
| is-left-tortoise-shell-bracket-present.ts | U+3014 | #6745 |
| is-right-tortoise-shell-bracket-present.ts | U+3015 | #6751 |
| is-left-white-lenticular-bracket-present.ts | U+3016 | #6752 |
| is-right-white-lenticular-bracket-present.ts | U+3017 | #6753 |
| is-left-white-tortoise-shell-bracket-present.ts | U+3018 | #6754 |
| is-right-white-tortoise-shell-bracket-present.ts | U+3019 | #6755 |
| is-left-white-square-bracket-present.ts | U+301A | #6761 |
| is-right-white-square-bracket-present.ts | U+301B | #6762 |
| is-wave-dash-present.ts | U+301C | #6763 |
| is-reversed-double-prime-quotation-mark-present.ts | U+301D | #6764 |
| is-double-prime-quotation-mark-present.ts | U+301E | #6765 |
| is-low-double-prime-quotation-mark-present.ts | U+301F | #6771 |
| is-postal-mark-face-present.ts | U+3020 | #6772 |
| is-hangzhou-numeral-one-present.ts | U+3021 | #6773 |
| is-hangzhou-numeral-two-present.ts | U+3022 | #6774 |
| is-hangzhou-numeral-three-present.ts | U+3023 | #6775 |
| is-hangzhou-numeral-four-present.ts | U+3024 | #6788 |
| is-hangzhou-numeral-five-present.ts | U+3025 | #6789 |
| is-hangzhou-numeral-six-present.ts | U+3026 | #6790 |
| is-hangzhou-numeral-seven-present.ts | U+3027 | #6791 |
| is-hangzhou-numeral-eight-present.ts | U+3028 | #6792 |
| is-hangzhou-numeral-nine-present.ts | U+3029 | #6798 |
| is-ideographic-level-tone-mark-present.ts | U+302A | #6799 |
| is-ideographic-rising-tone-mark-present.ts | U+302B | #6800 |
| is-ideographic-departing-tone-mark-present.ts | U+302C | #6801 |
| is-ideographic-entering-tone-mark-present.ts | U+302D | #6802 |
| is-hangul-single-dot-tone-mark-present.ts | U+302E | #6808 |
| is-hangul-double-dot-tone-mark-present.ts | U+302F | #6809 |
| is-wavy-dash-present.ts | U+3030 | #6810 |
| is-vertical-kana-repeat-mark-present.ts | U+3031 | #6811 |
| is-vertical-kana-repeat-with-voiced-sound-mark-present.ts | U+3032 | #6812 |
| is-vertical-kana-repeat-mark-upper-half-present.ts | U+3033 | #6856 |
| is-vertical-kana-repeat-with-voiced-sound-mark-upper-half-present.ts | U+3034 | #6857 |
| is-vertical-kana-repeat-mark-lower-half-present.ts | U+3035 | #6858 |
| is-circled-postal-mark-present.ts | U+3036 | #6859 |
| is-ideographic-telegraph-line-feed-separator-symbol-present.ts | U+3037 | #6860 |
| is-hangzhou-numeral-ten-present.ts | U+3038 | #6869 |
| is-hangzhou-numeral-twenty-present.ts | U+3039 | #6870 |
| is-hangzhou-numeral-thirty-present.ts | U+303A | #6871 |
| is-vertical-ideographic-iteration-mark-present.ts | U+303B | #6872 |
| is-masu-mark-present.ts | U+303C | #6873 |
| is-part-alternation-mark-present.ts | U+303D | #6879 |
| is-ideographic-variation-indicator-present.ts | U+303E | #6880 |
| is-ideographic-half-fill-space-present.ts | U+303F | #6881 |
| is-hiragana-letter-small-a-present.ts | U+3041 | #6882 |
| is-hiragana-letter-a-present.ts | U+3042 | #6883 |
| is-hiragana-letter-small-i-present.ts | U+3043 | #6889 |
| is-hiragana-letter-i-present.ts | U+3044 | #6890 |
| is-hiragana-letter-small-e-present.ts | U+3047 | #6891 |
| is-hiragana-letter-e-present.ts | U+3048 | #6892 |
| is-hiragana-letter-small-o-present.ts | U+3049 | #6893 |
| is-hiragana-letter-ka-present.ts | U+304B | #6954 |
| is-hiragana-letter-ga-present.ts | U+304C | #6955 |
| is-hiragana-letter-ki-present.ts | U+304D | #6956 |
| is-hiragana-letter-gi-present.ts | U+304E | #6957 |
| is-hiragana-letter-ku-present.ts | U+304F | #6958 |
| is-hiragana-letter-gu-present.ts | U+3050 | #6969 |
| is-hiragana-letter-ke-present.ts | U+3051 | #6970 |
| is-hiragana-letter-ge-present.ts | U+3052 | #6971 |
| is-hiragana-letter-ko-present.ts | U+3053 | #6972 |
| is-hiragana-letter-go-present.ts | U+3054 | #6973 |
| is-hiragana-letter-sa-present.ts | U+3055 | #6979 |
| is-hiragana-letter-za-present.ts | U+3056 | #6980 |
| is-hiragana-letter-si-present.ts | U+3057 | #6981 |
| is-hiragana-letter-zi-present.ts | U+3058 | #6982 |
| is-hiragana-letter-su-present.ts | U+3059 | #6983 |
| is-hiragana-letter-zu-present.ts | U+305A | #7182 |
| is-hiragana-letter-se-present.ts | U+305B | #7183 |
| is-hiragana-letter-ze-present.ts | U+305C | #7184 |
| is-hiragana-letter-so-present.ts | U+305D | #7185 |
| is-hiragana-letter-zo-present.ts | U+305E | #7186 |
| is-hiragana-letter-ta-present.ts | U+305F | #7192 |
| is-hiragana-letter-da-present.ts | U+3060 | #7193 |
| is-hiragana-letter-ti-present.ts | U+3061 | #7194 |
| is-hiragana-letter-di-present.ts | U+3062 | #7195 |
| is-hiragana-letter-small-tu-present.ts | U+3063 | #7196 |
| is-hiragana-letter-du-present.ts | U+3065 | #7202 |
| is-hiragana-letter-te-present.ts | U+3066 | #7203 |
| is-hiragana-letter-de-present.ts | U+3067 | #7204 |
| is-hiragana-letter-do-present.ts | U+3069 | #7205 |
| is-hiragana-letter-na-present.ts | U+306A | #7206 |
| is-hiragana-letter-ni-present.ts | U+306B | #7212 |
| is-hiragana-letter-nu-present.ts | U+306C | #7213 |
| is-hiragana-letter-ne-present.ts | U+306D | #7214 |
| is-hiragana-letter-no-present.ts | U+306E | #7215 |
| is-hiragana-letter-ha-present.ts | U+306F | #7216 |
| is-hiragana-letter-ba-present.ts | U+3070 | #7222 |
| is-hiragana-letter-pa-present.ts | U+3071 | #7223 |
| is-hiragana-letter-bi-present.ts | U+3073 | #7224 |
| is-hiragana-letter-pi-present.ts | U+3074 | #7225 |
| is-hiragana-letter-hu-present.ts | U+3075 | #7226 |
| is-hiragana-letter-bu-present.ts | U+3076 | #7247 |
| is-hiragana-letter-pu-present.ts | U+3077 | #7248 |
| is-hiragana-letter-he-present.ts | U+3078 | #7249 |
| is-hiragana-letter-be-present.ts | U+3079 | #7250 |
| is-hiragana-letter-pe-present.ts | U+307A | #7251 |
| is-hiragana-letter-ho-present.ts | U+307B | #7258 |
| is-hiragana-letter-bo-present.ts | U+307C | #7259 |
| is-hiragana-letter-po-present.ts | U+307D | #7260 |
| is-hiragana-letter-ma-present.ts | U+307E | #7261 |
| is-hiragana-letter-mi-present.ts | U+307F | #7262 |
| is-hiragana-letter-mu-present.ts | U+3080 | #7272 |
| is-hiragana-letter-me-present.ts | U+3081 | #7273 |
| is-hiragana-letter-mo-present.ts | U+3082 | #7274 |
| is-hiragana-letter-ya-present.ts | U+3084 | #7275 |
| is-hiragana-letter-small-ya-present.ts | U+3083 | #7276 |
| is-hiragana-letter-yu-present.ts | U+3086 | #7283 |
| is-hiragana-letter-small-yu-present.ts | U+3085 | #7284 |
| is-hiragana-letter-yo-present.ts | U+3088 | #7285 |
| is-hiragana-letter-small-yo-present.ts | U+3087 | #7286 |
| is-hiragana-letter-ra-present.ts | U+3089 | #7287 |
| is-hiragana-letter-ri-present.ts | U+308A | #7294 |
| is-hiragana-letter-ru-present.ts | U+308B | #7295 |
| is-hiragana-letter-re-present.ts | U+308C | #7296 |
| is-hiragana-letter-ro-present.ts | U+308D | #7297 |
| is-hiragana-letter-small-wa-present.ts | U+308E | #7298 |
| is-hiragana-letter-wi-present.ts | U+3090 | #7546 |
| is-hiragana-letter-we-present.ts | U+3091 | #7547 |
| is-hiragana-letter-wo-present.ts | U+3092 | #7548 |
| is-hiragana-letter-n-present.ts | U+3093 | #7549 |
| is-hiragana-letter-vu-present.ts | U+3094 | #7550 |
| is-hiragana-combining-voiced-sound-mark-present.ts | U+3099 | #7619 |
| is-hiragana-combining-semi-voiced-sound-mark-present.ts | U+309A | #7620 |
| is-hiragana-voiced-sound-mark-present.ts | U+309B | #7621 |
| is-hiragana-semi-voiced-sound-mark-present.ts | U+309C | #7622 |
| is-hiragana-iteration-mark-present.ts | U+309D | #7623 |
| is-hiragana-voiced-iteration-mark-present.ts | U+309E | #7666 |
| is-hiragana-digraph-yori-present.ts | U+309F | #7667 |
| is-katakana-hiragana-double-hyphen-present.ts | U+30A0 | #7668 |

/claim #6723
/claim #6730
/claim #6731
/claim #6732
/claim #6733
/claim #6734
/claim #6741
/claim #6742
/claim #6743
/claim #6744
/claim #6745
/claim #6751
/claim #6752
/claim #6753
/claim #6754
/claim #6755
/claim #6761
/claim #6762
/claim #6763
/claim #6764
/claim #6765
/claim #6771
/claim #6772
/claim #6773
/claim #6774
/claim #6775
/claim #6788
/claim #6789
/claim #6790
/claim #6791
/claim #6792
/claim #6798
/claim #6799
/claim #6800
/claim #6801
/claim #6802
/claim #6808
/claim #6809
/claim #6810
/claim #6811
/claim #6812
/claim #6856
/claim #6857
/claim #6858
/claim #6859
/claim #6860
/claim #6869
/claim #6870
/claim #6871
/claim #6872
/claim #6873
/claim #6879
/claim #6880
/claim #6881
/claim #6882
/claim #6883
/claim #6889
/claim #6890
/claim #6891
/claim #6892
/claim #6893
/claim #6954
/claim #6955
/claim #6956
/claim #6957
/claim #6958
/claim #6969
/claim #6970
/claim #6971
/claim #6972
/claim #6973
/claim #6979
/claim #6980
/claim #6981
/claim #6982
/claim #6983
/claim #7182
/claim #7183
/claim #7184
/claim #7185
/claim #7186
/claim #7192
/claim #7193
/claim #7194
/claim #7195
/claim #7196
/claim #7202
/claim #7203
/claim #7204
/claim #7205
/claim #7206
/claim #7212
/claim #7213
/claim #7214
/claim #7215
/claim #7216
/claim #7222
/claim #7223
/claim #7224
/claim #7225
/claim #7226
/claim #7247
/claim #7248
/claim #7249
/claim #7250
/claim #7251
/claim #7258
/claim #7259
/claim #7260
/claim #7261
/claim #7262
/claim #7272
/claim #7273
/claim #7274
/claim #7275
/claim #7276
/claim #7283
/claim #7284
/claim #7285
/claim #7286
/claim #7287
/claim #7294
/claim #7295
/claim #7296
/claim #7297
/claim #7298
/claim #7546
/claim #7547
/claim #7548
/claim #7549
/claim #7550
/claim #7619
/claim #7620
/claim #7621
/claim #7622
/claim #7623
/claim #7666
/claim #7667
/claim #7668
