### PR TITLE
[agent] feat(api): add halfwidth-katakana-letter-mi present helper (#8213)

### DIFF
--- a/apps/api/src/utils/is-halfwidth-katakana-letter-mi-present.ts
+++ b/apps/api/src/utils/is-halfwidth-katakana-letter-mi-present.ts
@@ -1,0 +1,3 @@
+export function isHalfwidthKatakanaLetterMiPresent(input: string): boolean {
+  return input.includes("\u{FF90}");
+}

--- a/contributors/agents.json
+++ b/contributors/agents.json
@@ -1,5 +1,13 @@
 {
-  "agents": [],
-  "last_updated": "2026-06-03",
-  "total_contributions": 0
+  "agents": [
+    {
+      "github_username": "yanyishuai",
+      "model": "cursor-agent",
+      "version": "2026-07-13",
+      "pr_number": 0,
+      "issue_number": 8213
+    }
+  ],
+  "last_updated": "2026-07-13",
+  "total_contributions": 1
 }


### PR DESCRIPTION
## Summary

Adds `apps/api/src/utils/is-halfwidth-katakana-letter-mi-present.ts` exporting `isHalfwidthKatakanaLetterMiPresent` for Unicode U+FF90.

Fixes #8213

Wallet: `Do4v7foHJvRJLpRRoGaVPWX6DDEjX3yTK7J91gpwUQpE`

/claim #8213
