### PR TITLE
[agent] refactor(api): split app construction from server startup

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,8 +3,7 @@
 <img width="663" height="183" alt="593560705-1a920eb5-e581-44ce-bcef-2ebf0566777f" src="https://github.com/user-attachments/assets/37891de4-a282-45a3-98aa-35598c4571c2" />
 
 
-TaskFlow is a full-stack task management SaaS monorepo built 
-with a modern TypeScript-first architecture.
+TaskFlow is a full-stack task management SaaS monorepo built with a modern TypeScript-first architecture.
 
 ## Workspace Structure
 
@@ -68,8 +67,7 @@ npm run dev -w apps/api
 
 ## Database
 
-Prisma schema is available in packages/db/prisma/schema.prisma 
-with models for:
+Prisma schema is available in packages/db/prisma/schema.prisma with models for:
 - Users
 - Tasks
 - Proposals
@@ -81,5 +79,4 @@ with models for:
 
 ## Environment Variables
 
-Each app/package expects its own .env values for DB, auth, 
-and integrations.
+Each app/package expects its own .env values for DB, auth, and integrations.

--- a/apps/api/src/app.ts
+++ b/apps/api/src/app.ts
@@ -1,0 +1,32 @@
+import express from "express";
+
+import usersRouter from "./routes/users";
+
+/**
+ * Create and configure the Express application.
+ *
+ * This module exports the app without starting a server, so it can be
+ * imported safely in route tests and other contexts where binding a port
+ * is undesirable.
+ *
+ * @returns A configured Express application instance.
+ */
+export function createApp(): express.Express {
+  const app = express();
+
+  app.use(express.json());
+
+  app.get("/health", (_req, res) => {
+    res.json({ status: "ok", service: "taskflow-api" });
+  });
+
+  app.use("/users", usersRouter);
+
+  return app;
+}
+
+/**
+ * A default application instance, exported for convenience.
+ * Use this when you don't need a fresh app (e.g. in production).
+ */
+export const app = createApp();

--- a/apps/api/src/index.ts
+++ b/apps/api/src/index.ts
@@ -1,18 +1,13 @@
-import express from "express";
+import { app } from "./app";
 
-import usersRouter from "./routes/users";
-
-const app = express();
 const port = process.env.PORT || 4000;
 
-app.use(express.json());
-
-app.get("/health", (_req, res) => {
-  res.json({ status: "ok", service: "taskflow-api" });
-});
-
-app.use("/users", usersRouter);
-
+/**
+ * Runtime entrypoint: start the Express server.
+ *
+ * App construction lives in ./app.ts so that importing the API module
+ * does not automatically bind a port. This keeps route tests fragile-free.
+ */
 app.listen(port, () => {
   console.log(`TaskFlow API listening on port ${port}`);
 });


### PR DESCRIPTION
## Summary
Split Express app construction from server startup so importing the API module does not automatically bind a port.

## Changes
- Created app.ts with createApp() function and default app export
- Moved Express app construction, middleware, and routes to app.ts
- Simplified index.ts to only import app and start server
- Importing API module no longer binds a port, making route tests fragile-free
- Server startup only happens in runtime entrypoint

/claim #720