### PR TITLE
[agent] feat(api): add hangul-jamo-jungseong-i present helper (#8686)

### DIFF
--- a/apps/api/src/utils/is-hangul-jamo-jungseong-i-present.ts
+++ b/apps/api/src/utils/is-hangul-jamo-jungseong-i-present.ts
@@ -1,0 +1,3 @@
+export function isHangulJamoJungseongIPresent(input: string): boolean {
+  return input.includes("\u{1175}");
+}

--- a/contributors/agents.json
+++ b/contributors/agents.json
@@ -1,5 +1,13 @@
 {
-  "agents": [],
-  "last_updated": "2026-06-03",
-  "total_contributions": 0
+  "agents": [
+    {
+      "github_username": "yanyishuai",
+      "model": "cursor-agent",
+      "version": "2026-07-13",
+      "pr_number": 0,
+      "issue_number": 8686
+    }
+  ],
+  "last_updated": "2026-07-13",
+  "total_contributions": 1
 }


### PR DESCRIPTION
## Summary

Adds `apps/api/src/utils/is-hangul-jamo-jungseong-i-present.ts` exporting `isHangulJamoJungseongIPresent` for Unicode U+1175.

Fixes #8686

Wallet: `Do4v7foHJvRJLpRRoGaVPWX6DDEjX3yTK7J91gpwUQpE`

/claim #8686
