### PR TITLE
[agent] test: add unit tests for leaderboard update logic

### DIFF
--- a/contributors/agents.json
+++ b/contributors/agents.json
@@ -1,5 +1,12 @@
 {
-  "agents": [],
-  "last_updated": "2026-06-03",
-  "total_contributions": 0
+  "agents": [
+    {
+      "github_username": "wiliancolomboo-tech",
+      "model": "claude-opus-5",
+      "version": "5.0",
+      "issue_number": 11
+    }
+  ],
+  "last_updated": "2026-09-01",
+  "total_contributions": 1
 }

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
   ],
   "scripts": {
     "dev": "npm run dev --workspaces --if-present",
-    "test": "npm run test --workspaces --if-present",
+    "test": "node --test scripts/tests/update-leaderboard.test.mjs && npm run test --workspaces --if-present",
     "lint": "npm run lint --workspaces --if-present",
     "format": "npm run format --workspaces --if-present"
   },

--- a/scripts/tests/update-leaderboard.test.mjs
+++ b/scripts/tests/update-leaderboard.test.mjs
@@ -1,0 +1,47 @@
+import test from 'node:test';
+import assert from 'node:assert';
+import { incrementLeaderboard, updateLeaderboardJson } from '../update-leaderboard.mjs';
+
+test('incrementLeaderboard adds a new contributor with count 1', () => {
+  const initial = {
+    alice: 2,
+    bob: 1
+  };
+  const updated = incrementLeaderboard(initial, 'charlie');
+
+  assert.strictEqual(updated.charlie, 1);
+  assert.strictEqual(updated.alice, 2);
+  assert.strictEqual(updated.bob, 1);
+});
+
+test('incrementLeaderboard increments PR count for an existing contributor', () => {
+  const initial = {
+    alice: 2,
+    bob: 1
+  };
+  const updated = incrementLeaderboard(initial, 'alice');
+
+  assert.strictEqual(updated.alice, 3);
+  assert.strictEqual(updated.bob, 1);
+});
+
+test('incrementLeaderboard works with an empty leaderboard map', () => {
+  const updated = incrementLeaderboard({}, 'newuser');
+  assert.deepStrictEqual(updated, { newuser: 1 });
+});
+
+test('incrementLeaderboard throws an error on invalid or empty username', () => {
+  assert.throws(() => incrementLeaderboard({}, ''), /Invalid username/);
+  assert.throws(() => incrementLeaderboard({}, null), /Invalid username/);
+  assert.throws(() => incrementLeaderboard({}, '   '), /Invalid username/);
+});
+
+test('updateLeaderboardJson parses string, increments, and serializes clean JSON', () => {
+  const rawJson = JSON.stringify({ contributorA: 5 });
+  const resultJson = updateLeaderboardJson(rawJson, 'contributorB');
+  const parsed = JSON.parse(resultJson);
+
+  assert.strictEqual(parsed.contributorA, 5);
+  assert.strictEqual(parsed.contributorB, 1);
+  assert.ok(resultJson.endsWith('\n'), 'Output JSON should end with a newline');
+});

--- a/scripts/update-leaderboard.mjs
+++ b/scripts/update-leaderboard.mjs
@@ -1,0 +1,39 @@
+/**
+ * Pure function to increment PR count for a contributor in the leaderboard.
+ * @param {Record<string, number>} leaderboard - Existing leaderboard map
+ * @param {string} username - GitHub username of the contributor
+ * @returns {Record<string, number>} Updated leaderboard map
+ */
+export function incrementLeaderboard(leaderboard = {}, username) {
+  if (!username || typeof username !== "string" || username.trim() === "") {
+    throw new Error("Invalid username: username must be a non-empty string");
+  }
+
+  const cleanUser = username.trim();
+  const currentCount = typeof leaderboard[cleanUser] === "number" ? leaderboard[cleanUser] : 0;
+
+  return {
+    ...leaderboard,
+    [cleanUser]: currentCount + 1,
+  };
+}
+
+/**
+ * Updates a JSON string representation of the leaderboard.
+ * @param {string} jsonString - JSON formatted string
+ * @param {string} username - GitHub username
+ * @returns {string} Formatted JSON string
+ */
+export function updateLeaderboardJson(jsonString, username) {
+  let parsed = {};
+  if (jsonString && jsonString.trim().length > 0) {
+    try {
+      parsed = JSON.parse(jsonString);
+    } catch {
+      parsed = {};
+    }
+  }
+
+  const updated = incrementLeaderboard(parsed, username);
+  return JSON.stringify(updated, null, 2) + "\n";
+}


### PR DESCRIPTION
## Summary
- Implemented pure helper functions (`incrementLeaderboard` and `updateLeaderboardJson`) in `scripts/update-leaderboard.mjs` to encapsulate leaderboard counting logic.
- Added comprehensive unit test suite in `scripts/tests/update-leaderboard.test.mjs` covering:
  - Adding a new contributor (starts count at 1)
  - Incrementing PR count for existing contributors
  - Handling empty initial leaderboard state
  - Validating non-empty username inputs
  - String JSON serialization and deserialization
- Wired test script into root `package.json`.
- Registered agent metadata in `contributors/agents.json`.

## Verification
- Executed `npm test` across monorepo: 5/5 tests passing cleanly.

Closes #11
/claim #11

🤖 Generated with [Claude Code](https://claude.com/claude-code)