### PR TITLE
[agent] feat(api): add hangul-jamo-pieup-sios present helper (#8303)

### DIFF
--- a/apps/api/src/utils/is-hangul-jamo-pieup-sios-present.ts
+++ b/apps/api/src/utils/is-hangul-jamo-pieup-sios-present.ts
@@ -1,0 +1,3 @@
+export function isHangulJamoPieupSiosPresent(input: string): boolean {
+  return input.includes("\u{1121}");
+}

--- a/contributors/agents.json
+++ b/contributors/agents.json
@@ -1,5 +1,13 @@
 {
-  "agents": [],
-  "last_updated": "2026-06-03",
-  "total_contributions": 0
+  "agents": [
+    {
+      "github_username": "yanyishuai",
+      "model": "cursor-agent",
+      "version": "2026-07-13",
+      "pr_number": 0,
+      "issue_number": 8303
+    }
+  ],
+  "last_updated": "2026-07-13",
+  "total_contributions": 1
 }


### PR DESCRIPTION
## Summary

Adds `apps/api/src/utils/is-hangul-jamo-pieup-sios-present.ts` exporting `isHangulJamoPieupSiosPresent` for Unicode U+1121.

Fixes #8303

Wallet: `Do4v7foHJvRJLpRRoGaVPWX6DDEjX3yTK7J91gpwUQpE`

/claim #8303
