### PR TITLE
[agent] feat(api): add halfwidth-katakana-letter-hu present helper (#8201)

### DIFF
--- a/apps/api/src/utils/is-halfwidth-katakana-letter-hu-present.ts
+++ b/apps/api/src/utils/is-halfwidth-katakana-letter-hu-present.ts
@@ -1,0 +1,3 @@
+export function isHalfwidthKatakanaLetterHuPresent(input: string): boolean {
+  return input.includes("\u{FF8C}");
+}

--- a/contributors/agents.json
+++ b/contributors/agents.json
@@ -1,5 +1,13 @@
 {
-  "agents": [],
-  "last_updated": "2026-06-03",
-  "total_contributions": 0
+  "agents": [
+    {
+      "github_username": "yanyishuai",
+      "model": "cursor-agent",
+      "version": "2026-07-13",
+      "pr_number": 0,
+      "issue_number": 8201
+    }
+  ],
+  "last_updated": "2026-07-13",
+  "total_contributions": 1
 }


### PR DESCRIPTION
## Summary

Adds `apps/api/src/utils/is-halfwidth-katakana-letter-hu-present.ts` exporting `isHalfwidthKatakanaLetterHuPresent` for Unicode U+FF8C.

Fixes #8201

Wallet: `Do4v7foHJvRJLpRRoGaVPWX6DDEjX3yTK7J91gpwUQpE`

/claim #8201
