### PR TITLE
refactor(ui): improve Button type annotations and add JSDoc

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,8 +3,7 @@
 <img width="663" height="183" alt="593560705-1a920eb5-e581-44ce-bcef-2ebf0566777f" src="https://github.com/user-attachments/assets/37891de4-a282-45a3-98aa-35598c4571c2" />
 
 
-TaskFlow is a full-stack task management SaaS monorepo built 
-with a modern TypeScript-first architecture.
+TaskFlow is a full-stack task management SaaS monorepo built with a modern TypeScript-first architecture.
 
 ## Workspace Structure
 
@@ -68,8 +67,7 @@ npm run dev -w apps/api
 
 ## Database
 
-Prisma schema is available in packages/db/prisma/schema.prisma 
-with models for:
+Prisma schema is available in packages/db/prisma/schema.prisma with models for:
 - Users
 - Tasks
 - Proposals
@@ -81,5 +79,4 @@ with models for:
 
 ## Environment Variables
 
-Each app/package expects its own .env values for DB, auth, 
-and integrations.
+Each app/package expects its own .env values for DB, auth, and integrations.

--- a/packages/ui/src/index.ts
+++ b/packages/ui/src/index.ts
@@ -1,9 +1,38 @@
+/**
+ * Props for the shared Button component.
+ *
+ * @property label - The text label displayed on the button.
+ * @property disabled - Whether the button is disabled and non-interactive.
+ */
 export type ButtonProps = {
   label: string;
   disabled?: boolean;
 };
 
-export function Button({ label, disabled = false }: ButtonProps) {
+/**
+ * The rendered output shape of a Button stub.
+ * Returned by the {@link Button} function for consumers that need a
+ * serializable representation of the button's visual state.
+ */
+export type ButtonRenderResult = {
+  type: "button";
+  label: string;
+  disabled: boolean;
+};
+
+/**
+ * Shared UI Button stub.
+ *
+ * Renders a serializable button descriptor from the given props.
+ * The public shape of {@link ButtonProps} and the returned object
+ * must remain stable for downstream consumers.
+ *
+ * @param props - The button configuration.
+ * @param props.label - The text label for the button.
+ * @param props.disabled - Whether the button is disabled. Defaults to `false`.
+ * @returns A {@link ButtonRenderResult} descriptor for the button.
+ */
+export function Button({ label, disabled = false }: ButtonProps): ButtonRenderResult {
   return {
     type: "button",
     label,


### PR DESCRIPTION
## Summary
Improved type annotations for the shared UI Button stub without changing its public shape.

## Changes
- Added explicit return type ButtonRenderResult for Button function
- Added JSDoc comments for ButtonProps, ButtonRenderResult, and Button
- Added parameter-level JSDoc documentation
- Preserved existing public shape of ButtonProps and Button

/claim #3