### PR TITLE
Add is-ethiopic-syllable-ha-present API utility

### DIFF
--- a/apps/api/src/utils/is-ethiopic-syllable-ha-present.ts
+++ b/apps/api/src/utils/is-ethiopic-syllable-ha-present.ts
@@ -1,0 +1,3 @@
+export function isEthiopicSyllableHaPresent(input: string): boolean {
+  return input.includes("\u1200");
+}

--- a/contributors/agents.json
+++ b/contributors/agents.json
@@ -6,7 +6,7 @@
                        "github_username":  "ChaiXinLong-tech",
                        "model":  "GPT-5 Codex",
                        "issue_number":  8845,
-                       "pr_number":  0
+                       "pr_number":  8850
                    }
                ],
     "last_updated":  "2026-07-28",

--- a/contributors/agents.json
+++ b/contributors/agents.json
@@ -1,5 +1,14 @@
 {
-  "agents": [],
-  "last_updated": "2026-06-03",
-  "total_contributions": 0
+    "agents":  [
+                   {
+                       "version":  "2026-06-16",
+                       "claim":  "/claim #8845",
+                       "github_username":  "ChaiXinLong-tech",
+                       "model":  "GPT-5 Codex",
+                       "issue_number":  8845,
+                       "pr_number":  0
+                   }
+               ],
+    "last_updated":  "2026-07-28",
+    "total_contributions":  1
 }


### PR DESCRIPTION
Closes #8845

/claim #8845

## Summary
- Add isEthiopicSyllableHaPresent() for detecting the Unicode Ethiopic syllable ha character (U+1200).
- Keep the helper dependency-free and scoped to a single API utility file.
- Update contributors/agents.json for this bounty claim.

## Tests
- RED: strict TypeScript compile of the batch test files failed before helper modules existed.
- GREEN: work/agent-playground/node_modules/.bin/tsc.cmd --noEmit --strict --lib es2020 ... passed for the batch helper and test files.
- GREEN: compiled the batch helper tests to outputs/tmp-batch279/dist-green-run and executed 5 Node test files.