### PR TITLE
Add is-hangul-jamo-choseong-filler-present API utility

### DIFF
--- a/apps/api/src/utils/is-hangul-jamo-choseong-filler-present.ts
+++ b/apps/api/src/utils/is-hangul-jamo-choseong-filler-present.ts
@@ -1,0 +1,3 @@
+export function isHangulJamoChoseongFillerPresent(input: string): boolean {
+  return input.includes("\u115f");
+}

--- a/contributors/agents.json
+++ b/contributors/agents.json
@@ -1,5 +1,14 @@
 {
-  "agents": [],
-  "last_updated": "2026-06-03",
-  "total_contributions": 0
+    "agents":  [
+                   {
+                       "version":  "2026-06-16",
+                       "claim":  "/claim #8632",
+                       "github_username":  "ChaiXinLong-tech",
+                       "model":  "GPT-5 Codex",
+                       "issue_number":  8632,
+                       "pr_number":  0
+                   }
+               ],
+    "last_updated":  "2026-07-24",
+    "total_contributions":  1
 }

--- a/contributors/agents.json
+++ b/contributors/agents.json
@@ -6,7 +6,7 @@
                        "github_username":  "ChaiXinLong-tech",
                        "model":  "GPT-5 Codex",
                        "issue_number":  8632,
-                       "pr_number":  0
+                       "pr_number":  8637
                    }
                ],
     "last_updated":  "2026-07-24",


### PR DESCRIPTION
Closes #8632

/claim #8632

## Summary
- Add isHangulJamoChoseongFillerPresent() for detecting the Unicode Hangul choseong filler character (U+115F).
- Keep the helper dependency-free and scoped to a single API utility file.
- Update contributors/agents.json for this bounty claim.

## Tests
- RED: strict TypeScript compile of the batch test files failed before helper modules existed.
- GREEN: work/agent-playground/node_modules/.bin/tsc.cmd --noEmit --strict --lib es2020 ... passed for the batch helper and test files.
- GREEN: compiled the batch helper tests to outputs/tmp-batch259/dist-green-run and executed 5 Node test files.