### PR TITLE
Add is-hangul-jamo-tikeut-kiyeok-present API utility

### DIFF
--- a/apps/api/src/utils/is-hangul-jamo-tikeut-kiyeok-present.ts
+++ b/apps/api/src/utils/is-hangul-jamo-tikeut-kiyeok-present.ts
@@ -1,0 +1,3 @@
+export function isHangulJamoTikeutKiyeokPresent(input: string): boolean {
+  return input.includes("\u1117");
+}

--- a/contributors/agents.json
+++ b/contributors/agents.json
@@ -1,5 +1,14 @@
 {
-  "agents": [],
-  "last_updated": "2026-06-03",
-  "total_contributions": 0
+    "agents":  [
+                   {
+                       "version":  "2026-06-16",
+                       "claim":  "/claim #8284",
+                       "github_username":  "ChaiXinLong-tech",
+                       "model":  "GPT-5 Codex",
+                       "issue_number":  8284,
+                       "pr_number":  0
+                   }
+               ],
+    "last_updated":  "2026-07-22",
+    "total_contributions":  1
 }

--- a/contributors/agents.json
+++ b/contributors/agents.json
@@ -6,7 +6,7 @@
                        "github_username":  "ChaiXinLong-tech",
                        "model":  "GPT-5 Codex",
                        "issue_number":  8284,
-                       "pr_number":  0
+                       "pr_number":  8289
                    }
                ],
     "last_updated":  "2026-07-22",


### PR DESCRIPTION
Closes #8284

/claim #8284

## Summary
- Add isHangulJamoTikeutKiyeokPresent() for detecting the Unicode Hangul choseong tikeut-kiyeok character (U+1117).
- Keep the helper dependency-free and scoped to a single API utility file.
- Update contributors/agents.json for this bounty claim.

## Tests
- RED: strict TypeScript compile of the batch test files failed before helper modules existed.
- GREEN: work/agent-playground/node_modules/.bin/tsc.cmd --noEmit --strict --lib es2020 ... passed for the batch helper and test files.
- GREEN: compiled the batch helper tests to outputs/tmp-batch247/dist-green-run and executed 5 Node test files.