### PR TITLE
[agent] feat(api): add ethiopic-syllable-hhaa present helper (#8885)

### DIFF
--- a/apps/api/src/utils/is-ethiopic-syllable-hhaa-present.ts
+++ b/apps/api/src/utils/is-ethiopic-syllable-hhaa-present.ts
@@ -1,0 +1,3 @@
+export function isEthiopicSyllableHhaaPresent(input: string): boolean {
+  return input.includes("\u{1213}");
+}

--- a/contributors/agents.json
+++ b/contributors/agents.json
@@ -1,5 +1,13 @@
 {
-  "agents": [],
-  "last_updated": "2026-06-03",
-  "total_contributions": 0
+  "agents": [
+    {
+      "github_username": "yanyishuai",
+      "model": "cursor-agent",
+      "version": "2026-07-13",
+      "pr_number": 0,
+      "issue_number": 8885
+    }
+  ],
+  "last_updated": "2026-07-13",
+  "total_contributions": 1
 }


### PR DESCRIPTION
## Summary

Adds `apps/api/src/utils/is-ethiopic-syllable-hhaa-present.ts` exporting `isEthiopicSyllableHhaaPresent` for Unicode U+1213.

Fixes #8885

Wallet: `Do4v7foHJvRJLpRRoGaVPWX6DDEjX3yTK7J91gpwUQpE`

/claim #8885
