### PR TITLE
fix(api): secure POST /users with server-generated ids and payload whitelist

### DIFF
--- a/apps/api/src/routes/users.ts
+++ b/apps/api/src/routes/users.ts
@@ -1,4 +1,5 @@
 import { Router } from "express";
+import { randomUUID } from 'crypto';
 
 const router = Router();
 
@@ -6,15 +7,27 @@ router.get("/", (_req, res) => {
   res.json({
     data: [],
     message: "User listing is not implemented yet."
-  });
-});
+  const { name, email } = req.body ?? {};
 
-router.post("/", (req, res) => {
+  if (typeof name !== 'string' || name.trim().length === 0) {
+    return res.status(400).json({ error: 'Valid name is required' });
+  }
+
+  if (typeof email !== 'string' || !/^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(email)) {
+    return res.status(400).json({ error: 'Valid email is required' });
   res.status(201).json({
     data: {
-      id: "stub-user-id",
+  // Reject any extra fields not in the whitelist
+  const allowedKeys = ['name', 'email'];
+  const extraKeys = Object.keys(req.body).filter((k) => !allowedKeys.includes(k));
+  if (extraKeys.length > 0) {
+    return res.status(400).json({ error: `Unexpected fields: ${extraKeys.join(', ')}` });
+  }
+
+  const user = { id: randomUUID(), name: name.trim(), email: email.trim() };
       ...req.body
-    },
+
+  return res.status(201).json(user);
     message: "User creation is not implemented yet."
   });
 });


### PR DESCRIPTION
## Summary Fixes security issue #2377 where `POST /users` accepted arbitrary request bodies including client-supplied `id` values and extra fields.  ## Changes - **Server-side ID generation**: User IDs are now generated with `randomUUID()`; any client-supplied `id` is ignored. - **Payload whitelist 