### PR TITLE
fix: add API error handler helper + JSON body size limit (closes #7, closes #9)

### DIFF
--- a/apps/api/src/index.ts
+++ b/apps/api/src/index.ts
@@ -5,7 +5,9 @@ import usersRouter from "./routes/users";
 const app = express();
 const port = process.env.PORT || 4000;
 
-app.use(express.json());
+// Conservative JSON body size limit to prevent resource exhaustion
+const MAX_BODY_SIZE = process.env.MAX_BODY_SIZE || "1mb";
+app.use(express.json({ limit: MAX_BODY_SIZE }));
 
 app.get("/health", (_req, res) => {
   res.json({ status: "ok", service: "taskflow-api" });
@@ -16,3 +18,5 @@ app.use("/users", usersRouter);
 app.listen(port, () => {
   console.log(`TaskFlow API listening on port ${port}`);
 });
+
+export default app;

--- a/apps/api/src/routes/users.ts
+++ b/apps/api/src/routes/users.ts
@@ -1,22 +1,37 @@
-import { Router } from "express";
+import { Router, Request, Response } from "express";
 
 const router = Router();
 
-router.get("/", (_req, res) => {
-  res.json({
-    data: [],
-    message: "User listing is not implemented yet."
-  });
+// Lightweight API error response helper
+function apiError(res: Response, message: string, status = 400): void {
+  res.status(status).json({ error: true, message });
+}
+
+router.get("/", (_req: Request, res: Response) => {
+  try {
+    res.json({
+      data: [],
+      message: "User listing is not implemented yet.",
+    });
+  } catch (err) {
+    const message = err instanceof Error ? err.message : "Internal server error";
+    apiError(res, message, 500);
+  }
 });
 
-router.post("/", (req, res) => {
-  res.status(201).json({
-    data: {
-      id: "stub-user-id",
-      ...req.body
-    },
-    message: "User creation is not implemented yet."
-  });
+router.post("/", (req: Request, res: Response) => {
+  try {
+    res.status(201).json({
+      data: {
+        id: "stub-user-id",
+        ...req.body,
+      },
+      message: "User creation is not implemented yet.",
+    });
+  } catch (err) {
+    const message = err instanceof Error ? err.message : "Internal server error";
+    apiError(res, message, 500);
+  }
 });
 
 export default router;


### PR DESCRIPTION
## Changes

### #7 — API Error Handling Helper
- Added `apiError()` helper for consistent JSON error responses
- Applied try/catch + apiError to both GET and POST /users routes
- Returns proper error shape: `{ error: true, message: string }`

### #9 — JSON Body Size Limit
- Added `express.json({ limit: MAX_BODY_SIZE })` — defaults to 1mb
- Configurable via `MAX_BODY_SIZE` env var
- Prevents resource exhaustion from oversized payloads

### Files Changed
- `apps/api/src/index.ts` — body size limit
- `apps/api/src/routes/users.ts` — error handler helper + try/catch