### PR TITLE
docs: add domain comments to Prisma schema models

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,8 +3,7 @@
 <img width="663" height="183" alt="593560705-1a920eb5-e581-44ce-bcef-2ebf0566777f" src="https://github.com/user-attachments/assets/37891de4-a282-45a3-98aa-35598c4571c2" />
 
 
-TaskFlow is a full-stack task management SaaS monorepo built 
-with a modern TypeScript-first architecture.
+TaskFlow is a full-stack task management SaaS monorepo built with a modern TypeScript-first architecture.
 
 ## Workspace Structure
 
@@ -68,8 +67,7 @@ npm run dev -w apps/api
 
 ## Database
 
-Prisma schema is available in packages/db/prisma/schema.prisma 
-with models for:
+Prisma schema is available in packages/db/prisma/schema.prisma with models for:
 - Users
 - Tasks
 - Proposals
@@ -81,5 +79,4 @@ with models for:
 
 ## Environment Variables
 
-Each app/package expects its own .env values for DB, auth, 
-and integrations.
+Each app/package expects its own .env values for DB, auth, and integrations.

--- a/packages/db/prisma/schema.prisma
+++ b/packages/db/prisma/schema.prisma
@@ -7,6 +7,9 @@ datasource db {
   url      = env("DATABASE_URL")
 }
 
+/// Represents a user account in the TaskFlow platform.
+/// Users can be either clients posting jobs or freelancers submitting proposals.
+/// Each user has a profile and owns jobs and proposals they create.
 model User {
   id        String     @id @default(cuid())
   email     String     @unique
@@ -17,6 +20,9 @@ model User {
   updatedAt DateTime   @updatedAt
 }
 
+/// Represents a task or job posting created by a client.
+/// Jobs go through a lifecycle (draft, open, in progress, completed)
+/// and can receive proposals from freelancers.
 model Job {
   id          String     @id @default(cuid())
   title       String
@@ -29,6 +35,9 @@ model Job {
   updatedAt   DateTime   @updatedAt
 }
 
+/// Represents a freelancer's proposal submitted for a specific job.
+/// Proposals include a summary and optional budget amount,
+/// and transition through statuses like pending, accepted, or rejected.
 model Proposal {
   id        String   @id @default(cuid())
   summary   String


### PR DESCRIPTION
## Summary
Added brief doc comments to Prisma schema models explaining their role in the TaskFlow domain.

## Changes
- Added doc comments to User model explaining platform role
- Added doc comments to Job model explaining job lifecycle
- Added doc comments to Proposal model explaining proposal workflow

/claim #5