### PR TITLE
Add is-newline-symbol-present API utility

### DIFF
--- a/apps/api/src/index.ts
+++ b/apps/api/src/index.ts
@@ -1,11 +1,17 @@
 import express from "express";
 
+import { isNewlineSymbolPresent } from './utils/string';
 import usersRouter from "./routes/users";
 
 const app = express();
 const port = process.env.PORT || 4000;
 
 app.use(express.json());
+
+app.get('/api/is-newline-symbol-present', (req, res) => {
+  const str = String(req.query.str ?? '');
+  res.json({ hasNewline: isNewlineSymbolPresent(str) });
+});
 
 app.get("/health", (_req, res) => {
   res.json({ status: "ok", service: "taskflow-api" });

--- a/apps/api/src/utils/string.ts
+++ b/apps/api/src/utils/string.ts
@@ -1,0 +1,7 @@
+/**
+ * Returns true if the string contains any newline control symbol.
+ * Recognizes LF (\n), CR (\r), and CRLF sequences.
+ */
+export function isNewlineSymbolPresent(value: string): boolean {
+  return /\r|\n/.test(value);
+}


### PR DESCRIPTION
## Summary Implements #4827 by adding a reusable `isNewlineSymbolPresent` utility and exposing it via a read-only GET endpoint.  ## Changes - **New**: `apps/api/src/utils/string.ts` - pure helper that detects LF/CR/CRLF in a string. - **Modified**: `apps/api/src/index.ts` - registers `/api/is-newlin