### PR TITLE
feat(api): add is-caret-symbol-present utility (Closes #4695)

### DIFF
--- a/apps/api/src/utils/is-caret-symbol-present.ts
+++ b/apps/api/src/utils/is-caret-symbol-present.ts
@@ -1,0 +1,7 @@
+/**
+ * Returns whether `value` contains the caret symbol.
+ * Dependency-free utility for API symbol checks.
+ */
+export function isCaretSymbolPresent(value: string): boolean {
+  return value.includes("^");
+}


### PR DESCRIPTION
## Closes #4695 (Algora $50)

Adds `apps/api/src/utils/is-caret-symbol-present.ts` exporting `isCaretSymbolPresent(value: string): boolean`. Dependency-free, returns whether the string contains the caret symbol.

### Acceptance
- [x] File at `apps/api/src/utils/is-caret-symbol-present.ts`
- [x] Exports `isCaretSymbolPresent(value: string): boolean`
- [x] Dependency-free and easy to verify