### PR TITLE
Add is-form-feed-symbol-present API utility

### DIFF
--- a/apps/api/src/index.ts
+++ b/apps/api/src/index.ts
@@ -1,5 +1,6 @@
 import express from "express";
 
+import { isFormFeedSymbolPresent } from '@xevrion/ui';
 import usersRouter from "./routes/users";
 
 const app = express();
@@ -9,6 +10,11 @@ app.use(express.json());
 
 app.get("/health", (_req, res) => {
   res.json({ status: "ok", service: "taskflow-api" });
+});
+
+app.get('/is-form-feed-symbol-present', (req, res) => {
+  const input = typeof req.query.input === 'string' ? req.query.input : '';
+  res.json({ result: isFormFeedSymbolPresent(input) });
 });
 
 app.use("/users", usersRouter);

--- a/packages/ui/src/index.ts
+++ b/packages/ui/src/index.ts
@@ -1,3 +1,10 @@
+/**
+ * Returns true if the string contains the ASCII form feed control character (\f, U+000C).
+ */
+export function isFormFeedSymbolPresent(value: string): boolean {
+  return value.includes('\f');
+}
+
 export type ButtonProps = {
   label: string;
   disabled?: boolean;


### PR DESCRIPTION
## Summary Implements #4831 by exposing a GET `/is-form-feed-symbol-present?input=...` endpoint that returns whether the provided string contains the ASCII form feed character (`\f`, U+000C).  ## Changes - **packages/ui/src/index.ts**: Added `isFormFeedSymbolPresent(value: string): boolean` utility.