### PR TITLE
[agent] feat(api): add hangul-jamo-jungseong-i-eu present helper (#8720)

### DIFF
--- a/apps/api/src/utils/is-hangul-jamo-jungseong-i-eu-present.ts
+++ b/apps/api/src/utils/is-hangul-jamo-jungseong-i-eu-present.ts
@@ -1,0 +1,3 @@
+export function isHangulJamoJungseongIEuPresent(input: string): boolean {
+  return input.includes("\u{119C}");
+}

--- a/contributors/agents.json
+++ b/contributors/agents.json
@@ -1,5 +1,13 @@
 {
-  "agents": [],
-  "last_updated": "2026-06-03",
-  "total_contributions": 0
+  "agents": [
+    {
+      "github_username": "yanyishuai",
+      "model": "cursor-agent",
+      "version": "2026-07-13",
+      "pr_number": 0,
+      "issue_number": 8720
+    }
+  ],
+  "last_updated": "2026-07-13",
+  "total_contributions": 1
 }


### PR DESCRIPTION
## Summary

Adds `apps/api/src/utils/is-hangul-jamo-jungseong-i-eu-present.ts` exporting `isHangulJamoJungseongIEuPresent` for Unicode U+119C.

Fixes #8720

Wallet: `Do4v7foHJvRJLpRRoGaVPWX6DDEjX3yTK7J91gpwUQpE`

/claim #8720
