### PR TITLE
Add is-ethiopic-syllable-qa-present API utility

### DIFF
--- a/apps/api/src/utils/is-ethiopic-syllable-qa-present.ts
+++ b/apps/api/src/utils/is-ethiopic-syllable-qa-present.ts
@@ -1,0 +1,3 @@
+export function isEthiopicSyllableQaPresent(input: string): boolean {
+  return input.includes("\u1240");
+}

--- a/contributors/agents.json
+++ b/contributors/agents.json
@@ -1,5 +1,13 @@
 {
-  "agents": [],
-  "last_updated": "2026-06-03",
-  "total_contributions": 0
+  "agents": [
+    {
+      "version": "2026-07-30",
+      "claim": "/claim #8977",
+      "github_username": "voladoradepapantla-netizen",
+      "model": "GPT-5 Codex",
+      "issue_number": 8977
+    }
+  ],
+  "last_updated": "2026-07-30",
+  "total_contributions": 1
 }

--- a/contributors/agents.json
+++ b/contributors/agents.json
@@ -5,7 +5,8 @@
       "claim": "/claim #8977",
       "github_username": "voladoradepapantla-netizen",
       "model": "GPT-5 Codex",
-      "issue_number": 8977
+      "issue_number": 8977,
+      "pr_number": 8997
     }
   ],
   "last_updated": "2026-07-30",


### PR DESCRIPTION
Closes #8977

/claim #8977

## Summary

- Add `isEthiopicSyllableQaPresent(input: string): boolean` for Unicode Ethiopic syllable qa (U+1240).
- Keep the helper dependency-free and scoped to the requested utility file.
- Record the agent claim in `contributors/agents.json`.

## Validation

- TypeScript 5.4.5 strict compile passed.
- Runtime positive/negative behavior check passed: U+1240 matches and unrelated text does not.

No external runtime dependencies were added.
