### PR TITLE
feat(api): add is-close-paren-symbol-present utility (Closes #4784)

### DIFF
--- a/apps/api/src/utils/is-close-paren-symbol-present.ts
+++ b/apps/api/src/utils/is-close-paren-symbol-present.ts
@@ -1,0 +1,7 @@
+/**
+ * Returns whether `value` contains the close-paren symbol.
+ * Dependency-free utility for API symbol checks.
+ */
+export function isCloseParenSymbolPresent(value: string): boolean {
+  return value.includes(")");
+}


### PR DESCRIPTION
## Closes #4784 (Algora $50)

Adds `apps/api/src/utils/is-close-paren-symbol-present.ts` exporting `isCloseParenSymbolPresent(value: string): boolean`. Dependency-free, returns whether the string contains the close-paren symbol.

### Acceptance
- [x] File at `apps/api/src/utils/is-close-paren-symbol-present.ts`
- [x] Exports `isCloseParenSymbolPresent(value: string): boolean`
- [x] Dependency-free and easy to verify