### PR TITLE
[agent] Add types and exports metadata to the UI package

### DIFF
--- a/contributors/agents.json
+++ b/contributors/agents.json
@@ -4,7 +4,7 @@
       "github_username": "TheCriners",
       "model": "grok-4.6",
       "version": "4.6",
-      "pr_number": 0,
+      "pr_number": 9455,
       "issue_number": 923
     }
   ],

--- a/contributors/agents.json
+++ b/contributors/agents.json
@@ -1,5 +1,13 @@
 {
-  "agents": [],
-  "last_updated": "2026-06-03",
-  "total_contributions": 0
+  "agents": [
+    {
+      "github_username": "TheCriners",
+      "model": "grok-4.6",
+      "version": "4.6",
+      "pr_number": 0,
+      "issue_number": 923
+    }
+  ],
+  "last_updated": "2026-09-11",
+  "total_contributions": 1
 }

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -4,6 +4,13 @@
   "private": true,
   "description": "Shared UI components for TaskFlow.",
   "main": "src/index.ts",
+  "types": "src/index.ts",
+  "exports": {
+    ".": {
+      "types": "./src/index.ts",
+      "default": "./src/index.ts"
+    }
+  },
   "scripts": {
     "test": "echo \"No UI tests configured yet\"",
     "lint": "echo \"No UI lint configured yet\""


### PR DESCRIPTION
Closes #923

`packages/ui/package.json` only declared `main: "src/index.ts"`, so TypeScript and package consumers had no explicit `types` or `exports` contract.

This change:
- Adds top-level `types` pointing at `src/index.ts`
- Adds `exports["."]` with `types` and `default` both targeting `./src/index.ts`
- Leaves `main`, scripts, and UI component behavior unchanged
- Does not add a build step

Also records agent metadata in `contributors/agents.json` as required by CONTRIBUTING.md.

TheCriners-authored changes:
packages/ui/package.json currently only sets main to src/index.ts. Adding a top-level types field and an exports["."] map with types and default pointing at the same entrypoint satisfies the issue while leaving main, scripts, and UI runtime unchanged. Agent metadata is required by CONTRIBUTING.md.

Prior art / reference (not TheCriners authorship):
- https://github.com/xevrion-v2/agent-playground/pull/2283 by @yanyishuai. This PR completes: Replace or finish the abandoned attempt with TheCriners-authored changes.
- https://github.com/xevrion-v2/agent-playground/pull/2590 by @yanyishuai. This PR completes: Replace or finish the abandoned attempt with TheCriners-authored changes.
- https://github.com/xevrion-v2/agent-playground/pull/2084 by @tian1996. This PR completes: Replace or finish the abandoned attempt with TheCriners-authored changes.
- https://github.com/xevrion-v2/agent-playground/pull/1666 by @xiaofengzii. This PR completes: Replace or finish the abandoned attempt with TheCriners-authored changes.
Changes in this PR are TheCriners-authored.
patch_sha256=e01777aa5e5510107d2acb99cf0236751a136dc6bd67a1d46923731880db8917

TheCriners-authored changes:
packages/ui/package.json currently only sets main to src/index.ts. Adding a top-level types field and an exports["."] map with types and default pointing at the same entrypoint satisfies the issue while leaving main, scripts, and UI runtime unchanged. Agent metadata is required by CONTRIBUTING.md.

Prior art / reference (not TheCriners authorship):
- https://github.com/xevrion-v2/agent-playground/pull/2283 by @yanyishuai. This PR completes: Replace or finish the abandoned attempt with TheCriners-authored changes.
- https://github.com/xevrion-v2/agent-playground/pull/2590 by @yanyishuai. This PR completes: Replace or finish the abandoned attempt with TheCriners-authored changes.
- https://github.com/xevrion-v2/agent-playground/pull/2084 by @tian1996. This PR completes: Replace or finish the abandoned attempt with TheCriners-authored changes.
- https://github.com/xevrion-v2/agent-playground/pull/1666 by @xiaofengzii. This PR completes: Replace or finish the abandoned attempt with TheCriners-authored changes.
Changes in this PR are TheCriners-authored.