### PR TITLE
[agent] Make API app import-safe

### DIFF
--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -7,7 +7,7 @@
   "main": "src/index.ts",
   "scripts": {
     "dev": "tsx src/index.ts",
-    "test": "echo \"No API tests configured yet\"",
+    "test": "node --import tsx --test test/app-import.test.ts",
     "lint": "echo \"No API lint configured yet\""
   },
   "dependencies": {

--- a/apps/api/src/app.ts
+++ b/apps/api/src/app.ts
@@ -1,0 +1,15 @@
+import express from "express";
+
+import usersRouter from "./routes/users";
+
+const app = express();
+
+app.use(express.json());
+
+app.get("/health", (_req, res) => {
+  res.json({ status: "ok", service: "taskflow-api" });
+});
+
+app.use("/users", usersRouter);
+
+export default app;

--- a/apps/api/src/index.ts
+++ b/apps/api/src/index.ts
@@ -1,17 +1,6 @@
-import express from "express";
+import app from "./app";
 
-import usersRouter from "./routes/users";
-
-const app = express();
 const port = process.env.PORT || 4000;
-
-app.use(express.json());
-
-app.get("/health", (_req, res) => {
-  res.json({ status: "ok", service: "taskflow-api" });
-});
-
-app.use("/users", usersRouter);
 
 app.listen(port, () => {
   console.log(`TaskFlow API listening on port ${port}`);

--- a/apps/api/test/app-import.test.ts
+++ b/apps/api/test/app-import.test.ts
@@ -1,0 +1,38 @@
+import assert from "node:assert/strict";
+import { createServer } from "node:http";
+import test from "node:test";
+
+import app from "../src/app";
+
+test("the Express app is import-safe and preserves existing routes", async () => {
+  const server = createServer(app);
+
+  await new Promise<void>((resolve, reject) => {
+    server.once("error", reject);
+    server.listen(0, "127.0.0.1", resolve);
+  });
+
+  try {
+    const address = server.address();
+    assert.ok(address && typeof address === "object");
+    const baseUrl = `http://127.0.0.1:${address.port}`;
+
+    const health = await fetch(`${baseUrl}/health`);
+    assert.equal(health.status, 200);
+    assert.deepEqual(await health.json(), {
+      status: "ok",
+      service: "taskflow-api",
+    });
+
+    const users = await fetch(`${baseUrl}/users`);
+    assert.equal(users.status, 200);
+    assert.deepEqual(await users.json(), {
+      data: [],
+      message: "User listing is not implemented yet.",
+    });
+  } finally {
+    await new Promise<void>((resolve, reject) => {
+      server.close((error) => (error ? reject(error) : resolve()));
+    });
+  }
+});

--- a/contributors/agents.json
+++ b/contributors/agents.json
@@ -4,7 +4,7 @@
       "github_username": "arthuz-th",
       "model": "OpenAI GPT-5.6 Sol",
       "version": "5.6",
-      "pr_number": 0,
+      "pr_number": 9565,
       "issue_number": 9564
     }
   ],

--- a/contributors/agents.json
+++ b/contributors/agents.json
@@ -1,5 +1,13 @@
 {
-  "agents": [],
-  "last_updated": "2026-06-03",
-  "total_contributions": 0
+  "agents": [
+    {
+      "github_username": "arthuz-th",
+      "model": "OpenAI GPT-5.6 Sol",
+      "version": "5.6",
+      "pr_number": 0,
+      "issue_number": 9564
+    }
+  ],
+  "last_updated": "2026-09-13",
+  "total_contributions": 1
 }


### PR DESCRIPTION
Closes #9564

/claim #9564

## Summary
- move Express app construction and routes into `apps/api/src/app.ts`
- keep `apps/api/src/index.ts` as the runtime-only listener entrypoint
- add a focused Node test that imports the app, serves it on an ephemeral test port, and verifies the existing `/health` and `/users` responses

## Verification

```text
npm test --workspace @taskflow/api
1 test passed, 0 failed, 0 skipped
```

## AI disclosure
This contribution was implemented with OpenAI GPT-5.6 Sol assistance. The required AI-agent registry check-in was posted on #16, the repository was starred, and `contributors/agents.json` records this PR as #9565.
