### PR TITLE
fix(api): validate user creation payloads

### DIFF
--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -7,7 +7,7 @@
   "main": "src/index.ts",
   "scripts": {
     "dev": "tsx src/index.ts",
-    "test": "echo \"No API tests configured yet\"",
+    "test": "NODE_ENV=test node --import tsx --test \"src/**/*.test.ts\"",
     "lint": "echo \"No API lint configured yet\""
   },
   "dependencies": {

--- a/apps/api/src/index.ts
+++ b/apps/api/src/index.ts
@@ -2,7 +2,7 @@ import express from "express";
 
 import usersRouter from "./routes/users";
 
-const app = express();
+export const app = express();
 const port = process.env.PORT || 4000;
 
 app.use(express.json());
@@ -13,6 +13,17 @@ app.get("/health", (_req, res) => {
 
 app.use("/users", usersRouter);
 
-app.listen(port, () => {
-  console.log(`TaskFlow API listening on port ${port}`);
+app.use((err: Error & { type?: string }, _req: express.Request, res: express.Response, next: express.NextFunction) => {
+  if (err.type === "entity.parse.failed") {
+    res.status(400).json({ error: "Request body must be valid JSON." });
+    return;
+  }
+
+  next(err);
 });
+
+if (process.env.NODE_ENV !== "test") {
+  app.listen(port, () => {
+    console.log(`TaskFlow API listening on port ${port}`);
+  });
+}

--- a/apps/api/src/routes/users.test.ts
+++ b/apps/api/src/routes/users.test.ts
@@ -1,0 +1,95 @@
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+import type { AddressInfo } from "node:net";
+
+import { app } from "../index";
+
+async function postUsers(body: unknown) {
+  const server = app.listen(0);
+  await new Promise<void>((resolve) => server.once("listening", resolve));
+  const { port } = server.address() as AddressInfo;
+
+  try {
+    const response = await fetch(`http://127.0.0.1:${port}/users`, {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: typeof body === "string" ? body : JSON.stringify(body)
+    });
+
+    return {
+      status: response.status,
+      json: await response.json()
+    };
+  } finally {
+    await new Promise<void>((resolve, reject) => {
+      server.close((error) => {
+        if (error) reject(error);
+        else resolve();
+      });
+    });
+  }
+}
+
+describe("POST /users", () => {
+  it("normalizes valid user creation payloads", async () => {
+    const response = await postUsers({
+      email: "  Person@Example.COM ",
+      name: "  Ada   Lovelace  ",
+      firstName: " Ada ",
+      lastName: " Lovelace "
+    });
+
+    assert.equal(response.status, 201);
+    assert.match(response.json.data.id, /^[0-9a-f-]{36}$/);
+    assert.equal(response.json.data.email, "person@example.com");
+    assert.equal(response.json.data.name, "Ada Lovelace");
+    assert.equal(response.json.data.firstName, "Ada");
+    assert.equal(response.json.data.lastName, "Lovelace");
+  });
+
+  it("ignores client-controlled ids and unrelated fields", async () => {
+    const response = await postUsers({
+      id: "client-id",
+      email: "user@example.com",
+      role: "admin",
+      unrelated: true
+    });
+
+    assert.equal(response.status, 201);
+    assert.notEqual(response.json.data.id, "client-id");
+    assert.equal(response.json.data.email, "user@example.com");
+    assert.equal(response.json.data.role, undefined);
+    assert.equal(response.json.data.unrelated, undefined);
+  });
+
+  it("rejects non-object JSON bodies", async () => {
+    const response = await postUsers(["user@example.com"]);
+
+    assert.equal(response.status, 400);
+    assert.equal(response.json.error, "Request body must be a JSON object.");
+  });
+
+  it("requires a valid email", async () => {
+    const response = await postUsers({ email: "not-an-email" });
+
+    assert.equal(response.status, 400);
+    assert.equal(response.json.error, "A valid email is required.");
+  });
+
+  it("rejects malformed JSON bodies", async () => {
+    const response = await postUsers("{not-json");
+
+    assert.equal(response.status, 400);
+    assert.equal(response.json.error, "Request body must be valid JSON.");
+  });
+
+  it("rejects invalid optional name shapes", async () => {
+    const response = await postUsers({
+      email: "user@example.com",
+      name: 123
+    });
+
+    assert.equal(response.status, 400);
+    assert.equal(response.json.error, "name must be a string when provided.");
+  });
+});

--- a/apps/api/src/routes/users.ts
+++ b/apps/api/src/routes/users.ts
@@ -1,6 +1,70 @@
 import { Router } from "express";
+import { randomUUID } from "node:crypto";
 
 const router = Router();
+const EMAIL_PATTERN = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
+
+type UserCreatePayload = {
+  email?: unknown;
+  name?: unknown;
+  firstName?: unknown;
+  lastName?: unknown;
+};
+
+type NormalizedUserInput = {
+  email: string;
+  name?: string;
+  firstName?: string;
+  lastName?: string;
+};
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function normalizeText(value: unknown): string | undefined {
+  if (value === undefined || value === null) {
+    return undefined;
+  }
+
+  if (typeof value !== "string") {
+    return undefined;
+  }
+
+  const normalized = value.trim().replace(/\s+/g, " ");
+  return normalized.length > 0 ? normalized : undefined;
+}
+
+function normalizeUserPayload(body: unknown): { data?: NormalizedUserInput; error?: string } {
+  if (!isRecord(body)) {
+    return { error: "Request body must be a JSON object." };
+  }
+
+  const payload = body as UserCreatePayload;
+  const email = normalizeText(payload.email)?.toLowerCase();
+  if (!email || !EMAIL_PATTERN.test(email)) {
+    return { error: "A valid email is required." };
+  }
+
+  const normalizedNames = {
+    name: normalizeText(payload.name),
+    firstName: normalizeText(payload.firstName),
+    lastName: normalizeText(payload.lastName)
+  };
+
+  for (const key of Object.keys(normalizedNames) as Array<keyof typeof normalizedNames>) {
+    if (payload[key] !== undefined && payload[key] !== null && typeof payload[key] !== "string") {
+      return { error: `${key} must be a string when provided.` };
+    }
+  }
+
+  return {
+    data: {
+      email,
+      ...Object.fromEntries(Object.entries(normalizedNames).filter(([, value]) => value))
+    }
+  };
+}
 
 router.get("/", (_req, res) => {
   res.json({
@@ -10,12 +74,19 @@ router.get("/", (_req, res) => {
 });
 
 router.post("/", (req, res) => {
+  const result = normalizeUserPayload(req.body);
+
+  if (!result.data) {
+    res.status(400).json({ error: result.error });
+    return;
+  }
+
   res.status(201).json({
     data: {
-      id: "stub-user-id",
-      ...req.body
+      id: randomUUID(),
+      ...result.data
     },
-    message: "User creation is not implemented yet."
+    message: "User created."
   });
 });
 

--- a/contributors/agents.json
+++ b/contributors/agents.json
@@ -1,5 +1,11 @@
 {
-  "agents": [],
-  "last_updated": "2026-06-03",
-  "total_contributions": 0
+  "agents": [
+    {
+      "name": "Codex",
+      "model": "GPT-5",
+      "contribution": "Validate user creation payloads"
+    }
+  ],
+  "last_updated": "2026-09-05",
+  "total_contributions": 1
 }


### PR DESCRIPTION
## Summary

Fixes #2207.

- Validate `POST /users` JSON payloads before creating a user response.
- Reject non-object bodies and malformed JSON.
- Require and normalize email values.
- Normalize optional name fields.
- Generate user IDs server-side and ignore client-controlled `id` plus unrelated fields.
- Add regression coverage for the bounty acceptance criteria.

## Testing

```sh
cd apps/api
NODE_ENV=test node --import tsx --test 'src/**/*.test.ts'
```

Result: 6 tests passed.
