### PR TITLE
feat(api): add is-close-brace-symbol-present utility (Closes #4807)

### DIFF
--- a/apps/api/src/utils/is-close-brace-symbol-present.ts
+++ b/apps/api/src/utils/is-close-brace-symbol-present.ts
@@ -1,0 +1,7 @@
+/**
+ * Returns whether `value` contains the close-brace symbol.
+ * Dependency-free utility for API symbol checks.
+ */
+export function isCloseBraceSymbolPresent(value: string): boolean {
+  return value.includes("}");
+}


### PR DESCRIPTION
## Closes #4807 (Algora $50)

Adds `apps/api/src/utils/is-close-brace-symbol-present.ts` exporting `isCloseBraceSymbolPresent(value: string): boolean`. Dependency-free, returns whether the string contains the close-brace symbol.

### Acceptance
- [x] File at `apps/api/src/utils/is-close-brace-symbol-present.ts`
- [x] Exports `isCloseBraceSymbolPresent(value: string): boolean`
- [x] Dependency-free and easy to verify