### PR TITLE
feat(api): add is-close-bracket-symbol-present utility (Closes #4806)

### DIFF
--- a/apps/api/src/utils/is-close-bracket-symbol-present.ts
+++ b/apps/api/src/utils/is-close-bracket-symbol-present.ts
@@ -1,0 +1,7 @@
+/**
+ * Returns whether `value` contains the close-bracket symbol.
+ * Dependency-free utility for API symbol checks.
+ */
+export function isCloseBracketSymbolPresent(value: string): boolean {
+  return value.includes("]");
+}


### PR DESCRIPTION
## Closes #4806 (Algora $50)

Adds `apps/api/src/utils/is-close-bracket-symbol-present.ts` exporting `isCloseBracketSymbolPresent(value: string): boolean`. Dependency-free, returns whether the string contains the close-bracket symbol.

### Acceptance
- [x] File at `apps/api/src/utils/is-close-bracket-symbol-present.ts`
- [x] Exports `isCloseBracketSymbolPresent(value: string): boolean`
- [x] Dependency-free and easy to verify