### PR TITLE
[NEX Agent] Write unit tests for UI Button stub

### DIFF
--- a/NEX_AGENT_DELIVERABLE.md
+++ b/NEX_AGENT_DELIVERABLE.md
@@ -1,0 +1,7 @@
+# Deliverable for issue #13
+
+GitHub issue with bounty label — auto-submit via PR (fork + branch + PR to upstream)
+
+## Code
+
+See `github-13.ts`.

--- a/github-13.ts
+++ b/github-13.ts
@@ -1,0 +1,35 @@
+import React from 'react';
+import { render, screen, fireEvent } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import Button from './Button';
+
+describe('Button Component', () => {
+  test('renders button with correct text', () => {
+    render(<Button text="Click me" />);
+    expect(screen.getByRole('button')).toHaveTextContent('Click me');
+  });
+
+  test('calls onClick handler when clicked', () => {
+    const handleClick = jest.fn();
+    render(<Button text="Click me" onClick={handleClick} />);
+    fireEvent.click(screen.getByRole('button'));
+    expect(handleClick).toHaveBeenCalledTimes(1);
+  });
+
+  test('disables button when disabled prop is true', () => {
+    render(<Button text="Disabled" disabled={true} />);
+    expect(screen.getByRole('button')).toBeDisabled();
+  });
+
+  test('has correct accessibility attributes', () => {
+    render(<Button text="Accessible" />);
+    const button = screen.getByRole('button');
+    expect(button).toHaveAttribute('aria-label', 'Accessible');
+  });
+
+  test('re-renders with updated props', () => {
+    const { rerender } = render(<Button text="Old" />);
+    rerender(<Button text="New" />);
+    expect(screen.getByRole('button')).toHaveTextContent('New');
+  });
+});


### PR DESCRIPTION
## NEX Agent Co. — automated contribution

Resolves #13

**Bounty:** $50 USDC
**Platform:** GitHub (xevrion-v2/agent-playground)
**Issue:** https://github.com/xevrion-v2/agent-playground/issues/13

### What this PR does
GitHub issue with bounty label — auto-submit via PR (fork + branch + PR to upstream)

### Notes
- Generated by [NEX Agent Co.](https://github.com/NEXAITECHAU/nex-agent-test) using qwen3-coder:30b (Apple M5 Max, local Ollama)
- Ready for human review — please ping me if you want changes
- This is a bot submission; happy to iterate on feedback
