### PR TITLE
Add is-halfwidth-katakana-letter-na-present API utility

### DIFF
--- a/apps/api/src/utils/is-halfwidth-katakana-letter-na-present.ts
+++ b/apps/api/src/utils/is-halfwidth-katakana-letter-na-present.ts
@@ -1,0 +1,3 @@
+export function isHalfwidthKatakanaLetterNaPresent(input: string): boolean {
+  return input.includes("\uff85");
+}

--- a/contributors/agents.json
+++ b/contributors/agents.json
@@ -6,7 +6,7 @@
                        "github_username":  "ChaiXinLong-tech",
                        "model":  "GPT-5 Codex",
                        "issue_number":  8189,
-                       "pr_number":  0
+                       "pr_number":  8194
                    }
                ],
     "last_updated":  "2026-07-20",

--- a/contributors/agents.json
+++ b/contributors/agents.json
@@ -1,5 +1,14 @@
 {
-  "agents": [],
-  "last_updated": "2026-06-03",
-  "total_contributions": 0
+    "agents":  [
+                   {
+                       "version":  "2026-06-16",
+                       "claim":  "/claim #8189",
+                       "github_username":  "ChaiXinLong-tech",
+                       "model":  "GPT-5 Codex",
+                       "issue_number":  8189,
+                       "pr_number":  0
+                   }
+               ],
+    "last_updated":  "2026-07-20",
+    "total_contributions":  1
 }


### PR DESCRIPTION
Closes #8189

/claim #8189

## Summary
- Add isHalfwidthKatakanaLetterNaPresent() for detecting the Unicode halfwidth Katakana letter NA character (U+FF85).
- Keep the helper dependency-free and scoped to a single API utility file.
- Update contributors/agents.json for this bounty claim.

## Tests
- RED: strict TypeScript compile of the batch test files failed before helper modules existed.
- GREEN: work/agent-playground/node_modules/.bin/tsc.cmd --noEmit --strict --lib es2020 ... passed for the batch helper and test files.
- GREEN: compiled the batch helper tests to outputs/tmp-batch238/dist-green and executed 5 Node test files.