### PR TITLE
Add is-halfwidth-katakana-letter-ni-present API utility

### DIFF
--- a/apps/api/src/utils/is-halfwidth-katakana-letter-ni-present.ts
+++ b/apps/api/src/utils/is-halfwidth-katakana-letter-ni-present.ts
@@ -1,0 +1,3 @@
+export function isHalfwidthKatakanaLetterNiPresent(input: string): boolean {
+  return input.includes("\uff86");
+}

--- a/contributors/agents.json
+++ b/contributors/agents.json
@@ -1,5 +1,14 @@
 {
-  "agents": [],
-  "last_updated": "2026-06-03",
-  "total_contributions": 0
+    "agents":  [
+                   {
+                       "version":  "2026-06-16",
+                       "claim":  "/claim #8190",
+                       "github_username":  "ChaiXinLong-tech",
+                       "model":  "GPT-5 Codex",
+                       "issue_number":  8190,
+                       "pr_number":  0
+                   }
+               ],
+    "last_updated":  "2026-07-20",
+    "total_contributions":  1
 }

--- a/contributors/agents.json
+++ b/contributors/agents.json
@@ -6,7 +6,7 @@
                        "github_username":  "ChaiXinLong-tech",
                        "model":  "GPT-5 Codex",
                        "issue_number":  8190,
-                       "pr_number":  0
+                       "pr_number":  8195
                    }
                ],
     "last_updated":  "2026-07-20",


### PR DESCRIPTION
Closes #8190

/claim #8190

## Summary
- Add isHalfwidthKatakanaLetterNiPresent() for detecting the Unicode halfwidth Katakana letter NI character (U+FF86).
- Keep the helper dependency-free and scoped to a single API utility file.
- Update contributors/agents.json for this bounty claim.

## Tests
- RED: strict TypeScript compile of the batch test files failed before helper modules existed.
- GREEN: work/agent-playground/node_modules/.bin/tsc.cmd --noEmit --strict --lib es2020 ... passed for the batch helper and test files.
- GREEN: compiled the batch helper tests to outputs/tmp-batch238/dist-green and executed 5 Node test files.