### PR TITLE
feat(api): add is-open-paren-symbol-present utility (Closes #4782)

### DIFF
--- a/apps/api/src/utils/is-open-paren-symbol-present.ts
+++ b/apps/api/src/utils/is-open-paren-symbol-present.ts
@@ -1,0 +1,7 @@
+/**
+ * Returns whether `value` contains the open-paren symbol.
+ * Dependency-free utility for API symbol checks.
+ */
+export function isOpenParenSymbolPresent(value: string): boolean {
+  return value.includes("(");
+}


### PR DESCRIPTION
## Closes #4782 (Algora $50)

Adds `apps/api/src/utils/is-open-paren-symbol-present.ts` exporting `isOpenParenSymbolPresent(value: string): boolean`. Dependency-free, returns whether the string contains the open-paren symbol.

### Acceptance
- [x] File at `apps/api/src/utils/is-open-paren-symbol-present.ts`
- [x] Exports `isOpenParenSymbolPresent(value: string): boolean`
- [x] Dependency-free and easy to verify