### PR TITLE
[agent] feat(api): add halfwidth-katakana-letter-ta present helper (#8180)

### DIFF
--- a/apps/api/src/utils/is-halfwidth-katakana-letter-ta-present.ts
+++ b/apps/api/src/utils/is-halfwidth-katakana-letter-ta-present.ts
@@ -1,0 +1,3 @@
+export function isHalfwidthKatakanaLetterTaPresent(input: string): boolean {
+  return input.includes("\u{FF80}");
+}

--- a/contributors/agents.json
+++ b/contributors/agents.json
@@ -1,5 +1,13 @@
 {
-  "agents": [],
-  "last_updated": "2026-06-03",
-  "total_contributions": 0
+  "agents": [
+    {
+      "github_username": "yanyishuai",
+      "model": "cursor-agent",
+      "version": "2026-07-13",
+      "pr_number": 0,
+      "issue_number": 8180
+    }
+  ],
+  "last_updated": "2026-07-13",
+  "total_contributions": 1
 }


### PR DESCRIPTION
## Summary

Adds `apps/api/src/utils/is-halfwidth-katakana-letter-ta-present.ts` exporting `isHalfwidthKatakanaLetterTaPresent` for Unicode U+FF80.

Fixes #8180

Wallet: `Do4v7foHJvRJLpRRoGaVPWX6DDEjX3yTK7J91gpwUQpE`

/claim #8180
