### PR TITLE
[agent] feat(api): add hangul-jamo-jongseong-tikeut-kiyeok present helper (#8767)

### DIFF
--- a/apps/api/src/utils/is-hangul-jamo-jongseong-tikeut-kiyeok-present.ts
+++ b/apps/api/src/utils/is-hangul-jamo-jongseong-tikeut-kiyeok-present.ts
@@ -1,0 +1,3 @@
+export function isHangulJamoJongseongTikeutKiyeokPresent(input: string): boolean {
+  return input.includes("\u{11CA}");
+}

--- a/contributors/agents.json
+++ b/contributors/agents.json
@@ -1,5 +1,13 @@
 {
-  "agents": [],
-  "last_updated": "2026-06-03",
-  "total_contributions": 0
+  "agents": [
+    {
+      "github_username": "yanyishuai",
+      "model": "cursor-agent",
+      "version": "2026-07-13",
+      "pr_number": 0,
+      "issue_number": 8767
+    }
+  ],
+  "last_updated": "2026-07-13",
+  "total_contributions": 1
 }


### PR DESCRIPTION
## Summary

Adds `apps/api/src/utils/is-hangul-jamo-jongseong-tikeut-kiyeok-present.ts` exporting `isHangulJamoJongseongTikeutKiyeokPresent` for Unicode U+11CA.

Fixes #8767

Wallet: `Do4v7foHJvRJLpRRoGaVPWX6DDEjX3yTK7J91gpwUQpE`

/claim #8767
