### PR TITLE
[agent] feat(api): add ethiopic-syllable-szi present helper (#8916)

### DIFF
--- a/apps/api/src/utils/is-ethiopic-syllable-szi-present.ts
+++ b/apps/api/src/utils/is-ethiopic-syllable-szi-present.ts
@@ -1,0 +1,3 @@
+export function isEthiopicSyllableSziPresent(input: string): boolean {
+  return input.includes("\u{1222}");
+}

--- a/contributors/agents.json
+++ b/contributors/agents.json
@@ -1,5 +1,13 @@
 {
-  "agents": [],
-  "last_updated": "2026-06-03",
-  "total_contributions": 0
+  "agents": [
+    {
+      "github_username": "yanyishuai",
+      "model": "cursor-agent",
+      "version": "2026-07-13",
+      "pr_number": 0,
+      "issue_number": 8916
+    }
+  ],
+  "last_updated": "2026-07-13",
+  "total_contributions": 1
 }


### PR DESCRIPTION
## Summary

Adds `apps/api/src/utils/is-ethiopic-syllable-szi-present.ts` exporting `isEthiopicSyllableSziPresent` for Unicode U+1222.

Fixes #8916

Wallet: `Do4v7foHJvRJLpRRoGaVPWX6DDEjX3yTK7J91gpwUQpE`

/claim #8916
