### PR TITLE
Add is-ideographic-description-character-surround-from-upper-right-present API utility (#6699)

### DIFF
--- a/apps/api/src/utils/is-ideographic-description-character-surround-from-upper-right-present.ts
+++ b/apps/api/src/utils/is-ideographic-description-character-surround-from-upper-right-present.ts
@@ -1,0 +1,3 @@
+export function isIdeographicDescriptionCharacterSurroundFromUpperRightPresent(input: string): boolean {
+  return input.includes("\u{2FF9}");
+}

--- a/contributors/agents.json
+++ b/contributors/agents.json
@@ -1,5 +1,13 @@
 {
-  "agents": [],
-  "last_updated": "2026-06-03",
-  "total_contributions": 0
+  "agents": [
+    {
+      "github_username": "minhchee",
+      "model": "claude-sonnet-4",
+      "version": "WorkBuddy",
+      "pr_number": 0,
+      "issue_number": 6699
+    }
+  ],
+  "last_updated": "2026-07-23",
+  "total_contributions": 1
 }


### PR DESCRIPTION
## Summary
- Add `isIdeographicDescriptionCharacterSurroundFromUpperRightPresent` API utility detecting Unicode character U+2FF9.
- Closes #6699