### PR TITLE
Fix #687: Bounty issue template omits required /bounty marker

### DIFF
--- a/.github/ISSUE_TEMPLATE/bounty_task.md
+++ b/.github/ISSUE_TEMPLATE/bounty_task.md
@@ -18,4 +18,4 @@ Describe the task, expected context, and files likely involved.
 
 ## Bounty Amount
 
-$50
+/bounty $50


### PR DESCRIPTION
Fixes #687

Actualiza la plantilla de bounty para usar el marcador legible por máquina requerido.

Submitted by novastreamdev.