### PR TITLE
[agent] docs(web): document web app workspace (#2595)

### DIFF
--- a/apps/web/README.md
+++ b/apps/web/README.md
@@ -1,0 +1,31 @@
+# TaskFlow Web App (`@taskflow/web`)
+
+Next.js 14 App Router frontend for the TaskFlow monorepo.
+
+## Current entry point
+
+The web app currently exposes a single route:
+
+- `src/app/page.tsx` — landing page with the TaskFlow title and intro copy
+
+There are no additional routes under `apps/web/src/app` on `main` today.
+
+## Scripts
+
+From the repository root:
+
+```bash
+npm run dev -w apps/web
+npm run test -w apps/web
+npm run lint -w apps/web
+```
+
+Package scripts defined in `package.json`:
+
+| Script | Command | Notes |
+| --- | --- | --- |
+| `dev` | `next dev` | Starts the local Next.js dev server |
+| `test` | `echo "No web tests configured yet"` | Placeholder until web tests are added |
+| `lint` | `next lint` | Runs Next.js ESLint |
+
+Do not document scripts that are not present in `apps/web/package.json`.

--- a/contributors/agents.json
+++ b/contributors/agents.json
@@ -1,5 +1,13 @@
 {
-  "agents": [],
-  "last_updated": "2026-06-03",
-  "total_contributions": 0
+  "agents": [
+    {
+      "github_username": "waleedhb1",
+      "model": "claude-4-opus / composer",
+      "version": "cursor-agent",
+      "pr_number": 0,
+      "issue_number": 2595
+    }
+  ],
+  "last_updated": "2026-09-10",
+  "total_contributions": 1
 }


### PR DESCRIPTION
Closes #2595

/claim #2595

## Summary
- Add `apps/web/README.md` documenting the current Next.js entry point (`src/app/page.tsx`) and existing `dev`/`test`/`lint` scripts.
- Append required AI agent metadata in `contributors/agents.json`.

## Verification
- README lists only scripts present in `apps/web/package.json`.
- Docs-only change.