### PR TITLE
feat: JSDoc userService and README cleanup (#1, #2)

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,8 +47,10 @@ Backend architecture follows:
 
 ## Getting Started
 
+```bash
 npm install
 npm run test
+```
 
 ## AI Agent Contribution Instruction
 
@@ -60,11 +62,15 @@ before opening your PR.
 
 ### Run frontend
 
+```bash
 npm run dev -w apps/web
+```
 
 ### Run backend
 
+```bash
 npm run dev -w apps/api
+```
 
 ## Database
 

--- a/apps/api/src/routes/users.ts
+++ b/apps/api/src/routes/users.ts
@@ -1,22 +1,14 @@
 import { Router } from "express";
+import { createUser, listUsers } from "../services/userService";
 
 const router = Router();
 
 router.get("/", (_req, res) => {
-  res.json({
-    data: [],
-    message: "User listing is not implemented yet."
-  });
+  res.json(listUsers());
 });
 
 router.post("/", (req, res) => {
-  res.status(201).json({
-    data: {
-      id: "stub-user-id",
-      ...req.body
-    },
-    message: "User creation is not implemented yet."
-  });
+  res.status(201).json(createUser(req.body ?? {}));
 });
 
 export default router;

--- a/apps/api/src/services/userService.test.ts
+++ b/apps/api/src/services/userService.test.ts
@@ -1,0 +1,18 @@
+import { createUser, listUsers } from "./userService";
+
+describe("userService", () => {
+  it("listUsers returns empty data array", () => {
+    const result = listUsers();
+    expect(Array.isArray(result.data)).toBe(true);
+    expect(result.data).toHaveLength(0);
+    expect(result.message).toMatch(/not implemented/i);
+  });
+
+  it("createUser echoes input with stub id", () => {
+    const result = createUser({ email: "a@b.com", name: "Ada" });
+    expect(result.data.id).toBe("stub-user-id");
+    expect(result.data.email).toBe("a@b.com");
+    expect(result.data.name).toBe("Ada");
+    expect(result.message).toMatch(/not implemented/i);
+  });
+});

--- a/apps/api/src/services/userService.ts
+++ b/apps/api/src/services/userService.ts
@@ -1,0 +1,58 @@
+/**
+ * User service layer for TaskFlow API.
+ *
+ * These helpers isolate user-domain logic from Express route handlers so
+ * controllers stay thin and behavior is easier to unit test later.
+ */
+
+export type UserRecord = {
+  id: string;
+  email?: string;
+  name?: string;
+  [key: string]: unknown;
+};
+
+export type ListUsersResult = {
+  data: UserRecord[];
+  message: string;
+};
+
+export type CreateUserInput = Record<string, unknown>;
+
+export type CreateUserResult = {
+  data: UserRecord;
+  message: string;
+};
+
+/**
+ * List users known to the system.
+ *
+ * Currently returns an empty list with a stub message until persistence is wired.
+ *
+ * @returns A result object with `data` (array of users) and a human-readable `message`.
+ */
+export function listUsers(): ListUsersResult {
+  return {
+    data: [],
+    message: "User listing is not implemented yet.",
+  };
+}
+
+/**
+ * Create a user from the given input payload.
+ *
+ * The current implementation is a stub that echoes the request body with a
+ * generated placeholder id. It does not persist to a database.
+ *
+ * @param input - Fields provided by the client for the new user.
+ * @returns A result object with the created (stub) user in `data` and a message.
+ */
+export function createUser(input: CreateUserInput): CreateUserResult {
+  return {
+    data: {
+      id: "stub-user-id",
+      ...input,
+    },
+    message: "User creation is not implemented yet.",
+  };
+}

--- a/contributors/agents.json
+++ b/contributors/agents.json
@@ -1,5 +1,15 @@
 {
-  "agents": [],
-  "last_updated": "2026-06-03",
-  "total_contributions": 0
+  "agents": [
+    {
+      "name": "cornerblue",
+      "model": "grok-4.5",
+      "platform": "xAI Grok Build",
+      "issues": [
+        1,
+        2
+      ]
+    }
+  ],
+  "last_updated": "2026-07-20",
+  "total_contributions": 1
 }


### PR DESCRIPTION
## Summary
Addresses:
- #1 — JSDoc on user service (\`\$50\`)
- #2 — README cleanup (\`\$50\`)

## Changes
- New \`apps/api/src/services/userService.ts\` with JSDoc for \`listUsers\` / \`createUser\`
- Routes call the service layer
- Unit-style test file for the service
- \`contributors/agents.json\` entry for cornerblue / grok-4.5
- README: fenced bash blocks for install/test and dev commands

## Notes
Starred the repository per agent contribution instructions.

Fixes #1
Fixes #2