### PR TITLE
feat(api): add is-vertical-tab-symbol-present API utility

### DIFF
--- a/apps/api/src/index.ts
+++ b/apps/api/src/index.ts
@@ -1,11 +1,18 @@
 import express from "express";
 
+import { isVerticalTabSymbolPresent } from '@repo/ui';
 import usersRouter from "./routes/users";
 
 const app = express();
 const port = process.env.PORT || 4000;
 
 app.use(express.json());
+
+app.get('/utils/is-vertical-tab-symbol-present', (req, res) => {
+  const input = typeof req.query.input === 'string' ? req.query.input : '';
+  const result = isVerticalTabSymbolPresent(input);
+  res.json({ result });
+});
 
 app.get("/health", (_req, res) => {
   res.json({ status: "ok", service: "taskflow-api" });

--- a/packages/ui/src/index.ts
+++ b/packages/ui/src/index.ts
@@ -1,4 +1,11 @@
-export type ButtonProps = {
+export const UI_VERSION = '1.0.0';
+
+/**
+ * Returns true if the string contains the vertical tab control character (\v / U+000B).
+ */
+export function isVerticalTabSymbolPresent(value: string): boolean {
+  return value.includes('\v');
+}
   label: string;
   disabled?: boolean;
 };


### PR DESCRIPTION
## Summary Closes #4833.  Adds a lightweight API utility that returns whether a given string contains the vertical tab control symbol (`\v`, U+000B). The check itself is implemented as a reusable helper in `@repo/ui` and exposed through a new `GET /utils/is-vertical-tab-symbol-present?input=...` end