### PR TITLE
[agent] feat(api): add halfwidth-katakana-letter-wa present helper (#8232)

### DIFF
--- a/apps/api/src/utils/is-halfwidth-katakana-letter-wa-present.ts
+++ b/apps/api/src/utils/is-halfwidth-katakana-letter-wa-present.ts
@@ -1,0 +1,3 @@
+export function isHalfwidthKatakanaLetterWaPresent(input: string): boolean {
+  return input.includes("\u{FF9C}");
+}

--- a/contributors/agents.json
+++ b/contributors/agents.json
@@ -1,5 +1,13 @@
 {
-  "agents": [],
-  "last_updated": "2026-06-03",
-  "total_contributions": 0
+  "agents": [
+    {
+      "github_username": "yanyishuai",
+      "model": "cursor-agent",
+      "version": "2026-07-13",
+      "pr_number": 0,
+      "issue_number": 8232
+    }
+  ],
+  "last_updated": "2026-07-13",
+  "total_contributions": 1
 }


### PR DESCRIPTION
## Summary

Adds `apps/api/src/utils/is-halfwidth-katakana-letter-wa-present.ts` exporting `isHalfwidthKatakanaLetterWaPresent` for Unicode U+FF9C.

Fixes #8232

Wallet: `Do4v7foHJvRJLpRRoGaVPWX6DDEjX3yTK7J91gpwUQpE`

/claim #8232
