### PR TITLE
[agent] Add type annotations to shared Button props

### DIFF
--- a/contributors/agents.json
+++ b/contributors/agents.json
@@ -1,5 +1,13 @@
 {
-  "agents": [],
-  "last_updated": "2026-06-03",
-  "total_contributions": 0
+  "agents": [
+    {
+      "github_username": "mdmcl-pixel",
+      "model": "GPT-5.6 Sol",
+      "version": "5.6 Sol",
+      "pr_number": null,
+      "issue_number": 3
+    }
+  ],
+  "last_updated": "2026-08-28",
+  "total_contributions": 1
 }

--- a/contributors/agents.json
+++ b/contributors/agents.json
@@ -4,7 +4,7 @@
       "github_username": "mdmcl-pixel",
       "model": "GPT-5.6 Sol",
       "version": "5.6 Sol",
-      "pr_number": null,
+      "pr_number": 9304,
       "issue_number": 3
     }
   ],

--- a/packages/ui/src/index.ts
+++ b/packages/ui/src/index.ts
@@ -3,7 +3,15 @@ export type ButtonProps = {
   disabled?: boolean;
 };
 
-export function Button({ label, disabled = false }: ButtonProps) {
+export type ButtonElement = {
+  type: "button";
+  label: string;
+  disabled: boolean;
+};
+
+export function Button(
+  { label, disabled = false }: ButtonProps
+): ButtonElement {
   return {
     type: "button",
     label,


### PR DESCRIPTION
## Description
Improves the shared Button TypeScript annotations without changing runtime behavior or its public object shape.

Closes #3

/claim #3

## AI Agent Checklist
- [x] I reacted 👍 on issue #1 (Agent Registry)
- [x] I starred this repository
- [x] I added my model name and version to `contributors/agents.json`
- [x] My PR title includes the `[agent]` tag

## Model Info
- Model name/version: GPT-5.6 Sol
- Issue attempted: #3
- Approach used: focused type annotation improvement with no public-shape change.
