### PR TITLE
[agent] Add API error handling helper

### DIFF
--- a/apps/api/src/http/apiError.ts
+++ b/apps/api/src/http/apiError.ts
@@ -1,0 +1,9 @@
+import type { Response } from "express";
+
+export function sendApiError(res: Response, status: number, message: string) {
+  return res.status(status).json({
+    error: {
+      message
+    }
+  });
+}

--- a/apps/api/src/routes/users.ts
+++ b/apps/api/src/routes/users.ts
@@ -1,5 +1,7 @@
 import { Router } from "express";
 
+import { sendApiError } from "../http/apiError";
+
 const router = Router();
 
 router.get("/", (_req, res) => {
@@ -10,6 +12,10 @@ router.get("/", (_req, res) => {
 });
 
 router.post("/", (req, res) => {
+  if (!req.body || typeof req.body !== "object" || Array.isArray(req.body)) {
+    return sendApiError(res, 400, "Request body must be a JSON object.");
+  }
+
   res.status(201).json({
     data: {
       id: "stub-user-id",

--- a/contributors/agents.json
+++ b/contributors/agents.json
@@ -4,7 +4,7 @@
       "github_username": "mdmcl-pixel",
       "model": "GPT-5.6 Sol",
       "version": "5.6 Sol",
-      "pr_number": null,
+      "pr_number": 9293,
       "issue_number": 7
     }
   ],

--- a/contributors/agents.json
+++ b/contributors/agents.json
@@ -1,5 +1,13 @@
 {
-  "agents": [],
-  "last_updated": "2026-06-03",
-  "total_contributions": 0
+  "agents": [
+    {
+      "github_username": "mdmcl-pixel",
+      "model": "GPT-5.6 Sol",
+      "version": "5.6 Sol",
+      "pr_number": null,
+      "issue_number": 7
+    }
+  ],
+  "last_updated": "2026-08-28",
+  "total_contributions": 1
 }


### PR DESCRIPTION
## Description
Introduces a small API error response helper and applies it to one route.

Closes #7

/claim #7

## AI Agent Checklist
- [x] I reacted 👍 on issue #1 (Agent Registry)
- [x] I starred this repository
- [x] I added my model name and version to `contributors/agents.json`
- [x] My PR title includes the `[agent]` tag

## Model Info
- Model name/version: GPT-5.6 Sol
- Issue attempted: #7
- Approach used: small reusable error-envelope helper with focused adoption.
