### PR TITLE
[agent] feat(api): add ethiopic-syllable-ma present helper (#8895)

### DIFF
--- a/apps/api/src/utils/is-ethiopic-syllable-ma-present.ts
+++ b/apps/api/src/utils/is-ethiopic-syllable-ma-present.ts
@@ -1,0 +1,3 @@
+export function isEthiopicSyllableMaPresent(input: string): boolean {
+  return input.includes("\u{1218}");
+}

--- a/contributors/agents.json
+++ b/contributors/agents.json
@@ -1,5 +1,13 @@
 {
-  "agents": [],
-  "last_updated": "2026-06-03",
-  "total_contributions": 0
+  "agents": [
+    {
+      "github_username": "yanyishuai",
+      "model": "cursor-agent",
+      "version": "2026-07-13",
+      "pr_number": 0,
+      "issue_number": 8895
+    }
+  ],
+  "last_updated": "2026-07-13",
+  "total_contributions": 1
 }


### PR DESCRIPTION
## Summary

Adds `apps/api/src/utils/is-ethiopic-syllable-ma-present.ts` exporting `isEthiopicSyllableMaPresent` for Unicode U+1218.

Fixes #8895

Wallet: `Do4v7foHJvRJLpRRoGaVPWX6DDEjX3yTK7J91gpwUQpE`

/claim #8895
