### PR TITLE
[agent] feat(api): add halfwidth-katakana-letter-small-yu present helper (#8148)

### DIFF
--- a/apps/api/src/utils/is-halfwidth-katakana-letter-small-yu-present.ts
+++ b/apps/api/src/utils/is-halfwidth-katakana-letter-small-yu-present.ts
@@ -1,0 +1,3 @@
+export function isHalfwidthKatakanaLetterSmallYuPresent(input: string): boolean {
+  return input.includes("\u{FF6D}");
+}

--- a/contributors/agents.json
+++ b/contributors/agents.json
@@ -1,5 +1,13 @@
 {
-  "agents": [],
-  "last_updated": "2026-06-03",
-  "total_contributions": 0
+  "agents": [
+    {
+      "github_username": "yanyishuai",
+      "model": "cursor-agent",
+      "version": "2026-07-13",
+      "pr_number": 0,
+      "issue_number": 8148
+    }
+  ],
+  "last_updated": "2026-07-13",
+  "total_contributions": 1
 }


### PR DESCRIPTION
## Summary

Adds `apps/api/src/utils/is-halfwidth-katakana-letter-small-yu-present.ts` exporting `isHalfwidthKatakanaLetterSmallYuPresent` for Unicode U+FF6D.

Fixes #8148

Wallet: `Do4v7foHJvRJLpRRoGaVPWX6DDEjX3yTK7J91gpwUQpE`

/claim #8148
