### PR TITLE
feat(api): add is-carriage-return-symbol-present utility endpoint

### DIFF
--- a/apps/api/src/index.ts
+++ b/apps/api/src/index.ts
@@ -1,5 +1,6 @@
 import express from "express";
 
+import { isCarriageReturnSymbolPresent } from '@xevrion/ui';
 import usersRouter from "./routes/users";
 
 const app = express();
@@ -12,6 +13,14 @@ app.get("/health", (_req, res) => {
 });
 
 app.use("/users", usersRouter);
+app.get('/utils/is-carriage-return-symbol-present', (req, res) => {
+  const input = typeof req.query.input === 'string' ? req.query.input : '';
+  const result = isCarriageReturnSymbolPresent(input);
+  res.json({
+    containsCarriageReturn: result,
+  });
+});
+
 
 app.listen(port, () => {
   console.log(`TaskFlow API listening on port ${port}`);

--- a/packages/ui/src/index.ts
+++ b/packages/ui/src/index.ts
@@ -1,4 +1,11 @@
-export type ButtonProps = {
+export const version = '0.1.0';
+
+/**
+ * Returns true if the string contains a carriage return character (\r).
+ */
+export function isCarriageReturnSymbolPresent(value: string): boolean {
+  return value.includes('\r');
+}
   label: string;
   disabled?: boolean;
 };


### PR DESCRIPTION
## Summary  Implements #4829 by adding a small API utility that reports whether a given string contains a carriage return symbol (`\r`).  ## Changes  - **`packages/ui/src/index.ts`** - adds `isCarriageReturnSymbolPresent(value: string): boolean` helper. - **`apps/api/src/index.ts`** - exposes `GET /