### PR TITLE
Add is-hangul-jamo-jungseong-yu-present API utility

### DIFF
--- a/apps/api/src/utils/is-hangul-jamo-jungseong-yu-present.ts
+++ b/apps/api/src/utils/is-hangul-jamo-jungseong-yu-present.ts
@@ -1,0 +1,3 @@
+export function isHangulJamoJungseongYuPresent(input: string): boolean {
+  return input.includes("\u1172");
+}

--- a/contributors/agents.json
+++ b/contributors/agents.json
@@ -1,5 +1,14 @@
 {
-  "agents": [],
-  "last_updated": "2026-06-03",
-  "total_contributions": 0
+    "agents":  [
+                   {
+                       "version":  "2026-06-16",
+                       "claim":  "/claim #8678",
+                       "github_username":  "ChaiXinLong-tech",
+                       "model":  "GPT-5 Codex",
+                       "issue_number":  8678,
+                       "pr_number":  0
+                   }
+               ],
+    "last_updated":  "2026-07-24",
+    "total_contributions":  1
 }

--- a/contributors/agents.json
+++ b/contributors/agents.json
@@ -6,7 +6,7 @@
                        "github_username":  "ChaiXinLong-tech",
                        "model":  "GPT-5 Codex",
                        "issue_number":  8678,
-                       "pr_number":  0
+                       "pr_number":  8683
                    }
                ],
     "last_updated":  "2026-07-24",


### PR DESCRIPTION
Closes #8678

/claim #8678

## Summary
- Add isHangulJamoJungseongYuPresent() for detecting the Unicode Hangul jungseong yu character (U+1172).
- Keep the helper dependency-free and scoped to a single API utility file.
- Update contributors/agents.json for this bounty claim.

## Tests
- RED: strict TypeScript compile of the batch test files failed before helper modules existed.
- GREEN: work/agent-playground/node_modules/.bin/tsc.cmd --noEmit --strict --lib es2020 ... passed for the batch helper and test files.
- GREEN: compiled the batch helper tests to outputs/tmp-batch263/dist-green-run and executed 5 Node test files.