### PR TITLE
[agent] feat(api): add CORS config helper for parsing allowed origins

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,8 +3,7 @@
 <img width="663" height="183" alt="593560705-1a920eb5-e581-44ce-bcef-2ebf0566777f" src="https://github.com/user-attachments/assets/37891de4-a282-45a3-98aa-35598c4571c2" />
 
 
-TaskFlow is a full-stack task management SaaS monorepo built 
-with a modern TypeScript-first architecture.
+TaskFlow is a full-stack task management SaaS monorepo built with a modern TypeScript-first architecture.
 
 ## Workspace Structure
 
@@ -68,8 +67,7 @@ npm run dev -w apps/api
 
 ## Database
 
-Prisma schema is available in packages/db/prisma/schema.prisma 
-with models for:
+Prisma schema is available in packages/db/prisma/schema.prisma with models for:
 - Users
 - Tasks
 - Proposals
@@ -81,5 +79,4 @@ with models for:
 
 ## Environment Variables
 
-Each app/package expects its own .env values for DB, auth, 
-and integrations.
+Each app/package expects its own .env values for DB, auth, and integrations.

--- a/apps/api/src/utils/corsConfig.test.ts
+++ b/apps/api/src/utils/corsConfig.test.ts
@@ -1,0 +1,158 @@
+/**
+ * Unit tests for the CORS configuration helper.
+ */
+
+import assert from "node:assert/strict";
+import {
+  parseAllowedOrigins,
+  isOriginAllowed,
+  buildCorsOptions,
+  CORS_ENV_VAR
+} from "./corsConfig";
+
+// Test 1: Parse single origin
+{
+  const result = parseAllowedOrigins("https://example.com");
+  assert.deepEqual(result.allowedOrigins, ["https://example.com"]);
+  assert.equal(result.allowAll, false);
+}
+
+// Test 2: Parse multiple comma-separated origins
+{
+  const result = parseAllowedOrigins("https://example.com,https://api.example.com");
+  assert.deepEqual(result.allowedOrigins, ["https://example.com", "https://api.example.com"]);
+}
+
+// Test 3: Parse origins with whitespace
+{
+  const result = parseAllowedOrigins("  https://example.com ,  https://api.example.com  ");
+  assert.deepEqual(result.allowedOrigins, ["https://example.com", "https://api.example.com"]);
+}
+
+// Test 4: Parse undefined input
+{
+  const result = parseAllowedOrigins(undefined);
+  assert.deepEqual(result.allowedOrigins, []);
+  assert.equal(result.allowAll, false);
+}
+
+// Test 5: Parse null input
+{
+  const result = parseAllowedOrigins(null);
+  assert.deepEqual(result.allowedOrigins, []);
+}
+
+// Test 6: Parse empty string
+{
+  const result = parseAllowedOrigins("");
+  assert.deepEqual(result.allowedOrigins, []);
+}
+
+// Test 7: Parse whitespace-only string
+{
+  const result = parseAllowedOrigins("   ");
+  assert.deepEqual(result.allowedOrigins, []);
+}
+
+// Test 8: Parse wildcard origin
+{
+  const result = parseAllowedOrigins("*");
+  assert.deepEqual(result.allowedOrigins, ["*"]);
+  assert.equal(result.allowAll, true);
+}
+
+// Test 9: Deduplicate origins
+{
+  const result = parseAllowedOrigins("https://example.com,https://example.com,https://api.example.com");
+  assert.deepEqual(result.allowedOrigins, ["https://example.com", "https://api.example.com"]);
+}
+
+// Test 10: Normalize trailing slashes
+{
+  const result = parseAllowedOrigins("https://example.com/,https://api.example.com//");
+  assert.deepEqual(result.allowedOrigins, ["https://example.com", "https://api.example.com"]);
+}
+
+// Test 11: Filter out empty entries between commas
+{
+  const result = parseAllowedOrigins("https://example.com,,https://api.example.com,");
+  assert.deepEqual(result.allowedOrigins, ["https://example.com", "https://api.example.com"]);
+}
+
+// Test 12: isOriginAllowed returns true for allowed origin
+{
+  const config = parseAllowedOrigins("https://example.com");
+  assert.equal(isOriginAllowed(config, "https://example.com"), true);
+}
+
+// Test 13: isOriginAllowed returns false for disallowed origin
+{
+  const config = parseAllowedOrigins("https://example.com");
+  assert.equal(isOriginAllowed(config, "https://evil.com"), false);
+}
+
+// Test 14: isOriginAllowed returns true when wildcard is present
+{
+  const config = parseAllowedOrigins("*");
+  assert.equal(isOriginAllowed(config, "https://anything.com"), true);
+}
+
+// Test 15: isOriginAllowed returns false for undefined origin (non-wildcard)
+{
+  const config = parseAllowedOrigins("https://example.com");
+  assert.equal(isOriginAllowed(config, undefined), false);
+}
+
+// Test 16: isOriginAllowed normalizes trailing slash in request origin
+{
+  const config = parseAllowedOrigins("https://example.com");
+  assert.equal(isOriginAllowed(config, "https://example.com/"), true);
+}
+
+// Test 17: buildCorsOptions returns object with origin function
+{
+  const options = buildCorsOptions("https://example.com");
+  assert.equal(typeof options.origin, "function");
+  assert.ok(Array.isArray(options.methods));
+  assert.ok(options.credentials === true);
+}
+
+// Test 18: buildCorsOptions origin callback allows matching origin
+{
+  const options = buildCorsOptions("https://example.com");
+  options.origin("https://example.com", (err, allow) => {
+    assert.equal(err, null);
+    assert.equal(allow, true);
+  });
+}
+
+// Test 19: buildCorsOptions origin callback rejects non-matching origin
+{
+  const options = buildCorsOptions("https://example.com");
+  options.origin("https://evil.com", (err, allow) => {
+    assert.equal(err, null);
+    assert.equal(allow, false);
+  });
+}
+
+// Test 20: buildCorsOptions origin callback allows no origin (server-to-server)
+{
+  const options = buildCorsOptions("https://example.com");
+  options.origin(undefined, (err, allow) => {
+    assert.equal(err, null);
+    assert.equal(allow, true);
+  });
+}
+
+// Test 21: CORS_ENV_VAR constant is correct
+{
+  assert.equal(CORS_ENV_VAR, "CORS_ALLOWED_ORIGINS");
+}
+
+// Test 22: Parse origins with ports
+{
+  const result = parseAllowedOrigins("http://localhost:3000,http://localhost:8080");
+  assert.deepEqual(result.allowedOrigins, ["http://localhost:3000", "http://localhost:8080"]);
+}
+
+console.log("All 22 CORS config tests passed!");

--- a/apps/api/src/utils/corsConfig.ts
+++ b/apps/api/src/utils/corsConfig.ts
@@ -1,0 +1,132 @@
+/**
+ * CORS configuration helper.
+ *
+ * Provides a dependency-free utility to parse comma-separated allowed
+ * CORS origins from environment-style strings, and to build an Express
+ * CORS options object suitable for use with the `cors` middleware or
+ * a custom implementation.
+ */
+
+/**
+ * Parsed CORS configuration.
+ */
+export type CorsConfig = {
+  /** The list of allowed origins, trimmed and deduplicated. */
+  allowedOrigins: string[];
+  /** Whether the wildcard origin "*" is present. */
+  allowAll: boolean;
+};
+
+/**
+ * Parse a comma-separated string of allowed CORS origins.
+ *
+ * Handles:
+ * - Empty / undefined input (returns empty list)
+ * - Whitespace around entries (trimmed)
+ * - Duplicate entries (deduplicated, preserving first occurrence)
+ * - The wildcard "*" origin (flagged via `allowAll`)
+ * - Trailing slashes on origins (normalized)
+ *
+ * @example
+ * ```ts
+ * parseAllowedOrigins("https://example.com, https://api.example.com");
+ * // => ["https://example.com", "https://api.example.com"]
+ *
+ * parseAllowedOrigins("*");
+ * // => ["*"]
+ * ```
+ *
+ * @param input - The raw environment-style string, or undefined.
+ * @returns A {@link CorsConfig} with parsed origins and flags.
+ */
+export function parseAllowedOrigins(input?: string | null): CorsConfig {
+  if (!input || typeof input !== "string" || input.trim().length === 0) {
+    return { allowedOrigins: [], allowAll: false };
+  }
+
+  const rawOrigins = input
+    .split(",")
+    .map((origin) => origin.trim())
+    .filter((origin) => origin.length > 0);
+
+  // Normalize: remove trailing slash, deduplicate
+  const seen = new Set<string>();
+  const allowedOrigins: string[] = [];
+
+  for (const origin of rawOrigins) {
+    const normalized = origin === "*" ? "*" : origin.replace(/\/+$/, "");
+    if (!seen.has(normalized)) {
+      seen.add(normalized);
+      allowedOrigins.push(normalized);
+    }
+  }
+
+  const allowAll = allowedOrigins.includes("*");
+
+  return { allowedOrigins, allowAll };
+}
+
+/**
+ * Check whether a specific request origin is allowed by the CORS config.
+ *
+ * @example
+ * ```ts
+ * const config = parseAllowedOrigins("https://example.com, https://api.example.com");
+ * isOriginAllowed(config, "https://example.com"); // => true
+ * isOriginAllowed(config, "https://evil.com");    // => false
+ * ```
+ *
+ * @param config - The parsed CORS config.
+ * @param origin - The request origin to check.
+ * @returns True if the origin is allowed (or wildcard is enabled).
+ */
+export function isOriginAllowed(config: CorsConfig, origin?: string): boolean {
+  if (config.allowAll) return true;
+  if (!origin) return false;
+  const normalized = origin.replace(/\/+$/, "");
+  return config.allowedOrigins.includes(normalized);
+}
+
+/**
+ * Build an Express-compatible CORS options object from an environment string.
+ *
+ * The returned object has an `origin` function that can be passed directly
+ * to the `cors` Express middleware.
+ *
+ * @example
+ * ```ts
+ * import cors from "cors";
+ * import { buildCorsOptions } from "./utils/corsConfig";
+ *
+ * const corsOptions = buildCorsOptions(process.env.CORS_ALLOWED_ORIGINS);
+ * app.use(cors(corsOptions));
+ * ```
+ *
+ * @param envValue - The raw CORS_ALLOWED_ORIGINS environment value.
+ * @returns An object with an `origin` callback and common CORS defaults.
+ */
+export function buildCorsOptions(envValue?: string | null) {
+  const config = parseAllowedOrigins(envValue);
+
+  return {
+    origin: (
+      requestOrigin: string | undefined,
+      callback: (err: Error | null, allow?: boolean) => void
+    ) => {
+      // Allow requests with no origin (e.g. curl, server-to-server)
+      if (!requestOrigin) {
+        return callback(null, true);
+      }
+      callback(null, isOriginAllowed(config, requestOrigin));
+    },
+    methods: ["GET", "POST", "PUT", "PATCH", "DELETE", "OPTIONS"],
+    allowedHeaders: ["Content-Type", "Authorization"],
+    credentials: true,
+    maxAge: 86400
+  };
+}
+
+/**
+ * Default environment variable name for CORS allowed origins.
+ */
+export const CORS_ENV_VAR = "CORS_ALLOWED_ORIGINS";


### PR DESCRIPTION
## Summary
Added a dependency-free helper to parse comma-separated allowed CORS origins from environment-style strings.

## Changes
- Added parseAllowedOrigins to parse comma-separated environment strings
- Added isOriginAllowed to check request origins against config
- Added buildCorsOptions to create Express-compatible CORS options
- Handle whitespace, duplicates, trailing slashes, wildcard, empty input
- Added 22 unit tests covering all parsing and validation scenarios
- Dependency-free implementation aligned with existing TypeScript/Express style

/claim #2833