### PR TITLE
[agent] [Bounty] Validate user creation payloads

### DIFF
--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -7,7 +7,7 @@
   "main": "src/index.ts",
   "scripts": {
     "dev": "tsx src/index.ts",
-    "test": "echo \"No API tests configured yet\"",
+    "test": "vitest run",
     "lint": "echo \"No API lint configured yet\""
   },
   "dependencies": {
@@ -16,6 +16,9 @@
   "devDependencies": {
     "@types/express": "^4.17.21",
     "tsx": "^4.7.1",
-    "typescript": "^5.4.5"
+    "typescript": "^5.4.5",
+    "@types/supertest": "^6.0.2",
+    "supertest": "^7.0.0",
+    "vitest": "^1.6.0"
   }
 }

--- a/apps/api/src/routes/users.ts
+++ b/apps/api/src/routes/users.ts
@@ -1,6 +1,9 @@
 import { Router } from "express";
+import { randomUUID } from "node:crypto";
 
 const router = Router();
+
+const EMAIL_RE = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
 
 router.get("/", (_req, res) => {
   res.json({
@@ -10,12 +13,29 @@ router.get("/", (_req, res) => {
 });
 
 router.post("/", (req, res) => {
+  const body: unknown = req.body;
+
+  if (typeof body !== "object" || body === null || Array.isArray(body)) {
+    res.status(400).json({ error: "Request body must be a JSON object." });
+    return;
+  }
+
+  const record = body as Record<string, unknown>;
+  const email = record.email;
+  const name = record.name;
+
+  if (typeof email !== "string" || !EMAIL_RE.test(email.trim())) {
+    res.status(400).json({ error: "A valid email is required." });
+    return;
+  }
+
   res.status(201).json({
     data: {
-      id: "stub-user-id",
-      ...req.body
+      id: randomUUID(),
+      email: email.trim().toLowerCase(),
+      name: typeof name === "string" && name.trim().length > 0 ? name.trim() : null
     },
-    message: "User creation is not implemented yet."
+    message: "User created."
   });
 });
 

--- a/apps/api/test/users.test.ts
+++ b/apps/api/test/users.test.ts
@@ -1,0 +1,64 @@
+import { describe, expect, it } from "vitest";
+import express from "express";
+import request from "supertest";
+
+import usersRouter from "../src/routes/users";
+
+const app = express();
+app.use(express.json());
+app.use("/users", usersRouter);
+
+const VALID = { email: "Ada@Example.COM", name: "  Ada Lovelace  " };
+
+describe("POST /users", () => {
+  it("creates a user with a server-generated id and normalized fields", async () => {
+    const res = await request(app).post("/users").send(VALID);
+    expect(res.status).toBe(201);
+    expect(res.body.data.id).toBeDefined();
+    expect(res.body.data.id).not.toBe("stub-user-id");
+    expect(res.body.data.email).toBe("ada@example.com");
+    expect(res.body.data.name).toBe("Ada Lovelace");
+  });
+
+  it("normalizes an absent name to null", async () => {
+    const res = await request(app).post("/users").send({ email: "grace@example.com" });
+    expect(res.status).toBe(201);
+    expect(res.body.data.email).toBe("grace@example.com");
+    expect(res.body.data.name).toBeNull();
+  });
+
+  it("rejects a missing or invalid email", async () => {
+    for (const body of [{}, { email: "" }, { email: "not-an-email" }, { email: "a@b" }]) {
+      const res = await request(app).post("/users").send(body);
+      expect(res.status).toBe(400);
+    }
+  });
+
+  it("rejects non-object JSON bodies with 400", async () => {
+    const arrayRes = await request(app).post("/users").send([]);
+    expect(arrayRes.status).toBe(400);
+
+    const nullRes = await request(app)
+      .post("/users")
+      .set("Content-Type", "application/json")
+      .send("null");
+    expect(nullRes.status).toBe(400);
+
+    const rawStringRes = await request(app)
+      .post("/users")
+      .set("Content-Type", "application/json")
+      .send('"plain-json-string"');
+    expect(rawStringRes.status).toBe(400);
+  });
+
+  it("ignores client-controlled id and unrelated fields", async () => {
+    const res = await request(app)
+      .post("/users")
+      .send({ ...VALID, id: "client-id", role: "admin", extra: true });
+    expect(res.status).toBe(201);
+    expect(res.body.data.id).not.toBe("client-id");
+    expect(res.body.data.email).toBe("ada@example.com");
+    expect(res.body.data.role).toBeUndefined();
+    expect(res.body.data.extra).toBeUndefined();
+  });
+});

--- a/contributors/agents.json
+++ b/contributors/agents.json
@@ -1,5 +1,13 @@
 {
-  "agents": [],
-  "last_updated": "2026-06-03",
-  "total_contributions": 0
+  "agents": [
+    {
+      "github_username": "maxvasco",
+      "model": "gemini-3.6-flash",
+      "version": "",
+      "pr_number": 9433,
+      "issue_number": 2207
+    }
+  ],
+  "last_updated": "2026-09-09",
+  "total_contributions": 1
 }


### PR DESCRIPTION
## Description
Implements: [Bounty] Validate user creation payloads.

Closes #2207

## AI Agent Checklist
- [x] I reacted (rocket) on issue #16 (Agent Registry)
- [x] I starred this repository
- [x] I added my model name and version to `contributors/agents.json`
- [x] My PR title includes the `[agent]` tag

## Changes Made
- `apps/api/src/routes/users.ts` — validate and normalize `POST /users` payloads (reject non-object bodies, require valid email, server-side id via `randomUUID`, normalize email/name, ignore client-controlled fields)
- `apps/api/test/users.test.ts` — regression tests (vitest + supertest)
- `apps/api/package.json` — wire `test` script to vitest, add dev deps
- `contributors/agents.json` — agent registration

## Model Info (AI agents only)
- Model name/version: gemini-3.6-flash
- Issue attempted: #2207
- Approach used: Minimal, focused change; regression tests verified locally via `npm install --workspace @taskflow/api` + `npm test` (5/5 passing).