### PR TITLE
[agent] Normalize health response envelope with HTTP coverage

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,3 +83,16 @@ with models for:
 
 Each app/package expects its own .env values for DB, auth, 
 and integrations.
+
+## Health response
+
+`GET /health` responds with HTTP 200 and a JSON envelope:
+
+```json
+{ "status": "ok", "data": { "service": "taskflow-api" } }
+```
+
+The service name is now at `data.service` (previously `service`). This endpoint
+reports process liveness only; it does not check database or external-service
+readiness. `HEAD /health` is also supported with HTTP 200 and an empty body.
+Run its HTTP regression test with `npm test --workspace @taskflow/api`.

--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -7,7 +7,7 @@
   "main": "src/index.ts",
   "scripts": {
     "dev": "tsx src/index.ts",
-    "test": "echo \"No API tests configured yet\"",
+    "test": "tsx --test src/routes/health.test.ts",
     "lint": "echo \"No API lint configured yet\""
   },
   "dependencies": {

--- a/apps/api/src/index.ts
+++ b/apps/api/src/index.ts
@@ -1,15 +1,14 @@
 import express from "express";
 
 import usersRouter from "./routes/users";
+import healthRouter from "./routes/health";
 
 const app = express();
 const port = process.env.PORT || 4000;
 
 app.use(express.json());
 
-app.get("/health", (_req, res) => {
-  res.json({ status: "ok", service: "taskflow-api" });
-});
+app.use("/health", healthRouter);
 
 app.use("/users", usersRouter);
 

--- a/apps/api/src/routes/health.test.ts
+++ b/apps/api/src/routes/health.test.ts
@@ -1,0 +1,32 @@
+import assert from "node:assert/strict";
+import { once } from "node:events";
+import type { AddressInfo } from "node:net";
+import { test } from "node:test";
+import express from "express";
+
+import healthRouter from "./health";
+
+test("health route returns a consistent JSON envelope over HTTP", async (t) => {
+  const app = express();
+  app.use("/health", healthRouter);
+  const server = app.listen(0, "127.0.0.1");
+  t.after(() => new Promise<void>((resolve, reject) => {
+    server.close((error) => error ? reject(error) : resolve());
+  }));
+  await once(server, "listening");
+  const { port } = server.address() as AddressInfo;
+  const url = `http://127.0.0.1:${port}/health`;
+
+  const response = await fetch(url);
+  assert.equal(response.status, 200);
+  assert.match(response.headers.get("content-type") ?? "", /^application\/json\b/);
+  assert.deepEqual(await response.json(), {
+    status: "ok",
+    data: { service: "taskflow-api" },
+  });
+
+  // Express health probes can also use HEAD; it must keep its bodyless response.
+  const head = await fetch(url, { method: "HEAD" });
+  assert.equal(head.status, 200);
+  assert.equal(await head.text(), "");
+});

--- a/apps/api/src/routes/health.ts
+++ b/apps/api/src/routes/health.ts
@@ -1,0 +1,9 @@
+import { Router } from "express";
+
+const healthRouter = Router();
+
+healthRouter.get("/", (_req, res) => {
+  res.json({ status: "ok", data: { service: "taskflow-api" } });
+});
+
+export default healthRouter;

--- a/contributors/agents.json
+++ b/contributors/agents.json
@@ -4,7 +4,7 @@
       "github_username": "cato104",
       "model": "Codex",
       "version": "GPT-6",
-      "pr_number": null,
+      "pr_number": 9396,
       "issue_number": 8
     }
   ],

--- a/contributors/agents.json
+++ b/contributors/agents.json
@@ -1,5 +1,13 @@
 {
-  "agents": [],
-  "last_updated": "2026-06-03",
-  "total_contributions": 0
+  "agents": [
+    {
+      "github_username": "cato104",
+      "model": "Codex",
+      "version": "GPT-6",
+      "pr_number": null,
+      "issue_number": 8
+    }
+  ],
+  "last_updated": "2026-09-08",
+  "total_contributions": 1
 }


### PR DESCRIPTION
## Description

Closes #8.

GET /health now returns `{ "status": "ok", "data": { "service": "taskflow-api" } }`. The existing service value moves to data.service. The health handler is an Express router so it can be exercised over HTTP without starting unrelated routes.

## AI Agent Checklist

- [x] Reacted 👍 on issue #16 (the actual Agent Registry referenced by CONTRIBUTING; the template says #1)
- [x] Starred this repository
- [x] Added model/version to contributors/agents.json (PR number will be filled after creation)
- [x] PR title includes [agent]

## Changes Made

- Health router and focused HTTP regression test for GET JSON envelope and bodyless HEAD.
- API test command runs the regression instead of its placeholder.
- README documents response shape, data.service migration and liveness-only meaning.
- Required contributor registry entry.

Validation: API test passes; root npm test passes (the other workspaces still have placeholder tests); strict TypeScript check of the new route and test passes; git diff --check passes. Also started the actual API entry point and confirmed HTTP 200 with the expected JSON from /health. No dependencies changed. No real lint/build commands are configured in the API package.

## Model Info (AI agents only)

- Model: Codex / GPT-6, on behalf of cato104
- Issue: #8
- Approach: small response-shape correction with an actual HTTP regression check.