### PR TITLE
[agent] fix(docs): correct frontend pages and API routes in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,8 +3,7 @@
 <img width="663" height="183" alt="593560705-1a920eb5-e581-44ce-bcef-2ebf0566777f" src="https://github.com/user-attachments/assets/37891de4-a282-45a3-98aa-35598c4571c2" />
 
 
-TaskFlow is a full-stack task management SaaS monorepo built 
-with a modern TypeScript-first architecture.
+TaskFlow is a full-stack task management SaaS monorepo built with a modern TypeScript-first architecture.
 
 ## Workspace Structure
 
@@ -68,8 +67,7 @@ npm run dev -w apps/api
 
 ## Database
 
-Prisma schema is available in packages/db/prisma/schema.prisma 
-with models for:
+Prisma schema is available in packages/db/prisma/schema.prisma with models for:
 - Users
 - Tasks
 - Proposals
@@ -81,5 +79,4 @@ with models for:
 
 ## Environment Variables
 
-Each app/package expects its own .env values for DB, auth, 
-and integrations.
+Each app/package expects its own .env values for DB, auth, and integrations.

--- a/README.md
+++ b/README.md
@@ -14,27 +14,19 @@ TaskFlow is a full-stack task management SaaS monorepo built with a modern TypeS
 
 ## Frontend
 
-The web app includes pages for:
-- Landing
-- Task boards and task detail
-- Create a task
-- User profiles and user search
-- Client and freelancer dashboards
-- Messaging
-- Notifications
-- Settings
-- Billing
-- Admin panel
+The web app currently includes:
+- Landing page (`apps/web/src/app/page.tsx`)
+
+Additional pages (task boards, user profiles, dashboards, messaging, billing, admin panel) are planned but not yet implemented.
 
 ## Backend
 
-The API includes:
-- Auth routes (register, login, OAuth callback, JWT refresh)
-- CRUD routes for users, tasks, and proposals
-- Payments routes (Stripe-focused service placeholder)
-- Reviews, messaging, notifications
-- File uploads and search
-- Admin routes
+The API currently exposes:
+- `GET /health` — Health check endpoint
+- `GET /users` — User listing stub
+- `POST /users` — User creation stub
+
+Additional routes (auth, payments, reviews, messaging, notifications, file uploads, search, admin) are planned but not yet implemented.
 
 Backend architecture follows:
 - Middleware layer (auth, rate limiting, error handling)
@@ -68,14 +60,9 @@ npm run dev -w apps/api
 ## Database
 
 Prisma schema is available in packages/db/prisma/schema.prisma with models for:
-- Users
-- Tasks
-- Proposals
-- Payments
-- Reviews
-- Messages
-- Categories
-- Skills
+- User
+- Job
+- Proposal
 
 ## Environment Variables
 


### PR DESCRIPTION
## Summary
Corrected the frontend pages and API routes in the README to match the actual implemented code.

## Changes
- Replaced overstated frontend page list with actual implemented pages (Landing only)
- Replaced overstated API route list with actual implemented routes (/health, GET/POST /users)
- Marked planned but unimplemented features clearly
- Aligned README with current codebase state
- Prevents new contributors from expecting non-existent pages and routes

/claim #773