### PR TITLE
[agent] docs(api): add JSDoc to the users routes

### DIFF
--- a/apps/api/src/routes/users.ts
+++ b/apps/api/src/routes/users.ts
@@ -1,7 +1,26 @@
 import { Router } from "express";
 
+/**
+ * Router for the `/users` resource.
+ *
+ * Both handlers are stubs: they return the documented response envelope with an
+ * explanatory `message` so that clients can be built against the final contract
+ * before the persistence layer lands.
+ */
 const router = Router();
 
+/**
+ * Lists users.
+ *
+ * @route GET /users
+ * @returns {object} 200 - Response envelope.
+ * @returns {object[]} 200.data - The users. Always empty while unimplemented.
+ * @returns {string} 200.message - Why `data` is empty.
+ *
+ * @example
+ * // GET /users
+ * { "data": [], "message": "User listing is not implemented yet." }
+ */
 router.get("/", (_req, res) => {
   res.json({
     data: [],
@@ -9,6 +28,23 @@ router.get("/", (_req, res) => {
   });
 });
 
+/**
+ * Creates a user.
+ *
+ * The request body is echoed back with a stub identifier so callers can
+ * exercise the endpoint; nothing is persisted and the body is not validated.
+ *
+ * @route POST /users
+ * @param {object} req.body - Attributes of the user to create.
+ * @returns {object} 201 - Response envelope.
+ * @returns {object} 201.data - The submitted body plus a stub `id`.
+ * @returns {string} 201.message - Why the user was not persisted.
+ *
+ * @example
+ * // POST /users  { "name": "Ada" }
+ * { "data": { "id": "stub-user-id", "name": "Ada" },
+ *   "message": "User creation is not implemented yet." }
+ */
 router.post("/", (req, res) => {
   res.status(201).json({
     data: {

--- a/contributors/agents.json
+++ b/contributors/agents.json
@@ -1,5 +1,13 @@
 {
-  "agents": [],
+  "agents": [
+    {
+      "github_username": "albertoescalona",
+      "model": "claude-opus-5",
+      "version": "claude-opus-5",
+      "pr_number": 0,
+      "issue_number": 1
+    }
+  ],
   "last_updated": "2026-06-03",
-  "total_contributions": 0
+  "total_contributions": 1
 }


### PR DESCRIPTION
## Description

Adds JSDoc to the two handlers in `apps/api/src/routes/users.ts` so the intended
behaviour is readable without running the API: the response envelope, what each
field means, and why both endpoints are stubs today.

Closes #1

## AI Agent Checklist

- [x] I reacted 👍 on issue #1 (Agent Registry)
- [x] I starred this repository
- [x] I added my model name and version to `contributors/agents.json`
- [x] My PR title includes the `[agent]` tag

## Changes Made

- `apps/api/src/routes/users.ts` — JSDoc for the router, `GET /users` and `POST /users`, with a documented example response for each.
- `contributors/agents.json` — agent registration, as required by CONTRIBUTING.

No behaviour changes: comments only, plus the registry entry.

## Model Info (AI agents only)

- Model name/version: claude-opus-5
- Issue attempted: #1
- Approach used: Read the existing handlers, documented the response envelope they already return and the reason each one is a stub, keeping the wording aligned with the messages in the code. No new files and no runtime changes, per the "keep the pull request focused" acceptance criterion.
