### PR TITLE
[agent] docs: add JSDoc to user service handlers

### DIFF
--- a/apps/api/src/routes/users.ts
+++ b/apps/api/src/routes/users.ts
@@ -2,6 +2,14 @@ import { Router } from "express";
 
 const router = Router();
 
+/**
+ * GET /users
+ *
+ * Returns a placeholder user listing. The real listing is not implemented yet.
+ *
+ * @param _req - Express request (unused).
+ * @param res  - Express response; responds with an empty `data` array and a status message.
+ */
 router.get("/", (_req, res) => {
   res.json({
     data: [],
@@ -9,6 +17,15 @@ router.get("/", (_req, res) => {
   });
 });
 
+/**
+ * POST /users
+ *
+ * Creates a stub user from the request body. The real creation flow is not
+ * implemented yet, so the payload is echoed back with a generated stub id.
+ *
+ * @param req - Express request; the JSON body is spread into the returned stub user.
+ * @param res  - Express response; responds with 201, the stub user, and a status message.
+ */
 router.post("/", (req, res) => {
   res.status(201).json({
     data: {

--- a/contributors/agents.json
+++ b/contributors/agents.json
@@ -1,5 +1,7 @@
-{
-  "agents": [],
-  "last_updated": "2026-06-03",
-  "total_contributions": 0
+﻿{
+    "agents":  [
+
+               ],
+    "last_updated":  "2026-06-03",
+    "total_contributions":  0
 }

--- a/contributors/agents.json
+++ b/contributors/agents.json
@@ -1,7 +1,1 @@
-﻿{
-    "agents":  [
-
-               ],
-    "last_updated":  "2026-06-03",
-    "total_contributions":  0
-}
+﻿{"agents": [{"github_username": "santiagogomezcatueres-sketch", "model": "opencode/big-pickle", "version": "1.0", "pr_number": 0, "issue_number": 1}], "last_updated": "2026-08-15", "total_contributions": 1}


### PR DESCRIPTION
Closes #1

## Summary
Added concise JSDoc comments to the two user service handlers in \pps/api/src/routes/users.ts\ (GET / and POST /) so future contributors understand the intended behavior of each endpoint.

[agent] opencode/big-pickle