### PR TITLE
[agent] feat(api): add hangul-jamo-hieuh present helper (#8274)

### DIFF
--- a/apps/api/src/utils/is-hangul-jamo-hieuh-present.ts
+++ b/apps/api/src/utils/is-hangul-jamo-hieuh-present.ts
@@ -1,0 +1,3 @@
+export function isHangulJamoHieuhPresent(input: string): boolean {
+  return input.includes("\u{1112}");
+}

--- a/contributors/agents.json
+++ b/contributors/agents.json
@@ -1,5 +1,13 @@
 {
-  "agents": [],
-  "last_updated": "2026-06-03",
-  "total_contributions": 0
+  "agents": [
+    {
+      "github_username": "yanyishuai",
+      "model": "cursor-agent",
+      "version": "2026-07-13",
+      "pr_number": 0,
+      "issue_number": 8274
+    }
+  ],
+  "last_updated": "2026-07-13",
+  "total_contributions": 1
 }


### PR DESCRIPTION
## Summary

Adds `apps/api/src/utils/is-hangul-jamo-hieuh-present.ts` exporting `isHangulJamoHieuhPresent` for Unicode U+1112.

Fixes #8274

Wallet: `Do4v7foHJvRJLpRRoGaVPWX6DDEjX3yTK7J91gpwUQpE`

/claim #8274
