### PR TITLE
[agent] fix: clean up README typos and grammar

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,8 +3,7 @@
 <img width="663" height="183" alt="593560705-1a920eb5-e581-44ce-bcef-2ebf0566777f" src="https://github.com/user-attachments/assets/37891de4-a282-45a3-98aa-35598c4571c2" />
 
 
-TaskFlow is a full-stack task management SaaS monorepo built 
-with a modern TypeScript-first architecture.
+TaskFlow is a full-stack task management SaaS monorepo built with a modern TypeScript-first architecture.
 
 ## Workspace Structure
 
@@ -17,7 +16,7 @@ with a modern TypeScript-first architecture.
 
 The web app includes pages for:
 - Landing
-- Task boards and task detail
+- Task boards and task details
 - Create a task
 - User profiles and user search
 - Client and freelancer dashboards
@@ -32,7 +31,7 @@ The web app includes pages for:
 The API includes:
 - Auth routes (register, login, OAuth callback, JWT refresh)
 - CRUD routes for users, tasks, and proposals
-- Payments routes (Stripe-focused service placeholder)
+- Payment routes (Stripe-focused service placeholder)
 - Reviews, messaging, notifications
 - File uploads and search
 - Admin routes

--- a/contributors/agents.json
+++ b/contributors/agents.json
@@ -1,5 +1,13 @@
 {
-  "agents": [],
-  "last_updated": "2026-06-03",
-  "total_contributions": 0
+  "agents": [
+    {
+      "github_username": "xiaoqiang518",
+      "model": "Tencent Hunyuan Hy3 + DeepSeek-V4 Pro (via Marvis)",
+      "version": "1.0",
+      "pr_number": 0,
+      "issue_number": 2
+    }
+  ],
+  "last_updated": "2026-08-26",
+  "total_contributions": 1
 }

--- a/contributors/agents.json
+++ b/contributors/agents.json
@@ -4,7 +4,7 @@
       "github_username": "xiaoqiang518",
       "model": "Tencent Hunyuan Hy3 + DeepSeek-V4 Pro (via Marvis)",
       "version": "1.0",
-      "pr_number": 0,
+      "pr_number": 9290,
       "issue_number": 2
     }
   ],


### PR DESCRIPTION
## Summary

Small cleanup PR for issue #2. Fixed the following in README.md:

- Merged the broken line wrap in the intro paragraph ("built\nwith" -> "built with")
- Fixed plural inconsistency: `task detail` -> `task details`
- Fixed plural inconsistency: `Payments routes` -> `Payment routes`
- Registered agent in `contributors/agents.json` per CONTRIBUTING requirements

Closes #2