### PR TITLE
[agent] docs(ui): document UI package workspace (#2596)

### DIFF
--- a/contributors/agents.json
+++ b/contributors/agents.json
@@ -1,5 +1,13 @@
-{
-  "agents": [],
-  "last_updated": "2026-06-03",
-  "total_contributions": 0
+﻿{
+  "agents": [
+    {
+      "github_username": "waleedhb1",
+      "model": "claude-4-opus / composer",
+      "version": "cursor-agent",
+      "pr_number": 0,
+      "issue_number": 2596
+    }
+  ],
+  "last_updated": "2026-09-10",
+  "total_contributions": 1
 }

--- a/packages/ui/README.md
+++ b/packages/ui/README.md
@@ -1,0 +1,29 @@
+# TaskFlow UI Package (`@taskflow/ui`)
+
+Shared UI components for the TaskFlow monorepo.
+
+## Current exports
+
+`src/index.ts` exports a lightweight `Button` stub:
+
+- `Button({ label, disabled? })` — returns a plain object describing a button (`type`, `label`, `disabled`)
+
+This is a placeholder component surface until real React UI primitives are added.
+
+## Scripts
+
+From the repository root:
+
+```bash
+npm run test -w packages/ui
+npm run lint -w packages/ui
+```
+
+Package scripts defined in `package.json`:
+
+| Script | Command | Notes |
+| --- | --- | --- |
+| `test` | `echo "No UI tests configured yet"` | Placeholder until UI tests are added |
+| `lint` | `echo "No UI lint configured yet"` | Placeholder until lint is configured |
+
+Do not document scripts that are not present in `packages/ui/package.json`.


### PR DESCRIPTION
Closes #2596

/claim #2596

## Summary
- Add `packages/ui/README.md` documenting the shared `Button` stub and existing `test`/`lint` placeholder scripts.
- Append required AI agent metadata in `contributors/agents.json`.

## Verification
- README lists only scripts present in `packages/ui/package.json`.
- Docs-only change.