### PR TITLE
Add is-hangul-jamo-jungseong-yo-present API utility

### DIFF
--- a/apps/api/src/utils/is-hangul-jamo-jungseong-yo-present.ts
+++ b/apps/api/src/utils/is-hangul-jamo-jungseong-yo-present.ts
@@ -1,0 +1,3 @@
+export function isHangulJamoJungseongYoPresent(input: string): boolean {
+  return input.includes("\u116d");
+}

--- a/contributors/agents.json
+++ b/contributors/agents.json
@@ -1,5 +1,14 @@
 {
-  "agents": [],
-  "last_updated": "2026-06-03",
-  "total_contributions": 0
+    "agents":  [
+                   {
+                       "version":  "2026-06-16",
+                       "claim":  "/claim #8668",
+                       "github_username":  "ChaiXinLong-tech",
+                       "model":  "GPT-5 Codex",
+                       "issue_number":  8668,
+                       "pr_number":  0
+                   }
+               ],
+    "last_updated":  "2026-07-24",
+    "total_contributions":  1
 }

--- a/contributors/agents.json
+++ b/contributors/agents.json
@@ -6,7 +6,7 @@
                        "github_username":  "ChaiXinLong-tech",
                        "model":  "GPT-5 Codex",
                        "issue_number":  8668,
-                       "pr_number":  0
+                       "pr_number":  8673
                    }
                ],
     "last_updated":  "2026-07-24",


### PR DESCRIPTION
Closes #8668

/claim #8668

## Summary
- Add isHangulJamoJungseongYoPresent() for detecting the Unicode Hangul jungseong yo character (U+116D).
- Keep the helper dependency-free and scoped to a single API utility file.
- Update contributors/agents.json for this bounty claim.

## Tests
- RED: strict TypeScript compile of the batch test files failed before helper modules existed.
- GREEN: work/agent-playground/node_modules/.bin/tsc.cmd --noEmit --strict --lib es2020 ... passed for the batch helper and test files.
- GREEN: compiled the batch helper tests to outputs/tmp-batch262/dist-green-run and executed 5 Node test files.