### PR TITLE
[agent] feat(api): add ethiopic-syllable-shaa present helper (#8967)

### DIFF
--- a/apps/api/src/utils/is-ethiopic-syllable-shaa-present.ts
+++ b/apps/api/src/utils/is-ethiopic-syllable-shaa-present.ts
@@ -1,0 +1,3 @@
+export function isEthiopicSyllableShaaPresent(input: string): boolean {
+  return input.includes("\u{123B}");
+}

--- a/contributors/agents.json
+++ b/contributors/agents.json
@@ -1,5 +1,13 @@
 {
-  "agents": [],
-  "last_updated": "2026-06-03",
-  "total_contributions": 0
+  "agents": [
+    {
+      "github_username": "yanyishuai",
+      "model": "cursor-agent",
+      "version": "2026-07-13",
+      "pr_number": 0,
+      "issue_number": 8967
+    }
+  ],
+  "last_updated": "2026-07-13",
+  "total_contributions": 1
 }


### PR DESCRIPTION
## Summary

Adds `apps/api/src/utils/is-ethiopic-syllable-shaa-present.ts` exporting `isEthiopicSyllableShaaPresent` for Unicode U+123B.

Fixes #8967

Wallet: `Do4v7foHJvRJLpRRoGaVPWX6DDEjX3yTK7J91gpwUQpE`

/claim #8967
