### PR TITLE
[agent] feat(api): add hangul-jamo-ssangpieup present helper (#8254)

### DIFF
--- a/apps/api/src/utils/is-hangul-jamo-ssangpieup-present.ts
+++ b/apps/api/src/utils/is-hangul-jamo-ssangpieup-present.ts
@@ -1,0 +1,3 @@
+export function isHangulJamoSsangpieupPresent(input: string): boolean {
+  return input.includes("\u{1108}");
+}

--- a/contributors/agents.json
+++ b/contributors/agents.json
@@ -1,5 +1,13 @@
 {
-  "agents": [],
-  "last_updated": "2026-06-03",
-  "total_contributions": 0
+  "agents": [
+    {
+      "github_username": "yanyishuai",
+      "model": "cursor-agent",
+      "version": "2026-07-13",
+      "pr_number": 0,
+      "issue_number": 8254
+    }
+  ],
+  "last_updated": "2026-07-13",
+  "total_contributions": 1
 }


### PR DESCRIPTION
## Summary

Adds `apps/api/src/utils/is-hangul-jamo-ssangpieup-present.ts` exporting `isHangulJamoSsangpieupPresent` for Unicode U+1108.

Fixes #8254

Wallet: `Do4v7foHJvRJLpRRoGaVPWX6DDEjX3yTK7J91gpwUQpE`

/claim #8254
