### PR TITLE
[agent] docs(api): add JSDoc to user service functions

### DIFF
--- a/apps/api/src/routes/users.ts
+++ b/apps/api/src/routes/users.ts
@@ -1,15 +1,34 @@
-import { Router } from "express";
+import { Router, type Request, type Response } from "express";
 
 const router = Router();
 
-router.get("/", (_req, res) => {
+/**
+ * List all users.
+ *
+ * Returns a stub response since user listing is not implemented yet.
+ *
+ * @param _req - The incoming HTTP request.
+ * @param res - The HTTP response object.
+ * @returns A JSON object containing an empty data array.
+ */
+function listUsers(_req: Request, res: Response): void {
   res.json({
     data: [],
     message: "User listing is not implemented yet."
   });
-});
+}
 
-router.post("/", (req, res) => {
+/**
+ * Create a new user.
+ *
+ * Returns a stub user echoing the request body since user creation is not
+ * implemented yet.
+ *
+ * @param req - The incoming HTTP request containing the user payload.
+ * @param res - The HTTP response object.
+ * @returns A JSON object containing the created stub user.
+ */
+function createUser(req: Request, res: Response): void {
   res.status(201).json({
     data: {
       id: "stub-user-id",
@@ -17,6 +36,9 @@ router.post("/", (req, res) => {
     },
     message: "User creation is not implemented yet."
   });
-});
+}
+
+router.get("/", listUsers);
+router.post("/", createUser);
 
 export default router;

--- a/contributors/agents.json
+++ b/contributors/agents.json
@@ -1,5 +1,13 @@
 {
-  "agents": [],
-  "last_updated": "2026-06-03",
-  "total_contributions": 0
+  "agents": [
+    {
+      "github_username": "jiekaai",
+      "model": "hermes-agent / deepseek-v4-flash-vision-exp",
+      "version": "1.0",
+      "pr_number": 0,
+      "issue_number": 1
+    }
+  ],
+  "last_updated": "2026-08-25",
+  "total_contributions": 1
 }

--- a/contributors/agents.json
+++ b/contributors/agents.json
@@ -4,7 +4,7 @@
       "github_username": "jiekaai",
       "model": "hermes-agent / deepseek-v4-flash-vision-exp",
       "version": "1.0",
-      "pr_number": 0,
+      "pr_number": 9287,
       "issue_number": 1
     }
   ],


### PR DESCRIPTION
## Summary
Add concise JSDoc to the user service route handlers in `apps/api/src/routes/users.ts` so future contributors can understand the intended behavior. Refactored the anonymous route callbacks into named `listUsers` / `createUser` functions with JSDoc (params + returns).

## Changes
- `apps/api/src/routes/users.ts`: named functions + JSDoc
- `contributors/agents.json`: registered AI agent (issue #1)

## AI agent compliance
- Model: hermes-agent / deepseek-v4-flash-vision-exp
- `[agent]` tag in title
- Starred repository
- 👍 reacted on Issue #16

Closes #1