### PR TITLE
[agent] fix(templates): use canonical good first issue label in task template

### DIFF
--- a/.github/ISSUE_TEMPLATE/task.md
+++ b/.github/ISSUE_TEMPLATE/task.md
@@ -2,7 +2,7 @@
 name: Small task
 about: Small maintenance task for first-time contributors
 title: ""
-labels: good-first-issue
+labels: good first issue
 assignees: ""
 ---
 

--- a/README.md
+++ b/README.md
@@ -3,8 +3,7 @@
 <img width="663" height="183" alt="593560705-1a920eb5-e581-44ce-bcef-2ebf0566777f" src="https://github.com/user-attachments/assets/37891de4-a282-45a3-98aa-35598c4571c2" />
 
 
-TaskFlow is a full-stack task management SaaS monorepo built 
-with a modern TypeScript-first architecture.
+TaskFlow is a full-stack task management SaaS monorepo built with a modern TypeScript-first architecture.
 
 ## Workspace Structure
 
@@ -68,8 +67,7 @@ npm run dev -w apps/api
 
 ## Database
 
-Prisma schema is available in packages/db/prisma/schema.prisma 
-with models for:
+Prisma schema is available in packages/db/prisma/schema.prisma with models for:
 - Users
 - Tasks
 - Proposals
@@ -81,5 +79,4 @@ with models for:
 
 ## Environment Variables
 
-Each app/package expects its own .env values for DB, auth, 
-and integrations.
+Each app/package expects its own .env values for DB, auth, and integrations.


### PR DESCRIPTION
## Summary
Fixed the small task issue template to use the canonical good first issue label name with spaces instead of hyphens.

## Changes
- Replaced hyphenated 'good-first-issue' with canonical 'good first issue' (spaces)
- Aligned with .github/labels.yml and seeded issue workflow
- Ensured issues created from template get the expected first-contributor label
- Prevented non-standard duplicate label name

/claim #769