### PR TITLE
[agent] feat(api): add hangul-jamo-ssangtikeut present helper (#8250)

### DIFF
--- a/apps/api/src/utils/is-hangul-jamo-ssangtikeut-present.ts
+++ b/apps/api/src/utils/is-hangul-jamo-ssangtikeut-present.ts
@@ -1,0 +1,3 @@
+export function isHangulJamoSsangtikeutPresent(input: string): boolean {
+  return input.includes("\u{1104}");
+}

--- a/contributors/agents.json
+++ b/contributors/agents.json
@@ -1,5 +1,13 @@
 {
-  "agents": [],
-  "last_updated": "2026-06-03",
-  "total_contributions": 0
+  "agents": [
+    {
+      "github_username": "yanyishuai",
+      "model": "cursor-agent",
+      "version": "2026-07-13",
+      "pr_number": 0,
+      "issue_number": 8250
+    }
+  ],
+  "last_updated": "2026-07-13",
+  "total_contributions": 1
 }


### PR DESCRIPTION
## Summary

Adds `apps/api/src/utils/is-hangul-jamo-ssangtikeut-present.ts` exporting `isHangulJamoSsangtikeutPresent` for Unicode U+1104.

Fixes #8250

Wallet: `Do4v7foHJvRJLpRRoGaVPWX6DDEjX3yTK7J91gpwUQpE`

/claim #8250
