### PR TITLE
Add Hangul jongseong tikeut-kiyeok API utility

### DIFF
--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -7,7 +7,7 @@
   "main": "src/index.ts",
   "scripts": {
     "dev": "tsx src/index.ts",
-    "test": "echo \"No API tests configured yet\"",
+    "test": "tsx src/utils/*.test.ts",
     "lint": "echo \"No API lint configured yet\""
   },
   "dependencies": {

--- a/apps/api/src/utils/is-hangul-jamo-jongseong-tikeut-kiyeok-present.test.ts
+++ b/apps/api/src/utils/is-hangul-jamo-jongseong-tikeut-kiyeok-present.test.ts
@@ -1,0 +1,7 @@
+import { strict as assert } from "node:assert";
+import { isHangulJamoJongseongTikeutKiyeokPresent } from "./is-hangul-jamo-jongseong-tikeut-kiyeok-present";
+
+assert.equal(isHangulJamoJongseongTikeutKiyeokPresent("plain text"), false);
+assert.equal(isHangulJamoJongseongTikeutKiyeokPresent("contains ᇊ jamo"), true);
+assert.equal(isHangulJamoJongseongTikeutKiyeokPresent("contains \\u11CA escape text only"), false);
+assert.equal(isHangulJamoJongseongTikeutKiyeokPresent("other jongseong ᇉ"), false);

--- a/apps/api/src/utils/is-hangul-jamo-jongseong-tikeut-kiyeok-present.ts
+++ b/apps/api/src/utils/is-hangul-jamo-jongseong-tikeut-kiyeok-present.ts
@@ -1,0 +1,3 @@
+export function isHangulJamoJongseongTikeutKiyeokPresent(input: string): boolean {
+  return input.includes("\u11CA");
+}


### PR DESCRIPTION
## Summary
- Adds `isHangulJamoJongseongTikeutKiyeokPresent(input: string): boolean` for U+11CA detection.
- Adds a small dependency-free TypeScript smoke test covering true, false, escaped-text, and adjacent-codepoint cases.
- Wires the API workspace test script to run the smoke tests with `tsx`.

Fixes #8767

## Verification
- `npm --workspace apps/api test`
