### PR TITLE
feat(api): limit JSON request body size

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,13 @@ Backend architecture follows:
 - Validation schemas (Zod)
 - Utility helpers
 
+### API request body limit
+
+The API accepts JSON request bodies up to **100 KB** by default. This
+conservative limit helps prevent unexpectedly large requests from consuming
+server resources. A route that legitimately needs a larger payload must opt
+into an appropriate limit explicitly.
+
 ## Getting Started
 
 npm install

--- a/apps/api/src/index.ts
+++ b/apps/api/src/index.ts
@@ -4,8 +4,11 @@ import usersRouter from "./routes/users";
 
 const app = express();
 const port = process.env.PORT || 4000;
+const JSON_BODY_LIMIT = "100kb";
 
-app.use(express.json());
+// Keep request bodies small by default; routes should opt into larger limits
+// explicitly when they need to accept larger payloads.
+app.use(express.json({ limit: JSON_BODY_LIMIT }));
 
 app.get("/health", (_req, res) => {
   res.json({ status: "ok", service: "taskflow-api" });


### PR DESCRIPTION
Closes #9

## Summary
- enforce a conservative 100 KB limit for Express JSON request bodies
- document the default limit and route-level opt-out guidance

## Validation
- npm test
- git diff --check