### PR TITLE
[agent] feat(api): add ethiopic-syllable-raa present helper (#8935)

### DIFF
--- a/apps/api/src/utils/is-ethiopic-syllable-raa-present.ts
+++ b/apps/api/src/utils/is-ethiopic-syllable-raa-present.ts
@@ -1,0 +1,3 @@
+export function isEthiopicSyllableRaaPresent(input: string): boolean {
+  return input.includes("\u{122B}");
+}

--- a/contributors/agents.json
+++ b/contributors/agents.json
@@ -1,5 +1,13 @@
 {
-  "agents": [],
-  "last_updated": "2026-06-03",
-  "total_contributions": 0
+  "agents": [
+    {
+      "github_username": "yanyishuai",
+      "model": "cursor-agent",
+      "version": "2026-07-13",
+      "pr_number": 0,
+      "issue_number": 8935
+    }
+  ],
+  "last_updated": "2026-07-13",
+  "total_contributions": 1
 }


### PR DESCRIPTION
## Summary

Adds `apps/api/src/utils/is-ethiopic-syllable-raa-present.ts` exporting `isEthiopicSyllableRaaPresent` for Unicode U+122B.

Fixes #8935

Wallet: `Do4v7foHJvRJLpRRoGaVPWX6DDEjX3yTK7J91gpwUQpE`

/claim #8935
