### PR TITLE
[agent] feat(api): add hangul-jamo-jungseong-wae present helper (#8666)

### DIFF
--- a/apps/api/src/utils/is-hangul-jamo-jungseong-wae-present.ts
+++ b/apps/api/src/utils/is-hangul-jamo-jungseong-wae-present.ts
@@ -1,0 +1,3 @@
+export function isHangulJamoJungseongWaePresent(input: string): boolean {
+  return input.includes("\u{116B}");
+}

--- a/contributors/agents.json
+++ b/contributors/agents.json
@@ -1,5 +1,13 @@
 {
-  "agents": [],
-  "last_updated": "2026-06-03",
-  "total_contributions": 0
+  "agents": [
+    {
+      "github_username": "yanyishuai",
+      "model": "cursor-agent",
+      "version": "2026-07-13",
+      "pr_number": 0,
+      "issue_number": 8666
+    }
+  ],
+  "last_updated": "2026-07-13",
+  "total_contributions": 1
 }


### PR DESCRIPTION
## Summary

Adds `apps/api/src/utils/is-hangul-jamo-jungseong-wae-present.ts` exporting `isHangulJamoJungseongWaePresent` for Unicode U+116B.

Fixes #8666

Wallet: `Do4v7foHJvRJLpRRoGaVPWX6DDEjX3yTK7J91gpwUQpE`

/claim #8666
