### PR TITLE
[agent] fix(templates): use /bounty marker in bounty issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE/bounty_task.md
+++ b/.github/ISSUE_TEMPLATE/bounty_task.md
@@ -16,6 +16,4 @@ Describe the task, expected context, and files likely involved.
 - [ ] Documentation or tests are updated when relevant.
 - [ ] The pull request links this issue.
 
-## Bounty Amount
-
-$50
+/bounty $50

--- a/README.md
+++ b/README.md
@@ -3,8 +3,7 @@
 <img width="663" height="183" alt="593560705-1a920eb5-e581-44ce-bcef-2ebf0566777f" src="https://github.com/user-attachments/assets/37891de4-a282-45a3-98aa-35598c4571c2" />
 
 
-TaskFlow is a full-stack task management SaaS monorepo built 
-with a modern TypeScript-first architecture.
+TaskFlow is a full-stack task management SaaS monorepo built with a modern TypeScript-first architecture.
 
 ## Workspace Structure
 
@@ -68,8 +67,7 @@ npm run dev -w apps/api
 
 ## Database
 
-Prisma schema is available in packages/db/prisma/schema.prisma 
-with models for:
+Prisma schema is available in packages/db/prisma/schema.prisma with models for:
 - Users
 - Tasks
 - Proposals
@@ -81,5 +79,4 @@ with models for:
 
 ## Environment Variables
 
-Each app/package expects its own .env values for DB, auth, 
-and integrations.
+Each app/package expects its own .env values for DB, auth, and integrations.


### PR DESCRIPTION
## Summary
Updated the bounty issue template to use the machine-readable /bounty marker instead of plain text.

## Changes
- Replaced plain text '$50' with machine-readable '/bounty $50'
- Aligned template with bounty program instructions in #33
- Ensured issues created from template include the marker used by automation
- Made reward-backed work identifiable by contributors and bots

/claim #687