### PR TITLE
fix: ensure required labels exist before seeding issues

### DIFF
--- a/.github/workflows/seed-issues.yml
+++ b/.github/workflows/seed-issues.yml
@@ -90,6 +90,23 @@ jobs:
               }
             ];
 
+            const requiredLabels = ["good first issue", "bounty", "AI agent friendly"];
+            for (const label of requiredLabels) {
+              const existing = await github.rest.issues.listLabelsForRepo({
+                owner: context.repo.owner,
+                repo: context.repo.repo
+              });
+              const found = existing.data.some(l => l.name === label);
+              if (!found) {
+                await github.rest.issues.createLabel({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  name: label,
+                  color: label === "good first issue" ? "7057ff" : label === "bounty" ? "ffd700" : "008672"
+                });
+              }
+            }
+
             for (const issue of issues) {
               await github.rest.issues.create({
                 owner: context.repo.owner,

--- a/.github/workflows/seed-meta-issue.yml
+++ b/.github/workflows/seed-meta-issue.yml
@@ -35,6 +35,23 @@ jobs:
               "description, the better."
             ].join("\n");
 
+            const requiredLabels = ["bounty", "good first issue", "AI agent friendly"];
+            for (const label of requiredLabels) {
+              const existing = await github.rest.issues.listLabelsForRepo({
+                owner: context.repo.owner,
+                repo: context.repo.repo
+              });
+              const found = existing.data.some(l => l.name === label);
+              if (!found) {
+                await github.rest.issues.createLabel({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  name: label,
+                  color: label === "good first issue" ? "7057ff" : label === "bounty" ? "ffd700" : "008672"
+                });
+              }
+            }
+
             const createdIssue = await github.rest.issues.create({
               owner: context.repo.owner,
               repo: context.repo.repo,


### PR DESCRIPTION
## Summary

Fixes #957.

Both seed workflows (`seed-issues.yml` and `seed-meta-issue.yml`) call `github.rest.issues.create()` with hardcoded labels (`good first issue`, `bounty`, `AI agent friendly`), but they assume those labels already exist. In a fresh repository, this fails with a validation error.

## Changes

Both workflows now ensure the required labels exist before creating issues:

1. List existing labels in the repo
2. Create any missing labels with appropriate colors
3. Then proceed with issue creation as before

## Why this is safe

- Uses the same labels and colors defined in `create-labels.yml`
- No changes to issue titles, bodies, or pinning behavior
- Only adds label creation, doesn't modify existing issues
- Scoped to the two seed workflows only