### PR TITLE
[agent] feat(api): add task status constants

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,8 +3,7 @@
 <img width="663" height="183" alt="593560705-1a920eb5-e581-44ce-bcef-2ebf0566777f" src="https://github.com/user-attachments/assets/37891de4-a282-45a3-98aa-35598c4571c2" />
 
 
-TaskFlow is a full-stack task management SaaS monorepo built 
-with a modern TypeScript-first architecture.
+TaskFlow is a full-stack task management SaaS monorepo built with a modern TypeScript-first architecture.
 
 ## Workspace Structure
 
@@ -68,8 +67,7 @@ npm run dev -w apps/api
 
 ## Database
 
-Prisma schema is available in packages/db/prisma/schema.prisma 
-with models for:
+Prisma schema is available in packages/db/prisma/schema.prisma with models for:
 - Users
 - Tasks
 - Proposals
@@ -81,5 +79,4 @@ with models for:
 
 ## Environment Variables
 
-Each app/package expects its own .env values for DB, auth, 
-and integrations.
+Each app/package expects its own .env values for DB, auth, and integrations.

--- a/apps/api/src/constants/taskStatus.ts
+++ b/apps/api/src/constants/taskStatus.ts
@@ -1,0 +1,175 @@
+/**
+ * Task status constants for TaskFlow API task lifecycle values.
+ * Use these named constants instead of magic strings for consistency.
+ */
+
+// Core task statuses
+export const DRAFT = "DRAFT";
+export const OPEN = "OPEN";
+export const PENDING = "PENDING";
+export const IN_PROGRESS = "IN_PROGRESS";
+export const IN_REVIEW = "IN_REVIEW";
+export const COMPLETED = "COMPLETED";
+export const CANCELLED = "CANCELLED";
+export const CLOSED = "CLOSED";
+export const ARCHIVED = "ARCHIVED";
+
+// Extended task statuses
+export const TODO = "TODO";
+export const BACKLOG = "BACKLOG";
+export const READY = "READY";
+export const ASSIGNED = "ASSIGNED";
+export const ACCEPTED = "ACCEPTED";
+export const REJECTED = "REJECTED";
+export const BLOCKED = "BLOCKED";
+export const ON_HOLD = "ON_HOLD";
+export const PAUSED = "PAUSED";
+export const WAITING = "WAITING";
+export const NEEDS_INFO = "NEEDS_INFO";
+export const NEEDS_REVISION = "NEEDS_REVISION";
+export const APPROVED = "APPROVED";
+export const PUBLISHED = "PUBLISHED";
+export const EXPIRED = "EXPIRED";
+export const DELETED = "DELETED";
+
+// Task priority levels
+export const PRIORITY_LOW = "LOW";
+export const PRIORITY_MEDIUM = "MEDIUM";
+export const PRIORITY_HIGH = "HIGH";
+export const PRIORITY_URGENT = "URGENT";
+export const PRIORITY_CRITICAL = "CRITICAL";
+
+/**
+ * All valid task statuses in lifecycle order.
+ */
+export const TASK_STATUSES = [
+  DRAFT,
+  OPEN,
+  PENDING,
+  BACKLOG,
+  TODO,
+  READY,
+  ASSIGNED,
+  ACCEPTED,
+  IN_PROGRESS,
+  BLOCKED,
+  ON_HOLD,
+  PAUSED,
+  WAITING,
+  NEEDS_INFO,
+  NEEDS_REVISION,
+  IN_REVIEW,
+  APPROVED,
+  COMPLETED,
+  PUBLISHED,
+  CLOSED,
+  ARCHIVED,
+  CANCELLED,
+  REJECTED,
+  EXPIRED,
+  DELETED,
+] as const;
+
+/**
+ * Active task statuses (not terminal).
+ */
+export const ACTIVE_STATUSES = [
+  OPEN,
+  PENDING,
+  BACKLOG,
+  TODO,
+  READY,
+  ASSIGNED,
+  ACCEPTED,
+  IN_PROGRESS,
+  BLOCKED,
+  ON_HOLD,
+  PAUSED,
+  WAITING,
+  NEEDS_INFO,
+  NEEDS_REVISION,
+  IN_REVIEW,
+] as const;
+
+/**
+ * Terminal task statuses (final states).
+ */
+export const TERMINAL_STATUSES = [
+  COMPLETED,
+  CLOSED,
+  ARCHIVED,
+  CANCELLED,
+  REJECTED,
+  EXPIRED,
+  DELETED,
+] as const;
+
+/**
+ * Checks if a status is a valid task status.
+ */
+export const isValidTaskStatus = (status: string): boolean => {
+  return (TASK_STATUSES as readonly string[]).includes(status);
+};
+
+/**
+ * Checks if a status is an active (non-terminal) status.
+ */
+export const isActiveStatus = (status: string): boolean => {
+  return (ACTIVE_STATUSES as readonly string[]).includes(status);
+};
+
+/**
+ * Checks if a status is a terminal (final) status.
+ */
+export const isTerminalStatus = (status: string): boolean => {
+  return (TERMINAL_STATUSES as readonly string[]).includes(status);
+};
+
+/**
+ * Consolidated task status constants object for convenient lookup.
+ */
+export const TaskStatus = {
+  // Core
+  DRAFT,
+  OPEN,
+  PENDING,
+  IN_PROGRESS,
+  IN_REVIEW,
+  COMPLETED,
+  CANCELLED,
+  CLOSED,
+  ARCHIVED,
+  // Extended
+  TODO,
+  BACKLOG,
+  READY,
+  ASSIGNED,
+  ACCEPTED,
+  REJECTED,
+  BLOCKED,
+  ON_HOLD,
+  PAUSED,
+  WAITING,
+  NEEDS_INFO,
+  NEEDS_REVISION,
+  APPROVED,
+  PUBLISHED,
+  EXPIRED,
+  DELETED,
+  // Priorities
+  PRIORITY_LOW,
+  PRIORITY_MEDIUM,
+  PRIORITY_HIGH,
+  PRIORITY_URGENT,
+  PRIORITY_CRITICAL,
+  // Collections
+  ALL: TASK_STATUSES,
+  ACTIVE: ACTIVE_STATUSES,
+  TERMINAL: TERMINAL_STATUSES,
+  // Helpers
+  isValid: isValidTaskStatus,
+  isActive: isActiveStatus,
+  isTerminal: isTerminalStatus,
+} as const;
+
+export default TaskStatus;


### PR DESCRIPTION
## Summary
Added central task-status constants module for TaskFlow API task lifecycle values.

/claim #2840