### PR TITLE
fix: Improve Prisma schema comments

### DIFF
--- a/packages/db/prisma/schema.prisma
+++ b/packages/db/prisma/schema.prisma
@@ -1,3 +1,6 @@
+// Prisma schema for the TaskFlow domain.
+// Users post jobs, and freelancers submit proposals against those jobs.
+
 generator client {
   provider = "prisma-client-js"
 }
@@ -7,37 +10,40 @@ datasource db {
   url      = env("DATABASE_URL")
 }
 
+/// A registered TaskFlow user. Users can act as clients, freelancers, or admins.
 model User {
   id        String     @id @default(cuid())
   email     String     @unique
   name      String?
-  jobs      Job[]
-  proposals Proposal[]
+  jobs      Job[]      // Jobs posted by this user as a client
+  proposals Proposal[] // Proposals submitted by this user as a freelancer
   createdAt DateTime   @default(now())
   updatedAt DateTime   @updatedAt
 }
 
+/// A job posted by a client for freelancers to bid on.
 model Job {
   id          String     @id @default(cuid())
   title       String
   description String?
-  status      String     @default("draft")
+  status      String     @default("draft") // draft | open | in_progress | completed | cancelled
   ownerId     String
-  owner       User       @relation(fields: [ownerId], references: [id])
-  proposals   Proposal[]
+  owner       User       @relation(fields: [ownerId], references: [id]) // The client who posted the job
+  proposals   Proposal[] // Bids submitted for this job
   createdAt   DateTime   @default(now())
   updatedAt   DateTime   @updatedAt
 }
 
+/// A freelancer's bid on a job, including the proposed amount and status.
 model Proposal {
   id        String   @id @default(cuid())
   summary   String
   amount    Decimal?
-  status    String   @default("pending")
+  status    String   @default("pending") // pending | accepted | rejected
   userId    String
-  user      User     @relation(fields: [userId], references: [id])
+  user      User     @relation(fields: [userId], references: [id]) // The freelancer who submitted the bid
   jobId     String
-  job       Job      @relation(fields: [jobId], references: [id])
+  job       Job      @relation(fields: [jobId], references: [id]) // The job being bid on
   createdAt DateTime @default(now())
   updatedAt DateTime @updatedAt
 }


### PR DESCRIPTION
## Summary
Add doc comments to the Prisma schema models (User, Job, Proposal) explaining their role in the TaskFlow domain. No structural changes — comments only.

Closes #5