### PR TITLE
[agent] Validate user creation payloads

### DIFF
--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -7,7 +7,7 @@
   "main": "src/index.ts",
   "scripts": {
     "dev": "tsx src/index.ts",
-    "test": "echo \"No API tests configured yet\"",
+    "test": "tsx --test src/routes/users.test.ts",
     "lint": "echo \"No API lint configured yet\""
   },
   "dependencies": {

--- a/apps/api/src/routes/users.test.ts
+++ b/apps/api/src/routes/users.test.ts
@@ -1,0 +1,63 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { validateCreateUserPayload } from "./users";
+
+test("rejects non-object request bodies", () => {
+  for (const body of [null, [], "user@example.com", 42, true]) {
+    const result = validateCreateUserPayload(body);
+    assert.equal(result.ok, false);
+  }
+});
+
+test("requires a valid email", () => {
+  for (const body of [{}, { email: "" }, { email: "invalid" }, { email: "a@b" }]) {
+    const result = validateCreateUserPayload(body);
+    assert.equal(result.ok, false);
+  }
+});
+
+test("normalizes email and optional name", () => {
+  const result = validateCreateUserPayload({
+    email: "  USER@Example.COM ",
+    name: "  Ada Lovelace  "
+  });
+
+  assert.deepEqual(result, {
+    ok: true,
+    value: {
+      email: "user@example.com",
+      name: "Ada Lovelace"
+    }
+  });
+});
+
+test("ignores client-controlled id and unrelated fields", () => {
+  const result = validateCreateUserPayload({
+    id: "client-id",
+    email: "user@example.com",
+    role: "admin",
+    unexpected: true
+  });
+
+  assert.deepEqual(result, {
+    ok: true,
+    value: {
+      email: "user@example.com"
+    }
+  });
+});
+
+test("drops a blank optional name after normalization", () => {
+  const result = validateCreateUserPayload({
+    email: "user@example.com",
+    name: "   "
+  });
+
+  assert.deepEqual(result, {
+    ok: true,
+    value: {
+      email: "user@example.com"
+    }
+  });
+});

--- a/apps/api/src/routes/users.ts
+++ b/apps/api/src/routes/users.ts
@@ -1,6 +1,48 @@
+import { randomUUID } from "node:crypto";
 import { Router } from "express";
 
 const router = Router();
+
+const EMAIL_RE = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
+
+type CreateUserInput = {
+  email: string;
+  name?: string;
+};
+
+type ValidationResult =
+  | { ok: true; value: CreateUserInput }
+  | { ok: false; error: string };
+
+export function validateCreateUserPayload(body: unknown): ValidationResult {
+  if (body === null || Array.isArray(body) || typeof body !== "object") {
+    return { ok: false, error: "Request body must be a JSON object." };
+  }
+
+  const payload = body as Record<string, unknown>;
+  if (typeof payload.email !== "string") {
+    return { ok: false, error: "A valid email is required." };
+  }
+
+  const email = payload.email.trim().toLowerCase();
+  if (!EMAIL_RE.test(email)) {
+    return { ok: false, error: "A valid email is required." };
+  }
+
+  const value: CreateUserInput = { email };
+  if (payload.name !== undefined) {
+    if (typeof payload.name !== "string") {
+      return { ok: false, error: "Name must be a string when provided." };
+    }
+
+    const name = payload.name.trim();
+    if (name) {
+      value.name = name;
+    }
+  }
+
+  return { ok: true, value };
+}
 
 router.get("/", (_req, res) => {
   res.json({
@@ -10,10 +52,17 @@ router.get("/", (_req, res) => {
 });
 
 router.post("/", (req, res) => {
-  res.status(201).json({
+  const result = validateCreateUserPayload(req.body);
+  if (!result.ok) {
+    return res.status(400).json({
+      error: result.error
+    });
+  }
+
+  return res.status(201).json({
     data: {
-      id: "stub-user-id",
-      ...req.body
+      id: randomUUID(),
+      ...result.value
     },
     message: "User creation is not implemented yet."
   });

--- a/contributors/agents.json
+++ b/contributors/agents.json
@@ -1,5 +1,13 @@
 {
-  "agents": [],
-  "last_updated": "2026-06-03",
-  "total_contributions": 0
+  "agents": [
+    {
+      "github_username": "mdmcl-pixel",
+      "model": "GPT-5.6 Sol",
+      "version": "GPT-5.6 Sol",
+      "pr_number": 0,
+      "issue_number": 2207
+    }
+  ],
+  "last_updated": "2026-08-28",
+  "total_contributions": 1
 }


### PR DESCRIPTION
## Description
Validates user creation payloads: require a valid email, normalize accepted values, keep server-generated ids authoritative, and reject invalid shapes.

Closes #2207

/claim #2207

## AI Agent Checklist
- [x] I reacted 👍 on issue #1 (Agent Registry)
- [x] I starred this repository
- [x] I added my model name and version to `contributors/agents.json`
- [x] My PR title includes the `[agent]` tag

## Model Info
- Model name/version: GPT-5.6 Sol
- Issue attempted: #2207
- Approach used: focused input-validation and server-authoritative-id hardening with tests.
