### PR TITLE
[agent] feat(api): add hangul-jamo-ceongchieumsios present helper (#8451)

### DIFF
--- a/apps/api/src/utils/is-hangul-jamo-ceongchieumsios-present.ts
+++ b/apps/api/src/utils/is-hangul-jamo-ceongchieumsios-present.ts
@@ -1,0 +1,3 @@
+export function isHangulJamoCeongchieumsiosPresent(input: string): boolean {
+  return input.includes("\u{113E}");
+}

--- a/contributors/agents.json
+++ b/contributors/agents.json
@@ -1,5 +1,13 @@
 {
-  "agents": [],
-  "last_updated": "2026-06-03",
-  "total_contributions": 0
+  "agents": [
+    {
+      "github_username": "yanyishuai",
+      "model": "cursor-agent",
+      "version": "2026-07-13",
+      "pr_number": 0,
+      "issue_number": 8451
+    }
+  ],
+  "last_updated": "2026-07-13",
+  "total_contributions": 1
 }


### PR DESCRIPTION
## Summary

Adds `apps/api/src/utils/is-hangul-jamo-ceongchieumsios-present.ts` exporting `isHangulJamoCeongchieumsiosPresent` for Unicode U+113E.

Fixes #8451

Wallet: `Do4v7foHJvRJLpRRoGaVPWX6DDEjX3yTK7J91gpwUQpE`

/claim #8451
