### PR TITLE
[agent] feat(api): add halfwidth-katakana-letter-ti present helper (#8181)

### DIFF
--- a/apps/api/src/utils/is-halfwidth-katakana-letter-ti-present.ts
+++ b/apps/api/src/utils/is-halfwidth-katakana-letter-ti-present.ts
@@ -1,0 +1,3 @@
+export function isHalfwidthKatakanaLetterTiPresent(input: string): boolean {
+  return input.includes("\u{FF81}");
+}

--- a/contributors/agents.json
+++ b/contributors/agents.json
@@ -1,5 +1,13 @@
 {
-  "agents": [],
-  "last_updated": "2026-06-03",
-  "total_contributions": 0
+  "agents": [
+    {
+      "github_username": "yanyishuai",
+      "model": "cursor-agent",
+      "version": "2026-07-13",
+      "pr_number": 0,
+      "issue_number": 8181
+    }
+  ],
+  "last_updated": "2026-07-13",
+  "total_contributions": 1
 }


### PR DESCRIPTION
## Summary

Adds `apps/api/src/utils/is-halfwidth-katakana-letter-ti-present.ts` exporting `isHalfwidthKatakanaLetterTiPresent` for Unicode U+FF81.

Fixes #8181

Wallet: `Do4v7foHJvRJLpRRoGaVPWX6DDEjX3yTK7J91gpwUQpE`

/claim #8181
