### PR TITLE
Add is-hangul-jamo-jungseong-ssangaraea-present API utility

### DIFF
--- a/apps/api/src/utils/is-hangul-jamo-jungseong-ssangaraea-present.ts
+++ b/apps/api/src/utils/is-hangul-jamo-jungseong-ssangaraea-present.ts
@@ -1,0 +1,3 @@
+export function isHangulJamoJungseongSsangaraeaPresent(input: string): boolean {
+  return input.includes("\u11A2");
+}

--- a/contributors/agents.json
+++ b/contributors/agents.json
@@ -6,7 +6,7 @@
                        "github_username":  "ChaiXinLong-tech",
                        "model":  "GPT-5 Codex",
                        "issue_number":  8728,
-                       "pr_number":  0
+                       "pr_number":  8733
                    }
                ],
     "last_updated":  "2026-07-25",

--- a/contributors/agents.json
+++ b/contributors/agents.json
@@ -1,5 +1,14 @@
 {
-  "agents": [],
-  "last_updated": "2026-06-03",
-  "total_contributions": 0
+    "agents":  [
+                   {
+                       "version":  "2026-06-16",
+                       "claim":  "/claim #8728",
+                       "github_username":  "ChaiXinLong-tech",
+                       "model":  "GPT-5 Codex",
+                       "issue_number":  8728,
+                       "pr_number":  0
+                   }
+               ],
+    "last_updated":  "2026-07-25",
+    "total_contributions":  1
 }


### PR DESCRIPTION
Closes #8728

/claim #8728

## Summary
- Add isHangulJamoJungseongSsangaraeaPresent() for detecting the Unicode Hangul jungseong ssangaraea character (U+11A2).
- Keep the helper dependency-free and scoped to a single API utility file.
- Update contributors/agents.json for this bounty claim.

## Tests
- RED: strict TypeScript compile of the batch test files failed before helper modules existed.
- GREEN: work/agent-playground/node_modules/.bin/tsc.cmd --noEmit --strict --lib es2020 ... passed for the batch helper and test files.
- GREEN: compiled the batch helper tests to outputs/tmp-batch268/dist-green-run and executed 5 Node test files.