### PR TITLE
docs: add JSDoc to userService routes

### DIFF
--- a/apps/api/src/routes/users.ts
+++ b/apps/api/src/routes/users.ts
@@ -1,15 +1,35 @@
-import { Router } from "express";
+import { Router, type Request, type Response } from "express";
 
 const router = Router();
 
-router.get("/", (_req, res) => {
+/**
+ * GET /users
+ *
+ * Lists users. Currently a stub: returns an empty data array with an
+ * explanatory message until real user storage is implemented.
+ *
+ * @param _req - Incoming request (unused).
+ * @param res - Express response; responds with 200 and a JSON envelope.
+ * @returns JSON `{ data: User[], message: string }`.
+ */
+router.get("/", (_req: Request, res: Response) => {
   res.json({
     data: [],
     message: "User listing is not implemented yet."
   });
 });
 
-router.post("/", (req, res) => {
+/**
+ * POST /users
+ *
+ * Creates a user. Currently a stub: echoes the request body back with a
+ * placeholder id and a 201 status until real persistence is implemented.
+ *
+ * @param req - Incoming request; body is spread into the returned user object.
+ * @param res - Express response; responds with 201 and a JSON envelope.
+ * @returns JSON `{ data: { id: string } & req.body, message: string }`.
+ */
+router.post("/", (req: Request, res: Response) => {
   res.status(201).json({
     data: {
       id: "stub-user-id",


### PR DESCRIPTION
Closes #1

## Summary
- Added concise JSDoc comments to both route handlers in `apps/api/src/routes/users.ts`, documenting purpose, params, return shape, and stub status.
- No behavior change; typed the handler params explicitly (`Request`/`Response`).

## Test
- Type-level change only; handlers' runtime behavior unchanged.
