### PR TITLE
[agent] feat(api): add hangul-jamo-ssangrieul present helper (#8291)

### DIFF
--- a/apps/api/src/utils/is-hangul-jamo-ssangrieul-present.ts
+++ b/apps/api/src/utils/is-hangul-jamo-ssangrieul-present.ts
@@ -1,0 +1,3 @@
+export function isHangulJamoSsangrieulPresent(input: string): boolean {
+  return input.includes("\u{1119}");
+}

--- a/contributors/agents.json
+++ b/contributors/agents.json
@@ -1,5 +1,13 @@
 {
-  "agents": [],
-  "last_updated": "2026-06-03",
-  "total_contributions": 0
+  "agents": [
+    {
+      "github_username": "yanyishuai",
+      "model": "cursor-agent",
+      "version": "2026-07-13",
+      "pr_number": 0,
+      "issue_number": 8291
+    }
+  ],
+  "last_updated": "2026-07-13",
+  "total_contributions": 1
 }


### PR DESCRIPTION
## Summary

Adds `apps/api/src/utils/is-hangul-jamo-ssangrieul-present.ts` exporting `isHangulJamoSsangrieulPresent` for Unicode U+1119.

Fixes #8291

Wallet: `Do4v7foHJvRJLpRRoGaVPWX6DDEjX3yTK7J91gpwUQpE`

/claim #8291
