### PR TITLE
feat(api): add is-form-feed-symbol-present utility (Closes #4831)

### DIFF
--- a/apps/api/src/utils/is-form-feed-symbol-present.ts
+++ b/apps/api/src/utils/is-form-feed-symbol-present.ts
@@ -1,0 +1,7 @@
+/**
+ * Returns whether `value` contains the form-feed symbol.
+ * Dependency-free utility for API symbol checks.
+ */
+export function isFormFeedSymbolPresent(value: string): boolean {
+  return value.includes("");
+}


### PR DESCRIPTION
## Closes #4831 (Algora $50)

Adds `apps/api/src/utils/is-form-feed-symbol-present.ts` exporting `isFormFeedSymbolPresent(value: string): boolean`. Dependency-free, returns whether the string contains the form-feed symbol.

### Acceptance
- [x] File at `apps/api/src/utils/is-form-feed-symbol-present.ts`
- [x] Exports `isFormFeedSymbolPresent(value: string): boolean`
- [x] Dependency-free and easy to verify