### PR TITLE
feat(api): add shared error response helper

### DIFF
--- a/apps/api/src/routes/users.ts
+++ b/apps/api/src/routes/users.ts
@@ -1,5 +1,7 @@
 import { Router } from "express";
 
+import { sendApiError } from "../utils/api-response";
+
 const router = Router();
 
 router.get("/", (_req, res) => {
@@ -10,6 +12,10 @@ router.get("/", (_req, res) => {
 });
 
 router.post("/", (req, res) => {
+  if (!req.body || Object.keys(req.body).length === 0) {
+    return sendApiError(res, 400, "Request body is required.");
+  }
+
   res.status(201).json({
     data: {
       id: "stub-user-id",

--- a/apps/api/src/utils/api-response.ts
+++ b/apps/api/src/utils/api-response.ts
@@ -1,0 +1,14 @@
+import type { Response } from "express";
+
+export function sendApiError(
+  res: Response,
+  statusCode: number,
+  message: string
+) {
+  return res.status(statusCode).json({
+    error: {
+      message,
+      statusCode
+    }
+  });
+}


### PR DESCRIPTION
Closes #7

## Summary
- add a small shared helper for consistent API error responses
- use it when the users endpoint receives an empty request body

## Validation
- TypeScript compile check
- git diff --check