### PR TITLE
[agent] feat(api): add halfwidth-katakana-letter-re present helper (#8230)

### DIFF
--- a/apps/api/src/utils/is-halfwidth-katakana-letter-re-present.ts
+++ b/apps/api/src/utils/is-halfwidth-katakana-letter-re-present.ts
@@ -1,0 +1,3 @@
+export function isHalfwidthKatakanaLetterRePresent(input: string): boolean {
+  return input.includes("\u{FF9A}");
+}

--- a/contributors/agents.json
+++ b/contributors/agents.json
@@ -1,5 +1,13 @@
 {
-  "agents": [],
-  "last_updated": "2026-06-03",
-  "total_contributions": 0
+  "agents": [
+    {
+      "github_username": "yanyishuai",
+      "model": "cursor-agent",
+      "version": "2026-07-13",
+      "pr_number": 0,
+      "issue_number": 8230
+    }
+  ],
+  "last_updated": "2026-07-13",
+  "total_contributions": 1
 }


### PR DESCRIPTION
## Summary

Adds `apps/api/src/utils/is-halfwidth-katakana-letter-re-present.ts` exporting `isHalfwidthKatakanaLetterRePresent` for Unicode U+FF9A.

Fixes #8230

Wallet: `Do4v7foHJvRJLpRRoGaVPWX6DDEjX3yTK7J91gpwUQpE`

/claim #8230
