### PR TITLE
test(api): add unit tests for user routes

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,8 +3,7 @@
 <img width="663" height="183" alt="593560705-1a920eb5-e581-44ce-bcef-2ebf0566777f" src="https://github.com/user-attachments/assets/37891de4-a282-45a3-98aa-35598c4571c2" />
 
 
-TaskFlow is a full-stack task management SaaS monorepo built 
-with a modern TypeScript-first architecture.
+TaskFlow is a full-stack task management SaaS monorepo built with a modern TypeScript-first architecture.
 
 ## Workspace Structure
 
@@ -68,8 +67,7 @@ npm run dev -w apps/api
 
 ## Database
 
-Prisma schema is available in packages/db/prisma/schema.prisma 
-with models for:
+Prisma schema is available in packages/db/prisma/schema.prisma with models for:
 - Users
 - Tasks
 - Proposals
@@ -81,5 +79,4 @@ with models for:
 
 ## Environment Variables
 
-Each app/package expects its own .env values for DB, auth, 
-and integrations.
+Each app/package expects its own .env values for DB, auth, and integrations.

--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -7,7 +7,7 @@
   "main": "src/index.ts",
   "scripts": {
     "dev": "tsx src/index.ts",
-    "test": "echo \"No API tests configured yet\"",
+    "test": "tsx src/routes/users.test.ts",
     "lint": "echo \"No API lint configured yet\""
   },
   "dependencies": {

--- a/apps/api/src/routes/users.test.ts
+++ b/apps/api/src/routes/users.test.ts
@@ -1,0 +1,121 @@
+import assert from "node:assert/strict";
+import express from "express";
+import usersRouter from "./users";
+
+// Helper: create an Express app with the users router mounted
+function createTestApp() {
+  const app = express();
+  app.use(express.json());
+  app.use("/users", usersRouter);
+  return app;
+}
+
+// Helper: simulate a request to the Express app
+async function simulateRequest(
+  app: express.Express,
+  method: "GET" | "POST",
+  path: string,
+  body?: unknown
+): Promise<{ status: number; body: unknown }> {
+  return new Promise((resolve, reject) => {
+    const server = app.listen(0, () => {
+      const port = (server.address() as { port: number }).port;
+      const options: RequestInit = {
+        method,
+        headers: { "Content-Type": "application/json" }
+      };
+      if (body !== undefined) {
+        options.body = JSON.stringify(body);
+      }
+      fetch(`http://localhost:${port}${path}`, options)
+        .then(async (res) => {
+          const text = await res.text();
+          let parsedBody: unknown = text;
+          try {
+            parsedBody = JSON.parse(text);
+          } catch {
+            // not JSON, keep as text
+          }
+          server.close();
+          resolve({ status: res.status, body: parsedBody });
+        })
+        .catch((err) => {
+          server.close();
+          reject(err);
+        });
+    });
+  });
+}
+
+const app = createTestApp();
+
+// Test 1: GET /users returns 200
+{
+  const res = await simulateRequest(app, "GET", "/users");
+  assert.equal(res.status, 200, "GET /users should return 200");
+}
+
+// Test 2: GET /users returns data array
+{
+  const res = await simulateRequest(app, "GET", "/users");
+  const body = res.body as { data: unknown[] };
+  assert.ok(Array.isArray(body.data), "GET /users should return data array");
+  assert.equal(body.data.length, 0, "GET /users should return empty array for stub");
+}
+
+// Test 3: GET /users returns not implemented message
+{
+  const res = await simulateRequest(app, "GET", "/users");
+  const body = res.body as { message: string };
+  assert.ok(body.message.includes("not implemented"), "GET /users should mention not implemented");
+}
+
+// Test 4: POST /users returns 201
+{
+  const res = await simulateRequest(app, "POST", "/users", { email: "test@example.com" });
+  assert.equal(res.status, 201, "POST /users should return 201");
+}
+
+// Test 5: POST /users returns data with id
+{
+  const res = await simulateRequest(app, "POST", "/users", { email: "test@example.com" });
+  const body = res.body as { data: { id: string } };
+  assert.ok(body.data.id, "POST /users should return data with id");
+  assert.equal(body.data.id, "stub-user-id", "POST /users should return stub user id");
+}
+
+// Test 6: POST /users echoes request body
+{
+  const payload = { email: "echo@example.com", name: "Test User" };
+  const res = await simulateRequest(app, "POST", "/users", payload);
+  const body = res.body as { data: { email: string; name: string } };
+  assert.equal(body.data.email, payload.email, "POST /users should echo email");
+  assert.equal(body.data.name, payload.name, "POST /users should echo name");
+}
+
+// Test 7: POST /users returns not implemented message
+{
+  const res = await simulateRequest(app, "POST", "/users", { email: "test@example.com" });
+  const body = res.body as { message: string };
+  assert.ok(body.message.includes("not implemented"), "POST /users should mention not implemented");
+}
+
+// Test 8: POST /users with empty body still returns 201
+{
+  const res = await simulateRequest(app, "POST", "/users", {});
+  assert.equal(res.status, 201, "POST /users with empty body should return 201");
+}
+
+// Test 9: GET /users returns JSON content type
+{
+  const res = await simulateRequest(app, "GET", "/users");
+  assert.equal(typeof res.body, "object", "GET /users should return JSON object");
+}
+
+// Test 10: POST /users returns JSON content type
+{
+  const res = await simulateRequest(app, "POST", "/users", { email: "test@example.com" });
+  assert.equal(typeof res.body, "object", "POST /users should return JSON object");
+}
+
+console.log("All 10 user route tests passed!");


### PR DESCRIPTION
## Summary
Added unit tests for the user route stubs.

## Changes
- Added 10 unit tests covering GET /users and POST /users
- Test status codes, response shape, data array, stub messages
- Test request body echo, empty body handling, JSON responses
- Use Express test app with real HTTP server via fetch
- Updated package.json test script to run with tsx

/claim #12