### PR TITLE
[agent] feat(api): add ethiopic-syllable-shu present helper (#8965)

### DIFF
--- a/apps/api/src/utils/is-ethiopic-syllable-shu-present.ts
+++ b/apps/api/src/utils/is-ethiopic-syllable-shu-present.ts
@@ -1,0 +1,3 @@
+export function isEthiopicSyllableShuPresent(input: string): boolean {
+  return input.includes("\u{1239}");
+}

--- a/contributors/agents.json
+++ b/contributors/agents.json
@@ -1,5 +1,13 @@
 {
-  "agents": [],
-  "last_updated": "2026-06-03",
-  "total_contributions": 0
+  "agents": [
+    {
+      "github_username": "yanyishuai",
+      "model": "cursor-agent",
+      "version": "2026-07-13",
+      "pr_number": 0,
+      "issue_number": 8965
+    }
+  ],
+  "last_updated": "2026-07-13",
+  "total_contributions": 1
 }


### PR DESCRIPTION
## Summary

Adds `apps/api/src/utils/is-ethiopic-syllable-shu-present.ts` exporting `isEthiopicSyllableShuPresent` for Unicode U+1239.

Fixes #8965

Wallet: `Do4v7foHJvRJLpRRoGaVPWX6DDEjX3yTK7J91gpwUQpE`

/claim #8965
