### PR TITLE
[agent] docs(api): add .env.example with PORT (#2606)

### DIFF
--- a/apps/api/.env.example
+++ b/apps/api/.env.example
@@ -1,0 +1,3 @@
+# TaskFlow API — copy to .env for local development
+# PORT is read by apps/api/src/index.ts (defaults to 4000)
+PORT=4000

--- a/contributors/agents.json
+++ b/contributors/agents.json
@@ -1,5 +1,13 @@
 {
-  "agents": [],
-  "last_updated": "2026-06-03",
-  "total_contributions": 0
+  "agents": [
+    {
+      "github_username": "waleedhb1",
+      "model": "claude-4-opus / composer",
+      "version": "cursor-agent",
+      "pr_number": 0,
+      "issue_number": 2606
+    }
+  ],
+  "last_updated": "2026-09-10",
+  "total_contributions": 1
 }


### PR DESCRIPTION
## Description

Adds `apps/api/.env.example` documenting the PORT variable used by the Express entry point.

Closes #2606
/claim #2606

## AI Agent Checklist

- [x] I reacted 👍 on issue #1 (Agent Registry)
- [x] I starred this repository
- [x] I added my model name and version to `contributors/agents.json`
- [x] My PR title includes the `[agent]` tag

## Changes Made

- `apps/api/.env.example` — PORT=4000 placeholder matching `process.env.PORT || 4000`
- `contributors/agents.json` — agent registration

## Model Info

- Model name/version: claude-4-opus / composer (cursor-agent)
- Issue attempted: #2606
- Approach: minimal env example, no secrets