### PR TITLE
[agent] feat(api): validate and normalize user creation payloads

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,8 +3,7 @@
 <img width="663" height="183" alt="593560705-1a920eb5-e581-44ce-bcef-2ebf0566777f" src="https://github.com/user-attachments/assets/37891de4-a282-45a3-98aa-35598c4571c2" />
 
 
-TaskFlow is a full-stack task management SaaS monorepo built 
-with a modern TypeScript-first architecture.
+TaskFlow is a full-stack task management SaaS monorepo built with a modern TypeScript-first architecture.
 
 ## Workspace Structure
 
@@ -68,8 +67,7 @@ npm run dev -w apps/api
 
 ## Database
 
-Prisma schema is available in packages/db/prisma/schema.prisma 
-with models for:
+Prisma schema is available in packages/db/prisma/schema.prisma with models for:
 - Users
 - Tasks
 - Proposals
@@ -81,5 +79,4 @@ with models for:
 
 ## Environment Variables
 
-Each app/package expects its own .env values for DB, auth, 
-and integrations.
+Each app/package expects its own .env values for DB, auth, and integrations.

--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -7,7 +7,7 @@
   "main": "src/index.ts",
   "scripts": {
     "dev": "tsx src/index.ts",
-    "test": "echo \"No API tests configured yet\"",
+    "test": "tsx src/routes/users.validation.test.ts",
     "lint": "echo \"No API lint configured yet\""
   },
   "dependencies": {

--- a/apps/api/src/routes/users.ts
+++ b/apps/api/src/routes/users.ts
@@ -1,5 +1,7 @@
 import { Router } from "express";
 
+import { validateUserPayload } from "../utils/validateUserPayload";
+
 const router = Router();
 
 router.get("/", (_req, res) => {
@@ -10,11 +12,32 @@ router.get("/", (_req, res) => {
 });
 
 router.post("/", (req, res) => {
-  res.status(201).json({
-    data: {
-      id: "stub-user-id",
-      ...req.body
-    },
+  // Validate and normalize the request body
+  const validation = validateUserPayload(req.body);
+
+  if (!validation.success) {
+    return res.status(validation.statusCode).json({
+      status: "error",
+      error: {
+        code: "VALIDATION_ERROR",
+        message: validation.error
+      }
+    });
+  }
+
+  const { email, name } = validation.data;
+
+  // Generate id server-side — never trust client-supplied ids
+  const userId = `user-${Date.now()}`;
+
+  const user = {
+    id: userId,
+    email,
+    ...(name !== undefined && { name })
+  };
+
+  return res.status(201).json({
+    data: user,
     message: "User creation is not implemented yet."
   });
 });

--- a/apps/api/src/routes/users.validation.test.ts
+++ b/apps/api/src/routes/users.validation.test.ts
@@ -1,0 +1,161 @@
+import assert from "node:assert/strict";
+import express from "express";
+import usersRouter from "./users";
+
+// Helper: create an Express app with the users router
+function createTestApp() {
+  const app = express();
+  app.use(express.json());
+  app.use("/users", usersRouter);
+  return app;
+}
+
+// Helper: simulate a request
+async function simulateRequest(
+  app: express.Express,
+  method: "GET" | "POST",
+  path: string,
+  body?: unknown
+): Promise<{ status: number; body: unknown }> {
+  return new Promise((resolve, reject) => {
+    const server = app.listen(0, () => {
+      const port = (server.address() as { port: number }).port;
+      const options: RequestInit = {
+        method,
+        headers: { "Content-Type": "application/json" }
+      };
+      if (body !== undefined) {
+        options.body = JSON.stringify(body);
+      }
+      fetch(`http://localhost:${port}${path}`, options)
+        .then(async (res) => {
+          const text = await res.text();
+          let parsedBody: unknown = text;
+          try {
+            parsedBody = JSON.parse(text);
+          } catch {
+            // not JSON
+          }
+          server.close();
+          resolve({ status: res.status, body: parsedBody });
+        })
+        .catch((err) => {
+          server.close();
+          reject(err);
+        });
+    });
+  });
+}
+
+const app = createTestApp();
+
+// Test 1: Reject non-object JSON body (array)
+{
+  const res = await simulateRequest(app, "POST", "/users", ["not", "an", "object"]);
+  assert.equal(res.status, 400, "Array body should return 400");
+  const body = res.body as { error: { message: string } };
+  assert.ok(body.error.message.includes("object"), "Should mention object requirement");
+}
+
+// Test 2: Reject non-object JSON body (string)
+{
+  const res = await simulateRequest(app, "POST", "/users", "just a string");
+  assert.equal(res.status, 400, "String body should return 400");
+}
+
+// Test 3: Reject non-object JSON body (number)
+{
+  const res = await simulateRequest(app, "POST", "/users", 42);
+  assert.equal(res.status, 400, "Number body should return 400");
+}
+
+// Test 4: Reject missing email
+{
+  const res = await simulateRequest(app, "POST", "/users", { name: "Test" });
+  assert.equal(res.status, 400, "Missing email should return 400");
+  const body = res.body as { error: { message: string } };
+  assert.ok(body.error.message.includes("email"), "Should mention email required");
+}
+
+// Test 5: Reject invalid email format
+{
+  const res = await simulateRequest(app, "POST", "/users", { email: "not-an-email" });
+  assert.equal(res.status, 400, "Invalid email should return 400");
+}
+
+// Test 6: Accept valid email and return 201
+{
+  const res = await simulateRequest(app, "POST", "/users", { email: "user@example.com" });
+  assert.equal(res.status, 201, "Valid email should return 201");
+  const body = res.body as { data: { id: string; email: string } };
+  assert.ok(body.data.id, "Should return generated id");
+  assert.equal(body.data.email, "user@example.com", "Should return email");
+}
+
+// Test 7: Normalize email (trim + lowercase)
+{
+  const res = await simulateRequest(app, "POST", "/users", { email: "  User@Example.COM  " });
+  assert.equal(res.status, 201, "Email with whitespace should return 201");
+  const body = res.body as { data: { email: string } };
+  assert.equal(body.data.email, "user@example.com", "Email should be normalized");
+}
+
+// Test 8: Normalize name (trim + collapse spaces)
+{
+  const res = await simulateRequest(app, "POST", "/users", {
+    email: "user@example.com",
+    name: "  John   Doe  "
+  });
+  assert.equal(res.status, 201, "Name with extra spaces should return 201");
+  const body = res.body as { data: { name: string } };
+  assert.equal(body.data.name, "John Doe", "Name should be normalized");
+}
+
+// Test 9: Ignore client-supplied id
+{
+  const res = await simulateRequest(app, "POST", "/users", {
+    email: "user@example.com",
+    id: "malicious-client-id"
+  });
+  assert.equal(res.status, 201, "Client id should be ignored, not rejected");
+  const body = res.body as { data: { id: string } };
+  assert.notEqual(body.data.id, "malicious-client-id", "Client id should not be used");
+  assert.ok(body.data.id.startsWith("user-"), "Should use server-generated id");
+}
+
+// Test 10: Ignore unrelated/extra fields
+{
+  const res = await simulateRequest(app, "POST", "/users", {
+    email: "user@example.com",
+    isAdmin: true,
+    role: "superuser",
+    password: "hacked"
+  });
+  assert.equal(res.status, 201, "Extra fields should be ignored, not rejected");
+  const body = res.body as { data: Record<string, unknown> };
+  assert.equal(Object.keys(body.data).length, 2, "Should only have id and email");
+  assert.ok(!("isAdmin" in body.data), "Should not include isAdmin");
+  assert.ok(!("password" in body.data), "Should not include password");
+}
+
+// Test 11: Reject name that is not a string
+{
+  const res = await simulateRequest(app, "POST", "/users", {
+    email: "user@example.com",
+    name: 12345
+  });
+  assert.equal(res.status, 400, "Non-string name should return 400");
+}
+
+// Test 12: Empty name after trimming is omitted
+{
+  const res = await simulateRequest(app, "POST", "/users", {
+    email: "user@example.com",
+    name: "   "
+  });
+  assert.equal(res.status, 201, "Whitespace-only name should return 201");
+  const body = res.body as { data: Record<string, unknown> };
+  assert.ok(!("name" in body.data), "Empty name should be omitted");
+}
+
+console.log("All 12 user payload validation tests passed!");

--- a/apps/api/src/utils/validateUserPayload.ts
+++ b/apps/api/src/utils/validateUserPayload.ts
@@ -1,0 +1,133 @@
+/**
+ * User creation payload validation utilities.
+ *
+ * Ensures that POST /users receives well-formed input and returns
+ * normalized, server-controlled user objects.
+ */
+
+/**
+ * Result of a user payload validation attempt.
+ */
+export type UserValidationResult =
+  | { success: true; data: ValidatedUserPayload }
+  | { success: false; error: string; statusCode: number };
+
+/**
+ * A validated and normalized user creation payload.
+ * Only allowed fields are present; client-controlled id is stripped.
+ */
+export type ValidatedUserPayload = {
+  email: string;
+  name?: string;
+};
+
+/**
+ * Simple email format validation.
+ * Checks for basic structure: local@domain.tld
+ * Not RFC 5322 complete, but sufficient for API input guarding.
+ *
+ * @param value - The value to check.
+ * @returns True if the value looks like a valid email address.
+ */
+export function isValidEmail(value: unknown): value is string {
+  if (typeof value !== "string") return false;
+  const trimmed = value.trim();
+  if (trimmed.length === 0 || trimmed.length > 254) return false;
+  return /^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(trimmed);
+}
+
+/**
+ * Check whether a value is a plain object (not array, not null).
+ *
+ * @param value - The value to check.
+ * @returns True if the value is a plain object.
+ */
+export function isPlainObject(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+/**
+ * Normalize an email address: trim whitespace and lowercase.
+ *
+ * @param email - The raw email string.
+ * @returns The normalized email.
+ */
+export function normalizeEmail(email: string): string {
+  return email.trim().toLowerCase();
+}
+
+/**
+ * Normalize a name: trim whitespace and collapse internal spaces.
+ *
+ * @param name - The raw name string.
+ * @returns The normalized name, or undefined if empty after trimming.
+ */
+export function normalizeName(name: string): string | undefined {
+  const trimmed = name.trim().replace(/\s+/g, " ");
+  return trimmed.length > 0 ? trimmed : undefined;
+}
+
+/**
+ * Validate and normalize a user creation payload.
+ *
+ * Rules enforced:
+ * - Body must be a plain JSON object (arrays, strings, numbers rejected)
+ * - Email is required and must match a basic email pattern
+ * - Email is normalized (trimmed, lowercased)
+ * - Name is optional; if present it must be a string and is normalized
+ * - Client-supplied `id` and any other unknown fields are ignored
+ *
+ * @param body - The raw request body from Express.
+ * @returns A validation result with either normalized data or an error.
+ */
+export function validateUserPayload(body: unknown): UserValidationResult {
+  // Reject non-object bodies (arrays, strings, numbers, null)
+  if (!isPlainObject(body)) {
+    return {
+      success: false,
+      error: "Request body must be a JSON object.",
+      statusCode: 400
+    };
+  }
+
+  // Email is required
+  if (!("email" in body)) {
+    return {
+      success: false,
+      error: "email is required.",
+      statusCode: 400
+    };
+  }
+
+  // Email must be valid
+  if (!isValidEmail(body.email)) {
+    return {
+      success: false,
+      error: "email must be a valid email address.",
+      statusCode: 400
+    };
+  }
+
+  const email = normalizeEmail(body.email as string);
+
+  // Name is optional, but if present must be a string
+  let name: string | undefined;
+  if ("name" in body) {
+    if (typeof body.name !== "string") {
+      return {
+        success: false,
+        error: "name must be a string when provided.",
+        statusCode: 400
+      };
+    }
+    name = normalizeName(body.name);
+  }
+
+  // Build normalized payload — only allowed fields, no client id
+  const data: ValidatedUserPayload = { email };
+  if (name !== undefined) {
+    data.name = name;
+  }
+
+  return { success: true, data };
+}


### PR DESCRIPTION
## Summary
POST /users previously trusted arbitrary request bodies. This PR adds validation so user creation generates ids server-side, requires a valid email, normalizes optional names, and rejects invalid JSON shapes.

## Changes
- Added validateUserPayload utility with comprehensive validation
- Reject non-object JSON bodies (arrays, strings, numbers)
- Require and validate email format
- Normalize email (trim + lowercase) and name (trim + collapse spaces)
- Ignore client-controlled id and unrelated extra fields
- Generate server-side user ids
- Added 12 regression tests covering all validation scenarios
- Updated package.json test script

/claim #2207