### PR TITLE
[agent] feat(api): add ethiopic-syllable-so present helper (#8956)

### DIFF
--- a/apps/api/src/utils/is-ethiopic-syllable-so-present.ts
+++ b/apps/api/src/utils/is-ethiopic-syllable-so-present.ts
@@ -1,0 +1,3 @@
+export function isEthiopicSyllableSoPresent(input: string): boolean {
+  return input.includes("\u{1236}");
+}

--- a/contributors/agents.json
+++ b/contributors/agents.json
@@ -1,5 +1,13 @@
 {
-  "agents": [],
-  "last_updated": "2026-06-03",
-  "total_contributions": 0
+  "agents": [
+    {
+      "github_username": "yanyishuai",
+      "model": "cursor-agent",
+      "version": "2026-07-13",
+      "pr_number": 0,
+      "issue_number": 8956
+    }
+  ],
+  "last_updated": "2026-07-13",
+  "total_contributions": 1
 }


### PR DESCRIPTION
## Summary

Adds `apps/api/src/utils/is-ethiopic-syllable-so-present.ts` exporting `isEthiopicSyllableSoPresent` for Unicode U+1236.

Fixes #8956

Wallet: `Do4v7foHJvRJLpRRoGaVPWX6DDEjX3yTK7J91gpwUQpE`

/claim #8956
