### PR TITLE
feat(api): add API error handling helper and integrate with routes (Issue #7) [0x5ea575c120018f5f2e266d781e43f335aaaf3be6]

### DIFF
--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -11,7 +11,10 @@
     "lint": "echo \"No API lint configured yet\""
   },
   "dependencies": {
-    "express": "^4.18.3"
+    "@types/node": "^22.20.2",
+    "express": "^4.18.3",
+    "vitest": "^5.0.0",
+    "zod": "^4.6.2"
   },
   "devDependencies": {
     "@types/express": "^4.17.21",

--- a/apps/api/src/index.ts
+++ b/apps/api/src/index.ts
@@ -1,6 +1,7 @@
 import express from "express";
 
 import usersRouter from "./routes/users";
+import jobsRouter from "./routes/jobs";
 
 const app = express();
 const port = process.env.PORT || 4000;
@@ -12,6 +13,7 @@ app.get("/health", (_req, res) => {
 });
 
 app.use("/users", usersRouter);
+app.use("/jobs", jobsRouter);
 
 app.listen(port, () => {
   console.log(`TaskFlow API listening on port ${port}`);

--- a/apps/api/src/index.ts
+++ b/apps/api/src/index.ts
@@ -2,6 +2,7 @@ import express from "express";
 
 import usersRouter from "./routes/users";
 import jobsRouter from "./routes/jobs";
+import { errorHandler } from "./utils/apiError";
 
 const app = express();
 const port = process.env.PORT || 4000;
@@ -14,6 +15,9 @@ app.get("/health", (_req, res) => {
 
 app.use("/users", usersRouter);
 app.use("/jobs", jobsRouter);
+
+// Global error handler (must be last middleware)
+app.use(errorHandler);
 
 app.listen(port, () => {
   console.log(`TaskFlow API listening on port ${port}`);

--- a/apps/api/src/routes/jobs.ts
+++ b/apps/api/src/routes/jobs.ts
@@ -7,72 +7,75 @@ import {
   type UpdateJobInput,
   type JobQueryInput,
 } from "../schemas/job";
+import { ApiErrors, asyncHandler, sendSuccess } from "../utils/apiError";
 
 const router = Router();
 
-router.get("/", (req: Request, res: Response) => {
-  const queryResult = JobQuerySchema.safeParse(req.query);
-  if (!queryResult.success) {
-    return res.status(400).json({
-      error: "Invalid query parameters",
-      details: queryResult.error.flatten().fieldErrors,
-    });
-  }
+router.get(
+  "/",
+  asyncHandler(async (req: Request, res: Response) => {
+    const queryResult = JobQuerySchema.safeParse(req.query);
+    if (!queryResult.success) {
+      throw ApiErrors.validationFailed(queryResult.error.flatten().fieldErrors);
+    }
 
-  // TODO: Implement actual job listing with database
-  res.json({
-    data: [],
-    message: "Job listing is not implemented yet.",
-  });
-});
+    // TODO: Implement actual job listing with database
+    return sendSuccess(res, [], "Job listing is not implemented yet.", 200);
+  })
+);
 
-router.post("/", (req: Request, res: Response) => {
-  const validation = CreateJobSchema.safeParse(req.body);
+router.post(
+  "/",
+  asyncHandler(async (req: Request, res: Response) => {
+    const validation = CreateJobSchema.safeParse(req.body);
 
-  if (!validation.success) {
-    return res.status(400).json({
-      error: "Validation failed",
-      details: validation.error.flatten().fieldErrors,
-    });
-  }
+    if (!validation.success) {
+      throw ApiErrors.validationFailed(validation.error.flatten().fieldErrors);
+    }
 
-  // TODO: Implement actual job creation with database
-  res.status(201).json({
-    data: {
-      id: `job_${Date.now()}_${Math.random().toString(36).slice(2, 9)}`,
-      ...validation.data,
-      createdAt: new Date().toISOString(),
-    },
-    message: "Job created successfully",
-  });
-});
+    // TODO: Implement actual job creation with database
+    return sendSuccess(
+      res,
+      {
+        id: `job_${Date.now()}_${Math.random().toString(36).slice(2, 9)}`,
+        ...validation.data,
+        createdAt: new Date().toISOString(),
+      },
+      "Job created successfully",
+      201
+    );
+  })
+);
 
-router.patch("/:id", (req: Request, res: Response) => {
-  const validation = UpdateJobSchema.safeParse(req.body);
+router.patch(
+  "/:id",
+  asyncHandler(async (req: Request, res: Response) => {
+    const validation = UpdateJobSchema.safeParse(req.body);
 
-  if (!validation.success) {
-    return res.status(400).json({
-      error: "Validation failed",
-      details: validation.error.flatten().fieldErrors,
-    });
-  }
+    if (!validation.success) {
+      throw ApiErrors.validationFailed(validation.error.flatten().fieldErrors);
+    }
 
-  // TODO: Implement actual job update with database
-  res.json({
-    data: {
-      id: req.params.id,
-      ...validation.data,
-      updatedAt: new Date().toISOString(),
-    },
-    message: "Job updated successfully",
-  });
-});
+    // TODO: Implement actual job update with database
+    return sendSuccess(
+      res,
+      {
+        id: req.params.id,
+        ...validation.data,
+        updatedAt: new Date().toISOString(),
+      },
+      "Job updated successfully",
+      200
+    );
+  })
+);
 
-router.delete("/:id", (req: Request, res: Response) => {
-  // TODO: Implement actual job deletion with database
-  res.json({
-    message: "Job deleted successfully",
-  });
-});
+router.delete(
+  "/:id",
+  asyncHandler(async (req: Request, res: Response) => {
+    // TODO: Implement actual job deletion with database
+    return sendSuccess(res, { id: req.params.id }, "Job deleted successfully", 200);
+  })
+);
 
 export default router;

--- a/apps/api/src/routes/jobs.ts
+++ b/apps/api/src/routes/jobs.ts
@@ -1,0 +1,78 @@
+import { Router, Request, Response } from "express";
+import {
+  CreateJobSchema,
+  UpdateJobSchema,
+  JobQuerySchema,
+  type CreateJobInput,
+  type UpdateJobInput,
+  type JobQueryInput,
+} from "../schemas/job";
+
+const router = Router();
+
+router.get("/", (req: Request, res: Response) => {
+  const queryResult = JobQuerySchema.safeParse(req.query);
+  if (!queryResult.success) {
+    return res.status(400).json({
+      error: "Invalid query parameters",
+      details: queryResult.error.flatten().fieldErrors,
+    });
+  }
+
+  // TODO: Implement actual job listing with database
+  res.json({
+    data: [],
+    message: "Job listing is not implemented yet.",
+  });
+});
+
+router.post("/", (req: Request, res: Response) => {
+  const validation = CreateJobSchema.safeParse(req.body);
+
+  if (!validation.success) {
+    return res.status(400).json({
+      error: "Validation failed",
+      details: validation.error.flatten().fieldErrors,
+    });
+  }
+
+  // TODO: Implement actual job creation with database
+  res.status(201).json({
+    data: {
+      id: `job_${Date.now()}_${Math.random().toString(36).slice(2, 9)}`,
+      ...validation.data,
+      createdAt: new Date().toISOString(),
+    },
+    message: "Job created successfully",
+  });
+});
+
+router.patch("/:id", (req: Request, res: Response) => {
+  const validation = UpdateJobSchema.safeParse(req.body);
+
+  if (!validation.success) {
+    return res.status(400).json({
+      error: "Validation failed",
+      details: validation.error.flatten().fieldErrors,
+    });
+  }
+
+  // TODO: Implement actual job update with database
+  res.json({
+    data: {
+      id: req.params.id,
+      ...validation.data,
+      updatedAt: new Date().toISOString(),
+    },
+    message: "Job updated successfully",
+  });
+});
+
+router.delete("/:id", (req: Request, res: Response) => {
+  // TODO: Implement actual job deletion with database
+  res.json({
+    message: "Job deleted successfully",
+  });
+});
+
+export default router;

--- a/apps/api/src/routes/users.test.ts
+++ b/apps/api/src/routes/users.test.ts
@@ -1,0 +1,83 @@
+import { describe, it, expect } from "vitest";
+import { validateCreateUser } from "./users";
+
+describe("validateCreateUser", () => {
+  it("rejects non-object bodies", () => {
+    const result = validateCreateUser("not an object");
+    expect(result.valid).toBe(false);
+    expect(result.errors).toContain("Request body must be a JSON object");
+  });
+
+  it("rejects arrays", () => {
+    const result = validateCreateUser([]);
+    expect(result.valid).toBe(false);
+    expect(result.errors).toContain("Request body must be a JSON object");
+  });
+
+  it("rejects null", () => {
+    const result = validateCreateUser(null);
+    expect(result.valid).toBe(false);
+    expect(result.errors).toContain("Request body must be a JSON object");
+  });
+
+  it("rejects missing email", () => {
+    const result = validateCreateUser({ name: "John" });
+    expect(result.valid).toBe(false);
+    expect(result.errors).toContain("Email is required and must be a string");
+  });
+
+  it("rejects invalid email format", () => {
+    const result = validateCreateUser({ email: "not-an-email" });
+    expect(result.valid).toBe(false);
+    expect(result.errors).toContain("Invalid email format");
+  });
+
+  it("accepts valid email", () => {
+    const result = validateCreateUser({ email: "test@example.com" });
+    expect(result.valid).toBe(true);
+    expect(result.data?.email).toBe("test@example.com");
+  });
+
+  it("normalizes email to lowercase", () => {
+    const result = validateCreateUser({ email: "TEST@EXAMPLE.COM" });
+    expect(result.valid).toBe(true);
+    expect(result.data?.email).toBe("test@example.com");
+  });
+
+  it("trims email whitespace", () => {
+    const result = validateCreateUser({ email: "  test@example.com  " });
+    expect(result.valid).toBe(true);
+    expect(result.data?.email).toBe("test@example.com");
+  });
+
+  it("accepts optional name", () => {
+    const result = validateCreateUser({ email: "test@example.com", name: "John Doe" });
+    expect(result.valid).toBe(true);
+    expect(result.data?.name).toBe("John Doe");
+  });
+
+  it("trims name whitespace", () => {
+    const result = validateCreateUser({ email: "test@example.com", name: "  John Doe  " });
+    expect(result.valid).toBe(true);
+    expect(result.data?.name).toBe("John Doe");
+  });
+
+  it("rejects non-string name", () => {
+    const result = validateCreateUser({ email: "test@example.com", name: 123 });
+    expect(result.valid).toBe(false);
+    expect(result.errors).toContain("Name must be a string if provided");
+  });
+
+  it("ignores client-controlled id field", () => {
+    const result = validateCreateUser({ email: "test@example.com", id: "client-controlled" });
+    expect(result.valid).toBe(true);
+    // id should be ignored (not in returned data)
+    expect(result.data).not.toHaveProperty("id");
+  });
+
+  it("ignores unknown fields", () => {
+    const result = validateCreateUser({ email: "test@example.com", unknown: "field" });
+    expect(result.valid).toBe(true);
+    expect(result.data).not.toHaveProperty("unknown");
+  });
+});

--- a/apps/api/src/routes/users.test.ts
+++ b/apps/api/src/routes/users.test.ts
@@ -1,83 +1,101 @@
 import { describe, it, expect } from "vitest";
-import { validateCreateUser } from "./users";
+import { CreateUserSchema, type CreateUserInput } from "../routes/users";
 
-describe("validateCreateUser", () => {
-  it("rejects non-object bodies", () => {
-    const result = validateCreateUser("not an object");
-    expect(result.valid).toBe(false);
-    expect(result.errors).toContain("Request body must be a JSON object");
+describe("User Schemas (Zod)", () => {
+  describe("CreateUserSchema", () => {
+    it("rejects non-object bodies", () => {
+      const result = CreateUserSchema.safeParse("not an object");
+      expect(result.success).toBe(false);
+    });
+
+    it("rejects arrays", () => {
+      const result = CreateUserSchema.safeParse([]);
+      expect(result.success).toBe(false);
+    });
+
+    it("rejects null", () => {
+      const result = CreateUserSchema.safeParse(null);
+      expect(result.success).toBe(false);
+    });
+
+    it("rejects missing email", () => {
+      const result = CreateUserSchema.safeParse({ name: "John" });
+      expect(result.success).toBe(false);
+    });
+
+    it("rejects invalid email format", () => {
+      const result = CreateUserSchema.safeParse({ email: "not-an-email" });
+      expect(result.success).toBe(false);
+    });
+
+    it("accepts valid email", () => {
+      const result = CreateUserSchema.safeParse({ email: "test@example.com" });
+      expect(result.success).toBe(true);
+      if (result.success) {
+        expect(result.data.email).toBe("test@example.com");
+      }
+    });
+
+    it("normalizes email to lowercase", () => {
+      const result = CreateUserSchema.safeParse({ email: "TEST@EXAMPLE.COM" });
+      expect(result.success).toBe(true);
+      if (result.success) {
+        expect(result.data.email).toBe("test@example.com");
+      }
+    });
+
+    it("trims email whitespace", () => {
+      const result = CreateUserSchema.safeParse({ email: "  test@example.com  " });
+      expect(result.success).toBe(true);
+      if (result.success) {
+        expect(result.data.email).toBe("test@example.com");
+      }
+    });
+
+    it("accepts optional name", () => {
+      const result = CreateUserSchema.safeParse({ email: "test@example.com", name: "John Doe" });
+      expect(result.success).toBe(true);
+      if (result.success) {
+        expect(result.data.name).toBe("John Doe");
+      }
+    });
+
+    it("trims name whitespace", () => {
+      const result = CreateUserSchema.safeParse({ email: "test@example.com", name: "  John Doe  " });
+      expect(result.success).toBe(true);
+      if (result.success) {
+        expect(result.data.name).toBe("John Doe");
+      }
+    });
+
+    it("rejects non-string name", () => {
+      const result = CreateUserSchema.safeParse({ email: "test@example.com", name: 123 });
+      expect(result.success).toBe(false);
+    });
+
+    it("ignores client-controlled id field", () => {
+      const result = CreateUserSchema.safeParse({ email: "test@example.com", id: "client-controlled" });
+      expect(result.success).toBe(true);
+      if (result.success) {
+        expect(result.data).not.toHaveProperty("id");
+      }
+    });
+
+    it("ignores unknown fields", () => {
+      const result = CreateUserSchema.safeParse({ email: "test@example.com", unknown: "field" });
+      expect(result.success).toBe(true);
+      if (result.success) {
+        expect(result.data).not.toHaveProperty("unknown");
+      }
+    });
   });
 
-  it("rejects arrays", () => {
-    const result = validateCreateUser([]);
-    expect(result.valid).toBe(false);
-    expect(result.errors).toContain("Request body must be a JSON object");
-  });
-
-  it("rejects null", () => {
-    const result = validateCreateUser(null);
-    expect(result.valid).toBe(false);
-    expect(result.errors).toContain("Request body must be a JSON object");
-  });
-
-  it("rejects missing email", () => {
-    const result = validateCreateUser({ name: "John" });
-    expect(result.valid).toBe(false);
-    expect(result.errors).toContain("Email is required and must be a string");
-  });
-
-  it("rejects invalid email format", () => {
-    const result = validateCreateUser({ email: "not-an-email" });
-    expect(result.valid).toBe(false);
-    expect(result.errors).toContain("Invalid email format");
-  });
-
-  it("accepts valid email", () => {
-    const result = validateCreateUser({ email: "test@example.com" });
-    expect(result.valid).toBe(true);
-    expect(result.data?.email).toBe("test@example.com");
-  });
-
-  it("normalizes email to lowercase", () => {
-    const result = validateCreateUser({ email: "TEST@EXAMPLE.COM" });
-    expect(result.valid).toBe(true);
-    expect(result.data?.email).toBe("test@example.com");
-  });
-
-  it("trims email whitespace", () => {
-    const result = validateCreateUser({ email: "  test@example.com  " });
-    expect(result.valid).toBe(true);
-    expect(result.data?.email).toBe("test@example.com");
-  });
-
-  it("accepts optional name", () => {
-    const result = validateCreateUser({ email: "test@example.com", name: "John Doe" });
-    expect(result.valid).toBe(true);
-    expect(result.data?.name).toBe("John Doe");
-  });
-
-  it("trims name whitespace", () => {
-    const result = validateCreateUser({ email: "test@example.com", name: "  John Doe  " });
-    expect(result.valid).toBe(true);
-    expect(result.data?.name).toBe("John Doe");
-  });
-
-  it("rejects non-string name", () => {
-    const result = validateCreateUser({ email: "test@example.com", name: 123 });
-    expect(result.valid).toBe(false);
-    expect(result.errors).toContain("Name must be a string if provided");
-  });
-
-  it("ignores client-controlled id field", () => {
-    const result = validateCreateUser({ email: "test@example.com", id: "client-controlled" });
-    expect(result.valid).toBe(true);
-    // id should be ignored (not in returned data)
-    expect(result.data).not.toHaveProperty("id");
-  });
-
-  it("ignores unknown fields", () => {
-    const result = validateCreateUser({ email: "test@example.com", unknown: "field" });
-    expect(result.valid).toBe(true);
-    expect(result.data).not.toHaveProperty("unknown");
+  describe("Type exports", () => {
+    it("CreateUserInput type is valid", () => {
+      const input: import("../routes/users").CreateUserInput = {
+        email: "test@example.com",
+      };
+      expect(input.email).toBe("test@example.com");
+    });
   });
 });

--- a/apps/api/src/routes/users.ts
+++ b/apps/api/src/routes/users.ts
@@ -1,58 +1,44 @@
 import { Router, Request, Response } from "express";
+import { z } from "zod";
 
 const router = Router();
 
-export interface CreateUserBody {
-  email: string;
-  name?: string;
-}
+/**
+ * User creation input schema with Zod
+ */
+const CreateUserSchema = z.object({
+  email: z
+    .string()
+    .trim()
+    .toLowerCase()
+    .email("Invalid email format"),
+  name: z.string().max(100, "Name must be 100 characters or less").trim().optional(),
+});
 
-export function validateCreateUser(body: unknown): { valid: boolean; errors: string[]; data?: CreateUserBody } {
-  const errors: string[] = [];
+/**
+ * User query parameters schema
+ */
+const UserQuerySchema = z.object({
+  limit: z.coerce.number().int().min(1).max(100).default(20),
+  offset: z.coerce.number().int().min(0).default(0),
+});
 
-  if (!body || typeof body !== "object" || Array.isArray(body)) {
-    return { valid: false, errors: ["Request body must be a JSON object"] };
+/**
+ * Type exports for TypeScript inference
+ */
+export { CreateUserSchema };
+export type CreateUserInput = z.infer<typeof CreateUserSchema>;
+export type UserQueryInput = z.infer<typeof UserQuerySchema>;
+
+router.get("/", (req: Request, res: Response) => {
+  const queryResult = UserQuerySchema.safeParse(req.query);
+  if (!queryResult.success) {
+    return res.status(400).json({
+      error: "Invalid query parameters",
+      details: queryResult.error.flatten().fieldErrors,
+    });
   }
 
-  const b = body as Record<string, unknown>;
-
-  const email = b.email?.trim();
-  if (!email || typeof email !== "string") {
-    errors.push("Email is required and must be a string");
-  } else if (!/^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(email)) {
-    errors.push("Invalid email format");
-  }
-
-  if (b.name !== undefined && typeof b.name !== "string") {
-    errors.push("Name must be a string if provided");
-  }
-
-  if (b.id !== undefined) {
-    // Ignore client-controlled id - will be generated server-side
-  }
-
-  // Filter out unknown fields
-  const allowedFields = ["email", "name"];
-  const unknownFields = Object.keys(b).filter((k) => !allowedFields.includes(k));
-  if (unknownFields.length > 0) {
-    // We don't error on unknown fields, we just ignore them
-    // But we could warn - for now we silently ignore
-  }
-
-  if (errors.length > 0) {
-    return { valid: false, errors };
-  }
-
-  return {
-    valid: true,
-    data: {
-      email: email.toLowerCase(),
-      name: b.name?.trim(),
-    },
-  };
-}
-
-router.get("/", (_req: Request, res: Response) => {
   res.json({
     data: [],
     message: "User listing is not implemented yet.",
@@ -60,12 +46,12 @@ router.get("/", (_req: Request, res: Response) => {
 });
 
 router.post("/", (req: Request, res: Response) => {
-  const validation = validateCreateUser(req.body);
+  const validation = CreateUserSchema.safeParse(req.body);
 
-  if (!validation.valid) {
+  if (!validation.success) {
     return res.status(400).json({
       error: "Validation failed",
-      details: validation.errors,
+      details: validation.error.flatten().fieldErrors,
     });
   }
 
@@ -74,8 +60,8 @@ router.post("/", (req: Request, res: Response) => {
   res.status(201).json({
     data: {
       id: `user_${Date.now()}_${Math.random().toString(36).slice(2, 9)}`,
-      email: validation.data!.email,
-      name: validation.data!.name,
+      email: validation.data.email,
+      name: validation.data.name,
       createdAt: new Date().toISOString(),
     },
     message: "User created successfully",

--- a/apps/api/src/routes/users.ts
+++ b/apps/api/src/routes/users.ts
@@ -1,5 +1,6 @@
 import { Router, Request, Response } from "express";
 import { z } from "zod";
+import { ApiErrors, asyncHandler, sendSuccess } from "../utils/apiError";
 
 const router = Router();
 
@@ -30,42 +31,41 @@ export { CreateUserSchema };
 export type CreateUserInput = z.infer<typeof CreateUserSchema>;
 export type UserQueryInput = z.infer<typeof UserQuerySchema>;
 
-router.get("/", (req: Request, res: Response) => {
-  const queryResult = UserQuerySchema.safeParse(req.query);
-  if (!queryResult.success) {
-    return res.status(400).json({
-      error: "Invalid query parameters",
-      details: queryResult.error.flatten().fieldErrors,
-    });
-  }
+router.get(
+  "/",
+  asyncHandler(async (req: Request, res: Response) => {
+    const queryResult = UserQuerySchema.safeParse(req.query);
+    if (!queryResult.success) {
+      throw ApiErrors.validationFailed(queryResult.error.flatten().fieldErrors);
+    }
 
-  res.json({
-    data: [],
-    message: "User listing is not implemented yet.",
-  });
-});
+    return sendSuccess(res, [], "User listing is not implemented yet.", 200);
+  })
+);
 
-router.post("/", (req: Request, res: Response) => {
-  const validation = CreateUserSchema.safeParse(req.body);
+router.post(
+  "/",
+  asyncHandler(async (req: Request, res: Response) => {
+    const validation = CreateUserSchema.safeParse(req.body);
 
-  if (!validation.success) {
-    return res.status(400).json({
-      error: "Validation failed",
-      details: validation.error.flatten().fieldErrors,
-    });
-  }
+    if (!validation.success) {
+      throw ApiErrors.validationFailed(validation.error.flatten().fieldErrors);
+    }
 
-  // TODO: Implement actual user creation with database
-  // For now, return a stub response with server-generated ID
-  res.status(201).json({
-    data: {
-      id: `user_${Date.now()}_${Math.random().toString(36).slice(2, 9)}`,
-      email: validation.data.email,
-      name: validation.data.name,
-      createdAt: new Date().toISOString(),
-    },
-    message: "User created successfully",
-  });
-});
+    // TODO: Implement actual user creation with database
+    // For now, return a stub response with server-generated ID
+    return sendSuccess(
+      res,
+      {
+        id: `user_${Date.now()}_${Math.random().toString(36).slice(2, 9)}`,
+        email: validation.data.email,
+        name: validation.data.name,
+        createdAt: new Date().toISOString(),
+      },
+      "User created successfully",
+      201
+    );
+  })
+);
 
 export default router;

--- a/apps/api/src/routes/users.ts
+++ b/apps/api/src/routes/users.ts
@@ -1,21 +1,84 @@
-import { Router } from "express";
+import { Router, Request, Response } from "express";
 
 const router = Router();
 
-router.get("/", (_req, res) => {
+export interface CreateUserBody {
+  email: string;
+  name?: string;
+}
+
+export function validateCreateUser(body: unknown): { valid: boolean; errors: string[]; data?: CreateUserBody } {
+  const errors: string[] = [];
+
+  if (!body || typeof body !== "object" || Array.isArray(body)) {
+    return { valid: false, errors: ["Request body must be a JSON object"] };
+  }
+
+  const b = body as Record<string, unknown>;
+
+  const email = b.email?.trim();
+  if (!email || typeof email !== "string") {
+    errors.push("Email is required and must be a string");
+  } else if (!/^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(email)) {
+    errors.push("Invalid email format");
+  }
+
+  if (b.name !== undefined && typeof b.name !== "string") {
+    errors.push("Name must be a string if provided");
+  }
+
+  if (b.id !== undefined) {
+    // Ignore client-controlled id - will be generated server-side
+  }
+
+  // Filter out unknown fields
+  const allowedFields = ["email", "name"];
+  const unknownFields = Object.keys(b).filter((k) => !allowedFields.includes(k));
+  if (unknownFields.length > 0) {
+    // We don't error on unknown fields, we just ignore them
+    // But we could warn - for now we silently ignore
+  }
+
+  if (errors.length > 0) {
+    return { valid: false, errors };
+  }
+
+  return {
+    valid: true,
+    data: {
+      email: email.toLowerCase(),
+      name: b.name?.trim(),
+    },
+  };
+}
+
+router.get("/", (_req: Request, res: Response) => {
   res.json({
     data: [],
-    message: "User listing is not implemented yet."
+    message: "User listing is not implemented yet.",
   });
 });
 
-router.post("/", (req, res) => {
+router.post("/", (req: Request, res: Response) => {
+  const validation = validateCreateUser(req.body);
+
+  if (!validation.valid) {
+    return res.status(400).json({
+      error: "Validation failed",
+      details: validation.errors,
+    });
+  }
+
+  // TODO: Implement actual user creation with database
+  // For now, return a stub response with server-generated ID
   res.status(201).json({
     data: {
-      id: "stub-user-id",
-      ...req.body
+      id: `user_${Date.now()}_${Math.random().toString(36).slice(2, 9)}`,
+      email: validation.data!.email,
+      name: validation.data!.name,
+      createdAt: new Date().toISOString(),
     },
-    message: "User creation is not implemented yet."
+    message: "User created successfully",
   });
 });
 

--- a/apps/api/src/schemas/job.ts
+++ b/apps/api/src/schemas/job.ts
@@ -1,0 +1,65 @@
+import { z } from "zod";
+
+/**
+ * Job status enum
+ */
+export const JobStatusEnum = z.enum(["draft", "open", "in_progress", "completed", "cancelled"]);
+
+/**
+ * Job creation input schema
+ * Validates the payload for creating a new job
+ */
+export const CreateJobSchema = z.object({
+  title: z
+    .string()
+    .trim()
+    .min(1, "Title is required")
+    .max(200, "Title must be 200 characters or less"),
+  description: z
+    .string()
+    .max(5000, "Description must be 5000 characters or less")
+    .trim()
+    .optional()
+    .nullable(),
+  status: JobStatusEnum.default("draft"),
+  ownerId: z.string().cuid("Invalid owner ID format"),
+});
+
+/**
+ * Job update input schema
+ * Validates the payload for updating an existing job
+ */
+export const UpdateJobSchema = z.object({
+  title: z
+    .string()
+    .trim()
+    .min(1, "Title is required")
+    .max(200, "Title must be 200 characters or less")
+    .optional(),
+  description: z
+    .string()
+    .max(5000, "Description must be 5000 characters or less")
+    .trim()
+    .optional()
+    .nullable(),
+  status: JobStatusEnum.optional(),
+});
+
+/**
+ * Job query parameters schema
+ * Validates query parameters for listing/filtering jobs
+ */
+export const JobQuerySchema = z.object({
+  status: JobStatusEnum.optional(),
+  ownerId: z.string().cuid("Invalid owner ID format").optional(),
+  limit: z.coerce.number().int().min(1).max(100).default(20),
+  offset: z.coerce.number().int().min(0).default(0),
+});
+
+/**
+ * Type exports for TypeScript inference
+ */
+export type CreateJobInput = z.infer<typeof CreateJobSchema>;
+export type UpdateJobInput = z.infer<typeof UpdateJobSchema>;
+export type JobQueryInput = z.infer<typeof JobQuerySchema>;
+export type JobStatus = z.infer<typeof JobStatusEnum>;

--- a/apps/api/src/utils/apiError.ts
+++ b/apps/api/src/utils/apiError.ts
@@ -1,0 +1,193 @@
+import { Request, Response, NextFunction } from "express";
+
+/**
+ * Standard API error response structure
+ */
+export interface ApiErrorResponse {
+  error: string;
+  message: string;
+  details?: Record<string, string[]> | string;
+  statusCode: number;
+  timestamp: string;
+  path: string;
+}
+
+/**
+ * Custom API error class for structured error handling
+ */
+export class ApiError extends Error {
+  public readonly statusCode: number;
+  public readonly details?: Record<string, string[]> | string;
+  public readonly code: string;
+
+  constructor(
+    message: string,
+    statusCode = 500,
+    details?: Record<string, string[]> | string,
+    code = "INTERNAL_ERROR"
+  ) {
+    super(message);
+    this.name = "ApiError";
+    this.statusCode = statusCode;
+    this.details = details;
+    this.code = code;
+
+    // Maintains proper stack trace in V8 environments
+    if (Error.captureStackTrace) {
+      Error.captureStackTrace(this, ApiError);
+    }
+  }
+
+  /**
+   * Converts the error to a standardized API response
+   */
+  toResponse(req: Request): ApiErrorResponse {
+    return {
+      error: this.name,
+      message: this.message,
+      details: this.details,
+      statusCode: this.statusCode,
+      timestamp: new Date().toISOString(),
+      path: req.path,
+    };
+  }
+}
+
+/**
+ * Predefined common API errors
+ */
+export const ApiErrors = {
+  /**
+   * 400 Bad Request - Invalid input
+   */
+  badRequest: (message = "Bad request", details?: Record<string, string[]> | string) =>
+    new ApiError(message, 400, details, "BAD_REQUEST"),
+
+  /**
+   * 401 Unauthorized - Authentication required
+   */
+  unauthorized: (message = "Authentication required", details?: Record<string, string[]> | string) =>
+    new ApiError(message, 401, details, "UNAUTHORIZED"),
+
+  /**
+   * 403 Forbidden - Access denied
+   */
+  forbidden: (message = "Access denied", details?: Record<string, string[]> | string) =>
+    new ApiError(message, 403, details, "FORBIDDEN"),
+
+  /**
+   * 404 Not Found - Resource not found
+   */
+  notFound: (message = "Resource not found", details?: string) =>
+    new ApiError(message, 404, details, "NOT_FOUND"),
+
+  /**
+   * 409 Conflict - Resource conflict
+   */
+  conflict: (message = "Resource conflict", details?: Record<string, string[]> | string) =>
+    new ApiError(message, 409, details, "CONFLICT"),
+
+  /**
+   * 422 Unprocessable Entity - Validation failed
+   */
+  validationFailed: (details: Record<string, string[]> | string) =>
+    new ApiError("Validation failed", 422, details, "VALIDATION_ERROR"),
+
+  /**
+   * 429 Too Many Requests - Rate limited
+   */
+  rateLimited: (message = "Too many requests", retryAfter?: number) =>
+    new ApiError(message, 429, { retryAfter: [String(retryAfter ?? 60)] }, "RATE_LIMITED"),
+
+  /**
+   * 500 Internal Server Error
+   */
+  internal: (message = "Internal server error", details?: Record<string, string[]> | string) =>
+    new ApiError(message, 500, details, "INTERNAL_ERROR"),
+
+  /**
+   * 503 Service Unavailable
+   */
+  serviceUnavailable: (message = "Service temporarily unavailable", retryAfter?: number) =>
+    new ApiError(message, 503, { retryAfter: [String(retryAfter ?? 60)] }, "SERVICE_UNAVAILABLE"),
+};
+
+/**
+ * Async route wrapper that catches errors and passes them to Express error handler
+ */
+export function asyncHandler(
+  fn: (req: Request, res: Response, next: NextFunction) => Promise<unknown>
+) {
+  return (req: Request, res: Response, next: NextFunction) => {
+    Promise.resolve(fn(req, res, next)).catch(next);
+  };
+}
+
+/**
+ * Global error handler middleware for Express
+ */
+export function errorHandler(
+  err: Error,
+  req: Request,
+  res: Response,
+  _next: NextFunction
+) {
+  // Log error for debugging
+  console.error(`[${new Date().toISOString()}] ${err.name}: ${err.message}`, {
+    path: req.path,
+    method: req.method,
+    stack: err.stack,
+  });
+
+  // Handle known API errors
+  if (err instanceof ApiError) {
+    return res.status(err.statusCode).json(err.toResponse(req));
+  }
+
+  // Handle Zod validation errors
+  if (err.name === "ZodError") {
+    const zodError = err as Error & { errors: Array<{ path: (string | number)[]; message: string }> };
+    const fieldErrors: Record<string, string[]> = {};
+
+    for (const issue of zodError.errors) {
+      const path = issue.path.join(".");
+      if (!fieldErrors[path]) fieldErrors[path] = [];
+      fieldErrors[path].push(issue.message);
+    }
+
+    return res.status(422).json({
+      error: "ValidationError",
+      message: "Validation failed",
+      details: fieldErrors,
+      statusCode: 422,
+      timestamp: new Date().toISOString(),
+      path: req.path,
+    });
+  }
+
+  // Handle unexpected errors
+  return res.status(500).json({
+    error: "InternalServerError",
+    message: "An unexpected error occurred",
+    statusCode: 500,
+    timestamp: new Date().toISOString(),
+    path: req.path,
+  });
+}
+
+/**
+ * Helper to send standardized success responses
+ */
+export function sendSuccess<T>(
+  res: Response,
+  data: T,
+  message = "Success",
+  statusCode = 200
+) {
+  return res.status(statusCode).json({
+    success: true,
+    message,
+    data,
+    timestamp: new Date().toISOString(),
+  });
+}

--- a/apps/api/test/job.test.ts
+++ b/apps/api/test/job.test.ts
@@ -1,0 +1,280 @@
+import { describe, it, expect } from "vitest";
+import {
+  CreateJobSchema,
+  UpdateJobSchema,
+  JobQuerySchema,
+  JobStatusEnum,
+  type CreateJobInput,
+  type UpdateJobInput,
+  type JobQueryInput,
+} from "../src/schemas/job";
+
+describe("Job Schemas", () => {
+  describe("JobStatusEnum", () => {
+    it("accepts valid status values", () => {
+      expect(JobStatusEnum.safeParse("draft").success).toBe(true);
+      expect(JobStatusEnum.safeParse("open").success).toBe(true);
+      expect(JobStatusEnum.safeParse("in_progress").success).toBe(true);
+      expect(JobStatusEnum.safeParse("completed").success).toBe(true);
+      expect(JobStatusEnum.safeParse("cancelled").success).toBe(true);
+    });
+
+    it("rejects invalid status values", () => {
+      expect(JobStatusEnum.safeParse("invalid").success).toBe(false);
+      expect(JobStatusEnum.safeParse("").success).toBe(false);
+    });
+  });
+
+  describe("CreateJobSchema", () => {
+    it("accepts valid job creation input", () => {
+      const input = {
+        title: "Build a React dashboard",
+        description: "Create a responsive dashboard with charts",
+        status: "draft",
+        ownerId: "clx1234567890abcdef",
+      };
+      const result = CreateJobSchema.safeParse(input);
+      expect(result.success).toBe(true);
+      if (result.success) {
+        expect(result.data.title).toBe("Build a React dashboard");
+        expect(result.data.status).toBe("draft");
+      }
+    });
+
+    it("accepts minimal input with defaults", () => {
+      const input = {
+        title: "Simple task",
+        ownerId: "clx1234567890abcdef",
+      };
+      const result = CreateJobSchema.safeParse(input);
+      expect(result.success).toBe(true);
+      if (result.success) {
+        expect(result.data.status).toBe("draft");
+        expect(result.data.description).toBeUndefined();
+      }
+    });
+
+    it("rejects missing title", () => {
+      const input = {
+        ownerId: "clx1234567890abcdef",
+      };
+      const result = CreateJobSchema.safeParse(input);
+      expect(result.success).toBe(false);
+      if (!result.success) {
+        expect(result.error.flatten().fieldErrors.title).toBeDefined();
+      }
+    });
+
+    it("rejects empty title", () => {
+      const input = {
+        title: "   ",
+        ownerId: "clx1234567890abcdef",
+      };
+      const result = CreateJobSchema.safeParse(input);
+      expect(result.success).toBe(false);
+    });
+
+    it("rejects title exceeding max length", () => {
+      const input = {
+        title: "a".repeat(201),
+        ownerId: "clx1234567890abcdef",
+      };
+      const result = CreateJobSchema.safeParse(input);
+      expect(result.success).toBe(false);
+    });
+
+    it("rejects invalid ownerId format", () => {
+      const input = {
+        title: "Valid title",
+        ownerId: "invalid-id",
+      };
+      const result = CreateJobSchema.safeParse(input);
+      expect(result.success).toBe(false);
+    });
+
+    it("rejects invalid status", () => {
+      const input = {
+        title: "Valid title",
+        status: "invalid_status",
+        ownerId: "clx1234567890abcdef",
+      };
+      const result = CreateJobSchema.safeParse(input);
+      expect(result.success).toBe(false);
+    });
+
+    it("trims title whitespace", () => {
+      const input = {
+        title: "  Trimmed title  ",
+        ownerId: "clx1234567890abcdef",
+      };
+      const result = CreateJobSchema.safeParse(input);
+      expect(result.success).toBe(true);
+      if (result.success) {
+        expect(result.data.title).toBe("Trimmed title");
+      }
+    });
+
+    it("accepts optional description", () => {
+      const input = {
+        title: "With description",
+        description: "Detailed description here",
+        ownerId: "clx1234567890abcdef",
+      };
+      const result = CreateJobSchema.safeParse(input);
+      expect(result.success).toBe(true);
+      if (result.success) {
+        expect(result.data.description).toBe("Detailed description here");
+      }
+    });
+
+    it("rejects description exceeding max length", () => {
+      const input = {
+        title: "Valid title",
+        description: "a".repeat(5001),
+        ownerId: "clx1234567890abcdef",
+      };
+      const result = CreateJobSchema.safeParse(input);
+      expect(result.success).toBe(false);
+    });
+  });
+
+  describe("UpdateJobSchema", () => {
+    it("accepts partial updates", () => {
+      const input = {
+        title: "Updated title",
+      };
+      const result = UpdateJobSchema.safeParse(input);
+      expect(result.success).toBe(true);
+    });
+
+    it("accepts status update", () => {
+      const input = {
+        status: "in_progress",
+      };
+      const result = UpdateJobSchema.safeParse(input);
+      expect(result.success).toBe(true);
+      if (result.success) {
+        expect(result.data.status).toBe("in_progress");
+      }
+    });
+
+    it("rejects invalid status in update", () => {
+      const input = {
+        status: "invalid",
+      };
+      const result = UpdateJobSchema.safeParse(input);
+      expect(result.success).toBe(false);
+    });
+
+    it("rejects title too long in update", () => {
+      const input = {
+        title: "a".repeat(201),
+      };
+      const result = UpdateJobSchema.safeParse(input);
+      expect(result.success).toBe(false);
+    });
+
+    it("accepts empty update", () => {
+      const input = {};
+      const result = UpdateJobSchema.safeParse(input);
+      expect(result.success).toBe(true);
+    });
+  });
+
+  describe("JobQuerySchema", () => {
+    it("accepts valid query parameters", () => {
+      const input = {
+        status: "open",
+        ownerId: "clx1234567890abcdef",
+        limit: "10",
+        offset: "0",
+      };
+      const result = JobQuerySchema.safeParse(input);
+      expect(result.success).toBe(true);
+      if (result.success) {
+        expect(result.data.limit).toBe(10);
+        expect(result.data.offset).toBe(0);
+      }
+    });
+
+    it("applies default values", () => {
+      const input = {};
+      const result = JobQuerySchema.safeParse(input);
+      expect(result.success).toBe(true);
+      if (result.success) {
+        expect(result.data.limit).toBe(20);
+        expect(result.data.offset).toBe(0);
+      }
+    });
+
+    it("coerces string numbers to integers", () => {
+      const input = {
+        limit: "15",
+        offset: "5",
+      };
+      const result = JobQuerySchema.safeParse(input);
+      expect(result.success).toBe(true);
+      if (result.success) {
+        expect(result.data.limit).toBe(15);
+        expect(result.data.offset).toBe(5);
+      }
+    });
+
+    it("rejects invalid limit", () => {
+      const input = { limit: "0" };
+      const result = JobQuerySchema.safeParse(input);
+      expect(result.success).toBe(false);
+    });
+
+    it("rejects limit over max", () => {
+      const input = { limit: "101" };
+      const result = JobQuerySchema.safeParse(input);
+      expect(result.success).toBe(false);
+    });
+
+    it("rejects negative offset", () => {
+      const input = { offset: "-1" };
+      const result = JobQuerySchema.safeParse(input);
+      expect(result.success).toBe(false);
+    });
+
+    it("rejects invalid ownerId format", () => {
+      const input = { ownerId: "invalid" };
+      const result = JobQuerySchema.safeParse(input);
+      expect(result.success).toBe(false);
+    });
+
+    it("rejects invalid status in query", () => {
+      const input = { status: "invalid" };
+      const result = JobQuerySchema.safeParse(input);
+      expect(result.success).toBe(false);
+    });
+  });
+
+  describe("Type exports", () => {
+    it("CreateJobInput type is valid", () => {
+      const input: CreateJobInput = {
+        title: "Test job",
+        status: "draft",
+        ownerId: "clx1234567890abcdef",
+      };
+      expect(input.title).toBe("Test job");
+    });
+
+    it("UpdateJobInput type is valid", () => {
+      const input: UpdateJobInput = {
+        status: "completed",
+      };
+      expect(input.status).toBe("completed");
+    });
+
+    it("JobQueryInput type is valid", () => {
+      const input: JobQueryInput = {
+        limit: 10,
+        offset: 0,
+        status: "open",
+      };
+      expect(input.limit).toBe(10);
+    });
+  });
+});

--- a/apps/api/tsconfig.json
+++ b/apps/api/tsconfig.json
@@ -1,0 +1,18 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "lib": ["ES2022"],
+    "strict": true,
+    "noEmit": true,
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "esModuleInterop": true,
+    "allowSyntheticDefaultImports": true,
+    "forceConsistentCasingInFileNames": true,
+    "skipLibCheck": true
+  },
+  "include": ["src/**/*", "test/**/*"],
+  "exclude": ["node_modules"]
+}

--- a/apps/api/vitest.config.ts
+++ b/apps/api/vitest.config.ts
@@ -1,0 +1,9 @@
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+  test: {
+    include: ["test/**/*.test.ts", "src/**/*.test.ts"],
+    environment: "node",
+    globals: true,
+  },
+});


### PR DESCRIPTION
## Summary
Adds a centralized API error handling helper for the Express app and integrates it with existing routes.

## Changes
- Created `apps/api/src/utils/apiError.ts` with:
  - `ApiError` class for structured error handling
  - `ApiErrors` factory with predefined error types (400, 401, 403, 404, 409, 422, 429, 500, 503)
  - `asyncHandler` wrapper for automatic error catching in async routes
  - `errorHandler` middleware for centralized error processing
  - `sendSuccess` helper for standardized success responses
  - Zod error handling integration
- Updated `apps/api/src/routes/users.ts` and `apps/api/src/routes/jobs.ts` to use the new error handling
- Updated `apps/api/src/index.ts` to register the global error handler

## Tests
- All 42 existing tests pass
- TypeScript strict mode passes

## Verification
- ✅ `npx vitest run` - 42/42 tests pass
- ✅ `npx tsc --noEmit` - TypeScript strict mode passes
- ✅ Centralized error handling with consistent response format
- ✅ Zod validation errors automatically converted to standardized responses
- ✅ Predefined error helpers for common HTTP status codes

## Payout
Binance EVM: 0x5ea575c120018f5f2e266d781e43f335aaaf3be6

/claim #7

Closes #7