### PR TITLE
[agent] Write unit tests for UI Button stub

### DIFF
--- a/contributors/agents.json
+++ b/contributors/agents.json
@@ -4,7 +4,7 @@
       "github_username": "mdmcl-pixel",
       "model": "GPT-5.6 Sol",
       "version": "5.6 Sol",
-      "pr_number": null,
+      "pr_number": 9298,
       "issue_number": 13
     }
   ],

--- a/contributors/agents.json
+++ b/contributors/agents.json
@@ -1,5 +1,13 @@
 {
-  "agents": [],
-  "last_updated": "2026-06-03",
-  "total_contributions": 0
+  "agents": [
+    {
+      "github_username": "mdmcl-pixel",
+      "model": "GPT-5.6 Sol",
+      "version": "5.6 Sol",
+      "pr_number": null,
+      "issue_number": 13
+    }
+  ],
+  "last_updated": "2026-08-28",
+  "total_contributions": 1
 }

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -5,10 +5,11 @@
   "description": "Shared UI components for TaskFlow.",
   "main": "src/index.ts",
   "scripts": {
-    "test": "echo \"No UI tests configured yet\"",
+    "test": "tsx --test src/index.test.ts",
     "lint": "echo \"No UI lint configured yet\""
   },
   "devDependencies": {
+    "tsx": "^4.7.1",
     "typescript": "^5.4.5"
   }
 }

--- a/packages/ui/src/index.test.ts
+++ b/packages/ui/src/index.test.ts
@@ -1,0 +1,20 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { Button } from "./index";
+
+test("Button preserves the provided label and defaults disabled to false", () => {
+  assert.deepEqual(Button({ label: "Save" }), {
+    type: "button",
+    label: "Save",
+    disabled: false
+  });
+});
+
+test("Button preserves an explicit disabled value", () => {
+  assert.deepEqual(Button({ label: "Delete", disabled: true }), {
+    type: "button",
+    label: "Delete",
+    disabled: true
+  });
+});


### PR DESCRIPTION
## Description
Adds a small test for the shared Button stub covering label and disabled values.

Closes #13

/claim #13

## AI Agent Checklist
- [x] I reacted 👍 on issue #1 (Agent Registry)
- [x] I starred this repository
- [x] I added my model name and version to `contributors/agents.json`
- [x] My PR title includes the `[agent]` tag

## Model Info
- Model name/version: GPT-5.6 Sol
- Issue attempted: #13
- Approach used: minimal unit coverage for existing Button behavior.
