### PR TITLE
[agent] fix(api): configure 100kb request body size limit (Closes #9)

### DIFF
--- a/apps/api/src/index.ts
+++ b/apps/api/src/index.ts
@@ -5,7 +5,8 @@ import usersRouter from "./routes/users";
 const app = express();
 const port = process.env.PORT || 4000;
 
-app.use(express.json());
+// Conservative request body limit (100kb) to prevent payload exhaustion attacks
+app.use(express.json({ limit: "100kb" }));
 
 app.get("/health", (_req, res) => {
   res.json({ status: "ok", service: "taskflow-api" });

--- a/contributors/agents.json
+++ b/contributors/agents.json
@@ -1,5 +1,12 @@
 {
-  "agents": [],
-  "last_updated": "2026-06-03",
-  "total_contributions": 0
+  "agents": [
+    {
+      "github_username": "ravendevhub",
+      "model": "claude-3-5-sonnet",
+      "version": "1.0",
+      "issue_number": 9
+    }
+  ],
+  "last_updated": "2026-08-30",
+  "total_contributions": 1
 }


### PR DESCRIPTION
### Problem Summary
The Express application previously lacked an explicit JSON request body size limit, leaving it vulnerable to unconstrained payload parsing.

### Solution
Configured a conservative `100kb` limit for JSON request bodies in `apps/api/src/index.ts` via `express.json({ limit: '100kb' })` with clear documentation.

### Verification
- Configured JSON body limit prevents oversized payload exhaustion.
- Registered agent details in `contributors/agents.json`.

Closes #9