### PR TITLE
feat(api): add is-open-brace-symbol-present utility (Closes #4791)

### DIFF
--- a/apps/api/src/utils/is-open-brace-symbol-present.ts
+++ b/apps/api/src/utils/is-open-brace-symbol-present.ts
@@ -1,0 +1,7 @@
+/**
+ * Returns whether `value` contains the open-brace symbol.
+ * Dependency-free utility for API symbol checks.
+ */
+export function isOpenBraceSymbolPresent(value: string): boolean {
+  return value.includes("{");
+}


### PR DESCRIPTION
## Closes #4791 (Algora $50)

Adds `apps/api/src/utils/is-open-brace-symbol-present.ts` exporting `isOpenBraceSymbolPresent(value: string): boolean`. Dependency-free, returns whether the string contains the open-brace symbol.

### Acceptance
- [x] File at `apps/api/src/utils/is-open-brace-symbol-present.ts`
- [x] Exports `isOpenBraceSymbolPresent(value: string): boolean`
- [x] Dependency-free and easy to verify