### PR TITLE
[agent] refactor(db): add Prisma enums for Job and Proposal status fields

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,8 +3,7 @@
 <img width="663" height="183" alt="593560705-1a920eb5-e581-44ce-bcef-2ebf0566777f" src="https://github.com/user-attachments/assets/37891de4-a282-45a3-98aa-35598c4571c2" />
 
 
-TaskFlow is a full-stack task management SaaS monorepo built 
-with a modern TypeScript-first architecture.
+TaskFlow is a full-stack task management SaaS monorepo built with a modern TypeScript-first architecture.
 
 ## Workspace Structure
 
@@ -68,8 +67,7 @@ npm run dev -w apps/api
 
 ## Database
 
-Prisma schema is available in packages/db/prisma/schema.prisma 
-with models for:
+Prisma schema is available in packages/db/prisma/schema.prisma with models for:
 - Users
 - Tasks
 - Proposals
@@ -81,5 +79,4 @@ with models for:
 
 ## Environment Variables
 
-Each app/package expects its own .env values for DB, auth, 
-and integrations.
+Each app/package expects its own .env values for DB, auth, and integrations.

--- a/packages/db/prisma/schema.prisma
+++ b/packages/db/prisma/schema.prisma
@@ -7,6 +7,35 @@ datasource db {
   url      = env("DATABASE_URL")
 }
 
+/// Lifecycle statuses for a Job posting.
+/// - draft: Job is created but not yet published
+/// - open: Job is published and accepting proposals
+/// - in_progress: Job has been accepted and work is underway
+/// - completed: Job has been completed successfully
+/// - cancelled: Job was cancelled before completion
+enum JobStatus {
+  draft
+  open
+  in_progress
+  completed
+  cancelled
+}
+
+/// Statuses for a Proposal submitted to a Job.
+/// - pending: Proposal has been submitted and is awaiting review
+/// - accepted: Proposal has been accepted by the job owner
+/// - rejected: Proposal has been rejected by the job owner
+/// - withdrawn: Proposal was withdrawn by the freelancer
+enum ProposalStatus {
+  pending
+  accepted
+  rejected
+  withdrawn
+}
+
+/// Represents a user account in the TaskFlow platform.
+/// Users can be either clients posting jobs or freelancers submitting proposals.
+/// Each user has a profile and owns jobs and proposals they create.
 model User {
   id        String     @id @default(cuid())
   email     String     @unique
@@ -17,11 +46,14 @@ model User {
   updatedAt DateTime   @updatedAt
 }
 
+/// Represents a task or job posting created by a client.
+/// Jobs go through a lifecycle (draft, open, in_progress, completed, cancelled)
+/// and can receive proposals from freelancers.
 model Job {
   id          String     @id @default(cuid())
   title       String
   description String?
-  status      String     @default("draft")
+  status      JobStatus  @default(draft)
   ownerId     String
   owner       User       @relation(fields: [ownerId], references: [id])
   proposals   Proposal[]
@@ -29,15 +61,18 @@ model Job {
   updatedAt   DateTime   @updatedAt
 }
 
+/// Represents a freelancer's proposal submitted for a specific job.
+/// Proposals include a summary and optional budget amount,
+/// and transition through statuses (pending, accepted, rejected, withdrawn).
 model Proposal {
-  id        String   @id @default(cuid())
+  id        String         @id @default(cuid())
   summary   String
   amount    Decimal?
-  status    String   @default("pending")
+  status    ProposalStatus @default(pending)
   userId    String
-  user      User     @relation(fields: [userId], references: [id])
+  user      User           @relation(fields: [userId], references: [id])
   jobId     String
-  job       Job      @relation(fields: [jobId], references: [id])
-  createdAt DateTime @default(now())
-  updatedAt DateTime @updatedAt
+  job       Job            @relation(fields: [jobId], references: [id])
+  createdAt DateTime       @default(now())
+  updatedAt DateTime       @updatedAt
 }


### PR DESCRIPTION
## Summary
Added Prisma enums for Job and Proposal status fields so the database layer enforces valid status values.

## Changes
- Added JobStatus enum (draft, open, in_progress, completed, cancelled)
- Added ProposalStatus enum (pending, accepted, rejected, withdrawn)
- Changed Job.status from String to JobStatus
- Changed Proposal.status from String to ProposalStatus

/claim #657