### PR TITLE
feat(api): add is-less-than-symbol-present utility (Closes #4751)

### DIFF
--- a/apps/api/src/utils/is-less-than-symbol-present.ts
+++ b/apps/api/src/utils/is-less-than-symbol-present.ts
@@ -1,0 +1,7 @@
+/**
+ * Returns whether `value` contains the less-than symbol.
+ * Dependency-free utility for API symbol checks.
+ */
+export function isLessThanSymbolPresent(value: string): boolean {
+  return value.includes("<");
+}


### PR DESCRIPTION
## Closes #4751 (Algora $50)

Adds `apps/api/src/utils/is-less-than-symbol-present.ts` exporting `isLessThanSymbolPresent(value: string): boolean`. Dependency-free, returns whether the string contains the less-than symbol.

### Acceptance
- [x] File at `apps/api/src/utils/is-less-than-symbol-present.ts`
- [x] Exports `isLessThanSymbolPresent(value: string): boolean`
- [x] Dependency-free and easy to verify