### PR TITLE
[agent] feat(api): add hangul-jamo-jungseong-e present helper (#8656)

### DIFF
--- a/apps/api/src/utils/is-hangul-jamo-jungseong-e-present.ts
+++ b/apps/api/src/utils/is-hangul-jamo-jungseong-e-present.ts
@@ -1,0 +1,3 @@
+export function isHangulJamoJungseongEPresent(input: string): boolean {
+  return input.includes("\u{1166}");
+}

--- a/contributors/agents.json
+++ b/contributors/agents.json
@@ -1,5 +1,13 @@
 {
-  "agents": [],
-  "last_updated": "2026-06-03",
-  "total_contributions": 0
+  "agents": [
+    {
+      "github_username": "yanyishuai",
+      "model": "cursor-agent",
+      "version": "2026-07-13",
+      "pr_number": 0,
+      "issue_number": 8656
+    }
+  ],
+  "last_updated": "2026-07-13",
+  "total_contributions": 1
 }


### PR DESCRIPTION
## Summary

Adds `apps/api/src/utils/is-hangul-jamo-jungseong-e-present.ts` exporting `isHangulJamoJungseongEPresent` for Unicode U+1166.

Fixes #8656

Wallet: `Do4v7foHJvRJLpRRoGaVPWX6DDEjX3yTK7J91gpwUQpE`

/claim #8656
