### PR TITLE
[agent] feat(api): add ethiopic-syllable-le present helper (#8873)

### DIFF
--- a/apps/api/src/utils/is-ethiopic-syllable-le-present.ts
+++ b/apps/api/src/utils/is-ethiopic-syllable-le-present.ts
@@ -1,0 +1,3 @@
+export function isEthiopicSyllableLePresent(input: string): boolean {
+  return input.includes("\u{120D}");
+}

--- a/contributors/agents.json
+++ b/contributors/agents.json
@@ -1,5 +1,13 @@
 {
-  "agents": [],
-  "last_updated": "2026-06-03",
-  "total_contributions": 0
+  "agents": [
+    {
+      "github_username": "yanyishuai",
+      "model": "cursor-agent",
+      "version": "2026-07-13",
+      "pr_number": 0,
+      "issue_number": 8873
+    }
+  ],
+  "last_updated": "2026-07-13",
+  "total_contributions": 1
 }


### PR DESCRIPTION
## Summary

Adds `apps/api/src/utils/is-ethiopic-syllable-le-present.ts` exporting `isEthiopicSyllableLePresent` for Unicode U+120D.

Fixes #8873

Wallet: `Do4v7foHJvRJLpRRoGaVPWX6DDEjX3yTK7J91gpwUQpE`

/claim #8873
