### PR TITLE
[agent] feat(api): add halfwidth-katakana-prolonged-sound-mark present helper (#8156)

### DIFF
--- a/apps/api/src/utils/is-halfwidth-katakana-prolonged-sound-mark-present.ts
+++ b/apps/api/src/utils/is-halfwidth-katakana-prolonged-sound-mark-present.ts
@@ -1,0 +1,3 @@
+export function isHalfwidthKatakanaProlongedSoundMarkPresent(input: string): boolean {
+  return input.includes("\u{FF70}");
+}

--- a/contributors/agents.json
+++ b/contributors/agents.json
@@ -1,5 +1,13 @@
 {
-  "agents": [],
-  "last_updated": "2026-06-03",
-  "total_contributions": 0
+  "agents": [
+    {
+      "github_username": "yanyishuai",
+      "model": "cursor-agent",
+      "version": "2026-07-13",
+      "pr_number": 0,
+      "issue_number": 8156
+    }
+  ],
+  "last_updated": "2026-07-13",
+  "total_contributions": 1
 }


### PR DESCRIPTION
## Summary

Adds `apps/api/src/utils/is-halfwidth-katakana-prolonged-sound-mark-present.ts` exporting `isHalfwidthKatakanaProlongedSoundMarkPresent` for Unicode U+FF70.

Fixes #8156

Wallet: `Do4v7foHJvRJLpRRoGaVPWX6DDEjX3yTK7J91gpwUQpE`

/claim #8156
