### PR TITLE
[agent] Add input validation to user routes

### DIFF
--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -7,7 +7,7 @@
   "main": "src/index.ts",
   "scripts": {
     "dev": "tsx src/index.ts",
-    "test": "echo \"No API tests configured yet\"",
+    "test": "tsx --test src/routes/users.test.ts",
     "lint": "echo \"No API lint configured yet\""
   },
   "dependencies": {

--- a/apps/api/src/routes/users.test.ts
+++ b/apps/api/src/routes/users.test.ts
@@ -1,0 +1,116 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import type { Request, Response } from "express";
+
+import router, { validateCreateUserPayload } from "./users";
+
+type CapturedResponse = {
+  statusCode: number;
+  body: unknown;
+};
+
+type RouteHandler = (
+  req: Request,
+  res: Response,
+  next: () => void
+) => unknown;
+
+type RouterLayer = {
+  route?: {
+    path: string;
+    methods: Record<string, boolean>;
+    stack: Array<{ handle: RouteHandler }>;
+  };
+};
+
+function getPostHandler(): RouteHandler {
+  const stack = (router as unknown as { stack: RouterLayer[] }).stack;
+  const layer = stack.find(
+    (entry) => entry.route?.path === "/" && entry.route.methods.post
+  );
+
+  assert.ok(layer?.route, "POST / route should exist");
+  return layer.route.stack[0].handle;
+}
+
+function createResponse(): { res: Response; captured: CapturedResponse } {
+  const captured: CapturedResponse = {
+    statusCode: 200,
+    body: undefined
+  };
+
+  const res = {
+    status(code: number) {
+      captured.statusCode = code;
+      return this;
+    },
+    json(body: unknown) {
+      captured.body = body;
+      return this;
+    }
+  } as Response;
+
+  return { res, captured };
+}
+
+test("validateCreateUserPayload rejects non-object request bodies", () => {
+  assert.deepEqual(validateCreateUserPayload(null), {
+    ok: false,
+    error: "Request body must be a JSON object."
+  });
+  assert.deepEqual(validateCreateUserPayload([]), {
+    ok: false,
+    error: "Request body must be a JSON object."
+  });
+});
+
+test("validateCreateUserPayload rejects missing or invalid required fields", () => {
+  assert.deepEqual(validateCreateUserPayload({ email: "user@example.com" }), {
+    ok: false,
+    error: "A non-empty name is required."
+  });
+  assert.deepEqual(
+    validateCreateUserPayload({ name: "Example User", email: "invalid" }),
+    {
+      ok: false,
+      error: "A valid email is required."
+    }
+  );
+});
+
+test("POST / returns 400 for an invalid user payload", () => {
+  const handler = getPostHandler();
+  const { res, captured } = createResponse();
+  const req = { body: {} } as Request;
+
+  handler(req, res, () => undefined);
+
+  assert.equal(captured.statusCode, 400);
+  assert.deepEqual(captured.body, {
+    error: "A non-empty name is required."
+  });
+});
+
+test("POST / trims valid user fields and preserves the stub response", () => {
+  const handler = getPostHandler();
+  const { res, captured } = createResponse();
+  const req = {
+    body: {
+      email: " user@example.com ",
+      name: " Example User "
+    }
+  } as Request;
+
+  handler(req, res, () => undefined);
+
+  assert.equal(captured.statusCode, 201);
+  assert.deepEqual(captured.body, {
+    data: {
+      id: "stub-user-id",
+      email: "user@example.com",
+      name: "Example User"
+    },
+    message: "User creation is not implemented yet."
+  });
+});

--- a/apps/api/src/routes/users.ts
+++ b/apps/api/src/routes/users.ts
@@ -2,6 +2,41 @@ import { Router } from "express";
 
 const router = Router();
 
+const EMAIL_RE = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
+
+type CreateUserInput = {
+  email: string;
+  name: string;
+};
+
+type ValidationResult =
+  | { ok: true; value: CreateUserInput }
+  | { ok: false; error: string };
+
+export function validateCreateUserPayload(body: unknown): ValidationResult {
+  if (body === null || Array.isArray(body) || typeof body !== "object") {
+    return { ok: false, error: "Request body must be a JSON object." };
+  }
+
+  const payload = body as Record<string, unknown>;
+
+  if (typeof payload.name !== "string" || payload.name.trim() === "") {
+    return { ok: false, error: "A non-empty name is required." };
+  }
+
+  if (typeof payload.email !== "string" || !EMAIL_RE.test(payload.email.trim())) {
+    return { ok: false, error: "A valid email is required." };
+  }
+
+  return {
+    ok: true,
+    value: {
+      name: payload.name.trim(),
+      email: payload.email.trim()
+    }
+  };
+}
+
 router.get("/", (_req, res) => {
   res.json({
     data: [],
@@ -10,10 +45,16 @@ router.get("/", (_req, res) => {
 });
 
 router.post("/", (req, res) => {
-  res.status(201).json({
+  const result = validateCreateUserPayload(req.body);
+
+  if (!result.ok) {
+    return res.status(400).json({ error: result.error });
+  }
+
+  return res.status(201).json({
     data: {
       id: "stub-user-id",
-      ...req.body
+      ...result.value
     },
     message: "User creation is not implemented yet."
   });

--- a/contributors/agents.json
+++ b/contributors/agents.json
@@ -1,5 +1,13 @@
 {
-  "agents": [],
-  "last_updated": "2026-06-03",
-  "total_contributions": 0
+  "agents": [
+    {
+      "github_username": "mdmcl-pixel",
+      "model": "GPT-5.6 Sol",
+      "version": "5.6 Sol",
+      "pr_number": null,
+      "issue_number": 6
+    }
+  ],
+  "last_updated": "2026-08-28",
+  "total_contributions": 1
 }

--- a/contributors/agents.json
+++ b/contributors/agents.json
@@ -4,7 +4,7 @@
       "github_username": "mdmcl-pixel",
       "model": "GPT-5.6 Sol",
       "version": "5.6 Sol",
-      "pr_number": null,
+      "pr_number": 9303,
       "issue_number": 6
     }
   ],


### PR DESCRIPTION
## Description
Adds lightweight validation to the user route stubs so invalid request shapes return a clear error response.

Closes #6

/claim #6

## AI Agent Checklist
- [x] I reacted 👍 on issue #1 (Agent Registry)
- [x] I starred this repository
- [x] I added my model name and version to `contributors/agents.json`
- [x] My PR title includes the `[agent]` tag

## Model Info
- Model name/version: GPT-5.6 Sol
- Issue attempted: #6
- Approach used: focused route validation with regression-safe behavior.
