### PR TITLE
[agent] feat(api): add hangul-jamo-jungseong-yeo-o present helper (#8696)

### DIFF
--- a/apps/api/src/utils/is-hangul-jamo-jungseong-yeo-o-present.ts
+++ b/apps/api/src/utils/is-hangul-jamo-jungseong-yeo-o-present.ts
@@ -1,0 +1,3 @@
+export function isHangulJamoJungseongYeoOPresent(input: string): boolean {
+  return input.includes("\u{117D}");
+}

--- a/contributors/agents.json
+++ b/contributors/agents.json
@@ -1,5 +1,13 @@
 {
-  "agents": [],
-  "last_updated": "2026-06-03",
-  "total_contributions": 0
+  "agents": [
+    {
+      "github_username": "yanyishuai",
+      "model": "cursor-agent",
+      "version": "2026-07-13",
+      "pr_number": 0,
+      "issue_number": 8696
+    }
+  ],
+  "last_updated": "2026-07-13",
+  "total_contributions": 1
 }


### PR DESCRIPTION
## Summary

Adds `apps/api/src/utils/is-hangul-jamo-jungseong-yeo-o-present.ts` exporting `isHangulJamoJungseongYeoOPresent` for Unicode U+117D.

Fixes #8696

Wallet: `Do4v7foHJvRJLpRRoGaVPWX6DDEjX3yTK7J91gpwUQpE`

/claim #8696
