### PR TITLE
[agent] feat(api): add ethiopic-syllable-lu present helper (#8864)

### DIFF
--- a/apps/api/src/utils/is-ethiopic-syllable-lu-present.ts
+++ b/apps/api/src/utils/is-ethiopic-syllable-lu-present.ts
@@ -1,0 +1,3 @@
+export function isEthiopicSyllableLuPresent(input: string): boolean {
+  return input.includes("\u{1209}");
+}

--- a/contributors/agents.json
+++ b/contributors/agents.json
@@ -1,5 +1,13 @@
 {
-  "agents": [],
-  "last_updated": "2026-06-03",
-  "total_contributions": 0
+  "agents": [
+    {
+      "github_username": "yanyishuai",
+      "model": "cursor-agent",
+      "version": "2026-07-13",
+      "pr_number": 0,
+      "issue_number": 8864
+    }
+  ],
+  "last_updated": "2026-07-13",
+  "total_contributions": 1
 }


### PR DESCRIPTION
## Summary

Adds `apps/api/src/utils/is-ethiopic-syllable-lu-present.ts` exporting `isEthiopicSyllableLuPresent` for Unicode U+1209.

Fixes #8864

Wallet: `Do4v7foHJvRJLpRRoGaVPWX6DDEjX3yTK7J91gpwUQpE`

/claim #8864
