### PR TITLE
[agent] feat(api): add halfwidth-katakana-voiced-sound-mark present helper (#8234)

### DIFF
--- a/apps/api/src/utils/is-halfwidth-katakana-voiced-sound-mark-present.ts
+++ b/apps/api/src/utils/is-halfwidth-katakana-voiced-sound-mark-present.ts
@@ -1,0 +1,3 @@
+export function isHalfwidthKatakanaVoicedSoundMarkPresent(input: string): boolean {
+  return input.includes("\u{FF9E}");
+}

--- a/contributors/agents.json
+++ b/contributors/agents.json
@@ -1,5 +1,13 @@
 {
-  "agents": [],
-  "last_updated": "2026-06-03",
-  "total_contributions": 0
+  "agents": [
+    {
+      "github_username": "yanyishuai",
+      "model": "cursor-agent",
+      "version": "2026-07-13",
+      "pr_number": 0,
+      "issue_number": 8234
+    }
+  ],
+  "last_updated": "2026-07-13",
+  "total_contributions": 1
 }


### PR DESCRIPTION
## Summary

Adds `apps/api/src/utils/is-halfwidth-katakana-voiced-sound-mark-present.ts` exporting `isHalfwidthKatakanaVoicedSoundMarkPresent` for Unicode U+FF9E.

Fixes #8234

Wallet: `Do4v7foHJvRJLpRRoGaVPWX6DDEjX3yTK7J91gpwUQpE`

/claim #8234
