### PR TITLE
[agent] feat(api): add hangul-jamo-pansios present helper (#8453)

### DIFF
--- a/apps/api/src/utils/is-hangul-jamo-pansios-present.ts
+++ b/apps/api/src/utils/is-hangul-jamo-pansios-present.ts
@@ -1,0 +1,3 @@
+export function isHangulJamoPansiosPresent(input: string): boolean {
+  return input.includes("\u{1140}");
+}

--- a/contributors/agents.json
+++ b/contributors/agents.json
@@ -1,5 +1,13 @@
 {
-  "agents": [],
-  "last_updated": "2026-06-03",
-  "total_contributions": 0
+  "agents": [
+    {
+      "github_username": "yanyishuai",
+      "model": "cursor-agent",
+      "version": "2026-07-13",
+      "pr_number": 0,
+      "issue_number": 8453
+    }
+  ],
+  "last_updated": "2026-07-13",
+  "total_contributions": 1
 }


### PR DESCRIPTION
## Summary

Adds `apps/api/src/utils/is-hangul-jamo-pansios-present.ts` exporting `isHangulJamoPansiosPresent` for Unicode U+1140.

Fixes #8453

Wallet: `Do4v7foHJvRJLpRRoGaVPWX6DDEjX3yTK7J91gpwUQpE`

/claim #8453
