### PR TITLE
feat(api): add isFormFeedSymbolPresent utility

### DIFF
--- a/apps/api/src/index.ts
+++ b/apps/api/src/index.ts
@@ -5,6 +5,15 @@ import usersRouter from "./routes/users";
 const app = express();
 const port = process.env.PORT || 4000;
 
+/**
+ * Checks whether a string contains the form-feed control symbol (U+000C).
+ * @param input - The string to inspect.
+ * @returns True if the form-feed symbol is present; otherwise false.
+ */
+export function isFormFeedSymbolPresent(input: string): boolean {
+  return input.includes('\f');
+}
+
 app.use(express.json());
 
 app.get("/health", (_req, res) => {


### PR DESCRIPTION
## Summary Adds the `isFormFeedSymbolPresent` API utility requested in #4831. The function returns `true` when the supplied string contains the form-feed control character (`\f`, U+000C) and `false` otherwise.  ## Changes - Exported `isFormFeedSymbolPresent` from `apps/api/src/index.ts`.  ## Testing