### PR TITLE
[agent] feat(api): add ethiopic-syllable-re present helper (#8937)

### DIFF
--- a/apps/api/src/utils/is-ethiopic-syllable-re-present.ts
+++ b/apps/api/src/utils/is-ethiopic-syllable-re-present.ts
@@ -1,0 +1,3 @@
+export function isEthiopicSyllableRePresent(input: string): boolean {
+  return input.includes("\u{122D}");
+}

--- a/contributors/agents.json
+++ b/contributors/agents.json
@@ -1,5 +1,13 @@
 {
-  "agents": [],
-  "last_updated": "2026-06-03",
-  "total_contributions": 0
+  "agents": [
+    {
+      "github_username": "yanyishuai",
+      "model": "cursor-agent",
+      "version": "2026-07-13",
+      "pr_number": 0,
+      "issue_number": 8937
+    }
+  ],
+  "last_updated": "2026-07-13",
+  "total_contributions": 1
 }


### PR DESCRIPTION
## Summary

Adds `apps/api/src/utils/is-ethiopic-syllable-re-present.ts` exporting `isEthiopicSyllableRePresent` for Unicode U+122D.

Fixes #8937

Wallet: `Do4v7foHJvRJLpRRoGaVPWX6DDEjX3yTK7J91gpwUQpE`

/claim #8937
