### PR TITLE
feat(api): add API error response helper and use in user route

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,8 +3,7 @@
 <img width="663" height="183" alt="593560705-1a920eb5-e581-44ce-bcef-2ebf0566777f" src="https://github.com/user-attachments/assets/37891de4-a282-45a3-98aa-35598c4571c2" />
 
 
-TaskFlow is a full-stack task management SaaS monorepo built 
-with a modern TypeScript-first architecture.
+TaskFlow is a full-stack task management SaaS monorepo built with a modern TypeScript-first architecture.
 
 ## Workspace Structure
 
@@ -68,8 +67,7 @@ npm run dev -w apps/api
 
 ## Database
 
-Prisma schema is available in packages/db/prisma/schema.prisma 
-with models for:
+Prisma schema is available in packages/db/prisma/schema.prisma with models for:
 - Users
 - Tasks
 - Proposals
@@ -81,5 +79,4 @@ with models for:
 
 ## Environment Variables
 
-Each app/package expects its own .env values for DB, auth, 
-and integrations.
+Each app/package expects its own .env values for DB, auth, and integrations.

--- a/apps/api/src/routes/users.ts
+++ b/apps/api/src/routes/users.ts
@@ -1,5 +1,7 @@
 import { Router } from "express";
 
+import { sendValidationError } from "../utils/errorHelper";
+
 const router = Router();
 
 router.get("/", (_req, res) => {
@@ -10,6 +12,12 @@ router.get("/", (_req, res) => {
 });
 
 router.post("/", (req, res) => {
+  const { email } = req.body;
+
+  if (!email || typeof email !== "string") {
+    return sendValidationError(res, "A valid email is required to create a user.");
+  }
+
   res.status(201).json({
     data: {
       id: "stub-user-id",

--- a/apps/api/src/utils/errorHelper.ts
+++ b/apps/api/src/utils/errorHelper.ts
@@ -1,0 +1,70 @@
+import type { Response } from "express";
+
+/**
+ * Standard shape for API error responses.
+ */
+export type ApiErrorResponse = {
+  status: "error";
+  error: {
+    code: string;
+    message: string;
+  };
+};
+
+/**
+ * Send a standardized error response to the client.
+ *
+ * @param res - The Express response object.
+ * @param statusCode - The HTTP status code to return.
+ * @param code - A machine-readable error code (e.g. "VALIDATION_ERROR").
+ * @param message - A human-readable error message.
+ * @returns The Express response for chaining.
+ */
+export function sendError(
+  res: Response,
+  statusCode: number,
+  code: string,
+  message: string
+): Response {
+  const body: ApiErrorResponse = {
+    status: "error",
+    error: {
+      code,
+      message
+    }
+  };
+  return res.status(statusCode).json(body);
+}
+
+/**
+ * Send a 400 Bad Request response for validation failures.
+ *
+ * @param res - The Express response object.
+ * @param message - A description of what failed validation.
+ * @returns The Express response for chaining.
+ */
+export function sendValidationError(res: Response, message: string): Response {
+  return sendError(res, 400, "VALIDATION_ERROR", message);
+}
+
+/**
+ * Send a 404 Not Found response when a resource does not exist.
+ *
+ * @param res - The Express response object.
+ * @param resource - The name of the resource that was not found.
+ * @returns The Express response for chaining.
+ */
+export function sendNotFound(res: Response, resource: string): Response {
+  return sendError(res, 404, "NOT_FOUND", `${resource} not found.`);
+}
+
+/**
+ * Send a 500 Internal Server Error response for unexpected failures.
+ *
+ * @param res - The Express response object.
+ * @param message - Optional detail about the internal error.
+ * @returns The Express response for chaining.
+ */
+export function sendInternalError(res: Response, message = "An unexpected error occurred."): Response {
+  return sendError(res, 500, "INTERNAL_ERROR", message);
+}


### PR DESCRIPTION
## Summary
Introduced a small API error response helper for the Express app and used it from the user creation route.

## Changes
- Created errorHelper utility with standardized error response shape
- Added sendError, sendValidationError, sendNotFound, sendInternalError helpers
- Used sendValidationError in POST /users route for email validation
- Included JSDoc comments for all exported functions

/claim #7