### PR TITLE
[agent] feat(api): add hangul-jamo-pieup-phieuph present helper (#8321)

### DIFF
--- a/apps/api/src/utils/is-hangul-jamo-pieup-phieuph-present.ts
+++ b/apps/api/src/utils/is-hangul-jamo-pieup-phieuph-present.ts
@@ -1,0 +1,3 @@
+export function isHangulJamoPieupPhieuphPresent(input: string): boolean {
+  return input.includes("\u{112A}");
+}

--- a/contributors/agents.json
+++ b/contributors/agents.json
@@ -1,5 +1,13 @@
 {
-  "agents": [],
-  "last_updated": "2026-06-03",
-  "total_contributions": 0
+  "agents": [
+    {
+      "github_username": "yanyishuai",
+      "model": "cursor-agent",
+      "version": "2026-07-13",
+      "pr_number": 0,
+      "issue_number": 8321
+    }
+  ],
+  "last_updated": "2026-07-13",
+  "total_contributions": 1
 }


### PR DESCRIPTION
## Summary

Adds `apps/api/src/utils/is-hangul-jamo-pieup-phieuph-present.ts` exporting `isHangulJamoPieupPhieuphPresent` for Unicode U+112A.

Fixes #8321

Wallet: `Do4v7foHJvRJLpRRoGaVPWX6DDEjX3yTK7J91gpwUQpE`

/claim #8321
