### PR TITLE
[agent] feat(api): add halfwidth-katakana-letter-small-yo present helper (#8154)

### DIFF
--- a/apps/api/src/utils/is-halfwidth-katakana-letter-small-yo-present.ts
+++ b/apps/api/src/utils/is-halfwidth-katakana-letter-small-yo-present.ts
@@ -1,0 +1,3 @@
+export function isHalfwidthKatakanaLetterSmallYoPresent(input: string): boolean {
+  return input.includes("\u{FF6E}");
+}

--- a/contributors/agents.json
+++ b/contributors/agents.json
@@ -1,5 +1,13 @@
 {
-  "agents": [],
-  "last_updated": "2026-06-03",
-  "total_contributions": 0
+  "agents": [
+    {
+      "github_username": "yanyishuai",
+      "model": "cursor-agent",
+      "version": "2026-07-13",
+      "pr_number": 0,
+      "issue_number": 8154
+    }
+  ],
+  "last_updated": "2026-07-13",
+  "total_contributions": 1
 }


### PR DESCRIPTION
## Summary

Adds `apps/api/src/utils/is-halfwidth-katakana-letter-small-yo-present.ts` exporting `isHalfwidthKatakanaLetterSmallYoPresent` for Unicode U+FF6E.

Fixes #8154

Wallet: `Do4v7foHJvRJLpRRoGaVPWX6DDEjX3yTK7J91gpwUQpE`

/claim #8154
