### PR TITLE
feat(api): add isCarriageReturnSymbolPresent API utility (#4829)

### DIFF
--- a/apps/api/src/index.ts
+++ b/apps/api/src/index.ts
@@ -1,5 +1,6 @@
 import express from "express";
 
+import { isCarriageReturnSymbolPresent } from './utils/string';
 import usersRouter from "./routes/users";
 
 const app = express();
@@ -13,6 +14,11 @@ app.get("/health", (_req, res) => {
 
 app.use("/users", usersRouter);
 
+
+app.get('/api/string/has-cr', (req, res) => {
+  const input = String(req.query.value ?? '');
+  res.json({ hasCarriageReturn: isCarriageReturnSymbolPresent(input) });
+});
 app.listen(port, () => {
   console.log(`TaskFlow API listening on port ${port}`);
 });

--- a/apps/api/src/utils/string.ts
+++ b/apps/api/src/utils/string.ts
@@ -1,0 +1,7 @@
+/**
+ * Returns true if the provided string contains at least one carriage return
+ * character (`\r`, U+000D).
+ */
+export function isCarriageReturnSymbolPresent(value: string): boolean {
+  return value.includes('\r');
+}


### PR DESCRIPTION
## Summary  Adds a small API utility that reports whether a string contains a carriage return symbol (`\r`), as requested in #4829.  ## Changes  - **New file**: `apps/api/src/utils/string.ts`   - Exports `isCarriageReturnSymbolPresent(value: string): boolean`. - **Modified**: `apps/api/src/index.ts`