### PR TITLE
feat(api): add is-tab-symbol-present API utility

### DIFF
--- a/apps/api/src/index.ts
+++ b/apps/api/src/index.ts
@@ -1,5 +1,6 @@
 import express from "express";
 
+import { isTabSymbolPresent } from '@repo/ui';
 import usersRouter from "./routes/users";
 
 const app = express();
@@ -8,6 +9,11 @@ const port = process.env.PORT || 4000;
 app.use(express.json());
 
 app.get("/health", (_req, res) => {
+app.get('/api/utils/is-tab-symbol-present', (req, res) => {
+  const input = String(req.query.value ?? '');
+  res.json({ result: isTabSymbolPresent(input) });
+});
+
   res.json({ status: "ok", service: "taskflow-api" });
 });
 

--- a/packages/ui/src/index.ts
+++ b/packages/ui/src/index.ts
@@ -1,3 +1,10 @@
+/**
+ * Returns true if the provided string contains a horizontal tab character (U+0009).
+ */
+export function isTabSymbolPresent(value: string): boolean {
+  return value.includes('\t');
+}
+
 export type ButtonProps = {
   label: string;
   disabled?: boolean;


### PR DESCRIPTION
## Summary Adds the `isTabSymbolPresent` utility to `@repo/ui` and exposes it via a read-only GET endpoint at `/api/utils/is-tab-symbol-present?value=...`.  ## Changes - **packages/ui/src/index.ts**: exports `isTabSymbolPresent(value: string): boolean`. - **apps/api/src/index.ts**: imports the utili