### PR TITLE
[agent] Add is-halfwidth-katakana-letter-hi-present API utility

### DIFF
--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -7,7 +7,7 @@
   "main": "src/index.ts",
   "scripts": {
     "dev": "tsx src/index.ts",
-    "test": "echo \"No API tests configured yet\"",
+    "test": "tsx src/utils/is-halfwidth-katakana-letter-hi-present.test.ts",
     "lint": "echo \"No API lint configured yet\""
   },
   "dependencies": {

--- a/apps/api/src/utils/is-halfwidth-katakana-letter-hi-present.test.ts
+++ b/apps/api/src/utils/is-halfwidth-katakana-letter-hi-present.test.ts
@@ -1,0 +1,10 @@
+import assert from "node:assert/strict";
+
+import { isHalfwidthKatakanaLetterHiPresent } from "./is-halfwidth-katakana-letter-hi-present";
+
+assert.equal(isHalfwidthKatakanaLetterHiPresent("prefix \uFF8B suffix"), true);
+assert.equal(isHalfwidthKatakanaLetterHiPresent("\uFF8B"), true);
+assert.equal(isHalfwidthKatakanaLetterHiPresent(""), false);
+assert.equal(isHalfwidthKatakanaLetterHiPresent("prefix suffix"), false);
+assert.equal(isHalfwidthKatakanaLetterHiPresent("\uFF8A"), false);
+assert.equal(isHalfwidthKatakanaLetterHiPresent("\u30D2"), false);

--- a/apps/api/src/utils/is-halfwidth-katakana-letter-hi-present.ts
+++ b/apps/api/src/utils/is-halfwidth-katakana-letter-hi-present.ts
@@ -1,0 +1,5 @@
+const HALFWIDTH_KATAKANA_LETTER_HI = "\uFF8B";
+
+export function isHalfwidthKatakanaLetterHiPresent(input: string): boolean {
+  return input.includes(HALFWIDTH_KATAKANA_LETTER_HI);
+}

--- a/contributors/agents.json
+++ b/contributors/agents.json
@@ -1,5 +1,13 @@
 {
-  "agents": [],
-  "last_updated": "2026-06-03",
-  "total_contributions": 0
+  "agents": [
+    {
+      "github_username": "HCDD1",
+      "model": "Codex / GPT-5",
+      "version": "2026-07-21",
+      "pr_number": 8206,
+      "issue_number": 8200
+    }
+  ],
+  "last_updated": "2026-07-21",
+  "total_contributions": 1
 }


### PR DESCRIPTION
## What changed
- Added `isHalfwidthKatakanaLetterHiPresent(input: string): boolean` for detecting U+FF8B halfwidth Katakana letter HI.
- Added a focused TypeScript smoke test covering positive, negative, empty-string, and nearby Unicode character cases.
- Wired the API workspace test script to run the new smoke test.

## Testing
- `npm test -w apps/api`
- `npm test`

Fixes #8200
/claim #8200