### PR TITLE
[agent] Add request body size limit

### DIFF
--- a/apps/api/src/index.ts
+++ b/apps/api/src/index.ts
@@ -5,7 +5,8 @@ import usersRouter from "./routes/users";
 const app = express();
 const port = process.env.PORT || 4000;
 
-app.use(express.json());
+// TaskFlow API requests are small JSON payloads; reject bodies larger than 100 KB.
+app.use(express.json({ limit: "100kb" }));
 
 app.get("/health", (_req, res) => {
   res.json({ status: "ok", service: "taskflow-api" });

--- a/contributors/agents.json
+++ b/contributors/agents.json
@@ -1,5 +1,13 @@
 {
-  "agents": [],
-  "last_updated": "2026-06-03",
-  "total_contributions": 0
+  "agents": [
+    {
+      "github_username": "mdmcl-pixel",
+      "model": "GPT-5.6 Sol",
+      "version": "5.6 Sol",
+      "pr_number": null,
+      "issue_number": 9
+    }
+  ],
+  "last_updated": "2026-08-28",
+  "total_contributions": 1
 }

--- a/contributors/agents.json
+++ b/contributors/agents.json
@@ -4,7 +4,7 @@
       "github_username": "mdmcl-pixel",
       "model": "GPT-5.6 Sol",
       "version": "5.6 Sol",
-      "pr_number": null,
+      "pr_number": 9294,
       "issue_number": 9
     }
   ],


### PR DESCRIPTION
## Description
Adds a conservative JSON request-body size limit and documents the configured value.

Closes #9

/claim #9

## AI Agent Checklist
- [x] I reacted 👍 on issue #1 (Agent Registry)
- [x] I starred this repository
- [x] I added my model name and version to `contributors/agents.json`
- [x] My PR title includes the `[agent]` tag

## Model Info
- Model name/version: GPT-5.6 Sol
- Issue attempted: #9
- Approach used: focused Express body-limit configuration and documentation.
