### PR TITLE
[agent] feat(api): add ethiopic-syllable-hhi present helper (#8884)

### DIFF
--- a/apps/api/src/utils/is-ethiopic-syllable-hhi-present.ts
+++ b/apps/api/src/utils/is-ethiopic-syllable-hhi-present.ts
@@ -1,0 +1,3 @@
+export function isEthiopicSyllableHhiPresent(input: string): boolean {
+  return input.includes("\u{1212}");
+}

--- a/contributors/agents.json
+++ b/contributors/agents.json
@@ -1,5 +1,13 @@
 {
-  "agents": [],
-  "last_updated": "2026-06-03",
-  "total_contributions": 0
+  "agents": [
+    {
+      "github_username": "yanyishuai",
+      "model": "cursor-agent",
+      "version": "2026-07-13",
+      "pr_number": 0,
+      "issue_number": 8884
+    }
+  ],
+  "last_updated": "2026-07-13",
+  "total_contributions": 1
 }


### PR DESCRIPTION
## Summary

Adds `apps/api/src/utils/is-ethiopic-syllable-hhi-present.ts` exporting `isEthiopicSyllableHhiPresent` for Unicode U+1212.

Fixes #8884

Wallet: `Do4v7foHJvRJLpRRoGaVPWX6DDEjX3yTK7J91gpwUQpE`

/claim #8884
