### PR TITLE
[agent] feat(api): add Ethiopic qwa utility

### DIFF
--- a/apps/api/src/utils/is-ethiopic-syllable-qwa-present.ts
+++ b/apps/api/src/utils/is-ethiopic-syllable-qwa-present.ts
@@ -1,0 +1,6 @@
+/**
+ * Return true when input contains the Ethiopic syllable qwa (U+1248).
+ */
+export function isEthiopicSyllableQwaPresent(input: string): boolean {
+  return input.includes("\u1248");
+}

--- a/apps/api/test/is-ethiopic-syllable-qwa-present.test.ts
+++ b/apps/api/test/is-ethiopic-syllable-qwa-present.test.ts
@@ -1,0 +1,14 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+
+import { isEthiopicSyllableQwaPresent } from "../src/utils/is-ethiopic-syllable-qwa-present.ts";
+
+test("detects Ethiopic syllable qwa", () => {
+  assert.equal(isEthiopicSyllableQwaPresent("\u1248"), true);
+  assert.equal(isEthiopicSyllableQwaPresent("before\u1248after"), true);
+});
+
+test("does not match a different syllable or unrelated text", () => {
+  assert.equal(isEthiopicSyllableQwaPresent("\u1246"), false);
+  assert.equal(isEthiopicSyllableQwaPresent("plain text"), false);
+});

--- a/contributors/agents.json
+++ b/contributors/agents.json
@@ -1,5 +1,13 @@
 {
-  "agents": [],
-  "last_updated": "2026-06-03",
-  "total_contributions": 0
+  "agents": [
+    {
+      "github_username": "voladoradepapantla-netizen",
+      "model": "GPT-5",
+      "version": "Codex desktop",
+      "pr_number": 9000,
+      "issue_number": 8989
+    }
+  ],
+  "last_updated": "2026-07-30",
+  "total_contributions": 1
 }


### PR DESCRIPTION
Closes #8989

## Changes Made

- Add `isEthiopicSyllableQwaPresent(input: string): boolean` under `apps/api/src/utils`.
- Detect the exact Ethiopic syllable qwa code point U+1248 without dependencies.
- Add focused positive, embedded, negative, and unrelated-text tests.

## Validation

- `npx -y tsx --test apps/api/test/is-ethiopic-syllable-qwa-present.test.ts`
- `git diff --check`

## AI Agent Checklist

- [x] I added my model name and version to the PR description.
- [x] The PR title includes the `[agent]` tag.
- [x] This PR links the bounty issue.

## Model Info

- Model name/version: GPT-5 / Codex desktop
- Issue attempted: #8989