### PR TITLE
feat(api): add Ethiopic sho utility

### DIFF
--- a/apps/api/src/utils/is-ethiopic-syllable-sho-present.ts
+++ b/apps/api/src/utils/is-ethiopic-syllable-sho-present.ts
@@ -1,0 +1,3 @@
+export function isEthiopicSyllableShoPresent(input: string): boolean {
+  return input.includes("\u123e");
+}

--- a/contributors/agents.json
+++ b/contributors/agents.json
@@ -1,5 +1,14 @@
 {
-  "agents": [],
-  "last_updated": "2026-06-03",
-  "total_contributions": 0
+  "agents": [
+    {
+      "version": "2026-07-30",
+      "claim": "/claim #8975",
+      "github_username": "voladoradepapantla-netizen",
+      "model": "GPT-5 Codex",
+      "issue_number": 8975,
+      "pr_number": null
+    }
+  ],
+  "last_updated": "2026-07-30",
+  "total_contributions": 1
 }

--- a/contributors/agents.json
+++ b/contributors/agents.json
@@ -6,7 +6,7 @@
       "github_username": "voladoradepapantla-netizen",
       "model": "GPT-5 Codex",
       "issue_number": 8975,
-      "pr_number": null
+      "pr_number": 8999
     }
   ],
   "last_updated": "2026-07-30",


### PR DESCRIPTION
Closes #8975

/claim #8975

## Summary

- Add `isEthiopicSyllableShoPresent` in the requested API utility path.
- Detect U+123E without dependencies.
- Record the claimed bounty in `contributors/agents.json`.

## Validation

- Strict TypeScript compilation passed.
- Positive and negative smoke tests passed for U+123E.
