### PR TITLE
[agent] Add is-halfwidth-katakana-letter-hu-present API utility

### DIFF
--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -7,7 +7,7 @@
   "main": "src/index.ts",
   "scripts": {
     "dev": "tsx src/index.ts",
-    "test": "echo \"No API tests configured yet\"",
+    "test": "tsx src/utils/is-halfwidth-katakana-letter-hu-present.test.ts",
     "lint": "echo \"No API lint configured yet\""
   },
   "dependencies": {

--- a/apps/api/src/utils/is-halfwidth-katakana-letter-hu-present.test.ts
+++ b/apps/api/src/utils/is-halfwidth-katakana-letter-hu-present.test.ts
@@ -1,0 +1,10 @@
+import assert from "node:assert/strict";
+
+import { isHalfwidthKatakanaLetterHuPresent } from "./is-halfwidth-katakana-letter-hu-present";
+
+assert.equal(isHalfwidthKatakanaLetterHuPresent("prefix \uFF8C suffix"), true);
+assert.equal(isHalfwidthKatakanaLetterHuPresent("\uFF8C"), true);
+assert.equal(isHalfwidthKatakanaLetterHuPresent(""), false);
+assert.equal(isHalfwidthKatakanaLetterHuPresent("prefix suffix"), false);
+assert.equal(isHalfwidthKatakanaLetterHuPresent("\uFF8B"), false);
+assert.equal(isHalfwidthKatakanaLetterHuPresent("\u30D5"), false);

--- a/apps/api/src/utils/is-halfwidth-katakana-letter-hu-present.ts
+++ b/apps/api/src/utils/is-halfwidth-katakana-letter-hu-present.ts
@@ -1,0 +1,5 @@
+const HALFWIDTH_KATAKANA_LETTER_HU = "\uFF8C";
+
+export function isHalfwidthKatakanaLetterHuPresent(input: string): boolean {
+  return input.includes(HALFWIDTH_KATAKANA_LETTER_HU);
+}

--- a/contributors/agents.json
+++ b/contributors/agents.json
@@ -1,5 +1,13 @@
 {
-  "agents": [],
-  "last_updated": "2026-06-03",
-  "total_contributions": 0
+  "agents": [
+    {
+      "github_username": "HCDD1",
+      "model": "Codex / GPT-5",
+      "version": "2026-07-21",
+      "pr_number": 8205,
+      "issue_number": 8201
+    }
+  ],
+  "last_updated": "2026-07-21",
+  "total_contributions": 1
 }


### PR DESCRIPTION
## What changed
- Added `isHalfwidthKatakanaLetterHuPresent(input: string): boolean` for detecting U+FF8C halfwidth Katakana letter HU.
- Added a focused TypeScript smoke test covering positive, negative, empty-string, and nearby Unicode character cases.
- Wired the API workspace test script to run the new smoke test.

## Testing
- `npm test -w apps/api`
- `npm test`

Fixes #8201
/claim #8201