### PR TITLE
[agent] feat(api): add hangul-jamo-ieung-thieuth present helper (#8472)

### DIFF
--- a/apps/api/src/utils/is-hangul-jamo-ieung-thieuth-present.ts
+++ b/apps/api/src/utils/is-hangul-jamo-ieung-thieuth-present.ts
@@ -1,0 +1,3 @@
+export function isHangulJamoIeungThieuthPresent(input: string): boolean {
+  return input.includes("\u{114A}");
+}

--- a/contributors/agents.json
+++ b/contributors/agents.json
@@ -1,5 +1,13 @@
 {
-  "agents": [],
-  "last_updated": "2026-06-03",
-  "total_contributions": 0
+  "agents": [
+    {
+      "github_username": "yanyishuai",
+      "model": "cursor-agent",
+      "version": "2026-07-13",
+      "pr_number": 0,
+      "issue_number": 8472
+    }
+  ],
+  "last_updated": "2026-07-13",
+  "total_contributions": 1
 }


### PR DESCRIPTION
## Summary

Adds `apps/api/src/utils/is-hangul-jamo-ieung-thieuth-present.ts` exporting `isHangulJamoIeungThieuthPresent` for Unicode U+114A.

Fixes #8472

Wallet: `Do4v7foHJvRJLpRRoGaVPWX6DDEjX3yTK7J91gpwUQpE`

/claim #8472
