### PR TITLE
Add is-newline-symbol-present API utility

### DIFF
--- a/apps/api/src/index.ts
+++ b/apps/api/src/index.ts
@@ -1,5 +1,6 @@
 import express from "express";
 
+import { isNewlineSymbolPresent } from './utils/string';
 import usersRouter from "./routes/users";
 
 const app = express();
@@ -13,6 +14,11 @@ app.get("/health", (_req, res) => {
 
 app.use("/users", usersRouter);
 
+
+app.get('/api/is-newline-symbol-present', (req, res) => {
+  const input = String(req.query.input ?? '');
+  res.json({ result: isNewlineSymbolPresent(input) });
+});
 app.listen(port, () => {
   console.log(`TaskFlow API listening on port ${port}`);
 });

--- a/apps/api/src/utils/string.ts
+++ b/apps/api/src/utils/string.ts
@@ -1,0 +1,7 @@
+/**
+ * Returns true if the string contains any newline control symbol.
+ * Recognizes LF (\n), CR (\r), and CRLF sequences.
+ */
+export function isNewlineSymbolPresent(value: string): boolean {
+  return /\r|\n/.test(value);
+}


### PR DESCRIPTION
## Summary Implements #4827 by adding a small API utility that detects whether a string contains newline control symbols (LF, CR, or CRLF).  ## Changes - Added `isNewlineSymbolPresent` helper in `apps/api/src/utils/string.ts` - Exposed `/api/is-newline-symbol-present?input=...` GET endpoint in `apps