### PR TITLE
[agent] feat(api): add Hangul jongseong ieung-ssangkiyeok helper (#8820)

### DIFF
--- a/apps/api/src/utils/is-hangul-jamo-jongseong-ieung-ssangkiyeok-present.ts
+++ b/apps/api/src/utils/is-hangul-jamo-jongseong-ieung-ssangkiyeok-present.ts
@@ -1,0 +1,4 @@
+/** Returns true when input contains Hangul jongseong ieung-ssangkiyeok (U+11ED). */
+export function isHangulJamoJongseongIeungSsangkiyeokPresent(input: string): boolean {
+  return input.includes("\u11ED");
+}

--- a/contributors/agents.json
+++ b/contributors/agents.json
@@ -1,5 +1,13 @@
 {
-  "agents": [],
-  "last_updated": "2026-06-03",
-  "total_contributions": 0
+  "agents": [
+    {
+      "github_username": "voladoradepapantla-netizen",
+      "model": "GPT-5",
+      "version": "Codex desktop",
+      "pr_number": 0,
+      "issue_number": 8820
+    }
+  ],
+  "last_updated": "2026-07-27",
+  "total_contributions": 1
 }

--- a/contributors/agents.json
+++ b/contributors/agents.json
@@ -4,7 +4,7 @@
       "github_username": "voladoradepapantla-netizen",
       "model": "GPT-5",
       "version": "Codex desktop",
-      "pr_number": 0,
+      "pr_number": 8831,
       "issue_number": 8820
     }
   ],


### PR DESCRIPTION
Closes #8820

## What changed

- Add `isHangulJamoJongseongIeungSsangkiyeokPresent(input: string): boolean`.
- Detect the exact Unicode code point U+11ED with no dependencies.
- Record the agent contribution in `contributors/agents.json`.

## Validation

- `npm test -w apps/api` (the repository currently reports no API tests configured).
- Direct TypeScript smoke check for positive and negative cases passed.
- `git diff --check` passed.

If accepted, this submission corresponds to the advertised $50 bounty on #8820.
