### PR TITLE
[agent] perf(db): add lookup indexes for Prisma relation fields

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,8 +3,7 @@
 <img width="663" height="183" alt="593560705-1a920eb5-e581-44ce-bcef-2ebf0566777f" src="https://github.com/user-attachments/assets/37891de4-a282-45a3-98aa-35598c4571c2" />
 
 
-TaskFlow is a full-stack task management SaaS monorepo built 
-with a modern TypeScript-first architecture.
+TaskFlow is a full-stack task management SaaS monorepo built with a modern TypeScript-first architecture.
 
 ## Workspace Structure
 
@@ -68,8 +67,7 @@ npm run dev -w apps/api
 
 ## Database
 
-Prisma schema is available in packages/db/prisma/schema.prisma 
-with models for:
+Prisma schema is available in packages/db/prisma/schema.prisma with models for:
 - Users
 - Tasks
 - Proposals
@@ -81,5 +79,4 @@ with models for:
 
 ## Environment Variables
 
-Each app/package expects its own .env values for DB, auth, 
-and integrations.
+Each app/package expects its own .env values for DB, auth, and integrations.

--- a/packages/db/prisma/schema.prisma
+++ b/packages/db/prisma/schema.prisma
@@ -27,6 +27,9 @@ model Job {
   proposals   Proposal[]
   createdAt   DateTime   @default(now())
   updatedAt   DateTime   @updatedAt
+
+  // Index for owner dashboards and job list queries by owner
+  @@index([ownerId])
 }
 
 model Proposal {
@@ -40,4 +43,9 @@ model Proposal {
   job       Job      @relation(fields: [jobId], references: [id])
   createdAt DateTime @default(now())
   updatedAt DateTime @updatedAt
+
+  // Index for a user's submitted proposals list
+  @@index([userId])
+  // Index for a job owner's proposal review queue
+  @@index([jobId])
 }


### PR DESCRIPTION
## Summary
Added lookup indexes for Prisma relation fields used by core TaskFlow workflow queries.

## Changes
- Added index on Job.ownerId for owner dashboards and job lists
- Added index on Proposal.userId for user's submitted proposals
- Added index on Proposal.jobId for job owner's proposal review queue
- PostgreSQL foreign keys don't auto-create indexes, so these prevent sequential scans

/claim #659