### PR TITLE
feat(api): add is-hash-symbol-present utility (Closes #4697)

### DIFF
--- a/apps/api/src/utils/is-hash-symbol-present.ts
+++ b/apps/api/src/utils/is-hash-symbol-present.ts
@@ -1,0 +1,7 @@
+/**
+ * Returns whether `value` contains the hash symbol.
+ * Dependency-free utility for API symbol checks.
+ */
+export function isHashSymbolPresent(value: string): boolean {
+  return value.includes("#");
+}


### PR DESCRIPTION
## Closes #4697 (Algora $50)

Adds `apps/api/src/utils/is-hash-symbol-present.ts` exporting `isHashSymbolPresent(value: string): boolean`. Dependency-free, returns whether the string contains the hash symbol.

### Acceptance
- [x] File at `apps/api/src/utils/is-hash-symbol-present.ts`
- [x] Exports `isHashSymbolPresent(value: string): boolean`
- [x] Dependency-free and easy to verify