### PR TITLE
feat(api): add is-carriage-return-symbol-present utility (Closes #4829)

### DIFF
--- a/apps/api/src/utils/is-carriage-return-symbol-present.ts
+++ b/apps/api/src/utils/is-carriage-return-symbol-present.ts
@@ -1,0 +1,7 @@
+/**
+ * Returns whether `value` contains the carriage-return symbol.
+ * Dependency-free utility for API symbol checks.
+ */
+export function isCarriageReturnSymbolPresent(value: string): boolean {
+  return value.includes("\r");
+}


### PR DESCRIPTION
## Closes #4829 (Algora $50)

Adds `apps/api/src/utils/is-carriage-return-symbol-present.ts` exporting `isCarriageReturnSymbolPresent(value: string): boolean`. Dependency-free, returns whether the string contains the carriage-return symbol.

### Acceptance
- [x] File at `apps/api/src/utils/is-carriage-return-symbol-present.ts`
- [x] Exports `isCarriageReturnSymbolPresent(value: string): boolean`
- [x] Dependency-free and easy to verify