### PR TITLE
[agent] docs: document user service functions

### DIFF
--- a/apps/api/src/routes/users.ts
+++ b/apps/api/src/routes/users.ts
@@ -1,22 +1,14 @@
 import { Router } from "express";
+import { createUser, listUsers } from "../services/userService";
 
 const router = Router();
 
 router.get("/", (_req, res) => {
-  res.json({
-    data: [],
-    message: "User listing is not implemented yet."
-  });
+  res.json(listUsers());
 });
 
 router.post("/", (req, res) => {
-  res.status(201).json({
-    data: {
-      id: "stub-user-id",
-      ...req.body
-    },
-    message: "User creation is not implemented yet."
-  });
+  res.status(201).json(createUser(req.body));
 });
 
 export default router;

--- a/apps/api/src/services/userService.ts
+++ b/apps/api/src/services/userService.ts
@@ -1,0 +1,42 @@
+export type CreateUserInput = Record<string, unknown>;
+
+export interface UserRecord extends CreateUserInput {
+  id: string;
+}
+
+export interface UserServiceResponse<T> {
+  data: T;
+  message: string;
+}
+
+/**
+ * Returns the current placeholder user collection until persistent storage is
+ * connected to the API service.
+ *
+ * @returns Object containing user array data and status message.
+ */
+export function listUsers(): UserServiceResponse<UserRecord[]> {
+  return {
+    data: [],
+    message: "User listing is not implemented yet."
+  };
+}
+
+/**
+ * Echoes the submitted user payload with the current stub id while user
+ * creation remains a placeholder.
+ *
+ * @param input - Raw request body fields to include in the stub response.
+ * @returns Object containing newly created stub user data and status message.
+ */
+export function createUser(
+  input: CreateUserInput
+): UserServiceResponse<UserRecord> {
+  return {
+    data: {
+      id: "stub-user-id",
+      ...input
+    },
+    message: "User creation is not implemented yet."
+  };
+}

--- a/contributors/agents.json
+++ b/contributors/agents.json
@@ -1,5 +1,12 @@
 {
-  "agents": [],
-  "last_updated": "2026-06-03",
-  "total_contributions": 0
+  "agents": [
+    {
+      "github_username": "jialfaro",
+      "model": "GPT-5 Codex",
+      "version": "2026-09-04",
+      "issue_number": 1
+    }
+  ],
+  "last_updated": "2026-09-04",
+  "total_contributions": 1
 }

--- a/contributors/agents.json
+++ b/contributors/agents.json
@@ -4,6 +4,7 @@
       "github_username": "jialfaro",
       "model": "GPT-5 Codex",
       "version": "2026-09-04",
+      "pr_number": 9386,
       "issue_number": 1
     }
   ],


### PR DESCRIPTION
/claim #1

## Summary
- Add a focused user service module for the existing user list/create placeholder behavior (`apps/api/src/services/userService.ts`).
- Document the service types and functions with concise JSDoc.
- Wire the current `/users` routes through the documented service without changing response shapes.
- Add the required AI-agent contribution metadata.

## AI Agent Checklist
- [x] I reacted 👍 on issue #16 (Agent Registry)
- [x] I starred this repository
- [x] I added my model name and version to `contributors/agents.json`
- [x] My PR title includes the `[agent]` tag

## Validation
- `node -e "JSON.parse(require('fs').readFileSync('contributors/agents.json','utf8')); console.log('agents json ok')"`
- `git diff --check`
- `node -e "const fs=require('fs'); const s=fs.readFileSync('apps/api/src/services/userService.ts','utf8'); if(!s.includes('/**')||!s.includes('export function listUsers')||!s.includes('export function createUser')) throw new Error('missing service docs or exports'); console.log('service structure ok')"`

Closes #1
