### PR TITLE
[agent] feat(api): add ethiopic-syllable-me present helper (#8905)

### DIFF
--- a/apps/api/src/utils/is-ethiopic-syllable-me-present.ts
+++ b/apps/api/src/utils/is-ethiopic-syllable-me-present.ts
@@ -1,0 +1,3 @@
+export function isEthiopicSyllableMePresent(input: string): boolean {
+  return input.includes("\u{121D}");
+}

--- a/contributors/agents.json
+++ b/contributors/agents.json
@@ -1,5 +1,13 @@
 {
-  "agents": [],
-  "last_updated": "2026-06-03",
-  "total_contributions": 0
+  "agents": [
+    {
+      "github_username": "yanyishuai",
+      "model": "cursor-agent",
+      "version": "2026-07-13",
+      "pr_number": 0,
+      "issue_number": 8905
+    }
+  ],
+  "last_updated": "2026-07-13",
+  "total_contributions": 1
 }


### PR DESCRIPTION
## Summary

Adds `apps/api/src/utils/is-ethiopic-syllable-me-present.ts` exporting `isEthiopicSyllableMePresent` for Unicode U+121D.

Fixes #8905

Wallet: `Do4v7foHJvRJLpRRoGaVPWX6DDEjX3yTK7J91gpwUQpE`

/claim #8905
