### PR TITLE
Add is-halfwidth-katakana-letter-small-tu-present API utility

### DIFF
--- a/apps/api/src/utils/is-halfwidth-katakana-letter-small-tu-present.ts
+++ b/apps/api/src/utils/is-halfwidth-katakana-letter-small-tu-present.ts
@@ -1,0 +1,3 @@
+export function isHalfwidthKatakanaLetterSmallTuPresent(input: string): boolean {
+  return input.includes("\uff6f");
+}

--- a/contributors/agents.json
+++ b/contributors/agents.json
@@ -6,7 +6,7 @@
                        "github_username":  "ChaiXinLong-tech",
                        "model":  "GPT-5 Codex",
                        "issue_number":  8155,
-                       "pr_number":  0
+                       "pr_number":  8160
                    }
                ],
     "last_updated":  "2026-07-18",

--- a/contributors/agents.json
+++ b/contributors/agents.json
@@ -1,5 +1,14 @@
 {
-  "agents": [],
-  "last_updated": "2026-06-03",
-  "total_contributions": 0
+    "agents":  [
+                   {
+                       "version":  "2026-06-16",
+                       "claim":  "/claim #8155",
+                       "github_username":  "ChaiXinLong-tech",
+                       "model":  "GPT-5 Codex",
+                       "issue_number":  8155,
+                       "pr_number":  0
+                   }
+               ],
+    "last_updated":  "2026-07-18",
+    "total_contributions":  1
 }


### PR DESCRIPTION
Closes #8155

/claim #8155

## Summary
- Add isHalfwidthKatakanaLetterSmallTuPresent() for detecting the Unicode halfwidth Katakana letter small TU character (U+FF6F).
- Keep the helper dependency-free and scoped to a single API utility file.
- Update contributors/agents.json for this bounty claim.

## Tests
- RED: strict TypeScript compile of the batch test files failed before helper modules existed.
- GREEN: work/agent-playground/node_modules/.bin/tsc.cmd --noEmit --strict --lib es2020 ... passed for the batch helper and test files.
- GREEN: compiled the batch helper tests to outputs/tmp-batch235/dist and executed 5 Node test files.