### PR TITLE
[agent] fix(api): validate user creation payloads

### DIFF
--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -7,7 +7,7 @@
   "main": "src/index.ts",
   "scripts": {
     "dev": "tsx src/index.ts",
-    "test": "echo \"No API tests configured yet\"",
+    "test": "tsx --test tests/**/*.test.ts",
     "lint": "echo \"No API lint configured yet\""
   },
   "dependencies": {

--- a/apps/api/src/routes/users.ts
+++ b/apps/api/src/routes/users.ts
@@ -10,12 +10,63 @@ router.get("/", (_req, res) => {
 });
 
 router.post("/", (req, res) => {
-  res.status(201).json({
-    data: {
-      id: "stub-user-id",
-      ...req.body
-    },
-    message: "User creation is not implemented yet."
+  if (
+    req.body === null ||
+    typeof req.body !== "object" ||
+    Array.isArray(req.body)
+  ) {
+    return res.status(400).json({
+      message: "Invalid request body"
+    });
+  }
+
+  const { email, name } = req.body as {
+    email?: unknown;
+    name?: unknown;
+  };
+
+  if (typeof email !== "string") {
+    return res.status(400).json({
+      message: "Invalid email"
+    });
+  }
+
+  const normalizedEmail =
+    email.trim().toLowerCase();
+
+  const emailPattern =
+    /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
+
+  if (!emailPattern.test(normalizedEmail)) {
+    return res.status(400).json({
+      message: "Invalid email"
+    });
+  }
+
+  if (
+    name !== undefined &&
+    typeof name !== "string"
+  ) {
+    return res.status(400).json({
+      message: "Invalid name"
+    });
+  }
+
+  const normalizedName =
+    typeof name === "string"
+      ? name.trim()
+      : undefined;
+
+  const newUser = {
+    id: "stub-user-id",
+    email: normalizedEmail,
+    name: normalizedName
+  };
+
+  return res.status(201).json({
+    data: newUser,
+    message:
+      "User creation is not implemented yet."
   });
 });
 

--- a/apps/api/tests/users.test.ts
+++ b/apps/api/tests/users.test.ts
@@ -1,0 +1,410 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import express from "express";
+import http from "node:http";
+
+import usersRouter from "../src/routes/users";
+
+type JsonRequestResult = {
+  status: number;
+  body: unknown;
+  raw: string;
+};
+
+async function requestJson(
+  app: express.Express,
+  method: string,
+  path: string,
+  payload: unknown
+): Promise<JsonRequestResult> {
+  const server = http.createServer(app);
+
+  await new Promise<void>((resolve, reject) => {
+    server.once("error", reject);
+
+    server.listen(0, "127.0.0.1", () => {
+      resolve();
+    });
+  });
+
+  try {
+    const address = server.address();
+
+    if (
+      !address ||
+      typeof address === "string"
+    ) {
+      throw new Error(
+        "Could not resolve local server"
+      );
+    }
+
+    const requestBody = JSON.stringify(payload);
+
+    return await new Promise<JsonRequestResult>(
+      (resolve, reject) => {
+        const req = http.request(
+          {
+            hostname: "127.0.0.1",
+            port: address.port,
+            path,
+            method,
+            headers: {
+              "content-type": "application/json",
+              "content-length":
+                Buffer.byteLength(requestBody)
+            }
+          },
+          (res) => {
+            const chunks: Buffer[] = [];
+
+            res.on("data", (chunk) => {
+              chunks.push(
+                Buffer.isBuffer(chunk)
+                  ? chunk
+                  : Buffer.from(chunk)
+              );
+            });
+
+            res.on("end", () => {
+              const raw = Buffer.concat(chunks)
+                .toString("utf8");
+
+              let body: unknown = raw;
+
+              try {
+                body = JSON.parse(raw);
+              } catch {
+                // Keep raw response.
+              }
+
+              resolve({
+                status: res.statusCode ?? 0,
+                body,
+                raw
+              });
+            });
+          }
+        );
+
+        req.once("error", reject);
+
+        req.write(requestBody);
+        req.end();
+      }
+    );
+  } finally {
+    await new Promise<void>((resolve, reject) => {
+      server.close((error) => {
+        if (error) {
+          reject(error);
+        } else {
+          resolve();
+        }
+      });
+    });
+  }
+}
+
+function createApp() {
+  const app = express();
+
+  app.use(express.json());
+  app.use("/users", usersRouter);
+
+  return app;
+}
+
+function unwrapUser(
+  result: JsonRequestResult
+): Record<string, unknown> {
+  const responseBody =
+    result.body as Record<string, unknown>;
+
+  if (
+    responseBody &&
+    typeof responseBody === "object" &&
+    responseBody.data &&
+    typeof responseBody.data === "object" &&
+    !Array.isArray(responseBody.data)
+  ) {
+    return responseBody.data as Record<string, unknown>;
+  }
+
+  return responseBody;
+}
+
+test(
+  "ignores client-controlled id",
+  async () => {
+    const result = await requestJson(
+      createApp(),
+      "POST",
+      "/users",
+      {
+        email: "user@example.com",
+        name: "Test User",
+        id: "client-controlled-id"
+      }
+    );
+
+    assert.equal(result.status, 201);
+
+    const user = unwrapUser(result);
+
+    assert.notEqual(
+      user.id,
+      "client-controlled-id"
+    );
+  }
+);
+
+test(
+  "ignores unrelated fields",
+  async () => {
+    const result = await requestJson(
+      createApp(),
+      "POST",
+      "/users",
+      {
+        email: "user@example.com",
+        name: "Test User",
+        unexpectedField: "must-not-survive"
+      }
+    );
+
+    assert.equal(result.status, 201);
+
+    const user = unwrapUser(result);
+
+    assert.equal(
+      Object.prototype.hasOwnProperty.call(
+        user,
+        "unexpectedField"
+      ),
+      false
+    );
+  }
+);
+
+test(
+  "normalizes email",
+  async () => {
+    const result = await requestJson(
+      createApp(),
+      "POST",
+      "/users",
+      {
+        email: "  USER@EXAMPLE.COM  ",
+        name: "Test User"
+      }
+    );
+
+    assert.equal(result.status, 201);
+
+    const user = unwrapUser(result);
+
+    assert.equal(
+      user.email,
+      "user@example.com"
+    );
+  }
+);
+
+test(
+  "normalizes name",
+  async () => {
+    const result = await requestJson(
+      createApp(),
+      "POST",
+      "/users",
+      {
+        email: "user@example.com",
+        name: "   Test User   "
+      }
+    );
+
+    assert.equal(result.status, 201);
+
+    const user = unwrapUser(result);
+
+    assert.equal(
+      user.name,
+      "Test User"
+    );
+  }
+);
+
+test(
+  "rejects missing email",
+  async () => {
+    const result = await requestJson(
+      createApp(),
+      "POST",
+      "/users",
+      {
+        name: "Test User"
+      }
+    );
+
+    assert.ok(
+      result.status >= 400 &&
+      result.status < 500
+    );
+  }
+);
+
+test(
+  "rejects malformed email without at-sign",
+  async () => {
+    const result = await requestJson(
+      createApp(),
+      "POST",
+      "/users",
+      {
+        email: "not-an-email",
+        name: "Test User"
+      }
+    );
+
+    assert.ok(
+      result.status >= 400 &&
+      result.status < 500
+    );
+  }
+);
+
+test(
+  "rejects email missing domain",
+  async () => {
+    const result = await requestJson(
+      createApp(),
+      "POST",
+      "/users",
+      {
+        email: "a@",
+        name: "Test User"
+      }
+    );
+
+    assert.ok(
+      result.status >= 400 &&
+      result.status < 500
+    );
+  }
+);
+
+test(
+  "rejects email missing local part",
+  async () => {
+    const result = await requestJson(
+      createApp(),
+      "POST",
+      "/users",
+      {
+        email: "@example.com",
+        name: "Test User"
+      }
+    );
+
+    assert.ok(
+      result.status >= 400 &&
+      result.status < 500
+    );
+  }
+);
+
+test(
+  "rejects email with multiple at-signs",
+  async () => {
+    const result = await requestJson(
+      createApp(),
+      "POST",
+      "/users",
+      {
+        email: "a@@example.com",
+        name: "Test User"
+      }
+    );
+
+    assert.ok(
+      result.status >= 400 &&
+      result.status < 500
+    );
+  }
+);
+
+test(
+  "rejects non-string name",
+  async () => {
+    const result = await requestJson(
+      createApp(),
+      "POST",
+      "/users",
+      {
+        email: "user@example.com",
+        name: 123
+      }
+    );
+
+    assert.ok(
+      result.status >= 400 &&
+      result.status < 500
+    );
+  }
+);
+
+test(
+  "rejects null body",
+  async () => {
+    const result = await requestJson(
+      createApp(),
+      "POST",
+      "/users",
+      null
+    );
+
+    assert.ok(
+      result.status >= 400 &&
+      result.status < 500
+    );
+  }
+);
+
+test(
+  "rejects array body",
+  async () => {
+    const result = await requestJson(
+      createApp(),
+      "POST",
+      "/users",
+      [
+        {
+          email: "user@example.com"
+        }
+      ]
+    );
+
+    assert.ok(
+      result.status >= 400 &&
+      result.status < 500
+    );
+  }
+);
+
+test(
+  "rejects numeric body",
+  async () => {
+    const result = await requestJson(
+      createApp(),
+      "POST",
+      "/users",
+      123
+    );
+
+    assert.ok(
+      result.status >= 400 &&
+      result.status < 500
+    );
+  }
+);

--- a/contributors/agents.json
+++ b/contributors/agents.json
@@ -4,7 +4,7 @@
       "github_username": "jmodria",
       "model": "GPT-5.6 Sol + qwen2.5-coder:7b",
       "version": "GPT-5.6 Sol / qwen2.5-coder:7b",
-      "pr_number": 0,
+      "pr_number": 9568,
       "issue_number": 2207
     }
   ],

--- a/contributors/agents.json
+++ b/contributors/agents.json
@@ -1,5 +1,13 @@
 {
-  "agents": [],
-  "last_updated": "2026-06-03",
-  "total_contributions": 0
+  "agents": [
+    {
+      "github_username": "jmodria",
+      "model": "GPT-5.6 Sol + qwen2.5-coder:7b",
+      "version": "GPT-5.6 Sol / qwen2.5-coder:7b",
+      "pr_number": 0,
+      "issue_number": 2207
+    }
+  ],
+  "last_updated": "2026-09-12",
+  "total_contributions": 1
 }


### PR DESCRIPTION
## Summary

Validates `POST /users` payloads before constructing the stub user response.

The change:

- rejects non-object JSON bodies, including `null`, arrays, strings, and numbers
- requires a valid email address
- trims and lowercases email addresses
- validates optional `name` values before trimming
- ignores client-controlled `id`
- ignores unrelated request fields
- preserves the existing response structure

## Verification

The fix was verified against a fresh repository clone in Docker.

Validated behavior:

- the regression test reproduces RED on the baseline and GREEN with the fix
- 13/13 hardened acceptance cases pass
- root test remains PASS
- root lint was already failing on the baseline and remains unchanged with the fix
- no new broad-check regression was detected
- the functional implementation is limited to `apps/api/src/routes/users.ts`, with regression tests and required contribution metadata added separately

Hardened cases include:

- client-controlled ID rejection
- extra-field rejection
- email normalization
- name normalization
- missing email
- malformed email variants
- invalid name type
- `null` body
- array body
- numeric body

## AI agent disclosure

This contribution was prepared with GPT-5.6 Sol and local `qwen2.5-coder:7b`, with automated regression and QA validation.

`contributors/agents.json` is updated as required by the repository contribution instructions.

Closes #2207