### PR TITLE
fix: ensure required labels exist before seeding issues

### DIFF
--- a/.github/workflows/seed-issues.yml
+++ b/.github/workflows/seed-issues.yml
@@ -11,6 +11,37 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
+      - name: Ensure required labels exist
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const REQUIRED_LABELS = [
+              { name: "good first issue", color: "7057ff", description: "Good for new contributors." },
+              { name: "bounty", color: "e4e669", description: "Reward-backed contribution task." },
+              { name: "AI agent friendly", color: "0e8a16", description: "Suitable for autonomous AI agents." }
+            ];
+
+            for (const label of REQUIRED_LABELS) {
+              try {
+                await github.rest.issues.createLabel({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  name: label.name,
+                  color: label.color,
+                  description: label.description
+                });
+              } catch (error) {
+                if (error.status !== 422) throw error;
+                await github.rest.issues.updateLabel({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  name: label.name,
+                  color: label.color,
+                  description: label.description
+                });
+              }
+            }
+
       - name: Create starter issues
         uses: actions/github-script@v7
         with:

--- a/.github/workflows/seed-meta-issue.yml
+++ b/.github/workflows/seed-meta-issue.yml
@@ -11,6 +11,37 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
+      - name: Ensure required labels exist
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const REQUIRED_LABELS = [
+              { name: "good first issue", color: "7057ff", description: "Good for new contributors." },
+              { name: "bounty", color: "e4e669", description: "Reward-backed contribution task." },
+              { name: "AI agent friendly", color: "0e8a16", description: "Suitable for autonomous AI agents." }
+            ];
+
+            for (const label of REQUIRED_LABELS) {
+              try {
+                await github.rest.issues.createLabel({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  name: label.name,
+                  color: label.color,
+                  description: label.description
+                });
+              } catch (error) {
+                if (error.status !== 422) throw error;
+                await github.rest.issues.updateLabel({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  name: label.name,
+                  color: label.color,
+                  description: label.description
+                });
+              }
+            }
+
       - name: Create and pin bug bounty program issue
         uses: actions/github-script@v7
         with:

--- a/apps/api/src/index.ts
+++ b/apps/api/src/index.ts
@@ -5,17 +5,10 @@ import usersRouter from "./routes/users";
 const app = express();
 const port = process.env.PORT || 4000;
 
-// JSON body size limit set to 1mb to prevent overly large payloads.
-app.use(express.json({ limit: "1mb" }));
+app.use(express.json());
 
 app.get("/health", (_req, res) => {
-  res.json({
-    status: "ok",
-    data: {
-      service: "taskflow-api",
-      uptime: process.uptime(),
-    },
-  });
+  res.json({ status: "ok", service: "taskflow-api" });
 });
 
 app.use("/users", usersRouter);

--- a/apps/api/src/index.ts
+++ b/apps/api/src/index.ts
@@ -5,10 +5,17 @@ import usersRouter from "./routes/users";
 const app = express();
 const port = process.env.PORT || 4000;
 
-app.use(express.json());
+// JSON body size limit set to 1mb to prevent overly large payloads.
+app.use(express.json({ limit: "1mb" }));
 
 app.get("/health", (_req, res) => {
-  res.json({ status: "ok", service: "taskflow-api" });
+  res.json({
+    status: "ok",
+    data: {
+      service: "taskflow-api",
+      uptime: process.uptime(),
+    },
+  });
 });
 
 app.use("/users", usersRouter);


### PR DESCRIPTION
## Summary
Both seed workflows (`seed-issues.yml` and `seed-meta-issue.yml`) call `github.rest.issues.create` with label names like `good first issue`, `bounty`, and `AI agent friendly`, but they assume those labels already exist. On a fresh repo — or before `create-labels.yml` has been run — this fails with a validation error.

### Fix
Added an `Ensure required labels exist` step to both workflows that mirrors the create-or-update pattern from `create-labels.yml`. It runs before any issue creation, making the first-run setup order-independent.

Closes #957