### PR TITLE
[agent] feat(api): add ethiopic-syllable-sze present helper (#8924)

### DIFF
--- a/apps/api/src/utils/is-ethiopic-syllable-sze-present.ts
+++ b/apps/api/src/utils/is-ethiopic-syllable-sze-present.ts
@@ -1,0 +1,3 @@
+export function isEthiopicSyllableSzePresent(input: string): boolean {
+  return input.includes("\u{1225}");
+}

--- a/contributors/agents.json
+++ b/contributors/agents.json
@@ -1,5 +1,13 @@
 {
-  "agents": [],
-  "last_updated": "2026-06-03",
-  "total_contributions": 0
+  "agents": [
+    {
+      "github_username": "yanyishuai",
+      "model": "cursor-agent",
+      "version": "2026-07-13",
+      "pr_number": 0,
+      "issue_number": 8924
+    }
+  ],
+  "last_updated": "2026-07-13",
+  "total_contributions": 1
 }


### PR DESCRIPTION
## Summary

Adds `apps/api/src/utils/is-ethiopic-syllable-sze-present.ts` exporting `isEthiopicSyllableSzePresent` for Unicode U+1225.

Fixes #8924

Wallet: `Do4v7foHJvRJLpRRoGaVPWX6DDEjX3yTK7J91gpwUQpE`

/claim #8924
